### PR TITLE
Fix role assignment endpoint path and request body

### DIFF
--- a/admin-ui/src/api/roles.ts
+++ b/admin-ui/src/api/roles.ts
@@ -31,7 +31,7 @@ export async function getUserRealmRoles(
   userId: string,
 ): Promise<Role[]> {
   const { data } = await apiClient.get<Role[]>(
-    `/realms/${realmName}/users/${userId}/roles`,
+    `/realms/${realmName}/users/${userId}/role-mappings/realm`,
   );
   return data;
 }
@@ -42,8 +42,8 @@ export async function assignUserRealmRoles(
   roleNames: string[],
 ): Promise<void> {
   await apiClient.post(
-    `/realms/${realmName}/users/${userId}/roles`,
-    { roles: roleNames },
+    `/realms/${realmName}/users/${userId}/role-mappings/realm`,
+    { roleNames },
   );
 }
 
@@ -53,7 +53,7 @@ export async function removeUserRealmRoles(
   roleNames: string[],
 ): Promise<void> {
   await apiClient.delete(
-    `/realms/${realmName}/users/${userId}/roles`,
-    { data: { roles: roleNames } },
+    `/realms/${realmName}/users/${userId}/role-mappings/realm`,
+    { data: { roleNames } },
   );
 }


### PR DESCRIPTION
## Summary
- Fixed role assignment endpoint from `/users/:id/roles` to `/users/:id/role-mappings/realm`
- Fixed request body from `{ roles: [...] }` to `{ roleNames: [...] }`
- Applied to GET, POST (assign), and DELETE (remove) role endpoints

## Related Issues
Closes #8
Closes #9

## Test plan
- [ ] Assign a role to a user via admin console
- [ ] Verify assigned roles are displayed
- [ ] Remove a role from a user and verify it's removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)