### PR TITLE
Fix regenerate secret response field name

### DIFF
--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -143,7 +143,7 @@ export class ClientsService {
 
     return {
       clientId,
-      secret: rawSecret,
+      clientSecret: rawSecret,
       secretWarning: 'Store this secret securely. It will not be shown again.',
     };
   }


### PR DESCRIPTION
## Summary
- Fix `regenerateSecret()` method in `ClientsService` to return `clientSecret` instead of `secret`

## Related Issue
Closes #2

## Test plan
- [ ] Regenerate a client secret via admin console
- [ ] Verify the new secret is displayed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)