### PR TITLE
Add theme template engine with inheritance and i18n support

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -38,6 +38,7 @@ import { EventsModule } from './events/events.module.js';
 import { MetricsModule } from './metrics/metrics.module.js';
 import { UserFederationModule } from './user-federation/user-federation.module.js';
 import { SamlModule } from './saml/saml.module.js';
+import { ThemeModule } from './theme/theme.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -86,6 +87,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     MetricsModule,
     UserFederationModule,
     SamlModule,
+    ThemeModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import cookieParser from 'cookie-parser';
 import { join } from 'path';
 import { AppModule } from './app.module.js';
 import { GlobalExceptionFilter } from './common/filters/http-exception.filter.js';
+import { registerHandlebarsHelpers } from './theme/handlebars-helpers.js';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -42,6 +43,9 @@ async function bootstrap() {
   app.setViewEngine('hbs');
   app.useStaticAssets(join(__dirname, '..', 'public'));
   app.useStaticAssets(join(__dirname, '..', 'themes'), { prefix: '/themes' });
+
+  // Register theme engine Handlebars helpers ({{msg}}, {{msgArgs}})
+  registerHandlebarsHelpers();
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/theme/handlebars-helpers.ts
+++ b/src/theme/handlebars-helpers.ts
@@ -1,0 +1,27 @@
+import hbs from 'hbs';
+
+/**
+ * Registers Handlebars helpers for the theme engine i18n system.
+ * Must be called once during app bootstrap (in main.ts).
+ */
+export function registerHandlebarsHelpers(): void {
+  // {{msg "loginTitle"}} — simple message lookup
+  hbs.registerHelper('msg', function (key: string, options: any) {
+    const messages: Record<string, string> = options?.data?.root?._messages ?? {};
+    return messages[key] ?? key;
+  });
+
+  // {{msgArgs "consentRequesting" clientName}} — message with argument substitution
+  // Supports {0}, {1}, ... placeholders in the message string
+  hbs.registerHelper('msgArgs', function (key: string, ...args: any[]) {
+    const options = args.pop(); // Handlebars passes options as last arg
+    const messages: Record<string, string> = options?.data?.root?._messages ?? {};
+    let text = messages[key] ?? key;
+
+    for (let i = 0; i < args.length; i++) {
+      text = text.replace(`{${i}}`, String(args[i] ?? ''));
+    }
+
+    return text;
+  });
+}

--- a/src/theme/theme-email.service.ts
+++ b/src/theme/theme-email.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Realm } from '@prisma/client';
+import { readFileSync } from 'fs';
+import Handlebars from 'handlebars';
+import { ThemeService } from './theme.service.js';
+import { ThemeTemplateService } from './theme-template.service.js';
+import { ThemeMessageService } from './theme-message.service.js';
+
+@Injectable()
+export class ThemeEmailService {
+  private readonly logger = new Logger(ThemeEmailService.name);
+  private compiledTemplates = new Map<string, HandlebarsTemplateDelegate>();
+
+  constructor(
+    private readonly themeService: ThemeService,
+    private readonly templateService: ThemeTemplateService,
+    private readonly messageService: ThemeMessageService,
+  ) {}
+
+  /**
+   * Renders an email template with theme support.
+   *
+   * @param realm - The current realm
+   * @param templateName - Email template name (e.g., "verify-email", "reset-password")
+   * @param data - Template data (URLs, user info, etc.)
+   * @returns Rendered HTML string
+   */
+  renderEmail(realm: Realm, templateName: string, data: Record<string, any>): string {
+    const themeName = this.themeService.getRealmThemeName(realm, 'email');
+    const templatePath = this.templateService.resolve(themeName, 'email', templateName);
+    const messages = this.messageService.getMessages(themeName, 'email', 'en');
+    const colors = this.themeService.resolveColors(themeName, realm);
+
+    const compiled = this.getCompiledTemplate(templatePath);
+
+    return compiled({
+      ...data,
+      ...colors,
+      _messages: messages,
+      realmName: realm.name,
+      realmDisplayName: realm.displayName ?? realm.name,
+    });
+  }
+
+  /**
+   * Gets a message value for use as email subject.
+   */
+  getSubject(realm: Realm, messageKey: string): string {
+    const themeName = this.themeService.getRealmThemeName(realm, 'email');
+    const messages = this.messageService.getMessages(themeName, 'email', 'en');
+    return messages[messageKey] ?? messageKey;
+  }
+
+  private getCompiledTemplate(templatePath: string): HandlebarsTemplateDelegate {
+    let compiled = this.compiledTemplates.get(templatePath);
+    if (!compiled) {
+      const source = readFileSync(templatePath, 'utf-8');
+      // Create a standalone Handlebars instance with the msg helper
+      compiled = Handlebars.compile(source);
+      this.compiledTemplates.set(templatePath, compiled);
+    }
+    return compiled;
+  }
+}

