### PR TITLE
Add authme-js client SDK for frontend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,57 @@ This starts 2 app instances behind an Nginx load balancer.
 
 ---
 
+## Client SDK
+
+AuthMe ships with `authme-js` — a zero-dependency TypeScript SDK for integrating frontend apps.
+
+```bash
+npm install authme-js
+```
+
+### Vanilla JavaScript
+
+```typescript
+import { AuthmeClient } from 'authme-js';
+
+const authme = new AuthmeClient({
+  url: 'http://localhost:3000',
+  realm: 'my-realm',
+  clientId: 'my-app',
+  redirectUri: 'http://localhost:5173/callback',
+});
+
+await authme.init();
+if (!authme.isAuthenticated()) {
+  await authme.login(); // redirects to AuthMe
+}
+```
+
+### React
+
+```tsx
+import { AuthmeClient } from 'authme-js';
+import { AuthmeProvider, useAuthme, useUser } from 'authme-js/react';
+
+const authme = new AuthmeClient({ url: '...', realm: '...', clientId: '...', redirectUri: '...' });
+
+<AuthmeProvider client={authme}>
+  <App />
+</AuthmeProvider>
+
+function App() {
+  const { isAuthenticated, login, logout } = useAuthme();
+  const user = useUser();
+  // ...
+}
+```
+
+AuthMe also works with any standard OIDC client library (`oidc-client-ts`, `react-oidc-context`, `next-auth`, etc.) since it implements standard OpenID Connect.
+
+See the full SDK documentation at [`packages/authme-js/README.md`](packages/authme-js/README.md).
+
+---
+
 ## Contributing
 
 Contributions are welcome! Please open an issue or submit a pull request.

