### PR TITLE
Phase 2: Self-Service & Account features

### DIFF
--- a/admin-ui/src/api/realms.ts
+++ b/admin-ui/src/api/realms.ts
@@ -29,3 +29,11 @@ export async function updateRealm(
 export async function deleteRealm(name: string): Promise<void> {
   await apiClient.delete(`/realms/${name}`);
 }
+
+export async function sendTestEmail(
+  name: string,
+  to: string,
+): Promise<{ message: string }> {
+  const { data } = await apiClient.post(`/realms/${name}/email/test`, { to });
+  return data;
+}

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -5,6 +5,12 @@ export interface Realm {
   enabled: boolean;
   accessTokenLifespan: number;
   refreshTokenLifespan: number;
+  smtpHost: string | null;
+  smtpPort: number | null;
+  smtpUser: string | null;
+  smtpPassword: string | null;
+  smtpFrom: string | null;
+  smtpSecure: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "hbs": "^4.2.0",
         "helmet": "^8.1.0",
         "jose": "^6.1.3",
+        "nodemailer": "^8.0.1",
         "prisma": "^7.4.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
@@ -40,6 +41,7 @@
         "@types/express": "^5.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.10.7",
+        "@types/nodemailer": "^7.0.10",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
@@ -3294,6 +3296,16 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.10.tgz",
+      "integrity": "sha512-tP+9WggTFN22Zxh0XFyst7239H0qwiRCogsk7v9aQS79sYAJY+WEbTHbNYcxUMaalHKmsNpxmoTe35hBEMMd6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -8669,6 +8681,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "hbs": "^4.2.0",
     "helmet": "^8.1.0",
     "jose": "^6.1.3",
+    "nodemailer": "^8.0.1",
     "prisma": "^7.4.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
@@ -58,6 +59,7 @@
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.10.7",
+    "@types/nodemailer": "^7.0.10",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,13 @@ model Realm {
   accessTokenLifespan  Int @default(300) @map("access_token_lifespan")
   refreshTokenLifespan Int @default(1800) @map("refresh_token_lifespan")
 
+  smtpHost     String?  @map("smtp_host")
+  smtpPort     Int?     @default(587) @map("smtp_port")
+  smtpUser     String?  @map("smtp_user")
+  smtpPassword String?  @map("smtp_password")
+  smtpFrom     String?  @map("smtp_from")
+  smtpSecure   Boolean  @default(false) @map("smtp_secure")
+
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
@@ -54,6 +61,7 @@ model User {
   consents            UserConsent[]
   federatedIdentities FederatedIdentity[]
   userGroups          UserGroup[]
+  verificationTokens  VerificationToken[]
 
   @@unique([realmId, username])
   @@unique([realmId, email])
@@ -288,6 +296,21 @@ model GroupRole {
 
   @@unique([groupId, roleId])
   @@map("group_roles")
+}
+
+// ─── VERIFICATION TOKENS ────────────────────────────────
+
+model VerificationToken {
+  id        String   @id @default(uuid())
+  tokenHash String   @unique @map("token_hash")
+  userId    String   @map("user_id")
+  type      String   // "email_verification" | "password_reset"
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("verification_tokens")
 }
 
 // ─── IDENTITY PROVIDERS (Social Login) ───────────────────

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -135,6 +135,16 @@ body {
   background: #f9fafb;
 }
 
+.auth-success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
 .auth-error {
   background: #fef2f2;
   color: #991b1b;

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -1,0 +1,136 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Render,
+  UseGuards,
+  Body,
+  Req,
+  Res,
+} from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
+import type { Realm } from '@prisma/client';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+import { Public } from '../common/decorators/public.decorator.js';
+import { LoginService } from '../login/login.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
+
+@ApiExcludeController()
+@Controller('realms/:realmName/account')
+@UseGuards(RealmGuard)
+@Public()
+export class AccountController {
+  constructor(
+    private readonly loginService: LoginService,
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  private async getSessionUser(realm: Realm, req: Request) {
+    const sessionToken = req.cookies?.['AUTHME_SESSION'];
+    if (!sessionToken) return null;
+    return this.loginService.validateLoginSession(realm, sessionToken);
+  }
+
+  @Get()
+  @Render('account')
+  async showAccount(
+    @CurrentRealm() realm: Realm,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      return res.redirect(`/realms/${realm.name}/login`);
+    }
+
+    const query = req.query as Record<string, string>;
+
+    return res.render('account', {
+      layout: 'layouts/main',
+      pageTitle: 'My Account',
+      realmName: realm.name,
+      realmDisplayName: realm.displayName ?? realm.name,
+      username: user.username,
+      email: user.email ?? '',
+      emailVerified: user.emailVerified,
+      firstName: user.firstName ?? '',
+      lastName: user.lastName ?? '',
+      success: query['success'] ?? '',
+      error: query['error'] ?? '',
+    });
+  }
+
+  @Post('profile')
+  async updateProfile(
+    @CurrentRealm() realm: Realm,
+    @Body() body: Record<string, string>,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      return res.redirect(`/realms/${realm.name}/login`);
+    }
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        firstName: body['firstName'] || null,
+        lastName: body['lastName'] || null,
+      },
+    });
+
+    res.redirect(`/realms/${realm.name}/account?success=${encodeURIComponent('Profile updated successfully.')}`);
+  }
+
+  @Post('password')
+  async changePassword(
+    @CurrentRealm() realm: Realm,
+    @Body() body: Record<string, string>,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      return res.redirect(`/realms/${realm.name}/login`);
+    }
+
+    const currentPassword = body['currentPassword'];
+    const newPassword = body['newPassword'];
+    const confirmPassword = body['confirmPassword'];
+
+    if (!currentPassword || !newPassword) {
+      return res.redirect(`/realms/${realm.name}/account?error=${encodeURIComponent('All password fields are required.')}`);
+    }
+
+    if (newPassword !== confirmPassword) {
+      return res.redirect(`/realms/${realm.name}/account?error=${encodeURIComponent('New passwords do not match.')}`);
+    }
+
+    if (newPassword.length < 8) {
+      return res.redirect(`/realms/${realm.name}/account?error=${encodeURIComponent('New password must be at least 8 characters.')}`);
+    }
+
+    // Verify current password
+    if (!user.passwordHash) {
+      return res.redirect(`/realms/${realm.name}/account?error=${encodeURIComponent('Cannot change password for this account.')}`);
+    }
+
+    const valid = await this.crypto.verifyPassword(user.passwordHash, currentPassword);
+    if (!valid) {
+      return res.redirect(`/realms/${realm.name}/account?error=${encodeURIComponent('Current password is incorrect.')}`);
+    }
+
+    const passwordHash = await this.crypto.hashPassword(newPassword);
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: { passwordHash },
+    });
+
+    res.redirect(`/realms/${realm.name}/account?success=${encodeURIComponent('Password changed successfully.')}`);
+  }
+}