--- a/src/theme/theme-message.service.ts
+++ b/src/theme/theme-message.service.ts
@@ -1,0 +1,89 @@
+import { Injectable, type OnModuleInit, Logger } from '@nestjs/common';
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { ThemeService } from './theme.service.js';
+import type { ThemeType } from './theme.types.js';
+
+@Injectable()
+export class ThemeMessageService implements OnModuleInit {
+  private readonly logger = new Logger(ThemeMessageService.name);
+  // Cache: "themeName:themeType:locale" → messages
+  private cache = new Map<string, Record<string, string>>();
+
+  constructor(private readonly themeService: ThemeService) {}
+
+  async onModuleInit() {
+    // Pre-load messages for all known themes on startup
+    const themes = this.themeService.getAvailableThemes();
+    const types: ThemeType[] = ['login', 'account', 'email'];
+    for (const theme of themes) {
+      for (const type of types) {
+        this.getMessages(theme.name, type, 'en');
+      }
+    }
+    this.logger.log(`Pre-loaded messages for ${themes.length} theme(s)`);
+  }
+
+  /**
+   * Gets merged messages for a given theme, type, and locale.
+   * Walks the inheritance chain base-first so child messages override parent.
+   */
+  getMessages(themeName: string, themeType: ThemeType, locale: string): Record<string, string> {
+    const cacheKey = `${themeName}:${themeType}:${locale}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached) return cached;
+
+    const chain = this.themeService.getInheritanceChain(themeName);
+    const themesDir = this.themeService.getThemesDir();
+    const merged: Record<string, string> = {};
+
+    // Walk chain in reverse (base first) so child overrides parent
+    for (const theme of [...chain].reverse()) {
+      const filePath = join(themesDir, theme, themeType, 'messages', `messages_${locale}.properties`);
+      if (existsSync(filePath)) {
+        const parsed = this.parseProperties(filePath);
+        Object.assign(merged, parsed);
+      }
+    }
+
+    // Fallback to English if requested locale has no messages
+    if (locale !== 'en' && Object.keys(merged).length === 0) {
+      const fallback = this.getMessages(themeName, themeType, 'en');
+      this.cache.set(cacheKey, fallback);
+      return fallback;
+    }
+
+    this.cache.set(cacheKey, merged);
+    return merged;
+  }
+
+  /**
+   * Parses a Java-style .properties file into a key-value map.
+   */
+  private parseProperties(filePath: string): Record<string, string> {
+    const content = readFileSync(filePath, 'utf-8');
+    const result: Record<string, string> = {};
+
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      // Skip empty lines and comments
+      if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('!')) continue;
+
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex > 0) {
+        const key = trimmed.substring(0, eqIndex).trim();
+        const value = trimmed.substring(eqIndex + 1).trim();
+        result[key] = value;
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Clears the message cache (useful for hot-reload in dev).
+   */
+  clearCache(): void {
+    this.cache.clear();
+  }
+}

--- a/src/theme/theme-render.service.ts
+++ b/src/theme/theme-render.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import type { Response } from 'express';
+import type { Realm } from '@prisma/client';
+import { ThemeService } from './theme.service.js';
+import { ThemeTemplateService } from './theme-template.service.js';
+import { ThemeMessageService } from './theme-message.service.js';
+import type { ThemeType } from './theme.types.js';
+
+@Injectable()
+export class ThemeRenderService {
+  constructor(
+    private readonly themeService: ThemeService,
+    private readonly templateService: ThemeTemplateService,
+    private readonly messageService: ThemeMessageService,
+  ) {}
+
+  /**
+   * Renders a themed page. Replaces @Render() decorator and direct res.render() calls.
+   *
+   * @param res - Express response object
+   * @param realm - The current realm
+   * @param themeType - Theme type: 'login', 'account', or 'email'
+   * @param templateName - Template name without extension (e.g., "login", "account")
+   * @param data - Page-specific template data (form fields, errors, etc.)
+   */
+  render(
+    res: Response,
+    realm: Realm,
+    themeType: ThemeType,
+    templateName: string,
+    data: Record<string, any>,
+  ): void {
+    const themeName = this.themeService.getRealmThemeName(realm, themeType);
+    const templatePath = this.templateService.resolve(themeName, themeType, templateName);
+    const layoutPath = this.templateService.resolve(themeName, themeType, 'layouts/main');
+    const colors = this.themeService.resolveColors(themeName, realm);
+    const messages = this.messageService.getMessages(themeName, themeType, 'en');
+    const cssFiles = this.themeService.resolveCss(themeName, themeType);
+
+    res.render(templatePath, {
+      layout: layoutPath,
+      ...data,
+      ...colors,
+      _messages: messages,
+      themeCssFiles: cssFiles,
+      realmName: data.realmName ?? realm.name,
+      realmDisplayName: data.realmDisplayName ?? realm.displayName ?? realm.name,
+    });
+  }
+}

--- a/src/theme/theme-template.service.ts
+++ b/src/theme/theme-template.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { ThemeService } from './theme.service.js';
+import type { ThemeType } from './theme.types.js';
+
+@Injectable()
+export class ThemeTemplateService {
+  private readonly logger = new Logger(ThemeTemplateService.name);
+
+  constructor(private readonly themeService: ThemeService) {}
+
+  /**
+   * Resolves the absolute path to a template file by walking the theme
+   * inheritance chain. Returns the first matching file found.
+   *
+   * @param themeName - The theme to start resolution from (e.g., "dark")
+   * @param themeType - The theme type (login, account, email)
+   * @param templateName - The template name without extension (e.g., "login", "layouts/main")
+   * @returns Absolute path to the .hbs file
+   * @throws Error if template not found in any theme in the chain
+   */
+  resolve(themeName: string, themeType: ThemeType, templateName: string): string {
+    const chain = this.themeService.getInheritanceChain(themeName);
+    const themesDir = this.themeService.getThemesDir();
+
+    for (const theme of chain) {
+      const candidatePath = join(themesDir, theme, themeType, 'templates', templateName + '.hbs');
+      if (existsSync(candidatePath)) {
+        return candidatePath;
+      }
+    }
+
+    throw new Error(
+      `Template not found: ${templateName} for theme ${themeName}/${themeType}. ` +
+      `Searched chain: [${chain.join(' → ')}]`,
+    );
+  }
+
+  /**
+   * Checks whether a template exists in the inheritance chain.
+   */
+  exists(themeName: string, themeType: ThemeType, templateName: string): boolean {
+    try {
+      this.resolve(themeName, themeType, templateName);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/theme/theme.module.ts
+++ b/src/theme/theme.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { ThemeService } from './theme.service.js';
+import { ThemeTemplateService } from './theme-template.service.js';
+import { ThemeMessageService } from './theme-message.service.js';
+import { ThemeRenderService } from './theme-render.service.js';
+import { ThemeEmailService } from './theme-email.service.js';
+
+@Module({
+  providers: [
+    ThemeService,
+    ThemeTemplateService,
+    ThemeMessageService,
+    ThemeRenderService,
+    ThemeEmailService,
+  ],
+  exports: [
+    ThemeService,
+    ThemeTemplateService,
+    ThemeMessageService,
+    ThemeRenderService,
+    ThemeEmailService,
+  ],
+})
+export class ThemeModule {}

--- a/src/theme/theme.service.ts
+++ b/src/theme/theme.service.ts
@@ -1,0 +1,193 @@
+import { Injectable, type OnModuleInit, Logger } from '@nestjs/common';
+import type { Realm } from '@prisma/client';
+import { join } from 'path';
+import { readdir, readFile } from 'fs/promises';
+import type {
+  ThemeColors,
+  ThemeDefinition,
+  ThemeInfo,
+  ThemeType,
+  ResolvedTheme,
+} from './theme.types.js';
+
+function darkenHex(hex: string, percent: number): string {
+  const num = parseInt(hex.replace('#', ''), 16);
+  const r = Math.max(0, ((num >> 16) & 0xff) - Math.round(255 * percent / 100));
+  const g = Math.max(0, ((num >> 8) & 0xff) - Math.round(255 * percent / 100));
+  const b = Math.max(0, (num & 0xff) - Math.round(255 * percent / 100));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')}`;
+}
+
+@Injectable()
+export class ThemeService implements OnModuleInit {
+  private readonly logger = new Logger(ThemeService.name);
+  private themes = new Map<string, ThemeDefinition>();
+  private readonly themesDir = join(process.cwd(), 'themes');
+
+  private readonly defaultColors: ThemeColors = {
+    primaryColor: '#2563eb',
+    backgroundColor: '#f0f2f5',
+    cardColor: '#ffffff',
+    textColor: '#1a1a2e',
+    labelColor: '#374151',
+    inputBorderColor: '#d1d5db',
+    inputBgColor: '#ffffff',
+    mutedColor: '#6b7280',
+  };
+
+  async onModuleInit() {
+    await this.loadThemes();
+  }
+
+  getThemesDir(): string {
+    return this.themesDir;
+  }
+
+  private async loadThemes(): Promise<void> {
+    try {
+      const entries = await readdir(this.themesDir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+
+        const themeJsonPath = join(this.themesDir, entry.name, 'theme.json');
+        try {
+          const raw = await readFile(themeJsonPath, 'utf-8');
+          const theme = JSON.parse(raw) as ThemeDefinition;
+          // Normalize: ensure parent and types exist
+          if (!('parent' in theme)) {
+            (theme as any).parent = null;
+          }
+          if (!theme.types) {
+            theme.types = {};
+          }
+          this.themes.set(theme.name, theme);
+          this.logger.log(`Loaded theme: ${theme.name} (${theme.displayName})`);
+        } catch {
+          this.logger.warn(`Failed to load theme from ${themeJsonPath}`);
+        }
+      }
+
+      this.logger.log(`Loaded ${this.themes.size} theme(s)`);
+    } catch {
+      this.logger.warn(`Themes directory not found at ${this.themesDir}, using defaults`);
+    }
+  }
+
+  getTheme(name: string): ThemeDefinition | undefined {
+    return this.themes.get(name);
+  }
+
+  getAvailableThemes(): ThemeInfo[] {
+    return Array.from(this.themes.values()).map(({ name, displayName, description, colors }) => ({
+      name,
+      displayName,
+      description,
+      colors,
+    }));
+  }
+
+  /**
+   * Returns the theme inheritance chain from child to root.
+   * E.g., for "dark" with parent "authme": ["dark", "authme"]
+   */
+  getInheritanceChain(themeName: string): string[] {
+    const chain: string[] = [];
+    const visited = new Set<string>();
+    let current: string | null = themeName;
+
+    while (current && !visited.has(current)) {
+      visited.add(current);
+      chain.push(current);
+      const theme = this.themes.get(current);
+      current = theme?.parent ?? null;
+    }
+
+    return chain;
+  }
+
+  /**
+   * Resolves CSS file URLs for a given theme and type.
+   * Walks the inheritance chain base-to-child so base CSS loads first.
+   */
+  resolveCss(themeName: string, themeType: ThemeType): string[] {
+    const chain = this.getInheritanceChain(themeName);
+    const cssFiles: string[] = [];
+
+    // Walk base-to-child so base CSS loads first, child overrides last
+    for (const theme of [...chain].reverse()) {
+      const typeConfig = this.themes.get(theme)?.types?.[themeType];
+      if (typeConfig?.css) {
+        for (const cssFile of typeConfig.css) {
+          cssFiles.push(`/themes/${theme}/${themeType}/resources/${cssFile}`);
+        }
+      }
+    }
+
+    return cssFiles;
+  }
+
+  /**
+   * Resolves colors for a given theme with per-realm overrides.
+   */
+  resolveColors(themeName: string, realm: Realm): ResolvedTheme {
+    const baseTheme = this.themes.get(themeName);
+    const baseColors = baseTheme?.colors ?? this.defaultColors;
+
+    // Per-realm overrides from the theme JSON field
+    const realmTheme = (realm.theme ?? {}) as Record<string, unknown>;
+
+    const getString = (key: string, fallback: string): string => {
+      const realmVal = realmTheme[key];
+      if (typeof realmVal === 'string' && realmVal) return realmVal;
+      return fallback;
+    };
+
+    const primaryColor = getString('primaryColor', baseColors.primaryColor);
+
+    return {
+      primaryColor,
+      primaryHoverColor: getString('primaryHoverColor', darkenHex(primaryColor, 15)),
+      backgroundColor: getString('backgroundColor', baseColors.backgroundColor),
+      cardColor: getString('cardColor', baseColors.cardColor),
+      textColor: getString('textColor', baseColors.textColor),
+      labelColor: getString('labelColor', baseColors.labelColor),
+      inputBorderColor: getString('inputBorderColor', baseColors.inputBorderColor),
+      inputBgColor: getString('inputBgColor', baseColors.inputBgColor),
+      mutedColor: getString('mutedColor', baseColors.mutedColor),
+      logoUrl: getString('logoUrl', ''),
+      faviconUrl: getString('faviconUrl', ''),
+      appTitle: getString('appTitle', 'AuthMe'),
+      customCss: getString('customCss', ''),
+      themeCssFiles: [], // Will be set by ThemeRenderService
+    };
+  }
+
+  /**
+   * Backward-compatible method: resolves theme using the realm's themeName field.
+   * Used during migration before per-type fields are added.
+   */
+  resolveTheme(realm: Realm): ResolvedTheme {
+    const themeName = (realm as any).loginTheme ?? (realm as any).themeName ?? 'authme';
+    const resolved = this.resolveColors(themeName, realm);
+    resolved.themeCssFiles = this.resolveCss(themeName, 'login');
+    return resolved;
+  }
+
+  /**
+   * Get the realm's theme name for a given type.
+   */
+  getRealmThemeName(realm: Realm, themeType: ThemeType): string {
+    const r = realm as any;
+    switch (themeType) {
+      case 'login':
+        return r.loginTheme ?? r.themeName ?? 'authme';
+      case 'account':
+        return r.accountTheme ?? r.themeName ?? 'authme';
+      case 'email':
+        return r.emailTheme ?? r.themeName ?? 'authme';
+      default:
+        return r.themeName ?? 'authme';
+    }
+  }
+}

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -1,0 +1,49 @@
+export type ThemeType = 'login' | 'account' | 'email';
+
+export interface ThemeColors {
+  primaryColor: string;
+  backgroundColor: string;
+  cardColor: string;
+  textColor: string;
+  labelColor: string;
+  inputBorderColor: string;
+  inputBgColor: string;
+  mutedColor: string;
+}
+
+export interface ThemeTypeConfig {
+  css: string[];
+}
+
+export interface ThemeDefinition {
+  name: string;
+  displayName: string;
+  description: string;
+  parent: string | null;
+  colors: ThemeColors;
+  types: Partial<Record<ThemeType, ThemeTypeConfig>>;
+}
+
+export interface ThemeInfo {
+  name: string;
+  displayName: string;
+  description: string;
+  colors: ThemeColors;
+}
+
+export interface ResolvedTheme {
+  primaryColor: string;
+  primaryHoverColor: string;
+  backgroundColor: string;
+  cardColor: string;
+  textColor: string;
+  labelColor: string;
+  inputBorderColor: string;
+  inputBgColor: string;
+  mutedColor: string;
+  logoUrl: string;
+  faviconUrl: string;
+  appTitle: string;
+  customCss: string;
+  themeCssFiles: string[];
+}

--- a/src/types/hbs.d.ts
+++ b/src/types/hbs.d.ts
@@ -1,0 +1,5 @@
+declare module 'hbs' {
+  function registerHelper(name: string, fn: (...args: any[]) => any): void;
+  function registerPartial(name: string, partial: string): void;
+  export default { registerHelper, registerPartial };
+}


### PR DESCRIPTION
## Summary
- Create `src/theme/` module with core theme engine infrastructure
- **ThemeService**: Loads theme definitions, computes inheritance chains (child → parent → base), resolves colors with per-realm overrides
- **ThemeTemplateService**: Resolves template file paths through the inheritance chain
- **ThemeMessageService**: Loads and merges i18n `.properties` files with locale fallback
- **ThemeRenderService**: Controller-facing helper that assembles all theme data and calls `res.render()` with absolute paths
- **ThemeEmailService**: Renders email templates via standalone Handlebars compilation
- **Handlebars helpers**: `{{msg "key"}}` and `{{msgArgs "key" arg}}` for i18n in templates
- Register helpers in `main.ts`, add `ThemeModule` to `AppModule`

## Test plan
- [ ] `npm run build` succeeds
- [ ] TypeScript compilation clean (`npx tsc --noEmit`)
- [ ] Theme services are injectable and resolve correctly when wired to controllers (Phase 3)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)