### PR TITLE
Show backend validation messages in error displays

### DIFF
--- a/admin-ui/src/pages/clients/ClientCreatePage.tsx
+++ b/admin-ui/src/pages/clients/ClientCreatePage.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '../../api/clients';
+import { getErrorMessage } from '../../utils/getErrorMessage';
 
 export default function ClientCreatePage() {
   const { name } = useParams<{ name: string }>();
@@ -231,7 +232,7 @@ export default function ClientCreatePage() {
 
         {mutation.isError && (
           <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-            {(mutation.error as Error).message || 'Failed to create client.'}
+            {getErrorMessage(mutation.error, 'Failed to create client.')}
           </div>
         )}
 

--- a/admin-ui/src/pages/realms/RealmCreatePage.tsx
+++ b/admin-ui/src/pages/realms/RealmCreatePage.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createRealm } from '../../api/realms';
+import { getErrorMessage } from '../../utils/getErrorMessage';
 
 export default function RealmCreatePage() {
   const navigate = useNavigate();
@@ -114,7 +115,7 @@ export default function RealmCreatePage() {
 
         {mutation.isError && (
           <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-            {(mutation.error as Error).message || 'Failed to create realm.'}
+            {getErrorMessage(mutation.error, 'Failed to create realm.')}
           </div>
         )}
 

--- a/admin-ui/src/pages/roles/RoleListPage.tsx
+++ b/admin-ui/src/pages/roles/RoleListPage.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getRealmRoles, createRealmRole, deleteRealmRole } from '../../api/roles';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import { getErrorMessage } from '../../utils/getErrorMessage';
 
 export default function RoleListPage() {
   const { name } = useParams<{ name: string }>();
@@ -110,7 +111,7 @@ export default function RoleListPage() {
 
           {createMutation.isError && (
             <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-              {(createMutation.error as Error).message || 'Failed to create role.'}
+              {getErrorMessage(createMutation.error, 'Failed to create role.')}
             </div>
           )}
 

--- a/admin-ui/src/pages/users/UserCreatePage.tsx
+++ b/admin-ui/src/pages/users/UserCreatePage.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createUser } from '../../api/users';
+import { getErrorMessage } from '../../utils/getErrorMessage';
 
 export default function UserCreatePage() {
   const { name } = useParams<{ name: string }>();
@@ -119,7 +120,7 @@ export default function UserCreatePage() {
 
         {mutation.isError && (
           <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
-            {(mutation.error as Error).message || 'Failed to create user.'}
+            {getErrorMessage(mutation.error, 'Failed to create user.')}
           </div>
         )}
 

--- a/admin-ui/src/utils/getErrorMessage.ts
+++ b/admin-ui/src/utils/getErrorMessage.ts
@@ -1,0 +1,12 @@
+import type { AxiosError } from 'axios';
+
+export function getErrorMessage(error: unknown, fallback = 'An error occurred'): string {
+  if (error && typeof error === 'object' && 'response' in error) {
+    const axiosError = error as AxiosError<{ message?: string | string[] }>;
+    const msg = axiosError.response?.data?.message;
+    if (Array.isArray(msg)) return msg[0] || fallback;
+    if (typeof msg === 'string') return msg;
+  }
+  if (error instanceof Error) return error.message;
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- Added `getErrorMessage()` utility to extract backend error messages from Axios responses
- Updated all create/role pages to show actual validation errors instead of generic "Request failed with status code 400"

## Related Issue
Closes #27

## Test plan
- [ ] Try creating a realm with invalid name, verify meaningful error message
- [ ] Try creating a duplicate user, verify conflict message
- [ ] Try creating a duplicate role, verify conflict message

🤖 Generated with [Claude Code](https://claude.com/claude-code)