### PR TITLE
Fix email required mismatch in user create form

### DIFF
--- a/admin-ui/src/pages/users/UserCreatePage.tsx
+++ b/admin-ui/src/pages/users/UserCreatePage.tsx
@@ -59,7 +59,6 @@ export default function UserCreatePage() {
             </label>
             <input
               type="email"
-              required
               value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })}
               className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"


### PR DESCRIPTION
## Summary
- Removed `required` attribute from email input in UserCreatePage
- Backend `CreateUserDto` has email as optional, frontend now matches

## Related Issue
Closes #13

## Test plan
- [ ] Create a user without entering an email
- [ ] Verify the form submits successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)