--- a/packages/authme-js/.gitignore
+++ b/packages/authme-js/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/authme-js/README.md
+++ b/packages/authme-js/README.md
@@ -1,0 +1,245 @@
+# authme-js
+
+Client SDK for [AuthMe](https://github.com/Islamawad132/Authme) — an open-source Identity and Access Management server.
+
+Handles OAuth 2.0 Authorization Code + PKCE flow, token management, auto-refresh, and provides React bindings. Zero runtime dependencies.
+
+## Install
+
+```bash
+npm install authme-js
+```
+
+## Quick Start
+
+### Vanilla JavaScript / TypeScript
+
+```typescript
+import { AuthmeClient } from 'authme-js';
+
+const authme = new AuthmeClient({
+  url: 'http://localhost:3000',
+  realm: 'my-realm',
+  clientId: 'my-app',
+  redirectUri: 'http://localhost:5173/callback',
+});
+
+// Initialize (restores existing session if any)
+await authme.init();
+
+if (!authme.isAuthenticated()) {
+  // Redirects to AuthMe login page
+  await authme.login();
+}
+```
+
+On your callback page:
+
+```typescript
+const authme = new AuthmeClient({ /* same config */ });
+const success = await authme.handleCallback();
+if (success) {
+  const user = authme.getUserInfo();
+  console.log(`Welcome, ${user?.name}!`);
+}
+```
+
+### React
+
+```tsx
+import { AuthmeClient } from 'authme-js';
+import { AuthmeProvider, useAuthme, useUser, useRoles } from 'authme-js/react';
+
+const authme = new AuthmeClient({
+  url: 'http://localhost:3000',
+  realm: 'my-realm',
+  clientId: 'my-app',
+  redirectUri: 'http://localhost:5173/callback',
+});
+
+function App() {
+  return (
+    <AuthmeProvider client={authme}>
+      <Main />
+    </AuthmeProvider>
+  );
+}
+
+function Main() {
+  const { isAuthenticated, isLoading, login, logout } = useAuthme();
+  const user = useUser();
+  const { hasRealmRole } = useRoles();
+
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!isAuthenticated) {
+    return <button onClick={() => login()}>Sign In</button>;
+  }
+
+  return (
+    <div>
+      <p>Welcome, {user?.name}!</p>
+      {hasRealmRole('admin') && <p>You are an admin.</p>}
+      <button onClick={() => logout()}>Sign Out</button>
+    </div>
+  );
+}
+```
+
+## API Reference
+
+### `AuthmeClient`
+
+#### Constructor
+
+```typescript
+new AuthmeClient(config: AuthmeConfig)
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `url` | `string` | *required* | AuthMe server URL |
+| `realm` | `string` | *required* | Realm name |
+| `clientId` | `string` | *required* | OAuth2 client ID (PUBLIC client) |
+| `redirectUri` | `string` | *required* | Callback URL after login |
+| `scopes` | `string[]` | `['openid', 'profile', 'email']` | OAuth2 scopes |
+| `storage` | `'sessionStorage' \| 'localStorage' \| 'memory'` | `'sessionStorage'` | Token storage |
+| `autoRefresh` | `boolean` | `true` | Auto-refresh tokens before expiry |
+| `refreshBuffer` | `number` | `30` | Seconds before expiry to refresh |
+| `postLogoutRedirectUri` | `string` | — | URL to redirect after logout |
+
+#### Methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `init()` | `Promise<boolean>` | Initialize client, restore session. Returns `true` if authenticated. |
+| `login(options?)` | `Promise<void>` | Redirect to AuthMe login page |
+| `handleCallback(url?)` | `Promise<boolean>` | Exchange authorization code for tokens |
+| `logout()` | `Promise<void>` | Clear tokens and call server logout |
+| `getAccessToken()` | `string \| null` | Current access token (null if expired) |
+| `getTokenClaims()` | `TokenClaims \| null` | Parsed access token JWT payload |
+| `getIdTokenClaims()` | `TokenClaims \| null` | Parsed ID token JWT payload |
+| `isAuthenticated()` | `boolean` | Whether user has a valid access token |
+| `fetchUserInfo()` | `Promise<UserInfo \| null>` | Fetch user info from server |
+| `getUserInfo()` | `UserInfo \| null` | Cached user info (from ID token or last fetch) |
+| `hasRealmRole(role)` | `boolean` | Check realm role |
+| `hasClientRole(clientId, role)` | `boolean` | Check client role |
+| `getRealmRoles()` | `string[]` | All realm roles |
+| `getClientRoles(clientId)` | `string[]` | All client roles |
+| `refreshTokens()` | `Promise<TokenResponse>` | Manually refresh tokens |
+| `on(event, handler)` | `void` | Subscribe to events |
+| `off(event, handler)` | `void` | Unsubscribe from events |
+
+#### Events
+
+| Event | Payload | When |
+|-------|---------|------|
+| `authenticated` | `TokenResponse` | After successful login or callback |
+| `logout` | — | After logout |
+| `tokenRefreshed` | `TokenResponse` | After silent token refresh |
+| `error` | `Error` | On any auth error |
+| `ready` | `boolean` | After `init()` completes (true if authenticated) |
+
+### React Hooks
+
+#### `useAuthme()`
+
+```typescript
+const { isAuthenticated, isLoading, login, logout, token, client } = useAuthme();
+```
+
+#### `useUser()`
+
+```typescript
+const user = useUser();
+// user?.sub, user?.name, user?.email, user?.preferred_username, etc.
+```
+
+#### `useRoles()`
+
+```typescript
+const { hasRealmRole, hasClientRole, realmRoles, getClientRoles } = useRoles();
+
+hasRealmRole('admin');           // boolean
+hasClientRole('my-app', 'edit'); // boolean
+realmRoles;                      // string[]
+getClientRoles('my-app');        // string[]
+```
+
+## AuthMe Client Setup
+
+For the SDK to work, you need a **PUBLIC** client registered in AuthMe:
+
+1. Open the AuthMe Admin Console
+2. Go to your realm > Clients > Create
+3. Set **Client Type** to `PUBLIC`
+4. Add your app's URL to **Redirect URIs** (e.g. `http://localhost:5173/callback`)
+5. Add your app's origin to **Web Origins** (e.g. `http://localhost:5173`)
+6. Enable the `authorization_code` and `refresh_token` grant types
+
+## Using Generic OIDC Libraries
+
+Since AuthMe implements standard OpenID Connect, you can also use generic OIDC client libraries:
+
+### With `oidc-client-ts` + `react-oidc-context`
+
+```bash
+npm install oidc-client-ts react-oidc-context
+```
+
+```tsx
+import { AuthProvider, useAuth } from 'react-oidc-context';
+
+const oidcConfig = {
+  authority: 'http://localhost:3000/realms/my-realm',
+  client_id: 'my-app',
+  redirect_uri: 'http://localhost:5173/callback',
+};
+
+function App() {
+  return (
+    <AuthProvider {...oidcConfig}>
+      <Main />
+    </AuthProvider>
+  );
+}
+
+function Main() {
+  const auth = useAuth();
+
+  if (auth.isLoading) return <div>Loading...</div>;
+  if (!auth.isAuthenticated) {
+    return <button onClick={() => auth.signinRedirect()}>Sign In</button>;
+  }
+
+  return (
+    <div>
+      <p>Welcome, {auth.user?.profile.name}!</p>
+      <button onClick={() => auth.signoutRedirect()}>Sign Out</button>
+    </div>
+  );
+}
+```
+
+### With `next-auth` (Next.js)
+
+AuthMe works as a standard OIDC provider with `next-auth`:
+
+```typescript
+import NextAuth from 'next-auth';
+
+export const { handlers, auth } = NextAuth({
+  providers: [{
+    id: 'authme',
+    name: 'AuthMe',
+    type: 'oidc',
+    issuer: 'http://localhost:3000/realms/my-realm',
+    clientId: 'my-nextjs-app',
+    clientSecret: 'your-client-secret',
+  }],
+});
+```
+
+## License
+
+MIT

--- a/packages/authme-js/package.json
+++ b/packages/authme-js/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "authme-js",
+  "version": "0.1.0",
+  "description": "Client SDK for AuthMe Identity and Access Management Server",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./react": {
+      "import": {
+        "types": "./dist/react.d.ts",
+        "default": "./dist/react.js"
+      },
+      "require": {
+        "types": "./dist/react.d.cts",
+        "default": "./dist/react.cjs"
+      }
+    }
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsup": "^8.4.0",
+    "typescript": "^5.7.0",
+    "react": "^19.0.0",
+    "@types/react": "^19.0.0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "authme",
+    "oauth2",
+    "oidc",
+    "openid-connect",
+    "authentication",
+    "identity",
+    "pkce",
+    "react"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Islamawad132/Authme.git",
+    "directory": "packages/authme-js"
+  }
+}