--- a/src/account/account.module.ts
+++ b/src/account/account.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AccountController } from './account.controller.js';
+import { LoginModule } from '../login/login.module.js';
+
+@Module({
+  imports: [LoginModule],
+  controllers: [AccountController],
+})
+export class AccountModule {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,9 @@ import { BrokerModule } from './broker/broker.module.js';
 import { ConsentModule } from './consent/consent.module.js';
 import { GroupsModule } from './groups/groups.module.js';
 import { SessionsModule } from './sessions/sessions.module.js';
+import { EmailModule } from './email/email.module.js';
+import { VerificationModule } from './verification/verification.module.js';
+import { AccountModule } from './account/account.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 
 @Module({
@@ -40,6 +43,8 @@ import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
     }),
     PrismaModule,
     CryptoModule,
+    EmailModule,
+    VerificationModule,
     RealmsModule,
     UsersModule,
     ClientsModule,
@@ -55,6 +60,7 @@ import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
     SessionsModule,
     IdentityProvidersModule,
     BrokerModule,
+    AccountModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/email/email.module.ts
+++ b/src/email/email.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { EmailService } from './email.service.js';
+
+@Global()
+@Module({
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import * as nodemailer from 'nodemailer';
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async isConfigured(realmName: string): Promise<boolean> {
+    const realm = await this.prisma.realm.findUnique({
+      where: { name: realmName },
+      select: { smtpHost: true },
+    });
+    return !!realm?.smtpHost;
+  }
+
+  async sendEmail(
+    realmName: string,
+    to: string,
+    subject: string,
+    html: string,
+  ): Promise<void> {
+    const realm = await this.prisma.realm.findUnique({
+      where: { name: realmName },
+      select: {
+        smtpHost: true,
+        smtpPort: true,
+        smtpUser: true,
+        smtpPassword: true,
+        smtpFrom: true,
+        smtpSecure: true,
+      },
+    });
+
+    if (!realm?.smtpHost) {
+      this.logger.warn(`SMTP not configured for realm "${realmName}", skipping email to ${to}`);
+      return;
+    }
+
+    const transporter = nodemailer.createTransport({
+      host: realm.smtpHost,
+      port: realm.smtpPort ?? 587,
+      secure: realm.smtpSecure,
+      auth: realm.smtpUser
+        ? { user: realm.smtpUser, pass: realm.smtpPassword ?? '' }
+        : undefined,
+    });
+
+    await transporter.sendMail({
+      from: realm.smtpFrom ?? `noreply@${realm.smtpHost}`,
+      to,
+      subject,
+      html,
+    });
+
+    this.logger.log(`Email sent to ${to} (realm: ${realmName}, subject: ${subject})`);
+  }
+}

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -10,7 +10,8 @@ import {
   Res,
   BadRequestException,
 } from '@nestjs/common';
-import { ApiTags, ApiExcludeController } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+import { ApiExcludeController } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import type { Realm } from '@prisma/client';
 import { RealmGuard } from '../common/guards/realm.guard.js';
@@ -19,6 +20,10 @@ import { Public } from '../common/decorators/public.decorator.js';
 import { LoginService } from './login.service.js';
 import { OAuthService } from '../oauth/oauth.service.js';
 import { ConsentService } from '../consent/consent.service.js';
+import { VerificationService } from '../verification/verification.service.js';
+import { EmailService } from '../email/email.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   openid: 'Verify your identity',
@@ -36,7 +41,14 @@ export class LoginController {
     private readonly loginService: LoginService,
     private readonly oauthService: OAuthService,
     private readonly consentService: ConsentService,
+    private readonly verificationService: VerificationService,
+    private readonly emailService: EmailService,
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+    private readonly config: ConfigService,
   ) {}
+
+  // ─── LOGIN ──────────────────────────────────────────────
 
   @Get('login')
   @Render('login')
@@ -58,6 +70,7 @@ export class LoginController {
       code_challenge: query['code_challenge'] ?? '',
       code_challenge_method: query['code_challenge_method'] ?? '',
       error: query['error'] ?? '',
+      info: query['info'] ?? '',
     };
   }
 
@@ -91,6 +104,11 @@ export class LoginController {
         path: `/realms/${realm.name}`,
       });
 
