### PR TITLE
feat: add Register link on login page

### DIFF
--- a/views/login.hbs
+++ b/views/login.hbs
@@ -37,3 +37,7 @@
 
   <button type="submit" class="btn-primary">Sign In</button>
 </form>
+
+<div style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/register" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">Don't have an account? Register</a>
+</div>


### PR DESCRIPTION
## Summary
- Added a "Don't have an account? Register" link below the Sign In button on the login page
- Links to `/realms/:realmName/register` (the new registration page from PR #87)

## Test plan
- [ ] Open the login page — should see the Register link below Sign In
- [ ] Click the link — should navigate to the registration page

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)