### PR TITLE
Add password visibility toggle to all password inputs

### DIFF
--- a/admin-ui/src/components/PasswordInput.tsx
+++ b/admin-ui/src/components/PasswordInput.tsx
@@ -1,0 +1,31 @@
+import { useState, type InputHTMLAttributes } from 'react';
+
+type PasswordInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>;
+
+export default function PasswordInput(props: PasswordInputProps) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="relative">
+      <input {...props} type={visible ? 'text' : 'password'} className={`${props.className ?? ''} pr-10`} />
+      <button
+        type="button"
+        tabIndex={-1}
+        onClick={() => setVisible(!visible)}
+        className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600"
+        aria-label={visible ? 'Hide password' : 'Show password'}
+      >
+        {visible ? (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18" />
+          </svg>
+        ) : (
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+          </svg>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/LoginPage.tsx
+++ b/admin-ui/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../hooks/useAuth';
+import PasswordInput from '../components/PasswordInput';
 
 export default function LoginPage() {
   const [mode, setMode] = useState<'credentials' | 'apikey'>('credentials');
@@ -96,9 +97,8 @@ export default function LoginPage() {
                   >
                     Password
                   </label>
-                  <input
+                  <PasswordInput
                     id="password"
-                    type="password"
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     required
@@ -115,9 +115,8 @@ export default function LoginPage() {
                 >
                   Admin API Key
                 </label>
-                <input
+                <PasswordInput
                   id="apiKey"
-                  type="password"
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
                   required

--- a/admin-ui/src/pages/identity-providers/IdpCreatePage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpCreatePage.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createIdentityProvider } from '../../api/identityProviders';
+import PasswordInput from '../../components/PasswordInput';
 
 export default function IdpCreatePage() {
   const { name } = useParams<{ name: string }>();
@@ -137,8 +138,7 @@ export default function IdpCreatePage() {
             </div>
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">Client Secret *</label>
-              <input
-                type="password"
+              <PasswordInput
                 required
                 value={form.clientSecret}
                 onChange={(e) => set('clientSecret', e.target.value)}

--- a/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   deleteIdentityProvider,
 } from '../../api/identityProviders';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import PasswordInput from '../../components/PasswordInput';
 
 export default function IdpDetailPage() {
   const { name, alias } = useParams<{ name: string; alias: string }>();
@@ -194,8 +195,7 @@ export default function IdpDetailPage() {
             </div>
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">Client Secret</label>
-              <input
-                type="password"
+              <PasswordInput
                 required
                 value={form.clientSecret}
                 onChange={(e) => set('clientSecret', e.target.value)}

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -7,6 +7,7 @@ import { getClients } from '../../api/clients';
 import { getRealmRoles } from '../../api/roles';
 import { getGroups } from '../../api/groups';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import PasswordInput from '../../components/PasswordInput';
 
 function formatDuration(seconds: number): string {
   if (seconds < 60) return `${seconds}s`;
@@ -495,8 +496,7 @@ export default function RealmDetailPage() {
               </div>
               <div>
                 <label className="mb-1.5 block text-sm font-medium text-gray-700">Password</label>
-                <input
-                  type="password"
+                <PasswordInput
                   value={form.smtpPassword}
                   onChange={(e) => setForm({ ...form, smtpPassword: e.target.value })}
                   className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"

--- a/admin-ui/src/pages/user-federation/FederationCreatePage.tsx
+++ b/admin-ui/src/pages/user-federation/FederationCreatePage.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFederation } from '../../api/userFederation';
+import PasswordInput from '../../components/PasswordInput';
 
 export default function FederationCreatePage() {
   const { name } = useParams<{ name: string }>();
@@ -90,8 +91,7 @@ export default function FederationCreatePage() {
             </div>
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">Bind Credential *</label>
-              <input
-                type="password"
+              <PasswordInput
                 required
                 value={form.bindCredential}
                 onChange={(e) => set('bindCredential', e.target.value)}

--- a/admin-ui/src/pages/user-federation/FederationDetailPage.tsx
+++ b/admin-ui/src/pages/user-federation/FederationDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   syncFederation,
 } from '../../api/userFederation';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import PasswordInput from '../../components/PasswordInput';
 
 export default function FederationDetailPage() {
   const { name, id } = useParams<{ name: string; id: string }>();
@@ -298,8 +299,7 @@ export default function FederationDetailPage() {
             </div>
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700">Bind Credential *</label>
-              <input
-                type="password"
+              <PasswordInput
                 required
                 value={form.bindCredential}
                 onChange={(e) => set('bindCredential', e.target.value)}

--- a/admin-ui/src/pages/users/UserCreatePage.tsx
+++ b/admin-ui/src/pages/users/UserCreatePage.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createUser } from '../../api/users';
 import { getErrorMessage } from '../../utils/getErrorMessage';
+import PasswordInput from '../../components/PasswordInput';
 
 export default function UserCreatePage() {
   const { name } = useParams<{ name: string }>();
@@ -96,8 +97,7 @@ export default function UserCreatePage() {
           <label className="mb-1.5 block text-sm font-medium text-gray-700">
             Password
           </label>
-          <input
-            type="password"
+          <PasswordInput
             required
             value={form.password}
             onChange={(e) => setForm({ ...form, password: e.target.value })}

--- a/admin-ui/src/pages/users/UserDetailPage.tsx
+++ b/admin-ui/src/pages/users/UserDetailPage.tsx
@@ -12,6 +12,7 @@ import { getUserGroups, getGroups, addUserToGroup, removeUserFromGroup } from '.
 import { getUserSessions, revokeSession, revokeAllUserSessions } from '../../api/sessions';
 import type { SessionInfo } from '../../api/sessions';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import PasswordInput from '../../components/PasswordInput';
 
 export default function UserDetailPage() {
   const { name, id } = useParams<{ name: string; id: string }>();
@@ -322,8 +323,7 @@ export default function UserDetailPage() {
 
         <div>
           <label className="mb-1.5 block text-sm font-medium text-gray-700">New Password</label>
-          <input
-            type="password"
+          <PasswordInput
             required
             value={newPassword}
             onChange={(e) => setNewPassword(e.target.value)}

--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -210,3 +210,36 @@ body {
 .consent-buttons button {
   flex: 1;
 }
+
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 2.5rem;
+  width: 100%;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.625rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.125rem;
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.password-toggle:hover {
+  color: #4b5563;
+}
+
+.password-toggle svg {
+  width: 1rem;
+  height: 1rem;
+}

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -37,5 +37,30 @@
       {{{body}}}
     </div>
   </div>
+  <script>
+    document.querySelectorAll('input[type="password"]').forEach(function(input) {
+      var wrapper = document.createElement('div');
+      wrapper.className = 'password-wrapper';
+      input.parentNode.insertBefore(wrapper, input);
+      wrapper.appendChild(input);
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'password-toggle';
+      btn.setAttribute('tabindex', '-1');
+      btn.setAttribute('aria-label', 'Show password');
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>';
+      wrapper.appendChild(btn);
+
+      btn.addEventListener('click', function() {
+        var isPassword = input.type === 'password';
+        input.type = isPassword ? 'text' : 'password';
+        btn.setAttribute('aria-label', isPassword ? 'Hide password' : 'Show password');
+        btn.innerHTML = isPassword
+          ? '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18"/></svg>'
+          : '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>';
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds eye icon show/hide toggle to **all 20 password inputs** across the application
- **Admin console (React)**: Created reusable `PasswordInput` component used in 8 pages (LoginPage, UserCreate, UserDetail, RealmDetail SMTP, IdpCreate, IdpDetail, FederationCreate, FederationDetail)
- **Server-rendered pages (Handlebars)**: Auto-enhancement script in layout that wraps all `<input type="password">` fields with toggle buttons — covers login, account, change-password, reset-password, and device pages

Closes #79

## Test plan
- [ ] Login page: both password and API key fields show eye toggle
- [ ] User create/detail: password fields show toggle
- [ ] Realm detail: SMTP password field shows toggle
- [ ] IdP create/detail: client secret fields show toggle
- [ ] Federation create/detail: bind credential fields show toggle
- [ ] Server-rendered login page: password field shows toggle
- [ ] Account page: all 4 password fields show toggle
- [ ] Change password page: all 3 password fields show toggle
- [ ] Reset password page: both password fields show toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)