### PR TITLE
feat: add realm-level requireEmailVerification setting

### DIFF
--- a/prisma/migrations/20260216160000_add_require_email_verification/migration.sql
+++ b/prisma/migrations/20260216160000_add_require_email_verification/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "realms" ADD COLUMN "require_email_verification" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,9 @@ model Realm {
   failureResetTime      Int     @default(600)   @map("failure_reset_time")
   permanentLockoutAfter Int     @default(0)     @map("permanent_lockout_after")
 
+  // Email verification
+  requireEmailVerification Boolean @default(false) @map("require_email_verification")
+
   // MFA
   mfaRequired Boolean @default(false) @map("mfa_required")
 

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -95,6 +95,16 @@ export class LoginController {
         req.ip,
       );
 
+      // Check email verification requirement
+      if (realm.requireEmailVerification && user.email && !user.emailVerified) {
+        const params = new URLSearchParams();
+        params.set('error', 'Please verify your email address before signing in. Check your inbox for the verification link.');
+        for (const key of ['client_id', 'redirect_uri', 'response_type', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method']) {
+          if (body[key]) params.set(key, body[key]);
+        }
+        return res.redirect(`/realms/${realm.name}/login?${params.toString()}`);
+      }
+
       // Build OAuth params for later use
       const oauthParams: Record<string, string> = {};
       for (const key of ['response_type', 'client_id', 'redirect_uri', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method']) {

--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -130,6 +130,12 @@ export class CreateRealmDto {
   @Min(0)
   permanentLockoutAfter?: number;
 
+  // Email verification
+  @ApiPropertyOptional({ default: false, description: 'Require email verification before login' })
+  @IsOptional()
+  @IsBoolean()
+  requireEmailVerification?: boolean;
+
   // MFA
   @ApiPropertyOptional({ default: false })
   @IsOptional()


### PR DESCRIPTION
## Summary
- Added `requireEmailVerification` boolean field to the Realm model (default: `false`)
- When enabled, users with unverified emails are blocked from logging in
- Clear error message shown: "Please verify your email address before signing in"
- Includes Prisma migration and DTO update

## Test plan
- [ ] Enable `requireEmailVerification` on a realm via admin API
- [ ] Try to login with an unverified email user — should be blocked with error message
- [ ] Verify the email, then login — should succeed
- [ ] With setting disabled (default), unverified users can still login

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)