### PR TITLE
Fix client detail 404: navigate with clientId instead of UUID

### DIFF
--- a/admin-ui/src/pages/clients/ClientListPage.tsx
+++ b/admin-ui/src/pages/clients/ClientListPage.tsx
@@ -71,7 +71,7 @@ export default function ClientListPage() {
               clients.map((client) => (
                 <tr
                   key={client.id}
-                  onClick={() => navigate(`/console/realms/${name}/clients/${client.id}`)}
+                  onClick={() => navigate(`/console/realms/${name}/clients/${client.clientId}`)}
                   className="cursor-pointer hover:bg-gray-50"
                 >
                   <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-indigo-600">


### PR DESCRIPTION
## Summary
- Changed `ClientListPage` to navigate using `client.clientId` (e.g., `test-client`) instead of `client.id` (UUID)
- This was the root cause of all client detail/update/delete/regenerate operations failing

## Related Issue
Closes #25

## Test plan
- [ ] Click on a client in the client list
- [ ] Verify client detail page loads correctly
- [ ] Verify update, delete, and regenerate secret work

🤖 Generated with [Claude Code](https://claude.com/claude-code)