### PR TITLE
Add requireConsent field to client API

### DIFF
--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -20,6 +20,7 @@ const CLIENT_SELECT = {
   redirectUris: true,
   webOrigins: true,
   grantTypes: true,
+  requireConsent: true,
   createdAt: true,
   updatedAt: true,
 } as const;
@@ -64,6 +65,7 @@ export class ClientsService {
         redirectUris: dto.redirectUris ?? [],
         webOrigins: dto.webOrigins ?? [],
         grantTypes: dto.grantTypes ?? ['authorization_code'],
+        requireConsent: dto.requireConsent ?? false,
       },
       select: CLIENT_SELECT,
     });
@@ -111,6 +113,7 @@ export class ClientsService {
         redirectUris: dto.redirectUris,
         webOrigins: dto.webOrigins,
         grantTypes: dto.grantTypes,
+        requireConsent: dto.requireConsent,
       },
       select: CLIENT_SELECT,
     });

--- a/src/clients/dto/create-client.dto.ts
+++ b/src/clients/dto/create-client.dto.ts
@@ -51,4 +51,9 @@ export class CreateClientDto {
   @IsArray()
   @IsString({ each: true })
   grantTypes?: string[];
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  requireConsent?: boolean;
 }


### PR DESCRIPTION
## Summary
- Added `requireConsent` to `CLIENT_SELECT` so it's returned in all client API responses
- Added `requireConsent` field to `CreateClientDto` with validation
- `UpdateClientDto` inherits the field automatically via `PartialType`
- Updated `create()` and `update()` methods to persist `requireConsent`

## Related Issues
Closes #10
Closes #11
Closes #12

## Test plan
- [ ] Create a client with requireConsent enabled via admin console
- [ ] Verify requireConsent shows correctly on client detail page
- [ ] Toggle requireConsent and save, verify it persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)