### PR TITLE
Fix client create response field name

### DIFF
--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -71,7 +71,7 @@ export class ClientsService {
     return {
       ...client,
       ...(rawSecret
-        ? { secret: rawSecret, secretWarning: 'Store this secret securely. It will not be shown again.' }
+        ? { clientSecret: rawSecret, secretWarning: 'Store this secret securely. It will not be shown again.' }
         : {}),
     };
   }


### PR DESCRIPTION
## Summary
- Fix `create()` method in `ClientsService` to return `clientSecret` instead of `secret` in the response

## Related Issue
Closes #1

## Test plan
- [ ] Create a new CONFIDENTIAL client via admin console
- [ ] Verify the generated secret is displayed after creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)