### PR TITLE
Fix AdminApiKeyGuard security logic

### DIFF
--- a/src/common/guards/admin-api-key.guard.ts
+++ b/src/common/guards/admin-api-key.guard.ts
@@ -24,10 +24,22 @@ export class AdminApiKeyGuard implements CanActivate {
     if (isPublic) return true;
 
     const request = context.switchToHttp().getRequest<Request>();
-    const apiKey = request.headers['x-admin-api-key'];
+
+    // Only enforce API key on admin routes
+    if (!request.path.startsWith('/admin/') && !request.path.startsWith('/admin')) {
+      return true;
+    }
+
     const expectedKey = this.configService.get<string>('ADMIN_API_KEY');
 
-    if (!expectedKey || apiKey === expectedKey) return true;
+    if (!expectedKey) {
+      throw new UnauthorizedException('ADMIN_API_KEY is not configured');
+    }
+
+    const apiKey = request.headers['x-admin-api-key'];
+    if (typeof apiKey === 'string' && apiKey === expectedKey) {
+      return true;
+    }
 
     throw new UnauthorizedException('Invalid or missing admin API key');
   }


### PR DESCRIPTION
## Summary
- Guard now only enforces API key validation on `/admin/*` routes (path-based check)
- Rejects requests when `ADMIN_API_KEY` env var is not configured (previously allowed all requests through)
- Validates that the API key header is a string before comparing (handles Express array headers edge case)

## Related Issue
Closes #14

## Test plan
- [ ] Verify admin endpoints require valid API key
- [ ] Verify non-admin endpoints (OAuth, login, etc.) work without API key
- [ ] Verify app rejects admin requests when ADMIN_API_KEY is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)