### PR TITLE
Fix SPA fallback for deep links and page refresh

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -32,7 +32,7 @@ import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
       serveRoot: '/console',
       serveStaticOptions: {
         index: ['index.html'],
-        fallthrough: true,
+        fallthrough: false,
       },
     }),
     PrismaModule,


### PR DESCRIPTION
## Summary
- Changed `fallthrough: true` to `fallthrough: false` in ServeStaticModule
- Ensures browser refresh and direct URL navigation to `/console/*` routes serve `index.html`

## Related Issue
Closes #28

## Test plan
- [ ] Navigate to a client detail page, then refresh the browser
- [ ] Copy a deep URL and open it in a new tab
- [ ] Verify the admin console loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)