### PR TITLE
fix: add formAction to CSP directives to unblock login form

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ async function bootstrap() {
           styleSrc: ["'self'", "'unsafe-inline'"],
           imgSrc: ["'self'", 'data:', 'blob:'],
           connectSrc: ["'self'"],
+          formAction: ["'self'"],
           upgradeInsecureRequests: null,
         },
       },


### PR DESCRIPTION
## Summary
- Helmet's CSP was missing an explicit `formAction` directive, causing the browser to block login form POST submissions
- Added `formAction: ["'self'"]` to the CSP directives in `src/main.ts`

## Test plan
- [ ] Open AuthMe login page in browser
- [ ] Submit the login form — should no longer show CSP violation error
- [ ] Verify forgot-password form also submits correctly

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)