### PR TITLE
feat: add self-registration page for public user sign-up

### DIFF
--- a/views/register.hbs
+++ b/views/register.hbs
@@ -1,0 +1,48 @@
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<form method="POST" action="/realms/{{realmName}}/register" class="auth-form">
+  <div class="form-group">
+    <label for="username">Username</label>
+    <input type="text" id="username" name="username" required autocomplete="username" autofocus value="{{username}}">
+  </div>
+
+  <div class="form-group">
+    <label for="email">Email</label>
+    <input type="email" id="email" name="email" required autocomplete="email" value="{{email}}">
+  </div>
+
+  <div class="form-group">
+    <label for="firstName">First Name</label>
+    <input type="text" id="firstName" name="firstName" autocomplete="given-name" value="{{firstName}}">
+  </div>
+
+  <div class="form-group">
+    <label for="lastName">Last Name</label>
+    <input type="text" id="lastName" name="lastName" autocomplete="family-name" value="{{lastName}}">
+  </div>
+
+  <div class="form-group">
+    <label for="password">Password</label>
+    <input type="password" id="password" name="password" required autocomplete="new-password" minlength="{{passwordMinLength}}">
+    {{#if passwordHint}}
+    <small style="color: #6b7280; margin-top: 0.25rem; display: block;">{{passwordHint}}</small>
+    {{/if}}
+  </div>
+
+  <div class="form-group">
+    <label for="confirmPassword">Confirm Password</label>
+    <input type="password" id="confirmPassword" name="confirmPassword" required autocomplete="new-password">
+  </div>
+
+  <button type="submit" class="btn-primary">Create Account</button>
+</form>
+
+<div style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">Already have an account? Sign in</a>
+</div>


### PR DESCRIPTION
## Summary
- Added `GET /realms/:realmName/register` — renders a registration form (Handlebars)
- Added `POST /realms/:realmName/register` — handles form submission with full validation
- Password policy hints displayed based on realm settings
- Duplicate username/email checks with user-friendly error messages
- Auto-sends verification email after successful registration
- Redirects to login with success message after registration

## Test plan
- [ ] Open `/realms/my-app/register` — form should render with all fields
- [ ] Submit with empty fields — should show validation errors
- [ ] Submit with duplicate username — should show "already exists" error
- [ ] Submit with duplicate email — should show "already exists" error
- [ ] Submit with weak password — should show password policy errors
- [ ] Submit with mismatched passwords — should show "do not match" error
- [ ] Submit valid form — should redirect to login with success message
- [ ] Check email inbox — verification email should arrive

Fixes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)