### PR TITLE
Fix users pagination response format and params

### DIFF
--- a/admin-ui/src/api/users.ts
+++ b/admin-ui/src/api/users.ts
@@ -3,14 +3,14 @@ import type { User } from '../types';
 
 export async function getUsers(
   realmName: string,
-  skip = 0,
+  page = 1,
   limit = 50,
 ): Promise<User[]> {
-  const { data } = await apiClient.get<User[]>(
+  const { data } = await apiClient.get<{ users: User[]; total: number }>(
     `/realms/${realmName}/users`,
-    { params: { skip, limit } },
+    { params: { page, limit } },
   );
-  return data;
+  return data.users;
 }
 
 export async function getUserById(


### PR DESCRIPTION
## Summary
- Updated `getUsers()` to handle paginated `{ users, total }` response from backend
- Changed pagination parameter from `skip` to `page` to match backend `PaginationDto`

## Related Issues
Closes #4
Closes #5

## Test plan
- [ ] Navigate to Users list page in admin console
- [ ] Verify users are displayed correctly
- [ ] Verify pagination works

🤖 Generated with [Claude Code](https://claude.com/claude-code)