### PR TITLE
Add ThemeService and per-realm theme selection

### DIFF
--- a/prisma/migrations/20260216170000_add_theme_name/migration.sql
+++ b/prisma/migrations/20260216170000_add_theme_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "realms" ADD COLUMN "theme_name" VARCHAR(50) NOT NULL DEFAULT 'authme';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,8 @@ model Realm {
   adminEventsEnabled Boolean @default(false) @map("admin_events_enabled")
 
   // Theming
-  theme Json? @default("{}") @map("theme")
+  themeName String  @default("authme") @map("theme_name") @db.VarChar(50)
+  theme     Json?   @default("{}") @map("theme")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -20,7 +20,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
 import { MfaService } from '../mfa/mfa.service.js';
-import { getThemeVars } from '../login/theme.util.js';
+import { ThemeService } from '../login/theme.service.js';
 
 @ApiExcludeController()
 @Controller('realms/:realmName/account')
@@ -33,6 +33,7 @@ export class AccountController {
     private readonly crypto: CryptoService,
     private readonly passwordPolicyService: PasswordPolicyService,
     private readonly mfaService: MfaService,
+    private readonly themeService: ThemeService,
   ) {}
 
   private async getSessionUser(realm: Realm, req: Request) {
@@ -61,7 +62,7 @@ export class AccountController {
       pageTitle: 'My Account',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       username: user.username,
       email: user.email ?? '',
       emailVerified: user.emailVerified,
@@ -186,7 +187,7 @@ export class AccountController {
       pageTitle: 'Set Up Two-Factor Authentication',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       qrCodeDataUrl: setup.qrCodeDataUrl,
       secret: setup.secret,
       error: query['error'] ?? '',
@@ -224,7 +225,7 @@ export class AccountController {
       pageTitle: 'Two-Factor Authentication Enabled',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       activated: true,
       recoveryCodes,
     });

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -26,7 +26,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
 import { MfaService } from '../mfa/mfa.service.js';
-import { getThemeVars } from './theme.util.js';
+import { ThemeService } from './theme.service.js';
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   openid: 'Verify your identity',
@@ -51,6 +51,7 @@ export class LoginController {
     private readonly config: ConfigService,
     private readonly passwordPolicyService: PasswordPolicyService,
     private readonly mfaService: MfaService,
+    private readonly themeService: ThemeService,
   ) {}
 
   // ─── LOGIN ──────────────────────────────────────────────
@@ -66,7 +67,7 @@ export class LoginController {
       pageTitle: 'Sign In',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       client_id: query['client_id'] ?? '',
       redirect_uri: query['redirect_uri'] ?? '',
       response_type: query['response_type'] ?? '',
@@ -239,7 +240,7 @@ export class LoginController {
       pageTitle: 'Two-Factor Authentication',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       error: error ?? '',
     };
   }
@@ -320,7 +321,7 @@ export class LoginController {
       pageTitle: 'Change Password',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       token: query['token'] ?? '',
       error: query['error'] ?? '',
       info: query['info'] ?? '',
@@ -430,7 +431,7 @@ export class LoginController {
       pageTitle: 'Grant Access',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       clientName: consentReq.clientName,
       scopes: scopeDescriptions,
       authReqId: newReqId,
@@ -503,7 +504,7 @@ export class LoginController {
       pageTitle: 'Create Account',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       passwordMinLength: realm.passwordMinLength || 8,
       passwordHint: hints.length ? `Must contain ${hints.join(', ')}` : '',
       username: query['username'] ?? '',
@@ -645,7 +646,7 @@ export class LoginController {
       pageTitle: 'Email Verification',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
     };
 
     if (!token) {
@@ -678,7 +679,7 @@ export class LoginController {
       pageTitle: 'Forgot Password',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
       info: query['info'] ?? '',
       error: query['error'] ?? '',
     };
@@ -735,7 +736,7 @@ export class LoginController {
       pageTitle: 'Reset Password',
       realmName: realm.name,
       realmDisplayName: realm.displayName ?? realm.name,
-      ...getThemeVars(realm),
+      ...this.themeService.resolveTheme(realm),
     };
 
     if (!token) {

--- a/src/login/login.module.ts
+++ b/src/login/login.module.ts
@@ -1,13 +1,14 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { LoginController } from './login.controller.js';
 import { LoginService } from './login.service.js';
+import { ThemeService } from './theme.service.js';
 import { OAuthModule } from '../oauth/oauth.module.js';
 import { UserFederationModule } from '../user-federation/user-federation.module.js';
 
 @Module({
   imports: [forwardRef(() => OAuthModule), UserFederationModule],
   controllers: [LoginController],
-  providers: [LoginService],
-  exports: [LoginService],
+  providers: [LoginService, ThemeService],
+  exports: [LoginService, ThemeService],
 })
 export class LoginModule {}

--- a/src/login/theme.service.ts
+++ b/src/login/theme.service.ts
@@ -1,0 +1,156 @@
+import { Injectable, type OnModuleInit, Logger } from '@nestjs/common';
+import type { Realm } from '@prisma/client';
+import { join } from 'path';
+import { readdir, readFile } from 'fs/promises';
+
+export interface ThemeColors {
+  primaryColor: string;
+  backgroundColor: string;
+  cardColor: string;
+  textColor: string;
+  labelColor: string;
+  inputBorderColor: string;
+  inputBgColor: string;
+  mutedColor: string;
+}
+
+export interface ThemeDefinition {
+  name: string;
+  displayName: string;
+  description: string;
+  colors: ThemeColors;
+  css: string[];
+}
+
+export interface ThemeInfo {
+  name: string;
+  displayName: string;
+  description: string;
+  colors: ThemeColors;
+}
+
+export interface ResolvedTheme {
+  primaryColor: string;
+  primaryHoverColor: string;
+  backgroundColor: string;
+  cardColor: string;
+  textColor: string;
+  labelColor: string;
+  inputBorderColor: string;
+  inputBgColor: string;
+  mutedColor: string;
+  logoUrl: string;
+  faviconUrl: string;
+  appTitle: string;
+  customCss: string;
+  themeCssFiles: string[];
+}
+
+function darkenHex(hex: string, percent: number): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.max(0, ((num >> 16) & 0xff) - Math.round(255 * percent / 100));
+  const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * percent / 100));
+  const b = Math.max(0, (num & 0xff) - Math.round(255 * percent / 100));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+@Injectable()
+export class ThemeService implements OnModuleInit {
+  private readonly logger = new Logger(ThemeService.name);
+  private themes = new Map<string, ThemeDefinition>();
+  private readonly themesDir = join(process.cwd(), 'themes');
+
+  private readonly defaultColors: ThemeColors = {
+    primaryColor: '#2563eb',
+    backgroundColor: '#f0f2f5',
+    cardColor: '#ffffff',
+    textColor: '#1a1a2e',
+    labelColor: '#374151',
+    inputBorderColor: '#d1d5db',
+    inputBgColor: '#ffffff',
+    mutedColor: '#6b7280',
+  };
+
+  async onModuleInit() {
+    await this.loadThemes();
+  }
+
+  private async loadThemes(): Promise<void> {
+    try {
+      const entries = await readdir(this.themesDir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+
+        const themeJsonPath = join(this.themesDir, entry.name, 'theme.json');
+        try {
+          const raw = await readFile(themeJsonPath, 'utf-8');
+          const theme = JSON.parse(raw) as ThemeDefinition;
+          this.themes.set(theme.name, theme);
+          this.logger.log(`Loaded theme: ${theme.name} (${theme.displayName})`);
+        } catch {
+          this.logger.warn(`Failed to load theme from ${themeJsonPath}`);
+        }
+      }
+
+      this.logger.log(`Loaded ${this.themes.size} theme(s)`);
+    } catch {
+      this.logger.warn(`Themes directory not found at ${this.themesDir}, using defaults`);
+    }
+  }
+
+  getAvailableThemes(): ThemeInfo[] {
+    return Array.from(this.themes.values()).map(({ name, displayName, description, colors }) => ({
+      name,
+      displayName,
+      description,
+      colors,
+    }));
+  }
+
+  getTheme(name: string): ThemeDefinition | undefined {
+    return this.themes.get(name);
+  }
+
+  resolveTheme(realm: Realm): ResolvedTheme {
+    const themeName = (realm as any).themeName ?? 'authme';
+    const baseTheme = this.themes.get(themeName);
+    const baseColors = baseTheme?.colors ?? this.defaultColors;
+
+    // Per-realm overrides from the theme JSON field
+    const realmTheme = (realm.theme ?? {}) as Record<string, unknown>;
+
+    const getString = (key: string, fallback: string): string => {
+      const realmVal = realmTheme[key];
+      if (typeof realmVal === 'string' && realmVal) return realmVal;
+      return fallback;
+    };
+
+    const primaryColor = getString('primaryColor', baseColors.primaryColor);
+
+    // Build CSS file paths for this theme
+    const themeCssFiles: string[] = [];
+    if (baseTheme?.css) {
+      for (const cssFile of baseTheme.css) {
+        themeCssFiles.push(`/themes/${themeName}/${cssFile}`);
+      }
+    }
+
+    return {
+      primaryColor,
+      primaryHoverColor: getString('primaryHoverColor', darkenHex(primaryColor, 15)),
+      backgroundColor: getString('backgroundColor', baseColors.backgroundColor),
+      cardColor: getString('cardColor', baseColors.cardColor),
+      textColor: getString('textColor', baseColors.textColor),
+      labelColor: getString('labelColor', baseColors.labelColor),
+      inputBorderColor: getString('inputBorderColor', baseColors.inputBorderColor),
+      inputBgColor: getString('inputBgColor', baseColors.inputBgColor),
+      mutedColor: getString('mutedColor', baseColors.mutedColor),
+      logoUrl: getString('logoUrl', ''),
+      faviconUrl: getString('faviconUrl', ''),
+      appTitle: getString('appTitle', 'AuthMe'),
+      customCss: getString('customCss', ''),
+      themeCssFiles,
+    };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ async function bootstrap() {
   app.setBaseViewsDir(join(__dirname, '..', 'views'));
   app.setViewEngine('hbs');
   app.useStaticAssets(join(__dirname, '..', 'public'));
+  app.useStaticAssets(join(__dirname, '..', 'themes'), { prefix: '/themes' });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -167,7 +167,12 @@ export class CreateRealmDto {
   adminEventsEnabled?: boolean;
 
   // Theming
-  @ApiPropertyOptional({ description: 'Realm theme configuration' })
+  @ApiPropertyOptional({ default: 'authme', description: 'Name of the theme preset to use' })
+  @IsOptional()
+  @IsString()
+  themeName?: string;
+
+  @ApiPropertyOptional({ description: 'Realm theme configuration (color overrides)' })
   @IsOptional()
   @IsObject()
   theme?: Record<string, unknown>;

--- a/src/realms/realms.controller.ts
+++ b/src/realms/realms.controller.ts
@@ -14,6 +14,7 @@ import { RealmsService } from './realms.service.js';
 import { RealmExportService } from './realm-export.service.js';
 import { RealmImportService } from './realm-import.service.js';
 import { EmailService } from '../email/email.service.js';
+import { ThemeService } from '../login/theme.service.js';
 import { CreateRealmDto } from './dto/create-realm.dto.js';
 import { UpdateRealmDto } from './dto/update-realm.dto.js';
 
@@ -25,6 +26,7 @@ export class RealmsController {
     private readonly exportService: RealmExportService,
     private readonly importService: RealmImportService,
     private readonly emailService: EmailService,
+    private readonly themeService: ThemeService,
   ) {}
 
   @Post()
@@ -37,6 +39,12 @@ export class RealmsController {
   @ApiOperation({ summary: 'List all realms' })
   findAll() {
     return this.realmsService.findAll();
+  }
+
+  @Get('themes')
+  @ApiOperation({ summary: 'List available themes' })
+  getThemes() {
+    return this.themeService.getAvailableThemes();
   }
 
   @Get(':realmName')

--- a/src/realms/realms.module.ts
+++ b/src/realms/realms.module.ts
@@ -3,8 +3,10 @@ import { RealmsController } from './realms.controller.js';
 import { RealmsService } from './realms.service.js';
 import { RealmExportService } from './realm-export.service.js';
 import { RealmImportService } from './realm-import.service.js';
+import { LoginModule } from '../login/login.module.js';
 
 @Module({
+  imports: [LoginModule],
   controllers: [RealmsController],
   providers: [RealmsService, RealmExportService, RealmImportService],
   exports: [RealmsService],

--- a/views/layouts/main.hbs
+++ b/views/layouts/main.hbs
@@ -8,6 +8,9 @@
   <link rel="icon" href="{{faviconUrl}}">
   {{/if}}
   <link rel="stylesheet" href="/css/auth.css">
+  {{#each themeCssFiles}}
+  <link rel="stylesheet" href="{{this}}">
+  {{/each}}
   <style>
     :root {
       --primary-color: {{primaryColor}};
@@ -15,6 +18,10 @@
       --bg-color: {{backgroundColor}};
       --card-color: {{cardColor}};
       --text-color: {{textColor}};
+      --label-color: {{labelColor}};
+      --input-border-color: {{inputBorderColor}};
+      --input-bg-color: {{inputBgColor}};
+      --muted-color: {{mutedColor}};
     }
   </style>
   {{#if customCss}}


### PR DESCRIPTION
## Summary
- Create `ThemeService` that scans `themes/` directory on startup, caches theme definitions, and resolves themes by merging base theme colors with per-realm overrides
- Add `themeName` field to Realm model with Prisma migration (default: `authme`)
- Replace all `getThemeVars()` calls with `ThemeService.resolveTheme()` in LoginController and AccountController
- Update layout template with new CSS variables (`--label-color`, `--input-border-color`, `--input-bg-color`, `--muted-color`) and theme CSS file loading
- Add `GET /admin/realms/themes` endpoint to list available themes
- Serve `themes/` as static assets at `/themes/` prefix

## Test plan
- [ ] Build succeeds (`npm run build`)
- [ ] ThemeService loads all 3 themes on startup (check logs)
- [ ] Default theme renders correctly on login page
- [ ] `GET /admin/realms/themes` returns theme list with colors
- [ ] Per-realm color overrides still work on top of base theme

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)