--- a/packages/authme-js/src/client.ts
+++ b/packages/authme-js/src/client.ts
@@ -1,0 +1,467 @@
+import type {
+  AuthmeConfig,
+  AuthmeEventMap,
+  OpenIDConfiguration,
+  TokenClaims,
+  TokenResponse,
+  UserInfo,
+} from './types.js';
+import { generateCodeChallenge, generateCodeVerifier, generateState } from './pkce.js';
+import { getTokenExpiresIn, isTokenExpired, parseJwt } from './token.js';
+import { createStorage, type TokenStorage } from './storage.js';
+import { EventEmitter } from './events.js';
+
+const DEFAULT_SCOPES = ['openid', 'profile', 'email'];
+const DEFAULT_REFRESH_BUFFER = 30; // seconds before expiry to trigger refresh
+
+export class AuthmeClient {
+  private config: Required<
+    Pick<AuthmeConfig, 'url' | 'realm' | 'clientId' | 'redirectUri'>
+  > & {
+    scopes: string[];
+    autoRefresh: boolean;
+    refreshBuffer: number;
+    postLogoutRedirectUri?: string;
+  };
+
+  private storage: TokenStorage;
+  private events = new EventEmitter<AuthmeEventMap>();
+  private oidcConfig: OpenIDConfiguration | null = null;
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private cachedUserInfo: UserInfo | null = null;
+  private initialized = false;
+
+  constructor(config: AuthmeConfig) {
+    this.config = {
+      url: config.url.replace(/\/$/, ''),
+      realm: config.realm,
+      clientId: config.clientId,
+      redirectUri: config.redirectUri,
+      scopes: config.scopes ?? DEFAULT_SCOPES,
+      autoRefresh: config.autoRefresh ?? true,
+      refreshBuffer: config.refreshBuffer ?? DEFAULT_REFRESH_BUFFER,
+      postLogoutRedirectUri: config.postLogoutRedirectUri,
+    };
+    this.storage = createStorage(config.storage ?? 'sessionStorage');
+  }
+
+  // ── Initialization ──────────────────────────────────────────────
+
+  /**
+   * Initialize the client: fetch OIDC discovery document and restore any
+   * existing session from storage. Must be called before other methods.
+   */
+  async init(): Promise<boolean> {
+    await this.fetchDiscovery();
+
+    const accessToken = this.storage.get('access_token');
+    if (accessToken) {
+      try {
+        const claims = parseJwt(accessToken);
+        if (!isTokenExpired(claims)) {
+          this.scheduleRefresh();
+          this.initialized = true;
+          this.events.emit('ready', true);
+          return true;
+        }
+      } catch {
+        // Token is malformed, try refresh
+      }
+
+      // Try to refresh if we have a refresh token
+      const refreshToken = this.storage.get('refresh_token');
+      if (refreshToken) {
+        try {
+          await this.refreshTokens();
+          this.initialized = true;
+          this.events.emit('ready', true);
+          return true;
+        } catch {
+          this.clearTokens();
+        }
+      } else {
+        this.clearTokens();
+      }
+    }
+
+    this.initialized = true;
+    this.events.emit('ready', false);
+    return false;
+  }
+
+  // ── Auth Flow ───────────────────────────────────────────────────
+
+  /**
+   * Redirect the user to the AuthMe login page.
+   * Generates PKCE challenge and state parameter automatically.
+   */
+  async login(options?: { scope?: string[]; state?: string }): Promise<void> {
+    const config = await this.getOidcConfig();
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+    const state = options?.state ?? generateState();
+    const scopes = options?.scope ?? this.config.scopes;
+
+    this.storage.set('pkce_verifier', verifier);
+    this.storage.set('auth_state', state);
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      scope: scopes.join(' '),
+      state,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+    });
+
+    window.location.href = `${config.authorization_endpoint}?${params.toString()}`;
+  }
+
+  /**
+   * Handle the callback after login redirect. Exchanges the authorization
+   * code for tokens. Call this on your redirect URI page.
+   * Returns true if tokens were obtained successfully.
+   */
+  async handleCallback(url?: string): Promise<boolean> {
+    const currentUrl = url ?? window.location.href;
+    const params = new URL(currentUrl).searchParams;
+    const code = params.get('code');
+    const state = params.get('state');
+    const error = params.get('error');
+
+    if (error) {
+      const description = params.get('error_description') ?? error;
+      this.events.emit('error', new Error(description));
+      return false;
+    }
+
+    if (!code) {
+      return false;
+    }
+
+    // Verify state
+    const storedState = this.storage.get('auth_state');
+    if (storedState && state !== storedState) {
+      this.events.emit('error', new Error('State mismatch — possible CSRF attack'));
+      return false;
+    }
+
+    const verifier = this.storage.get('pkce_verifier');
+    if (!verifier) {
+      this.events.emit('error', new Error('Missing PKCE verifier'));
+      return false;
+    }
+
+    const config = await this.getOidcConfig();
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: this.config.redirectUri,
+      client_id: this.config.clientId,
+      code_verifier: verifier,
+    });
+
+    const response = await fetch(config.token_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: 'token_exchange_failed' }));
+      this.events.emit('error', new Error(err.error_description ?? err.error));
+      return false;
+    }
+
+    const tokens: TokenResponse = await response.json();
+    this.storeTokens(tokens);
+    this.scheduleRefresh();
+
+    // Clean up PKCE state
+    this.storage.remove('pkce_verifier');
+    this.storage.remove('auth_state');
+
+    // Clean authorization code from URL
+    if (typeof window !== 'undefined') {
+      const cleanUrl = new URL(window.location.href);
+      cleanUrl.searchParams.delete('code');
+      cleanUrl.searchParams.delete('state');
+      cleanUrl.searchParams.delete('session_state');
+      window.history.replaceState({}, '', cleanUrl.toString());
+    }
+
+    this.events.emit('authenticated', tokens);
+    return true;
+  }
+
+  /**
+   * Log the user out. Clears local tokens and calls the server logout endpoint.
+   */
+  async logout(): Promise<void> {
+    const refreshToken = this.storage.get('refresh_token');
+
+    if (refreshToken) {
+      try {
+        const config = await this.getOidcConfig();
+        if (config.end_session_endpoint) {
+          await fetch(config.end_session_endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ refresh_token: refreshToken }),
+          });
+        }
+      } catch {
+        // Best-effort server logout
+      }
+    }
+
+    this.clearTokens();
+    this.events.emit('logout');
+
+    if (this.config.postLogoutRedirectUri) {
+      window.location.href = this.config.postLogoutRedirectUri;
+    }
+  }
+
+  // ── Token Access ────────────────────────────────────────────────
+
+  /**
+   * Get the current access token string.
+   * Returns null if not authenticated or the token is expired.
+   */
+  getAccessToken(): string | null {
+    const token = this.storage.get('access_token');
+    if (!token) return null;
+
+    try {
+      const claims = parseJwt(token);
+      if (isTokenExpired(claims)) return null;
+      return token;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Get the parsed claims from the current access token. */
+  getTokenClaims(): TokenClaims | null {
+    const token = this.storage.get('access_token');
+    if (!token) return null;
+
+    try {
+      return parseJwt(token);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Get the parsed claims from the current ID token. */
+  getIdTokenClaims(): TokenClaims | null {
+    const token = this.storage.get('id_token');
+    if (!token) return null;
+
+    try {
+      return parseJwt(token);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Check if the user is currently authenticated with a valid access token. */
+  isAuthenticated(): boolean {
+    return this.getAccessToken() !== null;
+  }
+
+  // ── User Info ───────────────────────────────────────────────────
+
+  /**
+   * Fetch fresh user info from the userinfo endpoint.
+   * Caches the result — use getUserInfo() to retrieve cached data.
+   */
+  async fetchUserInfo(): Promise<UserInfo | null> {
+    const token = this.getAccessToken();
+    if (!token) return null;
+
+    const config = await this.getOidcConfig();
+    const response = await fetch(config.userinfo_endpoint, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!response.ok) return null;
+
+    this.cachedUserInfo = await response.json();
+    return this.cachedUserInfo;
+  }
+
+  /**
+   * Get user info from cached data or ID token claims.
+   * Call fetchUserInfo() first for fresh server data.
+   */
+  getUserInfo(): UserInfo | null {
+    if (this.cachedUserInfo) return this.cachedUserInfo;
+
+    const idClaims = this.getIdTokenClaims();
+    if (idClaims) {
+      return {
+        sub: idClaims.sub,
+        preferred_username: idClaims.preferred_username,
+        name: idClaims.name,
+        given_name: idClaims.given_name,
+        family_name: idClaims.family_name,
+        email: idClaims.email,
+        email_verified: idClaims.email_verified,
+      };
+    }
+
+    return null;
+  }
+
+  // ── Role Helpers ────────────────────────────────────────────────
+
+  /** Check if the user has a specific realm role. */
+  hasRealmRole(role: string): boolean {
+    const claims = this.getTokenClaims();
+    return claims?.realm_access?.roles?.includes(role) ?? false;
+  }
+
+  /** Check if the user has a specific client role. */
+  hasClientRole(clientId: string, role: string): boolean {
+    const claims = this.getTokenClaims();
+    return claims?.resource_access?.[clientId]?.roles?.includes(role) ?? false;
+  }
+
+  /** Get all realm roles for the current user. */
+  getRealmRoles(): string[] {
+    const claims = this.getTokenClaims();
+    return claims?.realm_access?.roles ?? [];
+  }
+
+  /** Get all client roles for a specific client. */
+  getClientRoles(clientId: string): string[] {
+    const claims = this.getTokenClaims();
+    return claims?.resource_access?.[clientId]?.roles ?? [];
+  }
+
+  // ── Token Refresh ───────────────────────────────────────────────
+
+  /**
+   * Manually refresh the access token using the refresh token.
+   * This is called automatically when autoRefresh is enabled.
+   */
+  async refreshTokens(): Promise<TokenResponse> {
+    const refreshToken = this.storage.get('refresh_token');
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    const config = await this.getOidcConfig();
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: this.config.clientId,
+    });
+
+    const response = await fetch(config.token_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      this.clearTokens();
+      const err = await response.json().catch(() => ({ error: 'refresh_failed' }));
+      throw new Error(err.error_description ?? err.error);
+    }
+
+    const tokens: TokenResponse = await response.json();
+    this.storeTokens(tokens);
+    this.scheduleRefresh();
+    this.events.emit('tokenRefreshed', tokens);
+    return tokens;
+  }
+
+  // ── Events ──────────────────────────────────────────────────────
+
+  /** Subscribe to an event. */
+  on<K extends keyof AuthmeEventMap>(
+    event: K,
+    handler: AuthmeEventMap[K] extends void ? () => void : (data: AuthmeEventMap[K]) => void,
+  ): void {
+    this.events.on(event, handler);
+  }
+
+  /** Unsubscribe from an event. */
+  off<K extends keyof AuthmeEventMap>(
+    event: K,
+    handler: AuthmeEventMap[K] extends void ? () => void : (data: AuthmeEventMap[K]) => void,
+  ): void {
+    this.events.off(event, handler);
+  }
+
+  // ── Internal ────────────────────────────────────────────────────
+
+  private async fetchDiscovery(): Promise<void> {
+    const url = `${this.config.url}/realms/${this.config.realm}/.well-known/openid-configuration`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch OIDC discovery document from ${url}`);
+    }
+    this.oidcConfig = await response.json();
+  }
+
+  private async getOidcConfig(): Promise<OpenIDConfiguration> {
+    if (!this.oidcConfig) {
+      await this.fetchDiscovery();
+    }
+    return this.oidcConfig!;
+  }
+
+  private storeTokens(tokens: TokenResponse): void {
+    this.storage.set('access_token', tokens.access_token);
+    if (tokens.refresh_token) {
+      this.storage.set('refresh_token', tokens.refresh_token);
+    }
+    if (tokens.id_token) {
+      this.storage.set('id_token', tokens.id_token);
+    }
+    // Clear cached user info so it's re-fetched with new token
+    this.cachedUserInfo = null;
+  }
+
+  private clearTokens(): void {
+    this.cancelRefreshTimer();
+    this.storage.clear();
+    this.cachedUserInfo = null;
+  }
+
+  private scheduleRefresh(): void {
+    if (!this.config.autoRefresh) return;
+    this.cancelRefreshTimer();
+
+    const token = this.storage.get('access_token');
+    if (!token) return;
+
+    try {
+      const claims = parseJwt(token);
+      const expiresIn = getTokenExpiresIn(claims);
+      const refreshIn = Math.max(0, expiresIn - this.config.refreshBuffer) * 1000;
+
+      this.refreshTimer = setTimeout(async () => {
+        try {
+          await this.refreshTokens();
+        } catch (err) {
+          this.events.emit('error', err instanceof Error ? err : new Error(String(err)));
+        }
+      }, refreshIn);
+    } catch {
+      // Token parse failure — don't schedule
+    }
+  }
+
+  private cancelRefreshTimer(): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+}

--- a/packages/authme-js/src/events.ts
+++ b/packages/authme-js/src/events.ts
@@ -1,0 +1,28 @@
+export type EventHandler<T> = T extends void ? () => void : (data: T) => void;
+
+export class EventEmitter<TMap extends Record<string, unknown>> {
+  private listeners = new Map<keyof TMap, Set<EventHandler<unknown>>>();
+
+  on<K extends keyof TMap>(event: K, handler: EventHandler<TMap[K]>): void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(handler as EventHandler<unknown>);
+  }
+
+  off<K extends keyof TMap>(event: K, handler: EventHandler<TMap[K]>): void {
+    this.listeners.get(event)?.delete(handler as EventHandler<unknown>);
+  }
+
+  emit<K extends keyof TMap>(event: K, ...args: TMap[K] extends void ? [] : [TMap[K]]): void {
+    const handlers = this.listeners.get(event);
+    if (!handlers) return;
+    for (const handler of handlers) {
+      try {
+        (handler as (...a: unknown[]) => void)(...args);
+      } catch {
+        // Don't let listener errors break the emitter
+      }
+    }
+  }
+}

--- a/packages/authme-js/src/index.ts
+++ b/packages/authme-js/src/index.ts
@@ -1,0 +1,10 @@
+export { AuthmeClient } from './client.js';
+export type {
+  AuthmeConfig,
+  AuthmeEventMap,
+  OpenIDConfiguration,
+  TokenClaims,
+  TokenResponse,
+  UserInfo,
+} from './types.js';
+export { parseJwt, isTokenExpired, getTokenExpiresIn } from './token.js';

--- a/packages/authme-js/src/pkce.ts
+++ b/packages/authme-js/src/pkce.ts
@@ -1,0 +1,30 @@
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/** Generate a cryptographically random PKCE code verifier. */
+export function generateCodeVerifier(): string {
+  const buffer = new Uint8Array(32);
+  crypto.getRandomValues(buffer);
+  return base64UrlEncode(buffer.buffer);
+}
+
+/** Generate a PKCE code challenge from a verifier using SHA-256. */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return base64UrlEncode(digest);
+}
+
+/** Generate a random state parameter for CSRF protection. */
+export function generateState(): string {
+  const buffer = new Uint8Array(16);
+  crypto.getRandomValues(buffer);
+  return base64UrlEncode(buffer.buffer);
+}

--- a/packages/authme-js/src/react.ts
+++ b/packages/authme-js/src/react.ts
@@ -1,0 +1,210 @@
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { AuthmeClient } from './client.js';
+import type { UserInfo } from './types.js';
+
+// Re-export core for convenience
+export { AuthmeClient } from './client.js';
+export type {
+  AuthmeConfig,
+  AuthmeEventMap,
+  TokenClaims,
+  TokenResponse,
+  UserInfo,
+} from './types.js';
+
+// ── Context ─────────────────────────────────────────────────────
+
+interface AuthmeContextValue {
+  client: AuthmeClient;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  user: UserInfo | null;
+  login: (options?: { scope?: string[] }) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthmeContext = createContext<AuthmeContextValue | null>(null);
+
+// ── Provider ────────────────────────────────────────────────────
+
+interface AuthmeProviderProps {
+  client: AuthmeClient;
+  children: ReactNode;
+  /** If true, automatically calls handleCallback when URL has ?code= (default: true) */
+  autoHandleCallback?: boolean;
+  /** Called when initialization is complete */
+  onReady?: (authenticated: boolean) => void;
+}
+
+export function AuthmeProvider({
+  client,
+  children,
+  autoHandleCallback = true,
+  onReady,
+}: AuthmeProviderProps) {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [user, setUser] = useState<UserInfo | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const onAuthenticated = () => {
+      if (!mounted) return;
+      setIsAuthenticated(true);
+      setUser(client.getUserInfo());
+    };
+
+    const onLogout = () => {
+      if (!mounted) return;
+      setIsAuthenticated(false);
+      setUser(null);
+    };
+
+    const onTokenRefreshed = () => {
+      if (!mounted) return;
+      setUser(client.getUserInfo());
+    };
+
+    client.on('authenticated', onAuthenticated);
+    client.on('logout', onLogout);
+    client.on('tokenRefreshed', onTokenRefreshed);
+
+    async function initialize() {
+      try {
+        // Check if URL has authorization code
+        const hasCode =
+          typeof window !== 'undefined' &&
+          new URL(window.location.href).searchParams.has('code');
+
+        if (hasCode && autoHandleCallback) {
+          const success = await client.handleCallback();
+          if (mounted) {
+            setIsAuthenticated(success);
+            if (success) setUser(client.getUserInfo());
+            setIsLoading(false);
+            onReady?.(success);
+          }
+          return;
+        }
+
+        const restored = await client.init();
+        if (mounted) {
+          setIsAuthenticated(restored);
+          if (restored) setUser(client.getUserInfo());
+          setIsLoading(false);
+          onReady?.(restored);
+        }
+      } catch {
+        if (mounted) {
+          setIsAuthenticated(false);
+          setIsLoading(false);
+          onReady?.(false);
+        }
+      }
+    }
+
+    initialize();
+
+    return () => {
+      mounted = false;
+      client.off('authenticated', onAuthenticated);
+      client.off('logout', onLogout);
+      client.off('tokenRefreshed', onTokenRefreshed);
+    };
+  }, [client, autoHandleCallback, onReady]);
+
+  const login = useCallback(
+    (options?: { scope?: string[] }) => client.login(options),
+    [client],
+  );
+
+  const logout = useCallback(() => client.logout(), [client]);
+
+  const value = useMemo(
+    () => ({ client, isAuthenticated, isLoading, user, login, logout }),
+    [client, isAuthenticated, isLoading, user, login, logout],
+  );
+
+  return createElement(AuthmeContext.Provider, { value }, children);
+}
+
+// ── Hooks ───────────────────────────────────────────────────────
+
+function useAuthmeContext(): AuthmeContextValue {
+  const ctx = useContext(AuthmeContext);
+  if (!ctx) {
+    throw new Error('useAuthme must be used within an <AuthmeProvider>');
+  }
+  return ctx;
+}
+
+/**
+ * Hook for authentication state and actions.
+ *
+ * ```tsx
+ * const { isAuthenticated, isLoading, login, logout } = useAuthme();
+ * ```
+ */
+export function useAuthme() {
+  const { client, isAuthenticated, isLoading, login, logout } = useAuthmeContext();
+  const token = isAuthenticated ? client.getAccessToken() : null;
+  return { isAuthenticated, isLoading, login, logout, token, client };
+}
+
+/**
+ * Hook for user information from the ID token or userinfo endpoint.
+ *
+ * ```tsx
+ * const user = useUser();
+ * // user?.name, user?.email, etc.
+ * ```
+ */
+export function useUser(): UserInfo | null {
+  const { user } = useAuthmeContext();
+  return user;
+}
+
+/**
+ * Hook for role-checking helpers.
+ *
+ * ```tsx
+ * const { hasRealmRole, hasClientRole } = useRoles();
+ * if (hasRealmRole('admin')) { ... }
+ * ```
+ */
+export function useRoles() {
+  const { client, isAuthenticated } = useAuthmeContext();
+
+  const hasRealmRole = useCallback(
+    (role: string) => (isAuthenticated ? client.hasRealmRole(role) : false),
+    [client, isAuthenticated],
+  );
+
+  const hasClientRole = useCallback(
+    (clientId: string, role: string) =>
+      isAuthenticated ? client.hasClientRole(clientId, role) : false,
+    [client, isAuthenticated],
+  );
+
+  const realmRoles = useMemo(
+    () => (isAuthenticated ? client.getRealmRoles() : []),
+    [client, isAuthenticated],
+  );
+
+  const getClientRoles = useCallback(
+    (clientId: string) => (isAuthenticated ? client.getClientRoles(clientId) : []),
+    [client, isAuthenticated],
+  );
+
+  return { hasRealmRole, hasClientRole, realmRoles, getClientRoles };
+}

--- a/packages/authme-js/src/storage.ts
+++ b/packages/authme-js/src/storage.ts
@@ -1,0 +1,68 @@
+export interface TokenStorage {
+  get(key: string): string | null;
+  set(key: string, value: string): void;
+  remove(key: string): void;
+  clear(): void;
+}
+
+const PREFIX = 'authme_';
+
+export class BrowserStorage implements TokenStorage {
+  private store: Storage;
+
+  constructor(type: 'sessionStorage' | 'localStorage') {
+    this.store = type === 'localStorage' ? localStorage : sessionStorage;
+  }
+
+  get(key: string): string | null {
+    return this.store.getItem(PREFIX + key);
+  }
+
+  set(key: string, value: string): void {
+    this.store.setItem(PREFIX + key, value);
+  }
+
+  remove(key: string): void {
+    this.store.removeItem(PREFIX + key);
+  }
+
+  clear(): void {
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < this.store.length; i++) {
+      const key = this.store.key(i);
+      if (key?.startsWith(PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+    for (const key of keysToRemove) {
+      this.store.removeItem(key);
+    }
+  }
+}
+
+export class MemoryStorage implements TokenStorage {
+  private store = new Map<string, string>();
+
+  get(key: string): string | null {
+    return this.store.get(PREFIX + key) ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.store.set(PREFIX + key, value);
+  }
+
+  remove(key: string): void {
+    this.store.delete(PREFIX + key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+export function createStorage(type: 'sessionStorage' | 'localStorage' | 'memory'): TokenStorage {
+  if (type === 'memory' || typeof window === 'undefined') {
+    return new MemoryStorage();
+  }
+  return new BrowserStorage(type);
+}

--- a/packages/authme-js/src/token.ts
+++ b/packages/authme-js/src/token.ts
@@ -1,0 +1,33 @@
+import type { TokenClaims } from './types.js';
+
+/**
+ * Parse a JWT token and return the decoded payload.
+ * This does NOT verify the signature — that's the server's responsibility.
+ */
+export function parseJwt(token: string): TokenClaims {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid JWT format');
+  }
+  const payload = parts[1];
+  const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const json = decodeURIComponent(
+    atob(padded)
+      .split('')
+      .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+      .join(''),
+  );
+  return JSON.parse(json);
+}
+
+/** Check if a token is expired, with an optional clock skew buffer in seconds. */
+export function isTokenExpired(claims: TokenClaims, clockSkew = 0): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  return claims.exp <= now + clockSkew;
+}
+
+/** Get the number of seconds until a token expires. Returns 0 if already expired. */
+export function getTokenExpiresIn(claims: TokenClaims): number {
+  const now = Math.floor(Date.now() / 1000);
+  return Math.max(0, claims.exp - now);
+}

--- a/packages/authme-js/src/types.ts
+++ b/packages/authme-js/src/types.ts
@@ -1,0 +1,121 @@
+/** Configuration for creating an AuthmeClient instance. */
+export interface AuthmeConfig {
+  /** Base URL of the AuthMe server (e.g. "http://localhost:3000") */
+  url: string;
+  /** Realm name to authenticate against */
+  realm: string;
+  /** OAuth2 client ID (must be registered in AuthMe as a PUBLIC client) */
+  clientId: string;
+  /** URL to redirect back to after login */
+  redirectUri: string;
+  /** OAuth2 scopes to request (default: ["openid", "profile", "email"]) */
+  scopes?: string[];
+  /** Storage type for tokens (default: "sessionStorage") */
+  storage?: 'sessionStorage' | 'localStorage' | 'memory';
+  /** Automatically refresh tokens before expiry (default: true) */
+  autoRefresh?: boolean;
+  /** Seconds before expiry to trigger a refresh (default: 30) */
+  refreshBuffer?: number;
+  /** URL to redirect to after logout (optional) */
+  postLogoutRedirectUri?: string;
+}
+
+/** Raw token response from the token endpoint. */
+export interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  id_token?: string;
+  scope?: string;
+}
+
+/** Parsed JWT claims from an access token. */
+export interface TokenClaims {
+  /** Subject (user ID) */
+  sub: string;
+  /** Issuer */
+  iss: string;
+  /** Audience (client ID) */
+  aud: string | string[];
+  /** Expiration time (unix seconds) */
+  exp: number;
+  /** Issued at (unix seconds) */
+  iat: number;
+  /** Token type */
+  typ?: string;
+  /** Authorized party (client ID) */
+  azp?: string;
+  /** Session ID */
+  sid?: string;
+  /** JWT ID */
+  jti?: string;
+  /** Granted scopes (space-separated) */
+  scope?: string;
+  /** Nonce (from authorization request) */
+  nonce?: string;
+  /** Authentication time (unix seconds) */
+  auth_time?: number;
+  /** Access token hash (ID tokens only) */
+  at_hash?: string;
+  /** Authentication Context Class Reference */
+  acr?: string;
+
+  // User claims (present based on scopes)
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  preferred_username?: string;
+  email?: string;
+  email_verified?: boolean;
+  updated_at?: number;
+
+  // Role claims
+  realm_access?: { roles: string[] };
+  resource_access?: Record<string, { roles: string[] }>;
+
+  // Allow additional custom claims
+  [key: string]: unknown;
+}
+
+/** User information returned by the userinfo endpoint or parsed from the ID token. */
+export interface UserInfo {
+  sub: string;
+  preferred_username?: string;
+  name?: string;
+  given_name?: string;
+  family_name?: string;
+  email?: string;
+  email_verified?: boolean;
+  [key: string]: unknown;
+}
+
+/** OIDC Discovery document shape. */
+export interface OpenIDConfiguration {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  userinfo_endpoint: string;
+  jwks_uri: string;
+  end_session_endpoint?: string;
+  introspection_endpoint?: string;
+  revocation_endpoint?: string;
+  device_authorization_endpoint?: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  subject_types_supported: string[];
+  id_token_signing_alg_values_supported: string[];
+  scopes_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  claims_supported: string[];
+  code_challenge_methods_supported?: string[];
+}
+
+/** Events emitted by AuthmeClient. */
+export type AuthmeEventMap = {
+  authenticated: TokenResponse;
+  logout: void;
+  tokenRefreshed: TokenResponse;
+  error: Error;
+  ready: boolean;
+};

--- a/packages/authme-js/tsconfig.json
+++ b/packages/authme-js/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/authme-js/tsup.config.ts
+++ b/packages/authme-js/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    react: 'src/react.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: true,
+  external: ['react'],
+});


### PR DESCRIPTION
## Summary
- Adds `authme-js` — a zero-dependency TypeScript client SDK at `packages/authme-js/`
- Handles OAuth 2.0 Authorization Code + PKCE flow end-to-end
- Automatic token refresh before expiry
- Role-checking helpers (`hasRealmRole`, `hasClientRole`)
- React bindings via `authme-js/react`: `AuthmeProvider`, `useAuthme()`, `useUser()`, `useRoles()`
- Dual ESM/CJS output with full TypeScript declarations
- SDK README includes full API reference + examples for using generic OIDC libs as alternatives
- Root README updated with Client SDK section

## Package structure
```
packages/authme-js/
├── src/
│   ├── types.ts      # TypeScript interfaces
│   ├── pkce.ts       # PKCE verifier/challenge (Web Crypto API)
│   ├── token.ts      # JWT parsing + expiry helpers
│   ├── storage.ts    # Storage abstraction (session/local/memory)
│   ├── events.ts     # Typed event emitter
│   ├── client.ts     # AuthmeClient class
│   ├── index.ts      # Core exports
│   └── react.ts      # React Provider + hooks
├── package.json      # Dual ESM/CJS exports
├── tsup.config.ts    # Build config
└── README.md         # Full documentation
```

## Test plan
- [ ] `cd packages/authme-js && npm run build` succeeds
- [ ] `dist/` contains ESM, CJS, and `.d.ts` files for both entry points
- [ ] Import `AuthmeClient` from `authme-js` works
- [ ] Import `AuthmeProvider` from `authme-js/react` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)