### PR TITLE
Fix frontend TypeScript types to match nullable Prisma fields

### DIFF
--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -47,7 +47,7 @@ export default function RealmDetailPage() {
   useEffect(() => {
     if (realm) {
       setForm({
-        displayName: realm.displayName,
+        displayName: realm.displayName ?? '',
         enabled: realm.enabled,
         accessTokenLifespan: realm.accessTokenLifespan,
         refreshTokenLifespan: realm.refreshTokenLifespan,

--- a/admin-ui/src/pages/users/UserDetailPage.tsx
+++ b/admin-ui/src/pages/users/UserDetailPage.tsx
@@ -48,10 +48,10 @@ export default function UserDetailPage() {
   useEffect(() => {
     if (user) {
       setForm({
-        email: user.email,
+        email: user.email ?? '',
         emailVerified: user.emailVerified,
-        firstName: user.firstName,
-        lastName: user.lastName,
+        firstName: user.firstName ?? '',
+        lastName: user.lastName ?? '',
         enabled: user.enabled,
       });
     }

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -1,7 +1,7 @@
 export interface Realm {
   id: string;
   name: string;
-  displayName: string;
+  displayName: string | null;
   enabled: boolean;
   accessTokenLifespan: number;
   refreshTokenLifespan: number;
@@ -13,10 +13,10 @@ export interface User {
   id: string;
   realmId: string;
   username: string;
-  email: string;
+  email: string | null;
   emailVerified: boolean;
-  firstName: string;
-  lastName: string;
+  firstName: string | null;
+  lastName: string | null;
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
@@ -28,8 +28,8 @@ export interface Client {
   clientId: string;
   clientType: 'CONFIDENTIAL' | 'PUBLIC';
   clientSecret?: string;
-  name: string;
-  description: string;
+  name: string | null;
+  description: string | null;
   enabled: boolean;
   redirectUris: string[];
   webOrigins: string[];
@@ -44,7 +44,7 @@ export interface Role {
   realmId: string;
   clientId: string | null;
   name: string;
-  description: string;
+  description: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- Updated `Realm`, `User`, `Client`, `Role` interfaces to use `string | null` for nullable fields
- Added nullish coalescing (`?? ''`) in form state initialization

## Related Issue
Closes #29

## Test plan
- [ ] Verify admin console builds without TypeScript errors
- [ ] Create/view entities with missing optional fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)