### PR TITLE
Add identity provider management UI

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -16,6 +16,9 @@ import GroupListPage from './pages/groups/GroupListPage';
 import GroupCreatePage from './pages/groups/GroupCreatePage';
 import GroupDetailPage from './pages/groups/GroupDetailPage';
 import SessionListPage from './pages/sessions/SessionListPage';
+import IdpListPage from './pages/identity-providers/IdpListPage';
+import IdpCreatePage from './pages/identity-providers/IdpCreatePage';
+import IdpDetailPage from './pages/identity-providers/IdpDetailPage';
 
 function ProtectedRoute() {
   const apiKey = sessionStorage.getItem('adminApiKey');
@@ -47,6 +50,9 @@ export default function App() {
           <Route path="/console/realms/:name/groups/create" element={<GroupCreatePage />} />
           <Route path="/console/realms/:name/groups/:groupId" element={<GroupDetailPage />} />
           <Route path="/console/realms/:name/sessions" element={<SessionListPage />} />
+          <Route path="/console/realms/:name/identity-providers" element={<IdpListPage />} />
+          <Route path="/console/realms/:name/identity-providers/create" element={<IdpCreatePage />} />
+          <Route path="/console/realms/:name/identity-providers/:alias" element={<IdpDetailPage />} />
         </Route>
       </Route>
 

--- a/admin-ui/src/api/identityProviders.ts
+++ b/admin-ui/src/api/identityProviders.ts
@@ -1,0 +1,71 @@
+import apiClient from './client';
+import type { IdentityProvider } from '../types';
+
+export async function getIdentityProviders(
+  realmName: string,
+): Promise<IdentityProvider[]> {
+  const { data } = await apiClient.get<IdentityProvider[]>(
+    `/realms/${realmName}/identity-providers`,
+  );
+  return data;
+}
+
+export async function getIdentityProvider(
+  realmName: string,
+  alias: string,
+): Promise<IdentityProvider> {
+  const { data } = await apiClient.get<IdentityProvider>(
+    `/realms/${realmName}/identity-providers/${alias}`,
+  );
+  return data;
+}
+
+export interface CreateIdpPayload {
+  alias: string;
+  displayName?: string;
+  enabled?: boolean;
+  providerType?: string;
+  clientId: string;
+  clientSecret: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  userinfoUrl?: string;
+  jwksUrl?: string;
+  issuer?: string;
+  defaultScopes?: string;
+  trustEmail?: boolean;
+  linkOnly?: boolean;
+  syncUserProfile?: boolean;
+}
+
+export async function createIdentityProvider(
+  realmName: string,
+  payload: CreateIdpPayload,
+): Promise<IdentityProvider> {
+  const { data } = await apiClient.post<IdentityProvider>(
+    `/realms/${realmName}/identity-providers`,
+    payload,
+  );
+  return data;
+}
+
+export async function updateIdentityProvider(
+  realmName: string,
+  alias: string,
+  payload: Partial<CreateIdpPayload>,
+): Promise<IdentityProvider> {
+  const { data } = await apiClient.put<IdentityProvider>(
+    `/realms/${realmName}/identity-providers/${alias}`,
+    payload,
+  );
+  return data;
+}
+
+export async function deleteIdentityProvider(
+  realmName: string,
+  alias: string,
+): Promise<void> {
+  await apiClient.delete(
+    `/realms/${realmName}/identity-providers/${alias}`,
+  );
+}

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -35,6 +35,7 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/roles`, label: 'Roles' },
         { to: `/console/realms/${currentRealm}/groups`, label: 'Groups' },
         { to: `/console/realms/${currentRealm}/sessions`, label: 'Sessions' },
+        { to: `/console/realms/${currentRealm}/identity-providers`, label: 'Identity Providers' },
       ]
     : [];
 

--- a/admin-ui/src/pages/identity-providers/IdpCreatePage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpCreatePage.tsx
@@ -1,0 +1,277 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createIdentityProvider } from '../../api/identityProviders';
+
+export default function IdpCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    alias: '',
+    displayName: '',
+    providerType: 'oidc',
+    clientId: '',
+    clientSecret: '',
+    authorizationUrl: '',
+    tokenUrl: '',
+    userinfoUrl: '',
+    jwksUrl: '',
+    issuer: '',
+    defaultScopes: 'openid email profile',
+    enabled: true,
+    trustEmail: false,
+    linkOnly: false,
+    syncUserProfile: true,
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createIdentityProvider(name!, {
+        alias: form.alias,
+        displayName: form.displayName || undefined,
+        providerType: form.providerType,
+        clientId: form.clientId,
+        clientSecret: form.clientSecret,
+        authorizationUrl: form.authorizationUrl,
+        tokenUrl: form.tokenUrl,
+        userinfoUrl: form.userinfoUrl || undefined,
+        jwksUrl: form.jwksUrl || undefined,
+        issuer: form.issuer || undefined,
+        defaultScopes: form.defaultScopes || undefined,
+        enabled: form.enabled,
+        trustEmail: form.trustEmail,
+        linkOnly: form.linkOnly,
+        syncUserProfile: form.syncUserProfile,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['identity-providers', name] });
+      navigate(`/console/realms/${name}/identity-providers`);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    mutation.mutate();
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Add Identity Provider</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        {/* General */}
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">General</h2>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Alias *</label>
+              <input
+                type="text"
+                required
+                pattern="^[a-z0-9-]+$"
+                title="Lowercase alphanumeric with hyphens"
+                value={form.alias}
+                onChange={(e) => set('alias', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Display Name</label>
+              <input
+                type="text"
+                value={form.displayName}
+                onChange={(e) => set('displayName', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Provider Type</label>
+              <select
+                value={form.providerType}
+                onChange={(e) => set('providerType', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              >
+                <option value="oidc">OpenID Connect</option>
+                <option value="saml">SAML</option>
+                <option value="oauth2">OAuth 2.0</option>
+              </select>
+            </div>
+            <div className="flex items-end gap-2 pb-1">
+              <input
+                type="checkbox"
+                id="enabled"
+                checked={form.enabled}
+                onChange={(e) => set('enabled', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <label htmlFor="enabled" className="text-sm font-medium text-gray-700">
+                Enabled
+              </label>
+            </div>
+          </div>
+        </div>
+
+        {/* OIDC Configuration */}
+        <div className="space-y-4 border-t border-gray-200 pt-4">
+          <h2 className="text-lg font-semibold text-gray-900">OIDC Configuration</h2>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Client ID *</label>
+              <input
+                type="text"
+                required
+                value={form.clientId}
+                onChange={(e) => set('clientId', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Client Secret *</label>
+              <input
+                type="password"
+                required
+                value={form.clientSecret}
+                onChange={(e) => set('clientSecret', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">Authorization URL *</label>
+            <input
+              type="url"
+              required
+              value={form.authorizationUrl}
+              onChange={(e) => set('authorizationUrl', e.target.value)}
+              placeholder="https://provider.com/authorize"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">Token URL *</label>
+            <input
+              type="url"
+              required
+              value={form.tokenUrl}
+              onChange={(e) => set('tokenUrl', e.target.value)}
+              placeholder="https://provider.com/token"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Userinfo URL</label>
+              <input
+                type="url"
+                value={form.userinfoUrl}
+                onChange={(e) => set('userinfoUrl', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">JWKS URL</label>
+              <input
+                type="url"
+                value={form.jwksUrl}
+                onChange={(e) => set('jwksUrl', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Issuer</label>
+              <input
+                type="text"
+                value={form.issuer}
+                onChange={(e) => set('issuer', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Default Scopes</label>
+              <input
+                type="text"
+                value={form.defaultScopes}
+                onChange={(e) => set('defaultScopes', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Behavior */}
+        <div className="space-y-3 border-t border-gray-200 pt-4">
+          <h2 className="text-lg font-semibold text-gray-900">Behavior</h2>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.trustEmail}
+                onChange={(e) => set('trustEmail', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm text-gray-700">Trust email from provider</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.syncUserProfile}
+                onChange={(e) => set('syncUserProfile', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm text-gray-700">Sync user profile on login</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.linkOnly}
+                onChange={(e) => set('linkOnly', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm text-gray-700">Link only (don&apos;t create new users)</span>
+            </label>
+          </div>
+        </div>
+
+        {mutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {(mutation.error as Error)?.message || 'Failed to create identity provider.'}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={() => navigate(`/console/realms/${name}/identity-providers`)}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating...' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
@@ -1,0 +1,338 @@
+import { useState, useEffect, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getIdentityProvider,
+  updateIdentityProvider,
+  deleteIdentityProvider,
+} from '../../api/identityProviders';
+import ConfirmDialog from '../../components/ConfirmDialog';
+
+export default function IdpDetailPage() {
+  const { name, alias } = useParams<{ name: string; alias: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [showDelete, setShowDelete] = useState(false);
+
+  const { data: idp, isLoading } = useQuery({
+    queryKey: ['identity-provider', name, alias],
+    queryFn: () => getIdentityProvider(name!, alias!),
+    enabled: !!name && !!alias,
+  });
+
+  const [form, setForm] = useState({
+    displayName: '',
+    providerType: 'oidc',
+    clientId: '',
+    clientSecret: '',
+    authorizationUrl: '',
+    tokenUrl: '',
+    userinfoUrl: '',
+    jwksUrl: '',
+    issuer: '',
+    defaultScopes: '',
+    enabled: true,
+    trustEmail: false,
+    linkOnly: false,
+    syncUserProfile: true,
+  });
+
+  useEffect(() => {
+    if (idp) {
+      setForm({
+        displayName: idp.displayName ?? '',
+        providerType: idp.providerType,
+        clientId: idp.clientId,
+        clientSecret: idp.clientSecret,
+        authorizationUrl: idp.authorizationUrl,
+        tokenUrl: idp.tokenUrl,
+        userinfoUrl: idp.userinfoUrl ?? '',
+        jwksUrl: idp.jwksUrl ?? '',
+        issuer: idp.issuer ?? '',
+        defaultScopes: idp.defaultScopes,
+        enabled: idp.enabled,
+        trustEmail: idp.trustEmail,
+        linkOnly: idp.linkOnly,
+        syncUserProfile: idp.syncUserProfile,
+      });
+    }
+  }, [idp]);
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      updateIdentityProvider(name!, alias!, {
+        displayName: form.displayName || undefined,
+        providerType: form.providerType,
+        clientId: form.clientId,
+        clientSecret: form.clientSecret,
+        authorizationUrl: form.authorizationUrl,
+        tokenUrl: form.tokenUrl,
+        userinfoUrl: form.userinfoUrl || undefined,
+        jwksUrl: form.jwksUrl || undefined,
+        issuer: form.issuer || undefined,
+        defaultScopes: form.defaultScopes || undefined,
+        enabled: form.enabled,
+        trustEmail: form.trustEmail,
+        linkOnly: form.linkOnly,
+        syncUserProfile: form.syncUserProfile,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['identity-provider', name, alias] });
+      queryClient.invalidateQueries({ queryKey: ['identity-providers', name] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteIdentityProvider(name!, alias!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['identity-providers', name] });
+      navigate(`/console/realms/${name}/identity-providers`);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    updateMutation.mutate();
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading provider...</div>;
+  }
+
+  if (!idp) {
+    return <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">Identity provider not found.</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{idp.alias}</h1>
+          {idp.displayName && (
+            <p className="mt-1 text-sm text-gray-500">{idp.displayName}</p>
+          )}
+        </div>
+        <button
+          onClick={() => setShowDelete(true)}
+          className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+        >
+          Delete
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        {/* General */}
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">General</h2>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Alias</label>
+              <input
+                type="text"
+                value={idp.alias}
+                disabled
+                className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Display Name</label>
+              <input
+                type="text"
+                value={form.displayName}
+                onChange={(e) => set('displayName', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Provider Type</label>
+              <select
+                value={form.providerType}
+                onChange={(e) => set('providerType', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              >
+                <option value="oidc">OpenID Connect</option>
+                <option value="saml">SAML</option>
+                <option value="oauth2">OAuth 2.0</option>
+              </select>
+            </div>
+            <div className="flex items-end gap-2 pb-1">
+              <input
+                type="checkbox"
+                id="enabled"
+                checked={form.enabled}
+                onChange={(e) => set('enabled', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <label htmlFor="enabled" className="text-sm font-medium text-gray-700">
+                Enabled
+              </label>
+            </div>
+          </div>
+        </div>
+
+        {/* OIDC Configuration */}
+        <div className="space-y-4 border-t border-gray-200 pt-4">
+          <h2 className="text-lg font-semibold text-gray-900">OIDC Configuration</h2>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Client ID</label>
+              <input
+                type="text"
+                required
+                value={form.clientId}
+                onChange={(e) => set('clientId', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Client Secret</label>
+              <input
+                type="password"
+                required
+                value={form.clientSecret}
+                onChange={(e) => set('clientSecret', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">Authorization URL</label>
+            <input
+              type="url"
+              required
+              value={form.authorizationUrl}
+              onChange={(e) => set('authorizationUrl', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-sm font-medium text-gray-700">Token URL</label>
+            <input
+              type="url"
+              required
+              value={form.tokenUrl}
+              onChange={(e) => set('tokenUrl', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Userinfo URL</label>
+              <input
+                type="url"
+                value={form.userinfoUrl}
+                onChange={(e) => set('userinfoUrl', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">JWKS URL</label>
+              <input
+                type="url"
+                value={form.jwksUrl}
+                onChange={(e) => set('jwksUrl', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Issuer</label>
+              <input
+                type="text"
+                value={form.issuer}
+                onChange={(e) => set('issuer', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Default Scopes</label>
+              <input
+                type="text"
+                value={form.defaultScopes}
+                onChange={(e) => set('defaultScopes', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Behavior */}
+        <div className="space-y-3 border-t border-gray-200 pt-4">
+          <h2 className="text-lg font-semibold text-gray-900">Behavior</h2>
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.trustEmail}
+                onChange={(e) => set('trustEmail', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm text-gray-700">Trust email from provider</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.syncUserProfile}
+                onChange={(e) => set('syncUserProfile', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm text-gray-700">Sync user profile on login</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.linkOnly}
+                onChange={(e) => set('linkOnly', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm text-gray-700">Link only (don&apos;t create new users)</span>
+            </label>
+          </div>
+        </div>
+
+        {updateMutation.isSuccess && (
+          <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
+            Identity provider updated successfully.
+          </div>
+        )}
+        {updateMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            Failed to update identity provider.
+          </div>
+        )}
+
+        <div className="flex justify-end border-t border-gray-200 pt-4">
+          <button
+            type="submit"
+            disabled={updateMutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+
+      <ConfirmDialog
+        isOpen={showDelete}
+        title="Delete Identity Provider"
+        message={`Are you sure you want to delete identity provider "${idp.alias}"?`}
+        onConfirm={() => deleteMutation.mutate()}
+        onCancel={() => setShowDelete(false)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/identity-providers/IdpListPage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpListPage.tsx
@@ -1,0 +1,81 @@
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getIdentityProviders } from '../../api/identityProviders';
+
+export default function IdpListPage() {
+  const { name } = useParams<{ name: string }>();
+
+  const { data: providers, isLoading } = useQuery({
+    queryKey: ['identity-providers', name],
+    queryFn: () => getIdentityProviders(name!),
+    enabled: !!name,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Identity Providers</h1>
+        <Link
+          to={`/console/realms/${name}/identity-providers/create`}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Add Provider
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="text-gray-500">Loading providers...</div>
+      ) : !providers || providers.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No identity providers configured.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Alias</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Display Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {providers.map((idp) => (
+                <tr key={idp.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <Link
+                      to={`/console/realms/${name}/identity-providers/${idp.alias}`}
+                      className="font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {idp.alias}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {idp.displayName || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                      {idp.providerType.toUpperCase()}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                        idp.enabled
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-red-100 text-red-700'
+                      }`}
+                    >
+                      {idp.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -49,6 +49,28 @@ export interface Role {
   updatedAt: string;
 }
 
+export interface IdentityProvider {
+  id: string;
+  realmId: string;
+  alias: string;
+  displayName: string | null;
+  enabled: boolean;
+  providerType: string;
+  clientId: string;
+  clientSecret: string;
+  authorizationUrl: string;
+  tokenUrl: string;
+  userinfoUrl: string | null;
+  jwksUrl: string | null;
+  issuer: string | null;
+  defaultScopes: string;
+  trustEmail: boolean;
+  linkOnly: boolean;
+  syncUserProfile: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Group {
   id: string;
   realmId: string;


### PR DESCRIPTION
## Summary
- **List page:** Table showing alias, display name, provider type (OIDC/SAML/OAuth2), and enabled/disabled status
- **Create page:** Full form with General (alias, display name, type, enabled), OIDC Configuration (client ID/secret, authorization/token/userinfo/JWKS URLs, issuer, scopes), and Behavior (trust email, sync profile, link only) sections
- **Detail page:** Edit all IdP settings, delete provider with confirmation dialog
- **Navigation:** Added "Identity Providers" to sidebar

## Test plan
- [ ] Create a new OIDC identity provider
- [ ] Verify it appears in the list with correct type badge
- [ ] Edit provider settings and save
- [ ] Delete provider with confirmation

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)