### PR TITLE
Restructure themes/ with templates, resources, and i18n messages

### DIFF
--- a/themes/authme/account/messages/messages_en.properties
+++ b/themes/authme/account/messages/messages_en.properties
@@ -1,0 +1,33 @@
+# Account page
+accountTitle=My Account
+accountVerified=Verified
+accountUnverified=Unverified
+accountProfile=Profile
+accountFirstName=First Name
+accountLastName=Last Name
+accountUpdateProfile=Update Profile
+accountChangePassword=Change Password
+accountCurrentPassword=Current Password
+accountNewPassword=New Password
+accountConfirmNewPassword=Confirm New Password
+accountChangePasswordSubmit=Change Password
+accountTwoFactor=Two-Factor Authentication
+accountMfaEnabled=Enabled
+accountMfaEnabledDesc=Your account is protected with TOTP.
+accountMfaDisableConfirm=Are you sure you want to disable two-factor authentication?
+accountMfaDisable=Disable Two-Factor Authentication
+accountMfaNotEnabled=Not enabled
+accountMfaNotEnabledDesc=Add an extra layer of security to your account.
+accountMfaSetup=Set Up Two-Factor Authentication
+
+# TOTP Setup (shared with login)
+totpSetupTitle=Set Up Two-Factor Authentication
+totpSetupSaveRecovery=Save your recovery codes!
+totpSetupRecoveryHelp=These codes can be used to access your account if you lose your authenticator. Each code can only be used once.
+totpSetupDone=Done
+totpSetupScanQr=Scan the QR code with your authenticator app (Google Authenticator, Authy, etc.)
+totpSetupQrAlt=TOTP QR Code
+totpSetupManualEntry=Or enter this code manually:
+totpSetupVerifyLabel=Enter the 6-digit code to verify
+totpSetupVerifyActivate=Verify & Activate
+totpSetupCancel=Cancel

