### PR TITLE
Add themes/ directory with built-in theme presets

### DIFF
--- a/public/css/auth.css
+++ b/public/css/auth.css
@@ -50,7 +50,7 @@ body {
 }
 
 .auth-realm {
-  color: #6b7280;
+  color: var(--muted-color, #6b7280);
   font-size: 0.875rem;
   margin-top: 0.25rem;
 }
@@ -77,16 +77,18 @@ body {
 .form-group label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--label-color, #374151);
 }
 
 .form-group input[type="text"],
 .form-group input[type="password"],
 .form-group input[type="email"] {
   padding: 0.625rem 0.75rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--input-border-color, #d1d5db);
   border-radius: 6px;
   font-size: 0.9375rem;
+  background: var(--input-bg-color, #ffffff);
+  color: var(--text-color, #1a1a2e);
   transition: border-color 0.15s;
   outline: none;
 }
@@ -104,7 +106,7 @@ body {
 
 .form-checkbox label {
   font-size: 0.8125rem;
-  color: #6b7280;
+  color: var(--muted-color, #6b7280);
 }
 
 .btn-primary {
@@ -125,8 +127,8 @@ body {
 
 .btn-secondary {
   background: var(--card-color, #fff);
-  color: #374151;
-  border: 1px solid #d1d5db;
+  color: var(--label-color, #374151);
+  border: 1px solid var(--input-border-color, #d1d5db);
   border-radius: 6px;
   padding: 0.625rem 1.25rem;
   font-size: 0.9375rem;
@@ -171,12 +173,12 @@ body {
 }
 
 .auth-error-page p {
-  color: #6b7280;
+  color: var(--muted-color, #6b7280);
   margin-bottom: 1.5rem;
 }
 
 .consent-description {
-  color: #6b7280;
+  color: var(--muted-color, #6b7280);
   font-size: 0.875rem;
   text-align: center;
   margin-bottom: 1rem;

--- a/themes/authme/theme.json
+++ b/themes/authme/theme.json
@@ -1,0 +1,16 @@
+{
+  "name": "authme",
+  "displayName": "AuthMe (Default)",
+  "description": "Clean light theme with blue accents",
+  "colors": {
+    "primaryColor": "#2563eb",
+    "backgroundColor": "#f0f2f5",
+    "cardColor": "#ffffff",
+    "textColor": "#1a1a2e",
+    "labelColor": "#374151",
+    "inputBorderColor": "#d1d5db",
+    "inputBgColor": "#ffffff",
+    "mutedColor": "#6b7280"
+  },
+  "css": []
+}

--- a/themes/dark/css/overrides.css
+++ b/themes/dark/css/overrides.css
@@ -1,0 +1,53 @@
+/* Dark theme overrides */
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group input[type="email"] {
+  color: #f1f5f9;
+}
+
+.form-group input:focus {
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.form-checkbox label {
+  color: var(--muted-color, #94a3b8);
+}
+
+.btn-secondary {
+  background: #334155;
+  color: #f1f5f9;
+  border-color: #475569;
+}
+
+.btn-secondary:hover {
+  background: #475569;
+}
+
+.auth-success {
+  background: #064e3b;
+  color: #6ee7b7;
+  border-color: #065f46;
+}
+
+.auth-error {
+  background: #450a0a;
+  color: #fca5a5;
+  border-color: #7f1d1d;
+}
+
+.consent-scopes li {
+  background: #334155;
+}
+
+.password-toggle {
+  color: #64748b;
+}
+
+.password-toggle:hover {
+  color: #94a3b8;
+}
+
+.auth-card {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}

--- a/themes/dark/theme.json
+++ b/themes/dark/theme.json
@@ -1,0 +1,16 @@
+{
+  "name": "dark",
+  "displayName": "Dark",
+  "description": "Modern dark theme with indigo accents",
+  "colors": {
+    "primaryColor": "#6366f1",
+    "backgroundColor": "#0f172a",
+    "cardColor": "#1e293b",
+    "textColor": "#f1f5f9",
+    "labelColor": "#cbd5e1",
+    "inputBorderColor": "#334155",
+    "inputBgColor": "#0f172a",
+    "mutedColor": "#94a3b8"
+  },
+  "css": ["css/overrides.css"]
+}

--- a/themes/forest/css/overrides.css
+++ b/themes/forest/css/overrides.css
@@ -1,0 +1,19 @@
+/* Forest theme overrides */
+
+.form-group input:focus {
+  box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.15);
+}
+
+.auth-success {
+  background: #ecfdf5;
+  color: #065f46;
+  border-color: #a7f3d0;
+}
+
+.consent-scopes li {
+  background: #f0fdf4;
+}
+
+.consent-scopes li::before {
+  color: #059669;
+}

--- a/themes/forest/theme.json
+++ b/themes/forest/theme.json
@@ -1,0 +1,16 @@
+{
+  "name": "forest",
+  "displayName": "Forest",
+  "description": "Nature-inspired theme with emerald accents",
+  "colors": {
+    "primaryColor": "#059669",
+    "backgroundColor": "#f0fdf4",
+    "cardColor": "#ffffff",
+    "textColor": "#1a2e1a",
+    "labelColor": "#374137",
+    "inputBorderColor": "#d1d5d1",
+    "inputBgColor": "#ffffff",
+    "mutedColor": "#6b7e6b"
+  },
+  "css": ["css/overrides.css"]
+}


### PR DESCRIPTION
## Summary
- Create Keycloak-inspired `themes/` directory with three built-in themes: **authme** (default light), **dark** (indigo/slate), and **forest** (emerald/green)
- Each theme has `theme.json` with metadata, colors, and optional CSS override files
- Update `auth.css` to use CSS variables (`--label-color`, `--input-border-color`, `--input-bg-color`, `--muted-color`) instead of hardcoded colors for proper dark theme support

## Test plan
- [ ] Verify theme.json files are valid JSON with correct structure
- [ ] Verify auth.css changes don't break existing default rendering
- [ ] Verify dark theme overrides.css handles all necessary dark-mode styles

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)