### PR TITLE
Add per-type theme selection to realm config and Admin UI

### DIFF
--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -94,6 +94,9 @@ export default function RealmDetailPage() {
     adminEventsEnabled: false,
     // Theme
     themeName: 'authme',
+    loginTheme: 'authme',
+    accountTheme: 'authme',
+    emailTheme: 'authme',
     theme: {
       logoUrl: '',
       faviconUrl: '',
@@ -141,7 +144,10 @@ export default function RealmDetailPage() {
         eventsExpiration: realm.eventsExpiration ?? 604800,
         adminEventsEnabled: realm.adminEventsEnabled ?? false,
         // Theme
-        themeName: (realm as any).themeName ?? 'authme',
+        themeName: realm.themeName ?? 'authme',
+        loginTheme: realm.loginTheme ?? 'authme',
+        accountTheme: realm.accountTheme ?? 'authme',
+        emailTheme: realm.emailTheme ?? 'authme',
         theme: {
           logoUrl: (realm.theme as any)?.logoUrl ?? '',
           faviconUrl: (realm.theme as any)?.faviconUrl ?? '',
@@ -975,16 +981,64 @@ export default function RealmDetailPage() {
       {activeTab === 'theme' && (
         <form onSubmit={handleSubmit} className="space-y-8 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
           <div>
-            <h2 className="text-lg font-semibold text-gray-900">Login Page Theme</h2>
+            <h2 className="text-lg font-semibold text-gray-900">Theme Settings</h2>
             <p className="mt-1 text-sm text-gray-500">
-              Customize the appearance of login and account pages for this realm.
+              Assign themes per page type and customize colors for this realm.
             </p>
           </div>
 
-          {/* Theme Preset Selector */}
+          {/* Per-Type Theme Selectors */}
           {themes && themes.length > 0 && (
             <div className="space-y-4">
-              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">Theme Preset</h3>
+              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">Theme Assignment</h3>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Login Theme</label>
+                  <select
+                    value={form.loginTheme}
+                    onChange={(e) => setForm({ ...form, loginTheme: e.target.value, themeName: e.target.value })}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                  >
+                    {themes.map((t: ThemeInfo) => (
+                      <option key={t.name} value={t.name}>{t.displayName}</option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-xs text-gray-400">Applied to login, register, consent, and other auth pages</p>
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Account Theme</label>
+                  <select
+                    value={form.accountTheme}
+                    onChange={(e) => setForm({ ...form, accountTheme: e.target.value })}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                  >
+                    {themes.map((t: ThemeInfo) => (
+                      <option key={t.name} value={t.name}>{t.displayName}</option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-xs text-gray-400">Applied to account management and TOTP setup pages</p>
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700">Email Theme</label>
+                  <select
+                    value={form.emailTheme}
+                    onChange={(e) => setForm({ ...form, emailTheme: e.target.value })}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                  >
+                    {themes.map((t: ThemeInfo) => (
+                      <option key={t.name} value={t.name}>{t.displayName}</option>
+                    ))}
+                  </select>
+                  <p className="mt-1 text-xs text-gray-400">Applied to verification and password reset emails</p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Theme Preset Selector (for color preview) */}
+          {themes && themes.length > 0 && (
+            <div className="space-y-4">
+              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-500">Color Preset</h3>
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
                 {themes.map((t: ThemeInfo) => (
                   <button
@@ -994,6 +1048,9 @@ export default function RealmDetailPage() {
                       setForm({
                         ...form,
                         themeName: t.name,
+                        loginTheme: t.name,
+                        accountTheme: t.name,
+                        emailTheme: t.name,
                         theme: {
                           ...form.theme,
                           primaryColor: t.colors.primaryColor,

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -34,7 +34,11 @@ export interface Realm {
   eventsExpiration: number;
   adminEventsEnabled: boolean;
   // Theming
+  themeName: string;
   theme: RealmTheme | null;
+  loginTheme: string;
+  accountTheme: string;
+  emailTheme: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/prisma/migrations/20260216180000_add_per_type_theme_fields/migration.sql
+++ b/prisma/migrations/20260216180000_add_per_type_theme_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "realms" ADD COLUMN "login_theme" VARCHAR(50) NOT NULL DEFAULT 'authme';
+ALTER TABLE "realms" ADD COLUMN "account_theme" VARCHAR(50) NOT NULL DEFAULT 'authme';
+ALTER TABLE "realms" ADD COLUMN "email_theme" VARCHAR(50) NOT NULL DEFAULT 'authme';
+
+-- Migrate existing theme_name to per-type fields
+UPDATE "realms" SET login_theme = theme_name, account_theme = theme_name, email_theme = theme_name;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,8 +55,11 @@ model Realm {
   adminEventsEnabled Boolean @default(false) @map("admin_events_enabled")
 
   // Theming
-  themeName String  @default("authme") @map("theme_name") @db.VarChar(50)
-  theme     Json?   @default("{}") @map("theme")
+  themeName    String  @default("authme") @map("theme_name") @db.VarChar(50)
+  theme        Json?   @default("{}") @map("theme")
+  loginTheme   String  @default("authme") @map("login_theme") @db.VarChar(50)
+  accountTheme String  @default("authme") @map("account_theme") @db.VarChar(50)
+  emailTheme   String  @default("authme") @map("email_theme") @db.VarChar(50)
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -176,4 +176,19 @@ export class CreateRealmDto {
   @IsOptional()
   @IsObject()
   theme?: Record<string, unknown>;
+
+  @ApiPropertyOptional({ default: 'authme', description: 'Login page theme' })
+  @IsOptional()
+  @IsString()
+  loginTheme?: string;
+
+  @ApiPropertyOptional({ default: 'authme', description: 'Account page theme' })
+  @IsOptional()
+  @IsString()
+  accountTheme?: string;
+
+  @ApiPropertyOptional({ default: 'authme', description: 'Email template theme' })
+  @IsOptional()
+  @IsString()
+  emailTheme?: string;
 }

--- a/src/theme/theme.service.ts
+++ b/src/theme/theme.service.ts
@@ -168,7 +168,7 @@ export class ThemeService implements OnModuleInit {
    * Used during migration before per-type fields are added.
    */
   resolveTheme(realm: Realm): ResolvedTheme {
-    const themeName = (realm as any).loginTheme ?? (realm as any).themeName ?? 'authme';
+    const themeName = realm.loginTheme ?? realm.themeName ?? 'authme';
     const resolved = this.resolveColors(themeName, realm);
     resolved.themeCssFiles = this.resolveCss(themeName, 'login');
     return resolved;
@@ -178,16 +178,15 @@ export class ThemeService implements OnModuleInit {
    * Get the realm's theme name for a given type.
    */
   getRealmThemeName(realm: Realm, themeType: ThemeType): string {
-    const r = realm as any;
     switch (themeType) {
       case 'login':
-        return r.loginTheme ?? r.themeName ?? 'authme';
+        return realm.loginTheme ?? realm.themeName ?? 'authme';
       case 'account':
-        return r.accountTheme ?? r.themeName ?? 'authme';
+        return realm.accountTheme ?? realm.themeName ?? 'authme';
       case 'email':
-        return r.emailTheme ?? r.themeName ?? 'authme';
+        return realm.emailTheme ?? realm.themeName ?? 'authme';
       default:
-        return r.themeName ?? 'authme';
+        return realm.themeName ?? 'authme';
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `loginTheme`, `accountTheme`, `emailTheme` columns to the Realm table (Prisma migration backfills from existing `themeName`)
- Updates DTOs to accept per-type theme fields via the Admin API
- Updates Admin UI theme tab with per-type theme dropdowns (Login Theme, Account Theme, Email Theme)
- Removes `as any` casts in ThemeService now that Prisma types include the new fields

## Test plan
- [ ] `npm run build` passes
- [ ] Migration applies cleanly on fresh and existing databases
- [ ] Admin UI theme tab shows 3 dropdowns for Login/Account/Email themes
- [ ] Setting Login Theme to "dark" only affects login pages, not account pages
- [ ] Setting Account Theme independently works
- [ ] API: `PUT /admin/realms/my-app` with `{ loginTheme: "dark" }` persists correctly
- [ ] Color preset buttons set all three theme types simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)