### PR TITLE
Fix role creation 500: use findFirst instead of findUnique

### DIFF
--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -13,10 +13,8 @@ export class RolesService {
   // ─── Realm Roles ────────────────────────────────────────
 
   async createRealmRole(realm: Realm, name: string, description?: string) {
-    const existing = await this.prisma.role.findUnique({
-      where: {
-        realmId_clientId_name: { realmId: realm.id, clientId: null as any, name },
-      },
+    const existing = await this.prisma.role.findFirst({
+      where: { realmId: realm.id, clientId: null, name },
     });
     if (existing) {
       throw new ConflictException(`Role '${name}' already exists`);


### PR DESCRIPTION
## Summary
- Changed `createRealmRole` to use `findFirst` instead of `findUnique` for duplicate check
- Prisma's `findUnique` cannot handle `null` values in composite unique keys, causing 500 error

## Related Issue
Closes #26

## Test plan
- [ ] Create a new realm role via admin console
- [ ] Verify it appears in the role list
- [ ] Try creating a duplicate role, verify conflict error

🤖 Generated with [Claude Code](https://claude.com/claude-code)