### PR TITLE
Fix SPA routes returning 404 on page refresh

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -54,10 +54,6 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, 'admin-ui'),
       serveRoot: '/console',
-      serveStaticOptions: {
-        index: ['index.html'],
-        fallthrough: false,
-      },
     }),
     PrismaModule,
     CryptoModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,20 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
+  // SPA fallback: serve index.html for /console/* navigation routes (skip static files)
+  const expressApp = app.getHttpAdapter().getInstance();
+  const adminUiIndex = join(__dirname, 'admin-ui', 'index.html');
+  expressApp.get(
+    '/console/{*path}',
+    (req: { path: string }, res: { sendFile: (path: string) => void }, next: () => void) => {
+      if (/\.\w+$/.test(req.path)) {
+        next();
+        return;
+      }
+      res.sendFile(adminUiIndex);
+    },
+  );
+
   const port = process.env['PORT'] ?? 3000;
   await app.listen(port);
   console.log(`AuthMe is running on http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- Fixes #77 — Navigating directly to `/console/realms`, `/console/login`, or any admin UI route (or refreshing the page) returned a 404 JSON error
- Removed `fallthrough: false` from `ServeStaticModule` config that blocked SPA route fallback
- Added Express catch-all handler for `/console/{*path}` that serves `index.html` so React Router handles client-side routing

## Test plan
- [x] `curl localhost:3000/console/realms` → 200 (was 404)
- [x] `curl localhost:3000/console/realms/master` → 200 (was 404)
- [x] `curl localhost:3000/console/login` → 200 (was 404)
- [x] `curl localhost:3000/console/realms/test-realm/users` → 200 (was 404)
- [x] Static assets (`/console/assets/*.js`, `/console/assets/*.css`) still load
- [x] API routes (`/admin/*`) unaffected (returns 401 as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)