### PR TITLE
Add theme selector to Admin UI

### DIFF
--- a/admin-ui/src/api/realms.ts
+++ b/admin-ui/src/api/realms.ts
@@ -51,6 +51,27 @@ export async function importRealm(
   return data;
 }
 
+export interface ThemeInfo {
+  name: string;
+  displayName: string;
+  description: string;
+  colors: {
+    primaryColor: string;
+    backgroundColor: string;
+    cardColor: string;
+    textColor: string;
+    labelColor: string;
+    inputBorderColor: string;
+    inputBgColor: string;
+    mutedColor: string;
+  };
+}
+
+export async function getThemes(): Promise<ThemeInfo[]> {
+  const { data } = await apiClient.get<ThemeInfo[]>('/realms/themes');
+  return data;
+}
+
 export async function sendTestEmail(
   name: string,
   to: string,


### PR DESCRIPTION
## Summary
- Add `getThemes()` API function to fetch available themes from `GET /admin/realms/themes`
- Add theme preset selector cards in the Theme tab with color preview chips, active indicator, and description
- Selecting a theme updates realm's `themeName` and applies the theme's default colors
- Add "Reset to theme defaults" button in Colors section

## Test plan
- [ ] Admin UI builds successfully
- [ ] Theme tab shows theme preset cards (AuthMe, Dark, Forest)
- [ ] Clicking a theme card selects it and updates color pickers
- [ ] "Reset to theme defaults" button restores active theme's colors
- [ ] Saving persists the selected theme

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)