+      // If no OAuth client_id, redirect to account portal
+      if (!body['client_id']) {
+        return res.redirect(302, `/realms/${realm.name}/account`);
+      }
+
       // Check if client requires consent before completing OAuth flow
       const oauthParams = {
         response_type: body['response_type'],
@@ -103,24 +121,22 @@ export class LoginController {
         code_challenge_method: body['code_challenge_method'],
       };
 
-      if (body['client_id']) {
-        const client = await this.oauthService.validateAuthRequest(realm, oauthParams as any);
+      const client = await this.oauthService.validateAuthRequest(realm, oauthParams as any);
 
-        if (client.requireConsent) {
-          const scopes = (body['scope'] ?? 'openid').split(' ').filter(Boolean);
-          const hasConsent = await this.consentService.hasConsent(user.id, client.id, scopes);
+      if (client.requireConsent) {
+        const scopes = (body['scope'] ?? 'openid').split(' ').filter(Boolean);
+        const hasConsent = await this.consentService.hasConsent(user.id, client.id, scopes);
 
-          if (!hasConsent) {
-            const reqId = this.consentService.storeConsentRequest({
-              userId: user.id,
-              clientId: client.id,
-              clientName: client.name ?? client.clientId,
-              realmName: realm.name,
-              scopes,
-              oauthParams,
-            });
-            return res.redirect(302, `/realms/${realm.name}/consent?req=${reqId}`);
-          }
+        if (!hasConsent) {
+          const reqId = this.consentService.storeConsentRequest({
+            userId: user.id,
+            clientId: client.id,
+            clientName: client.name ?? client.clientId,
+            realmName: realm.name,
+            scopes,
+            oauthParams,
+          });
+          return res.redirect(302, `/realms/${realm.name}/consent?req=${reqId}`);
         }
       }
 
@@ -144,6 +160,8 @@ export class LoginController {
     }
   }
 
+  // ─── CONSENT ────────────────────────────────────────────
+
   @Get('consent')
   @Render('consent')
   showConsentForm(
@@ -154,13 +172,11 @@ export class LoginController {
       throw new BadRequestException('Missing consent request ID');
     }
 
-    // Peek at the request without removing it (we need it for the POST)
     const consentReq = this.consentService.getConsentRequest(reqId);
     if (!consentReq) {
       throw new BadRequestException('Consent request expired or invalid');
     }
 
-    // Re-store it so the POST handler can retrieve it
     const newReqId = this.consentService.storeConsentRequest(consentReq);
 
     const scopeDescriptions = consentReq.scopes.map(
@@ -195,7 +211,6 @@ export class LoginController {
     }
 
     if (body['action'] === 'deny') {
-      // Redirect back to the client with error
       const redirectUri = new URL(consentReq.oauthParams['redirect_uri']);
       redirectUri.searchParams.set('error', 'access_denied');
       redirectUri.searchParams.set('error_description', 'User denied the consent request');
@@ -205,14 +220,12 @@ export class LoginController {
       return res.redirect(302, redirectUri.toString());
     }
 
-    // Grant consent
     await this.consentService.grantConsent(
       consentReq.userId,
       consentReq.clientId,
       consentReq.scopes,
     );
 
-    // Complete the OAuth flow
     const user = await this.loginService.findUserById(consentReq.userId);
     if (!user) {
       throw new BadRequestException('User not found');
@@ -225,5 +238,170 @@ export class LoginController {
     );
 
     res.redirect(302, result.redirectUrl);
+  }
+
+  // ─── EMAIL VERIFICATION ─────────────────────────────────
+
+  @Get('verify-email')
+  @Render('verify-email')
+  async verifyEmail(
+    @CurrentRealm() realm: Realm,
+    @Query('token') token: string,
+  ) {
+    const base = {
+      layout: 'layouts/main',
+      pageTitle: 'Email Verification',
+      realmName: realm.name,
+      realmDisplayName: realm.displayName ?? realm.name,
+    };
+
+    if (!token) {
+      return { ...base, success: false, error: 'Missing verification token.' };
+    }
+
+    const result = await this.verificationService.validateToken(token, 'email_verification');
+    if (!result) {
+      return { ...base, success: false, error: 'This verification link is invalid or has expired.' };
+    }
+
+    await this.prisma.user.update({
+      where: { id: result.userId },
+      data: { emailVerified: true },
+    });
+
+    return { ...base, success: true };
+  }
+
+  // ─── FORGOT / RESET PASSWORD ────────────────────────────
+
+  @Get('forgot-password')
+  @Render('forgot-password')
+  showForgotPasswordForm(
+    @CurrentRealm() realm: Realm,
+    @Query() query: Record<string, string>,
+  ) {
+    return {
+      layout: 'layouts/main',
+      pageTitle: 'Forgot Password',
+      realmName: realm.name,
+      realmDisplayName: realm.displayName ?? realm.name,
+      info: query['info'] ?? '',
+      error: query['error'] ?? '',
+    };
+  }
+
+  @Post('forgot-password')
+  async handleForgotPassword(
+    @CurrentRealm() realm: Realm,
+    @Body('email') email: string,
+    @Res() res: Response,
+  ) {
+    const successMessage = encodeURIComponent(
+      'If an account with that email exists, we sent a password reset link.',
+    );
+
+    if (email) {
+      const user = await this.prisma.user.findUnique({
+        where: { realmId_email: { realmId: realm.id, email } },
+      });
+
+      if (user) {
+        const rawToken = await this.verificationService.createToken(
+          user.id,
+          'password_reset',
+          3600,
+        );
+        const baseUrl = this.config.get<string>('BASE_URL', 'http://localhost:3000');
+        const resetUrl = `${baseUrl}/realms/${realm.name}/reset-password?token=${rawToken}`;
+
+        await this.emailService.sendEmail(
+          realm.name,
+          email,
+          'Reset Your Password — AuthMe',
+          `<h2>Reset Your Password</h2>
+          <p>Click the link below to reset your password. This link expires in 1 hour.</p>
+          <p><a href="${resetUrl}" style="display:inline-block;padding:10px 20px;background:#2563eb;color:#fff;text-decoration:none;border-radius:6px;">Reset Password</a></p>
+          <p style="color:#6b7280;font-size:0.875rem;">If you didn't request this, you can safely ignore this email.</p>`,
+        );
+      }
+    }
+
+    res.redirect(`/realms/${realm.name}/forgot-password?info=${successMessage}`);
+  }
+
+  @Get('reset-password')
+  @Render('reset-password')
+  async showResetPasswordForm(
+    @CurrentRealm() realm: Realm,
+    @Query('token') token: string,
+    @Query('error') error: string,
+  ) {
+    const base = {
+      layout: 'layouts/main',
+      pageTitle: 'Reset Password',
+      realmName: realm.name,
+      realmDisplayName: realm.displayName ?? realm.name,
+    };
+
+    if (!token) {
+      return { ...base, error: 'Missing reset token.', token: '' };
+    }
+
+    // Peek: validate token without consuming it
+    const tokenHash = this.crypto.sha256(token);
+    const record = await this.prisma.verificationToken.findUnique({
+      where: { tokenHash },
+    });
+
+    if (!record || record.type !== 'password_reset' || record.expiresAt < new Date()) {
+      return { ...base, error: 'This reset link is invalid or has expired.', token: '' };
+    }
+
+    return { ...base, token, error: error ?? '' };
+  }
+
+  @Post('reset-password')
+  async handleResetPassword(
+    @CurrentRealm() realm: Realm,
+    @Body() body: Record<string, string>,
+    @Res() res: Response,
+  ) {
+    const token = body['token'];
+    const password = body['password'];
+    const confirmPassword = body['confirmPassword'];
+
+    if (!token || !password) {
+      return res.redirect(
+        `/realms/${realm.name}/reset-password?token=${token ?? ''}&error=${encodeURIComponent('Missing required fields.')}`,
+      );
+    }
+
+    if (password !== confirmPassword) {
+      return res.redirect(
+        `/realms/${realm.name}/reset-password?token=${token}&error=${encodeURIComponent('Passwords do not match.')}`,
+      );
+    }
+
+    if (password.length < 8) {
+      return res.redirect(
+        `/realms/${realm.name}/reset-password?token=${token}&error=${encodeURIComponent('Password must be at least 8 characters.')}`,
+      );
+    }
+
+    const result = await this.verificationService.validateToken(token, 'password_reset');
+    if (!result) {
+      return res.redirect(
+        `/realms/${realm.name}/reset-password?error=${encodeURIComponent('This reset link is invalid or has expired.')}`,
+      );
+    }
+
+    const passwordHash = await this.crypto.hashPassword(password);
+    await this.prisma.user.update({
+      where: { id: result.userId },
+      data: { passwordHash },
+    });
+
+    const info = encodeURIComponent('Your password has been reset. You can now sign in.');
+    res.redirect(`/realms/${realm.name}/login?info=${info}`);
   }
 }

--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -30,4 +30,34 @@ export class CreateRealmDto {
   @IsInt()
   @Min(60)
   refreshTokenLifespan?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  smtpHost?: string;
+
+  @ApiPropertyOptional({ default: 587 })
+  @IsOptional()
+  @IsInt()
+  smtpPort?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  smtpUser?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  smtpPassword?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  smtpFrom?: string;
+
+  @ApiPropertyOptional({ default: false })
+  @IsOptional()
+  @IsBoolean()
+  smtpSecure?: boolean;
 }

--- a/src/realms/realms.controller.ts
+++ b/src/realms/realms.controller.ts
@@ -6,16 +6,21 @@ import {
   Delete,
   Body,
   Param,
+  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { RealmsService } from './realms.service.js';
+import { EmailService } from '../email/email.service.js';
 import { CreateRealmDto } from './dto/create-realm.dto.js';
 import { UpdateRealmDto } from './dto/update-realm.dto.js';
 
 @ApiTags('Realms')
 @Controller('admin/realms')
 export class RealmsController {
-  constructor(private readonly realmsService: RealmsService) {}
+  constructor(
+    private readonly realmsService: RealmsService,
+    private readonly emailService: EmailService,
+  ) {}
 
   @Post()
   @ApiOperation({ summary: 'Create a new realm' })
@@ -48,5 +53,27 @@ export class RealmsController {
   @ApiOperation({ summary: 'Delete a realm' })
   remove(@Param('realmName') realmName: string) {
     return this.realmsService.remove(realmName);
+  }
+
+  @Post(':realmName/email/test')
+  @ApiOperation({ summary: 'Send a test email' })
+  async sendTestEmail(
+    @Param('realmName') realmName: string,
+    @Body('to') to: string,
+  ) {
+    if (!to) {
+      throw new BadRequestException('Missing "to" email address');
+    }
+    const configured = await this.emailService.isConfigured(realmName);
+    if (!configured) {
+      throw new BadRequestException('SMTP is not configured for this realm');
+    }
+    await this.emailService.sendEmail(
+      realmName,
+      to,
+      'AuthMe Test Email',
+      '<h2>AuthMe Test Email</h2><p>If you received this email, your SMTP configuration is working correctly.</p>',
+    );
+    return { message: 'Test email sent successfully' };
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -72,4 +72,18 @@ export class UsersController {
   ) {
     return this.usersService.setPassword(realm, userId, dto.password);
   }
+
+  @Post(':userId/send-verification-email')
+  @ApiOperation({ summary: 'Send or resend verification email to a user' })
+  async sendVerificationEmail(
+    @CurrentRealm() realm: Realm,
+    @Param('userId') userId: string,
+  ) {
+    const user = await this.usersService.findById(realm, userId);
+    if (!user.email) {
+      return { message: 'User has no email address' };
+    }
+    await this.usersService.sendVerificationEmail(realm.name, user.id, user.email);
+    return { message: 'Verification email sent' };
+  }
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -13,6 +13,9 @@ describe('UsersService', () => {
   let service: UsersService;
   let prisma: MockPrismaService;
   let cryptoService: { hashPassword: jest.Mock; verifyPassword: jest.Mock; generateSecret: jest.Mock; sha256: jest.Mock };
+  let verificationService: { createToken: jest.Mock; validateToken: jest.Mock };
+  let emailService: { isConfigured: jest.Mock; sendEmail: jest.Mock };
+  let configService: { get: jest.Mock };
 
   const mockRealm: Realm = {
     id: 'realm-1',
@@ -46,7 +49,24 @@ describe('UsersService', () => {
       generateSecret: jest.fn(),
       sha256: jest.fn(),
     };
-    service = new UsersService(prisma as any, cryptoService as any);
+    verificationService = {
+      createToken: jest.fn().mockResolvedValue('raw-token'),
+      validateToken: jest.fn(),
+    };
+    emailService = {
+      isConfigured: jest.fn().mockResolvedValue(false),
+      sendEmail: jest.fn().mockResolvedValue(undefined),
+    };
+    configService = {
+      get: jest.fn().mockReturnValue('http://localhost:3000'),
+    };
+    service = new UsersService(
+      prisma as any,
+      cryptoService as any,
+      verificationService as any,
+      emailService as any,
+      configService as any,
+    );
   });
 
   describe('create', () => {

--- a/src/verification/verification.module.ts
+++ b/src/verification/verification.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { VerificationService } from './verification.service.js';
+
+@Global()
+@Module({
+  providers: [VerificationService],
+  exports: [VerificationService],
+})
+export class VerificationModule {}

--- a/src/verification/verification.service.ts
+++ b/src/verification/verification.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
+
+@Injectable()
+export class VerificationService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  async createToken(
+    userId: string,
+    type: string,
+    expiresInSeconds: number,
+  ): Promise<string> {
+    // Delete existing tokens of the same type for this user
+    await this.prisma.verificationToken.deleteMany({
+      where: { userId, type },
+    });
+
+    const rawToken = this.crypto.generateSecret(32);
+    const tokenHash = this.crypto.sha256(rawToken);
+
+    await this.prisma.verificationToken.create({
+      data: {
+        tokenHash,
+        userId,
+        type,
+        expiresAt: new Date(Date.now() + expiresInSeconds * 1000),
+      },
+    });
+
+    return rawToken;
+  }
+
+  async validateToken(
+    rawToken: string,
+    type: string,
+  ): Promise<{ userId: string } | null> {
+    const tokenHash = this.crypto.sha256(rawToken);
+
+    const record = await this.prisma.verificationToken.findUnique({
+      where: { tokenHash },
+    });
+
+    if (!record || record.type !== type || record.expiresAt < new Date()) {
+      // Clean up expired token if found
+      if (record) {
+        await this.prisma.verificationToken.delete({ where: { id: record.id } });
+      }
+      return null;
+    }
+
+    // One-time use: delete the token
+    await this.prisma.verificationToken.delete({ where: { id: record.id } });
+
+    return { userId: record.userId };
+  }
+}

--- a/views/account.hbs
+++ b/views/account.hbs
@@ -1,0 +1,60 @@
+{{#if success}}
+<div class="auth-success">{{success}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<h2 class="auth-subtitle">My Account</h2>
+
+<div style="margin-bottom: 1.5rem; text-align: center;">
+  <span style="font-weight: 600; color: #1a1a2e;">{{username}}</span>
+  {{#if email}}
+  <span style="color: #6b7280; font-size: 0.85rem;"> &middot; {{email}}</span>
+  {{#if emailVerified}}
+  <span style="color: #166534; font-size: 0.75rem; background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 4px; padding: 0.1rem 0.4rem; margin-left: 0.25rem;">Verified</span>
+  {{else}}
+  <span style="color: #92400e; font-size: 0.75rem; background: #fffbeb; border: 1px solid #fde68a; border-radius: 4px; padding: 0.1rem 0.4rem; margin-left: 0.25rem;">Unverified</span>
+  {{/if}}
+  {{/if}}
+</div>
+
+<div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 0.5rem;">
+  <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">Profile</h3>
+  <form method="POST" action="/realms/{{realmName}}/account/profile" class="auth-form">
+    <div class="form-group">
+      <label for="firstName">First Name</label>
+      <input type="text" id="firstName" name="firstName" value="{{firstName}}" autocomplete="given-name">
+    </div>
+
+    <div class="form-group">
+      <label for="lastName">Last Name</label>
+      <input type="text" id="lastName" name="lastName" value="{{lastName}}" autocomplete="family-name">
+    </div>
+
+    <button type="submit" class="btn-primary">Update Profile</button>
+  </form>
+</div>
+
+<div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 1.5rem;">
+  <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">Change Password</h3>
+  <form method="POST" action="/realms/{{realmName}}/account/password" class="auth-form">
+    <div class="form-group">
+      <label for="currentPassword">Current Password</label>
+      <input type="password" id="currentPassword" name="currentPassword" required autocomplete="current-password">
+    </div>
+
+    <div class="form-group">
+      <label for="newPassword">New Password</label>
+      <input type="password" id="newPassword" name="newPassword" required minlength="8" autocomplete="new-password">
+    </div>
+
+    <div class="form-group">
+      <label for="confirmPassword">Confirm New Password</label>
+      <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" autocomplete="new-password">
+    </div>
+
+    <button type="submit" class="btn-primary">Change Password</button>
+  </form>
+</div>

--- a/views/forgot-password.hbs
+++ b/views/forgot-password.hbs
@@ -1,0 +1,24 @@
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<p style="text-align: center; color: #6b7280; margin-bottom: 1.5rem; font-size: 0.9rem;">
+  Enter your email address and we'll send you a link to reset your password.
+</p>
+
+<form method="POST" action="/realms/{{realmName}}/forgot-password" class="auth-form">
+  <div class="form-group">
+    <label for="email">Email Address</label>
+    <input type="email" id="email" name="email" required autocomplete="email" autofocus>
+  </div>
+
+  <button type="submit" class="btn-primary">Send Reset Link</button>
+</form>
+
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: #4f46e5; text-decoration: none;">Back to Sign In</a>
+</p>

--- a/views/login.hbs
+++ b/views/login.hbs
@@ -1,3 +1,7 @@
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
 {{#if error}}
 <div class="auth-error">{{error}}</div>
 {{/if}}
@@ -13,9 +17,12 @@
     <input type="password" id="password" name="password" required autocomplete="current-password">
   </div>
 
-  <div class="form-group form-checkbox">
-    <input type="checkbox" id="rememberMe" name="rememberMe" value="true">
-    <label for="rememberMe">Remember me</label>
+  <div class="form-group" style="display: flex; justify-content: space-between; align-items: center;">
+    <div class="form-checkbox">
+      <input type="checkbox" id="rememberMe" name="rememberMe" value="true">
+      <label for="rememberMe">Remember me</label>
+    </div>
+    <a href="/realms/{{realmName}}/forgot-password" style="color: #4f46e5; text-decoration: none; font-size: 0.85rem;">Forgot password?</a>
   </div>
 
   <!-- Carry OAuth params through the form -->

--- a/views/reset-password.hbs
+++ b/views/reset-password.hbs
@@ -1,0 +1,27 @@
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<p style="text-align: center; color: #6b7280; margin-bottom: 1.5rem; font-size: 0.9rem;">
+  Enter your new password below.
+</p>
+
+<form method="POST" action="/realms/{{realmName}}/reset-password" class="auth-form">
+  <input type="hidden" name="token" value="{{token}}">
+
+  <div class="form-group">
+    <label for="password">New Password</label>
+    <input type="password" id="password" name="password" required minlength="8" autocomplete="new-password" autofocus>
+  </div>
+
+  <div class="form-group">
+    <label for="confirmPassword">Confirm Password</label>
+    <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" autocomplete="new-password">
+  </div>
+
+  <button type="submit" class="btn-primary">Reset Password</button>
+</form>
+
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: #4f46e5; text-decoration: none;">Back to Sign In</a>
+</p>

--- a/views/verify-email.hbs
+++ b/views/verify-email.hbs
@@ -1,0 +1,15 @@
+{{#if success}}
+<div class="auth-success">
+  Your email has been verified successfully!
+</div>
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" class="btn-primary" style="display: inline-block; text-decoration: none;">Sign In</a>
+</p>
+{{else}}
+<div class="auth-error">
+  {{#if error}}{{error}}{{else}}This verification link is invalid or has expired.{{/if}}
+</div>
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: #4f46e5; text-decoration: none;">Back to Sign In</a>
+</p>
+{{/if}}


### PR DESCRIPTION
## Summary
- **Email Infrastructure (#43):** Added nodemailer with per-realm SMTP configuration. New Email tab in admin UI realm settings with test email capability.
- **Email Verification (#44):** VerificationToken model with SHA-256 hashed tokens. Auto-sends verification email on user creation. Admin can resend via API.
- **Password Reset (#45):** Forgot password and reset password flows with secure one-time tokens (1h expiry). Anti-enumeration protection on forgot-password endpoint.
- **Account Portal (#46):** Self-service account page at `/realms/:name/account` with profile editing and password change. SSO session authenticated.

## New files
- `src/email/` — EmailModule + EmailService (nodemailer integration)
- `src/verification/` — VerificationModule + VerificationService (secure token management)
- `src/account/` — AccountModule + AccountController (self-service portal)
- `views/verify-email.hbs`, `views/forgot-password.hbs`, `views/reset-password.hbs`, `views/account.hbs`

## Modified files
- `prisma/schema.prisma` — SMTP fields on Realm, VerificationToken model
- `src/login/login.controller.ts` — Added verify-email, forgot/reset-password routes, account redirect
- `src/realms/` — SMTP fields in DTOs/service/controller, password redaction, test email endpoint
- `src/users/` — Verification email on user creation, resend verification endpoint
- `admin-ui/` — Email tab on realm settings page with SMTP config and test email
- `views/login.hbs` — Forgot password link, info message support

## Test plan
- [ ] Configure SMTP on realm via admin UI Email tab → send test email
- [ ] Create user → verify email received with verification link → click → email verified
- [ ] Click "Forgot password?" → enter email → check reset email → click → set new password → login
- [ ] Login without OAuth → redirected to account page → edit profile → change password
- [ ] Forgot-password with non-existent email → same response (no enumeration)
- [ ] Docker rebuild and end-to-end test

🤖 Generated with [Claude Code](https://claude.com/claude-code)