### PR TITLE
Implement user consent flow

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -18,6 +18,7 @@ import { ScopesModule } from './scopes/scopes.module.js';
 import { LoginModule } from './login/login.module.js';
 import { IdentityProvidersModule } from './identity-providers/identity-providers.module.js';
 import { BrokerModule } from './broker/broker.module.js';
+import { ConsentModule } from './consent/consent.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 
 @Module({
@@ -47,6 +48,7 @@ import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
     WellKnownModule,
     ScopesModule,
     LoginModule,
+    ConsentModule,
     IdentityProvidersModule,
     BrokerModule,
   ],

--- a/src/consent/consent.module.ts
+++ b/src/consent/consent.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { ConsentService } from './consent.service.js';
+
+@Global()
+@Module({
+  providers: [ConsentService],
+  exports: [ConsentService],
+})
+export class ConsentModule {}

--- a/src/consent/consent.service.ts
+++ b/src/consent/consent.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+import { randomBytes } from 'crypto';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+export interface ConsentRequest {
+  userId: string;
+  clientId: string;
+  clientName: string;
+  realmName: string;
+  scopes: string[];
+  oauthParams: Record<string, string>;
+}
+
+@Injectable()
+export class ConsentService {
+  private readonly pendingRequests = new Map<string, ConsentRequest>();
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Check if a user has already granted consent for the requested scopes.
+   */
+  async hasConsent(
+    userId: string,
+    clientId: string,
+    requestedScopes: string[],
+  ): Promise<boolean> {
+    const consent = await this.prisma.userConsent.findUnique({
+      where: { userId_clientId: { userId, clientId } },
+    });
+
+    if (!consent) return false;
+
+    // Check that every requested scope is covered by the stored consent
+    return requestedScopes.every((scope) => consent.scopes.includes(scope));
+  }
+
+  /**
+   * Grant consent: upsert the consent record with the given scopes.
+   */
+  async grantConsent(userId: string, clientId: string, scopes: string[]) {
+    return this.prisma.userConsent.upsert({
+      where: { userId_clientId: { userId, clientId } },
+      create: { userId, clientId, scopes },
+      update: { scopes },
+    });
+  }
+
+  /**
+   * Revoke consent for a user-client pair.
+   */
+  async revokeConsent(userId: string, clientId: string) {
+    await this.prisma.userConsent.deleteMany({
+      where: { userId, clientId },
+    });
+  }
+
+  /**
+   * Store a pending consent request in memory. Returns the request ID.
+   */
+  storeConsentRequest(data: ConsentRequest): string {
+    const id = randomBytes(16).toString('hex');
+    this.pendingRequests.set(id, data);
+
+    // Auto-cleanup after 10 minutes
+    setTimeout(() => this.pendingRequests.delete(id), 10 * 60 * 1000);
+
+    return id;
+  }
+
+  /**
+   * Retrieve and remove a pending consent request.
+   */
+  getConsentRequest(id: string): ConsentRequest | undefined {
+    const req = this.pendingRequests.get(id);
+    if (req) this.pendingRequests.delete(id);
+    return req;
+  }
+}

--- a/src/login/login.service.ts
+++ b/src/login/login.service.ts
@@ -75,4 +75,8 @@ export class LoginService {
 
     return session.user;
   }
+
+  async findUserById(userId: string): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { id: userId } });
+  }
 }


### PR DESCRIPTION
## Summary
- Created `ConsentModule` with `ConsentService` (check/grant/revoke consent, in-memory consent request storage)
- Wired consent check into OAuth authorization endpoint (SSO path)
- Wired consent check into login controller (post-login path)
- Added `GET/POST /realms/:realmName/consent` routes to render and handle consent page
- Uses existing `UserConsent` model, `Client.requireConsent` flag, and `views/consent.hbs` template

## Flow
1. User initiates OAuth flow → client has `requireConsent: true`
2. After login (or SSO), consent check runs
3. If no consent → redirect to consent page showing client name + scope descriptions
4. User clicks Allow → consent saved, authorization code issued
5. User clicks Deny → redirect to client with `error=access_denied`
6. On next login, saved consent is remembered (skip consent page)

## Test plan
- [ ] Create client with `requireConsent: true`
- [ ] Start authorization code flow → verify consent page appears after login
- [ ] Grant consent → verify redirect with authorization code
- [ ] Start flow again → verify consent is skipped (already granted)
- [ ] Deny consent → verify redirect with `error=access_denied`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)