--- a/themes/authme/account/resources/css/auth.css
+++ b/themes/authme/account/resources/css/auth.css
@@ -1,0 +1,247 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background: var(--bg-color, #f0f2f5);
+  color: var(--text-color, #1a1a2e);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.auth-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.auth-card {
+  background: var(--card-color, #fff);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.auth-logo {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-color, #1a1a2e);
+  letter-spacing: -0.5px;
+}
+
+.auth-logo-img {
+  max-height: 48px;
+  max-width: 200px;
+  object-fit: contain;
+}
+
+.auth-realm {
+  color: var(--muted-color, #6b7280);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.auth-subtitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-group label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--label-color, #374151);
+}
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group input[type="email"] {
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--input-border-color, #d1d5db);
+  border-radius: 6px;
+  font-size: 0.9375rem;
+  background: var(--input-bg-color, #ffffff);
+  color: var(--text-color, #1a1a2e);
+  transition: border-color 0.15s;
+  outline: none;
+}
+
+.form-group input:focus {
+  border-color: var(--primary-color, #2563eb);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-checkbox label {
+  font-size: 0.8125rem;
+  color: var(--muted-color, #6b7280);
+}
+
+.btn-primary {
+  background: var(--primary-color, #2563eb);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover-color, #1d4ed8);
+}
+
+.btn-secondary {
+  background: var(--card-color, #fff);
+  color: var(--label-color, #374151);
+  border: 1px solid var(--input-border-color, #d1d5db);
+  border-radius: 6px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+  transition: background 0.15s;
+}
+
+.btn-secondary:hover {
+  background: #f9fafb;
+}
+
+.auth-success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.auth-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.auth-error-page {
+  text-align: center;
+}
+
+.auth-error-page h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.auth-error-page p {
+  color: var(--muted-color, #6b7280);
+  margin-bottom: 1.5rem;
+}
+
+.consent-description {
+  color: var(--muted-color, #6b7280);
+  font-size: 0.875rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.consent-scopes {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1.5rem;
+}
+
+.consent-scopes li {
+  padding: 0.5rem 0.75rem;
+  background: #f9fafb;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  margin-bottom: 0.375rem;
+}
+
+.consent-scopes li::before {
+  content: "\2713 ";
+  color: var(--primary-color, #2563eb);
+  font-weight: 700;
+}
+
+.consent-buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.consent-buttons button {
+  flex: 1;
+}
+
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 2.5rem;
+  width: 100%;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.625rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.125rem;
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.password-toggle:hover {
+  color: #4b5563;
+}
+
+.password-toggle svg {
+  width: 1rem;
+  height: 1rem;
+}

--- a/themes/authme/account/templates/account.hbs
+++ b/themes/authme/account/templates/account.hbs
@@ -1,0 +1,91 @@
+{{#if success}}
+<div class="auth-success">{{success}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<h2 class="auth-subtitle">{{msg "accountTitle"}}</h2>
+
+<div style="margin-bottom: 1.5rem; text-align: center;">
+  <span style="font-weight: 600; color: #1a1a2e;">{{username}}</span>
+  {{#if email}}
+  <span style="color: #6b7280; font-size: 0.85rem;"> &middot; {{email}}</span>
+  {{#if emailVerified}}
+  <span style="color: #166534; font-size: 0.75rem; background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 4px; padding: 0.1rem 0.4rem; margin-left: 0.25rem;">{{msg "accountVerified"}}</span>
+  {{else}}
+  <span style="color: #92400e; font-size: 0.75rem; background: #fffbeb; border: 1px solid #fde68a; border-radius: 4px; padding: 0.1rem 0.4rem; margin-left: 0.25rem;">{{msg "accountUnverified"}}</span>
+  {{/if}}
+  {{/if}}
+</div>
+
+<div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 0.5rem;">
+  <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">{{msg "accountProfile"}}</h3>
+  <form method="POST" action="/realms/{{realmName}}/account/profile" class="auth-form">
+    <div class="form-group">
+      <label for="firstName">{{msg "accountFirstName"}}</label>
+      <input type="text" id="firstName" name="firstName" value="{{firstName}}" autocomplete="given-name">
+    </div>
+
+    <div class="form-group">
+      <label for="lastName">{{msg "accountLastName"}}</label>
+      <input type="text" id="lastName" name="lastName" value="{{lastName}}" autocomplete="family-name">
+    </div>
+
+    <button type="submit" class="btn-primary">{{msg "accountUpdateProfile"}}</button>
+  </form>
+</div>
+
+<div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 1.5rem;">
+  <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">{{msg "accountChangePassword"}}</h3>
+  <form method="POST" action="/realms/{{realmName}}/account/password" class="auth-form">
+    <div class="form-group">
+      <label for="currentPassword">{{msg "accountCurrentPassword"}}</label>
+      <input type="password" id="currentPassword" name="currentPassword" required autocomplete="current-password">
+    </div>
+
+    <div class="form-group">
+      <label for="newPassword">{{msg "accountNewPassword"}}</label>
+      <input type="password" id="newPassword" name="newPassword" required minlength="8" autocomplete="new-password">
+    </div>
+
+    <div class="form-group">
+      <label for="confirmPassword">{{msg "accountConfirmNewPassword"}}</label>
+      <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" autocomplete="new-password">
+    </div>
+
+    <button type="submit" class="btn-primary">{{msg "accountChangePasswordSubmit"}}</button>
+  </form>
+</div>
+
+<div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 1.5rem;">
+  <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">{{msg "accountTwoFactor"}}</h3>
+
+  {{#if mfaEnabled}}
+  <div style="background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 6px; padding: 0.75rem; margin-bottom: 1rem;">
+    <span style="color: #166534; font-weight: 500;">{{msg "accountMfaEnabled"}}</span>
+    <span style="color: #6b7280; font-size: 0.85rem;"> &mdash; {{msg "accountMfaEnabledDesc"}}</span>
+  </div>
+
+  <form method="POST" action="/realms/{{realmName}}/account/totp-disable" class="auth-form">
+    <div class="form-group">
+      <label for="disablePassword">{{msg "accountCurrentPassword"}}</label>
+      <input type="password" id="disablePassword" name="currentPassword" required autocomplete="current-password">
+    </div>
+    <button type="submit" class="btn-primary" style="background: #dc2626;"
+      onclick="return confirm('{{msg "accountMfaDisableConfirm"}}')">
+      {{msg "accountMfaDisable"}}
+    </button>
+  </form>
+  {{else}}
+  <div style="background: #fffbeb; border: 1px solid #fde68a; border-radius: 6px; padding: 0.75rem; margin-bottom: 1rem;">
+    <span style="color: #92400e; font-weight: 500;">{{msg "accountMfaNotEnabled"}}</span>
+    <span style="color: #6b7280; font-size: 0.85rem;"> &mdash; {{msg "accountMfaNotEnabledDesc"}}</span>
+  </div>
+
+  <a href="/realms/{{realmName}}/account/totp-setup" class="btn-primary" style="display: inline-block; text-align: center; text-decoration: none;">
+    {{msg "accountMfaSetup"}}
+  </a>
+  {{/if}}
+</div>

--- a/themes/authme/account/templates/layouts/main.hbs
+++ b/themes/authme/account/templates/layouts/main.hbs
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{pageTitle}} — {{appTitle}}</title>
+  {{#if faviconUrl}}
+  <link rel="icon" href="{{faviconUrl}}">
+  {{/if}}
+  {{#each themeCssFiles}}
+  <link rel="stylesheet" href="{{this}}">
+  {{/each}}
+  <style>
+    :root {
+      --primary-color: {{primaryColor}};
+      --primary-hover-color: {{primaryHoverColor}};
+      --bg-color: {{backgroundColor}};
+      --card-color: {{cardColor}};
+      --text-color: {{textColor}};
+      --label-color: {{labelColor}};
+      --input-border-color: {{inputBorderColor}};
+      --input-bg-color: {{inputBgColor}};
+      --muted-color: {{mutedColor}};
+    }
+  </style>
+  {{#if customCss}}
+  <style>{{{customCss}}}</style>
+  {{/if}}
+</head>
+<body>
+  <div class="auth-container">
+    <div class="auth-card">
+      <div class="auth-header">
+        {{#if logoUrl}}
+        <img src="{{logoUrl}}" alt="{{appTitle}}" class="auth-logo-img">
+        {{else}}
+        <h1 class="auth-logo">{{appTitle}}</h1>
+        {{/if}}
+        {{#if realmDisplayName}}
+        <p class="auth-realm">{{realmDisplayName}}</p>
+        {{/if}}
+      </div>
+      {{{body}}}
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('input[type="password"]').forEach(function(input) {
+      var wrapper = document.createElement('div');
+      wrapper.className = 'password-wrapper';
+      input.parentNode.insertBefore(wrapper, input);
+      wrapper.appendChild(input);
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'password-toggle';
+      btn.setAttribute('tabindex', '-1');
+      btn.setAttribute('aria-label', '{{msg "showPassword"}}');
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>';
+      wrapper.appendChild(btn);
+
+      btn.addEventListener('click', function() {
+        var isPassword = input.type === 'password';
+        input.type = isPassword ? 'text' : 'password';
+        btn.setAttribute('aria-label', isPassword ? '{{msg "hidePassword"}}' : '{{msg "showPassword"}}');
+        btn.innerHTML = isPassword
+          ? '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18"/></svg>'
+          : '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/themes/authme/account/templates/totp-setup.hbs
+++ b/themes/authme/account/templates/totp-setup.hbs
@@ -1,0 +1,51 @@
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+{{#if success}}
+<div class="auth-success">{{success}}</div>
+{{/if}}
+
+<h2 class="auth-subtitle">{{msg "totpSetupTitle"}}</h2>
+
+{{#if recoveryCodes}}
+<div style="background: #fffbeb; border: 1px solid #fde68a; border-radius: 8px; padding: 1rem; margin-bottom: 1rem;">
+  <p style="font-weight: 600; color: #92400e; margin-bottom: 0.5rem;">{{msg "totpSetupSaveRecovery"}}</p>
+  <p style="font-size: 0.8rem; color: #92400e; margin-bottom: 0.75rem;">
+    {{msg "totpSetupRecoveryHelp"}}
+  </p>
+  <div style="background: white; border-radius: 4px; padding: 0.75rem; font-family: monospace; font-size: 0.9rem; column-count: 2; column-gap: 1rem;">
+    {{#each recoveryCodes}}
+    <div style="margin-bottom: 0.25rem;">{{this}}</div>
+    {{/each}}
+  </div>
+</div>
+<a href="/realms/{{realmName}}/account" class="btn-primary" style="display: block; text-align: center; text-decoration: none;">{{msg "totpSetupDone"}}</a>
+{{else}}
+<p style="color: #6b7280; font-size: 0.85rem; margin-bottom: 1rem; text-align: center;">
+  {{msg "totpSetupScanQr"}}
+</p>
+
+<div style="text-align: center; margin-bottom: 1rem;">
+  <img src="{{qrCodeDataUrl}}" alt="{{msg "totpSetupQrAlt"}}" style="width: 200px; height: 200px;">
+</div>
+
+<div style="background: #f3f4f6; border-radius: 6px; padding: 0.75rem; margin-bottom: 1.25rem; text-align: center;">
+  <p style="font-size: 0.75rem; color: #6b7280; margin-bottom: 0.25rem;">{{msg "totpSetupManualEntry"}}</p>
+  <code style="font-size: 0.9rem; font-weight: 600; letter-spacing: 0.1rem;">{{secret}}</code>
+</div>
+
+<form method="POST" action="/realms/{{realmName}}/account/totp-verify" class="auth-form">
+  <div class="form-group">
+    <label for="code">{{msg "totpSetupVerifyLabel"}}</label>
+    <input type="text" id="code" name="code" pattern="[0-9]{6}" maxlength="6" inputmode="numeric" required autofocus
+      style="text-align: center; font-size: 1.5rem; letter-spacing: 0.5rem;">
+  </div>
+
+  <button type="submit" class="btn-primary">{{msg "totpSetupVerifyActivate"}}</button>
+</form>
+
+<div style="margin-top: 1rem; text-align: center;">
+  <a href="/realms/{{realmName}}/account" style="color: #6b7280; font-size: 0.85rem;">{{msg "totpSetupCancel"}}</a>
+</div>
+{{/if}}

--- a/themes/authme/email/messages/messages_en.properties
+++ b/themes/authme/email/messages/messages_en.properties
@@ -1,0 +1,20 @@
+# Email subjects
+verifyEmailSubject=Verify Your Email \u2014 AuthMe
+resetPasswordSubject=Reset Your Password \u2014 AuthMe
+testEmailSubject=AuthMe Test Email
+
+# Verify email
+verifyEmailTitle=Verify Your Email
+verifyEmailBody=Click the link below to verify your email address. This link expires in 24 hours.
+verifyEmailButton=Verify Email
+verifyEmailFooter=If you didn't create an account, you can safely ignore this email.
+
+# Reset password
+resetPasswordTitle=Reset Your Password
+resetPasswordBody=Click the link below to reset your password. This link expires in 1 hour.
+resetPasswordButton=Reset Password
+resetPasswordFooter=If you didn't request this, you can safely ignore this email.
+
+# Test email
+testEmailTitle=AuthMe Test Email
+testEmailBody=If you received this email, your SMTP configuration is working correctly.

--- a/themes/authme/email/templates/reset-password.hbs
+++ b/themes/authme/email/templates/reset-password.hbs
@@ -1,0 +1,8 @@
+<h2>{{msg "resetPasswordTitle"}}</h2>
+<p>{{msg "resetPasswordBody"}}</p>
+<p>
+  <a href="{{resetUrl}}" style="display:inline-block;padding:10px 20px;background:{{primaryColor}};color:#fff;text-decoration:none;border-radius:6px;">
+    {{msg "resetPasswordButton"}}
+  </a>
+</p>
+<p style="color:#6b7280;font-size:0.875rem;">{{msg "resetPasswordFooter"}}</p>

--- a/themes/authme/email/templates/test-email.hbs
+++ b/themes/authme/email/templates/test-email.hbs
@@ -1,0 +1,2 @@
+<h2>{{msg "testEmailTitle"}}</h2>
+<p>{{msg "testEmailBody"}}</p>

--- a/themes/authme/email/templates/verify-email.hbs
+++ b/themes/authme/email/templates/verify-email.hbs
@@ -1,0 +1,8 @@
+<h2>{{msg "verifyEmailTitle"}}</h2>
+<p>{{msg "verifyEmailBody"}}</p>
+<p>
+  <a href="{{verifyUrl}}" style="display:inline-block;padding:10px 20px;background:{{primaryColor}};color:#fff;text-decoration:none;border-radius:6px;">
+    {{msg "verifyEmailButton"}}
+  </a>
+</p>
+<p style="color:#6b7280;font-size:0.875rem;">{{msg "verifyEmailFooter"}}</p>

--- a/themes/authme/login/messages/messages_en.properties
+++ b/themes/authme/login/messages/messages_en.properties
@@ -1,0 +1,90 @@
+# Login page
+loginUsername=Username
+loginPassword=Password
+loginRememberMe=Remember me
+loginForgotPassword=Forgot password?
+loginSignIn=Sign In
+loginNoAccount=Don't have an account? Register
+
+# Register page
+registerUsername=Username
+registerEmail=Email
+registerFirstName=First Name
+registerLastName=Last Name
+registerPassword=Password
+registerConfirmPassword=Confirm Password
+registerCreateAccount=Create Account
+registerSignInPrompt=Already have an account? Sign in
+
+# Consent page
+consentRequestingAccess={0} is requesting access
+consentWouldLikeTo=This application would like to:
+consentAllow=Allow
+consentDeny=Deny
+
+# TOTP page
+totpTitle=Two-Factor Authentication
+totpInstruction=Enter the 6-digit code from your authenticator app.
+totpAuthCode=Authentication Code
+totpVerify=Verify
+totpUseRecovery=Use a recovery code instead
+totpRecoveryCode=Recovery Code
+totpVerifyRecovery=Verify Recovery Code
+totpUseAuthenticator=Use authenticator code instead
+
+# TOTP Setup page
+totpSetupTitle=Set Up Two-Factor Authentication
+totpSetupSaveRecovery=Save your recovery codes!
+totpSetupRecoveryHelp=These codes can be used to access your account if you lose your authenticator. Each code can only be used once.
+totpSetupDone=Done
+totpSetupScanQr=Scan the QR code with your authenticator app (Google Authenticator, Authy, etc.)
+totpSetupQrAlt=TOTP QR Code
+totpSetupManualEntry=Or enter this code manually:
+totpSetupVerifyLabel=Enter the 6-digit code to verify
+totpSetupVerifyActivate=Verify & Activate
+totpSetupCancel=Cancel
+
+# Change Password page
+changePasswordTitle=Change Password
+changePasswordExpired=Your password has expired and must be changed before you can continue.
+changePasswordCurrent=Current Password
+changePasswordNew=New Password
+changePasswordConfirm=Confirm New Password
+changePasswordRequirements=Password requirements:
+changePasswordSubmit=Change Password
+
+# Forgot Password page
+forgotPasswordInstruction=Enter your email address and we'll send you a link to reset your password.
+forgotPasswordEmail=Email Address
+forgotPasswordSubmit=Send Reset Link
+forgotPasswordBackToSignIn=Back to Sign In
+
+# Reset Password page
+resetPasswordInstruction=Enter your new password below.
+resetPasswordNew=New Password
+resetPasswordConfirm=Confirm Password
+resetPasswordSubmit=Reset Password
+resetPasswordBackToSignIn=Back to Sign In
+
+# Verify Email page
+verifyEmailSuccess=Your email has been verified successfully!
+verifyEmailSignIn=Sign In
+verifyEmailInvalid=This verification link is invalid or has expired.
+verifyEmailBackToSignIn=Back to Sign In
+
+# Error page
+errorGoBack=Go Back
+
+# Device Authorization page
+deviceTitle=Device Authorization
+deviceInstruction=Enter the code displayed on your device to authorize it.
+deviceCode=Device Code
+deviceCodePlaceholder=ABCD-EFGH
+deviceUsername=Username
+devicePassword=Password
+deviceAuthorize=Authorize Device
+deviceDeny=Deny
+
+# Layout
+showPassword=Show password
+hidePassword=Hide password

--- a/themes/authme/login/resources/css/auth.css
+++ b/themes/authme/login/resources/css/auth.css
@@ -1,0 +1,247 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  background: var(--bg-color, #f0f2f5);
+  color: var(--text-color, #1a1a2e);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.auth-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1rem;
+}
+
+.auth-card {
+  background: var(--card-color, #fff);
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.auth-logo {
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--text-color, #1a1a2e);
+  letter-spacing: -0.5px;
+}
+
+.auth-logo-img {
+  max-height: 48px;
+  max-width: 200px;
+  object-fit: contain;
+}
+
+.auth-realm {
+  color: var(--muted-color, #6b7280);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.auth-subtitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.form-group label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--label-color, #374151);
+}
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group input[type="email"] {
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--input-border-color, #d1d5db);
+  border-radius: 6px;
+  font-size: 0.9375rem;
+  background: var(--input-bg-color, #ffffff);
+  color: var(--text-color, #1a1a2e);
+  transition: border-color 0.15s;
+  outline: none;
+}
+
+.form-group input:focus {
+  border-color: var(--primary-color, #2563eb);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-checkbox label {
+  font-size: 0.8125rem;
+  color: var(--muted-color, #6b7280);
+}
+
+.btn-primary {
+  background: var(--primary-color, #2563eb);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover-color, #1d4ed8);
+}
+
+.btn-secondary {
+  background: var(--card-color, #fff);
+  color: var(--label-color, #374151);
+  border: 1px solid var(--input-border-color, #d1d5db);
+  border-radius: 6px;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  text-align: center;
+  transition: background 0.15s;
+}
+
+.btn-secondary:hover {
+  background: #f9fafb;
+}
+
+.auth-success {
+  background: #f0fdf4;
+  color: #166534;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.auth-error {
+  background: #fef2f2;
+  color: #991b1b;
+  border: 1px solid #fecaca;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.auth-error-page {
+  text-align: center;
+}
+
+.auth-error-page h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.auth-error-page p {
+  color: var(--muted-color, #6b7280);
+  margin-bottom: 1.5rem;
+}
+
+.consent-description {
+  color: var(--muted-color, #6b7280);
+  font-size: 0.875rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.consent-scopes {
+  list-style: none;
+  padding: 0;
+  margin-bottom: 1.5rem;
+}
+
+.consent-scopes li {
+  padding: 0.5rem 0.75rem;
+  background: #f9fafb;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  margin-bottom: 0.375rem;
+}
+
+.consent-scopes li::before {
+  content: "\2713 ";
+  color: var(--primary-color, #2563eb);
+  font-weight: 700;
+}
+
+.consent-buttons {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.consent-buttons button {
+  flex: 1;
+}
+
+.password-wrapper {
+  position: relative;
+}
+
+.password-wrapper input {
+  padding-right: 2.5rem;
+  width: 100%;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 0.625rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.125rem;
+  color: #9ca3af;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.password-toggle:hover {
+  color: #4b5563;
+}
+
+.password-toggle svg {
+  width: 1rem;
+  height: 1rem;
+}

--- a/themes/authme/login/templates/change-password.hbs
+++ b/themes/authme/login/templates/change-password.hbs
@@ -1,0 +1,44 @@
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
+<h2 class="auth-subtitle">{{msg "changePasswordTitle"}}</h2>
+<p style="color: #6b7280; font-size: 0.85rem; margin-bottom: 1.25rem; text-align: center;">
+  {{msg "changePasswordExpired"}}
+</p>
+
+<form method="POST" action="/realms/{{realmName}}/change-password" class="auth-form">
+  <input type="hidden" name="token" value="{{token}}" />
+
+  <div class="form-group">
+    <label for="currentPassword">{{msg "changePasswordCurrent"}}</label>
+    <input type="password" id="currentPassword" name="currentPassword" required autocomplete="current-password">
+  </div>
+
+  <div class="form-group">
+    <label for="newPassword">{{msg "changePasswordNew"}}</label>
+    <input type="password" id="newPassword" name="newPassword" required minlength="8" autocomplete="new-password">
+  </div>
+
+  <div class="form-group">
+    <label for="confirmPassword">{{msg "changePasswordConfirm"}}</label>
+    <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" autocomplete="new-password">
+  </div>
+
+  {{#if policyHints}}
+  <div style="background: #f3f4f6; border-radius: 6px; padding: 0.75rem; font-size: 0.8rem; color: #6b7280;">
+    <strong>{{msg "changePasswordRequirements"}}</strong>
+    <ul style="margin: 0.25rem 0 0 1rem; padding: 0;">
+      {{#each policyHints}}
+      <li>{{this}}</li>
+      {{/each}}
+    </ul>
+  </div>
+  {{/if}}
+
+  <button type="submit" class="btn-primary">{{msg "changePasswordSubmit"}}</button>
+</form>

--- a/themes/authme/login/templates/consent.hbs
+++ b/themes/authme/login/templates/consent.hbs
@@ -1,0 +1,18 @@
+<h2 class="auth-subtitle">{{msgArgs "consentRequestingAccess" clientName}}</h2>
+
+<p class="consent-description">{{msg "consentWouldLikeTo"}}</p>
+
+<ul class="consent-scopes">
+  {{#each scopes}}
+  <li>{{this}}</li>
+  {{/each}}
+</ul>
+
+<form method="POST" action="/realms/{{realmName}}/consent" class="auth-form consent-form">
+  <input type="hidden" name="auth_req_id" value="{{authReqId}}">
+
+  <div class="consent-buttons">
+    <button type="submit" name="action" value="grant" class="btn-primary">{{msg "consentAllow"}}</button>
+    <button type="submit" name="action" value="deny" class="btn-secondary">{{msg "consentDeny"}}</button>
+  </div>
+</form>

--- a/themes/authme/login/templates/device-success.hbs
+++ b/themes/authme/login/templates/device-success.hbs
@@ -1,0 +1,3 @@
+<h2 class="auth-subtitle">{{msg "deviceTitle"}}</h2>
+
+<div class="auth-success">{{message}}</div>

--- a/themes/authme/login/templates/device.hbs
+++ b/themes/authme/login/templates/device.hbs
@@ -1,0 +1,31 @@
+<h2 class="auth-subtitle">{{msg "deviceTitle"}}</h2>
+
+<p class="consent-description">{{msg "deviceInstruction"}}</p>
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<form method="POST" action="/realms/{{realmName}}/device" class="auth-form">
+  <div class="form-group">
+    <label for="user_code">{{msg "deviceCode"}}</label>
+    <input type="text" id="user_code" name="user_code" value="{{userCode}}" required
+      placeholder="{{msg "deviceCodePlaceholder"}}" autocomplete="off" autofocus
+      style="text-transform: uppercase; letter-spacing: 0.15em; text-align: center; font-size: 1.2rem;">
+  </div>
+
+  <div class="form-group">
+    <label for="username">{{msg "deviceUsername"}}</label>
+    <input type="text" id="username" name="username" required autocomplete="username">
+  </div>
+
+  <div class="form-group">
+    <label for="password">{{msg "devicePassword"}}</label>
+    <input type="password" id="password" name="password" required autocomplete="current-password">
+  </div>
+
+  <div class="consent-buttons">
+    <button type="submit" name="action" value="approve" class="btn-primary">{{msg "deviceAuthorize"}}</button>
+    <button type="submit" name="action" value="deny" class="btn-secondary">{{msg "deviceDeny"}}</button>
+  </div>
+</form>

--- a/themes/authme/login/templates/error.hbs
+++ b/themes/authme/login/templates/error.hbs
@@ -1,0 +1,7 @@
+<div class="auth-error-page">
+  <h2>{{errorTitle}}</h2>
+  <p>{{errorMessage}}</p>
+  {{#if backUrl}}
+  <a href="{{backUrl}}" class="btn-secondary">{{msg "errorGoBack"}}</a>
+  {{/if}}
+</div>

--- a/themes/authme/login/templates/forgot-password.hbs
+++ b/themes/authme/login/templates/forgot-password.hbs
@@ -1,0 +1,24 @@
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<p style="text-align: center; color: #6b7280; margin-bottom: 1.5rem; font-size: 0.9rem;">
+  {{msg "forgotPasswordInstruction"}}
+</p>
+
+<form method="POST" action="/realms/{{realmName}}/forgot-password" class="auth-form">
+  <div class="form-group">
+    <label for="email">{{msg "forgotPasswordEmail"}}</label>
+    <input type="email" id="email" name="email" required autocomplete="email" autofocus>
+  </div>
+
+  <button type="submit" class="btn-primary">{{msg "forgotPasswordSubmit"}}</button>
+</form>
+
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: #4f46e5; text-decoration: none;">{{msg "forgotPasswordBackToSignIn"}}</a>
+</p>

--- a/themes/authme/login/templates/layouts/main.hbs
+++ b/themes/authme/login/templates/layouts/main.hbs
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{pageTitle}} — {{appTitle}}</title>
+  {{#if faviconUrl}}
+  <link rel="icon" href="{{faviconUrl}}">
+  {{/if}}
+  {{#each themeCssFiles}}
+  <link rel="stylesheet" href="{{this}}">
+  {{/each}}
+  <style>
+    :root {
+      --primary-color: {{primaryColor}};
+      --primary-hover-color: {{primaryHoverColor}};
+      --bg-color: {{backgroundColor}};
+      --card-color: {{cardColor}};
+      --text-color: {{textColor}};
+      --label-color: {{labelColor}};
+      --input-border-color: {{inputBorderColor}};
+      --input-bg-color: {{inputBgColor}};
+      --muted-color: {{mutedColor}};
+    }
+  </style>
+  {{#if customCss}}
+  <style>{{{customCss}}}</style>
+  {{/if}}
+</head>
+<body>
+  <div class="auth-container">
+    <div class="auth-card">
+      <div class="auth-header">
+        {{#if logoUrl}}
+        <img src="{{logoUrl}}" alt="{{appTitle}}" class="auth-logo-img">
+        {{else}}
+        <h1 class="auth-logo">{{appTitle}}</h1>
+        {{/if}}
+        {{#if realmDisplayName}}
+        <p class="auth-realm">{{realmDisplayName}}</p>
+        {{/if}}
+      </div>
+      {{{body}}}
+    </div>
+  </div>
+  <script>
+    document.querySelectorAll('input[type="password"]').forEach(function(input) {
+      var wrapper = document.createElement('div');
+      wrapper.className = 'password-wrapper';
+      input.parentNode.insertBefore(wrapper, input);
+      wrapper.appendChild(input);
+
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'password-toggle';
+      btn.setAttribute('tabindex', '-1');
+      btn.setAttribute('aria-label', '{{msg "showPassword"}}');
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>';
+      wrapper.appendChild(btn);
+
+      btn.addEventListener('click', function() {
+        var isPassword = input.type === 'password';
+        input.type = isPassword ? 'text' : 'password';
+        btn.setAttribute('aria-label', isPassword ? '{{msg "hidePassword"}}' : '{{msg "showPassword"}}');
+        btn.innerHTML = isPassword
+          ? '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18"/></svg>'
+          : '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/><path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"/></svg>';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/themes/authme/login/templates/login.hbs
+++ b/themes/authme/login/templates/login.hbs
@@ -1,0 +1,43 @@
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<form method="POST" action="/realms/{{realmName}}/login" class="auth-form">
+  <div class="form-group">
+    <label for="username">{{msg "loginUsername"}}</label>
+    <input type="text" id="username" name="username" required autocomplete="username" autofocus>
+  </div>
+
+  <div class="form-group">
+    <label for="password">{{msg "loginPassword"}}</label>
+    <input type="password" id="password" name="password" required autocomplete="current-password">
+  </div>
+
+  <div class="form-group" style="display: flex; justify-content: space-between; align-items: center;">
+    <div class="form-checkbox">
+      <input type="checkbox" id="rememberMe" name="rememberMe" value="true">
+      <label for="rememberMe">{{msg "loginRememberMe"}}</label>
+    </div>
+    <a href="/realms/{{realmName}}/forgot-password" style="color: #4f46e5; text-decoration: none; font-size: 0.85rem;">{{msg "loginForgotPassword"}}</a>
+  </div>
+
+  <!-- Carry OAuth params through the form -->
+  <input type="hidden" name="client_id" value="{{client_id}}">
+  <input type="hidden" name="redirect_uri" value="{{redirect_uri}}">
+  <input type="hidden" name="response_type" value="{{response_type}}">
+  <input type="hidden" name="scope" value="{{scope}}">
+  <input type="hidden" name="state" value="{{state}}">
+  <input type="hidden" name="nonce" value="{{nonce}}">
+  <input type="hidden" name="code_challenge" value="{{code_challenge}}">
+  <input type="hidden" name="code_challenge_method" value="{{code_challenge_method}}">
+
+  <button type="submit" class="btn-primary">{{msg "loginSignIn"}}</button>
+</form>
+
+<div style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/register" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "loginNoAccount"}}</a>
+</div>

--- a/themes/authme/login/templates/register.hbs
+++ b/themes/authme/login/templates/register.hbs
@@ -1,0 +1,48 @@
+{{#if info}}
+<div class="auth-success">{{info}}</div>
+{{/if}}
+
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<form method="POST" action="/realms/{{realmName}}/register" class="auth-form">
+  <div class="form-group">
+    <label for="username">{{msg "registerUsername"}}</label>
+    <input type="text" id="username" name="username" required autocomplete="username" autofocus value="{{username}}">
+  </div>
+
+  <div class="form-group">
+    <label for="email">{{msg "registerEmail"}}</label>
+    <input type="email" id="email" name="email" required autocomplete="email" value="{{email}}">
+  </div>
+
+  <div class="form-group">
+    <label for="firstName">{{msg "registerFirstName"}}</label>
+    <input type="text" id="firstName" name="firstName" autocomplete="given-name" value="{{firstName}}">
+  </div>
+
+  <div class="form-group">
+    <label for="lastName">{{msg "registerLastName"}}</label>
+    <input type="text" id="lastName" name="lastName" autocomplete="family-name" value="{{lastName}}">
+  </div>
+
+  <div class="form-group">
+    <label for="password">{{msg "registerPassword"}}</label>
+    <input type="password" id="password" name="password" required autocomplete="new-password" minlength="{{passwordMinLength}}">
+    {{#if passwordHint}}
+    <small style="color: #6b7280; margin-top: 0.25rem; display: block;">{{passwordHint}}</small>
+    {{/if}}
+  </div>
+
+  <div class="form-group">
+    <label for="confirmPassword">{{msg "registerConfirmPassword"}}</label>
+    <input type="password" id="confirmPassword" name="confirmPassword" required autocomplete="new-password">
+  </div>
+
+  <button type="submit" class="btn-primary">{{msg "registerCreateAccount"}}</button>
+</form>
+
+<div style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "registerSignInPrompt"}}</a>
+</div>

--- a/themes/authme/login/templates/reset-password.hbs
+++ b/themes/authme/login/templates/reset-password.hbs
@@ -1,0 +1,27 @@
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<p style="text-align: center; color: #6b7280; margin-bottom: 1.5rem; font-size: 0.9rem;">
+  {{msg "resetPasswordInstruction"}}
+</p>
+
+<form method="POST" action="/realms/{{realmName}}/reset-password" class="auth-form">
+  <input type="hidden" name="token" value="{{token}}">
+
+  <div class="form-group">
+    <label for="password">{{msg "resetPasswordNew"}}</label>
+    <input type="password" id="password" name="password" required minlength="8" autocomplete="new-password" autofocus>
+  </div>
+
+  <div class="form-group">
+    <label for="confirmPassword">{{msg "resetPasswordConfirm"}}</label>
+    <input type="password" id="confirmPassword" name="confirmPassword" required minlength="8" autocomplete="new-password">
+  </div>
+
+  <button type="submit" class="btn-primary">{{msg "resetPasswordSubmit"}}</button>
+</form>
+
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: #4f46e5; text-decoration: none;">{{msg "resetPasswordBackToSignIn"}}</a>
+</p>

--- a/themes/authme/login/templates/totp.hbs
+++ b/themes/authme/login/templates/totp.hbs
@@ -1,0 +1,50 @@
+{{#if error}}
+<div class="auth-error">{{error}}</div>
+{{/if}}
+
+<h2 class="auth-subtitle">{{msg "totpTitle"}}</h2>
+<p style="color: #6b7280; font-size: 0.85rem; margin-bottom: 1.25rem; text-align: center;">
+  {{msg "totpInstruction"}}
+</p>
+
+<form method="POST" action="/realms/{{realmName}}/totp" class="auth-form" id="totpForm">
+  <div class="form-group">
+    <label for="code">{{msg "totpAuthCode"}}</label>
+    <input type="text" id="code" name="code" pattern="[0-9]{6}" maxlength="6" inputmode="numeric" autocomplete="one-time-code" required autofocus
+      style="text-align: center; font-size: 1.5rem; letter-spacing: 0.5rem;">
+  </div>
+
+  <button type="submit" class="btn-primary">{{msg "totpVerify"}}</button>
+</form>
+
+<div style="margin-top: 1rem; text-align: center;">
+  <button type="button" id="toggleRecovery" class="btn-link" style="color: #2563eb; background: none; border: none; cursor: pointer; font-size: 0.85rem; text-decoration: underline;">
+    {{msg "totpUseRecovery"}}
+  </button>
+</div>
+
+<form method="POST" action="/realms/{{realmName}}/totp" class="auth-form" id="recoveryForm" style="display: none;">
+  <div class="form-group">
+    <label for="recoveryCode">{{msg "totpRecoveryCode"}}</label>
+    <input type="text" id="recoveryCode" name="recoveryCode" required autocomplete="off"
+      style="text-align: center; font-size: 1.1rem; letter-spacing: 0.15rem;">
+  </div>
+
+  <button type="submit" class="btn-primary">{{msg "totpVerifyRecovery"}}</button>
+</form>
+
+<script>
+  document.getElementById('toggleRecovery').addEventListener('click', function() {
+    var totpForm = document.getElementById('totpForm');
+    var recoveryForm = document.getElementById('recoveryForm');
+    if (recoveryForm.style.display === 'none') {
+      recoveryForm.style.display = '';
+      totpForm.style.display = 'none';
+      this.textContent = '{{msg "totpUseAuthenticator"}}';
+    } else {
+      recoveryForm.style.display = 'none';
+      totpForm.style.display = '';
+      this.textContent = '{{msg "totpUseRecovery"}}';
+    }
+  });
+</script>

--- a/themes/authme/login/templates/verify-email.hbs
+++ b/themes/authme/login/templates/verify-email.hbs
@@ -1,0 +1,15 @@
+{{#if success}}
+<div class="auth-success">
+  {{msg "verifyEmailSuccess"}}
+</div>
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" class="btn-primary" style="display: inline-block; text-decoration: none;">{{msg "verifyEmailSignIn"}}</a>
+</p>
+{{else}}
+<div class="auth-error">
+  {{#if error}}{{error}}{{else}}{{msg "verifyEmailInvalid"}}{{/if}}
+</div>
+<p style="text-align: center; margin-top: 1rem;">
+  <a href="/realms/{{realmName}}/login" style="color: #4f46e5; text-decoration: none;">{{msg "verifyEmailBackToSignIn"}}</a>
+</p>
+{{/if}}

--- a/themes/authme/theme.json
+++ b/themes/authme/theme.json
@@ -2,6 +2,7 @@
   "name": "authme",
   "displayName": "AuthMe (Default)",
   "description": "Clean light theme with blue accents",
+  "parent": null,
   "colors": {
     "primaryColor": "#2563eb",
     "backgroundColor": "#f0f2f5",
@@ -12,5 +13,13 @@
     "inputBgColor": "#ffffff",
     "mutedColor": "#6b7280"
   },
-  "css": []
+  "types": {
+    "login": {
+      "css": ["css/auth.css"]
+    },
+    "account": {
+      "css": ["css/auth.css"]
+    },
+    "email": {}
+  }
 }

--- a/themes/dark/login/resources/css/overrides.css
+++ b/themes/dark/login/resources/css/overrides.css
@@ -1,0 +1,53 @@
+/* Dark theme overrides */
+
+.form-group input[type="text"],
+.form-group input[type="password"],
+.form-group input[type="email"] {
+  color: #f1f5f9;
+}
+
+.form-group input:focus {
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.2);
+}
+
+.form-checkbox label {
+  color: var(--muted-color, #94a3b8);
+}
+
+.btn-secondary {
+  background: #334155;
+  color: #f1f5f9;
+  border-color: #475569;
+}
+
+.btn-secondary:hover {
+  background: #475569;
+}
+
+.auth-success {
+  background: #064e3b;
+  color: #6ee7b7;
+  border-color: #065f46;
+}
+
+.auth-error {
+  background: #450a0a;
+  color: #fca5a5;
+  border-color: #7f1d1d;
+}
+
+.consent-scopes li {
+  background: #334155;
+}
+
+.password-toggle {
+  color: #64748b;
+}
+
+.password-toggle:hover {
+  color: #94a3b8;
+}
+
+.auth-card {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}

--- a/themes/dark/theme.json
+++ b/themes/dark/theme.json
@@ -2,6 +2,7 @@
   "name": "dark",
   "displayName": "Dark",
   "description": "Modern dark theme with indigo accents",
+  "parent": "authme",
   "colors": {
     "primaryColor": "#6366f1",
     "backgroundColor": "#0f172a",
@@ -12,5 +13,11 @@
     "inputBgColor": "#0f172a",
     "mutedColor": "#94a3b8"
   },
-  "css": ["css/overrides.css"]
+  "types": {
+    "login": {
+      "css": ["css/overrides.css"]
+    },
+    "account": {},
+    "email": {}
+  }
 }

--- a/themes/forest/login/resources/css/overrides.css
+++ b/themes/forest/login/resources/css/overrides.css
@@ -1,0 +1,19 @@
+/* Forest theme overrides */
+
+.form-group input:focus {
+  box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.15);
+}
+
+.auth-success {
+  background: #ecfdf5;
+  color: #065f46;
+  border-color: #a7f3d0;
+}
+
+.consent-scopes li {
+  background: #f0fdf4;
+}
+
+.consent-scopes li::before {
+  color: #059669;
+}

--- a/themes/forest/theme.json
+++ b/themes/forest/theme.json
@@ -2,6 +2,7 @@
   "name": "forest",
   "displayName": "Forest",
   "description": "Nature-inspired theme with emerald accents",
+  "parent": "authme",
   "colors": {
     "primaryColor": "#059669",
     "backgroundColor": "#f0fdf4",
@@ -12,5 +13,11 @@
     "inputBgColor": "#ffffff",
     "mutedColor": "#6b7e6b"
   },
-  "css": ["css/overrides.css"]
+  "types": {
+    "login": {
+      "css": ["css/overrides.css"]
+    },
+    "account": {},
+    "email": {}
+  }
 }


### PR DESCRIPTION
## Summary
- Migrate from flat `views/` to Keycloak-style theme directory structure
- Move all 13 templates into `themes/authme/{login,account}/templates/`
- Move CSS to `themes/{name}/{type}/resources/css/`
- Extract all hardcoded UI strings into `messages_en.properties` files (3 files: login, account, email)
- Replace hardcoded strings in templates with `{{msg "key"}}` Handlebars helpers
- Create email templates extracted from hardcoded HTML (verify-email, reset-password, test-email)
- Update `theme.json` files to new format with `parent` inheritance and `types` config

## Test plan
- [ ] `npm run build` succeeds
- [ ] Theme files properly structured in `themes/` directory
- [ ] All 14 templates have `{{msg}}` calls replacing hardcoded strings
- [ ] Message files contain all extracted strings

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)