### PR TITLE
Fix 4 MFA/2FA security bugs

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -201,13 +201,10 @@ export class AccountController {
       return res.redirect(`/realms/${realm.name}/account/totp-setup?error=${encodeURIComponent('Please enter the verification code.')}`);
     }
 
-    const activated = await this.mfaService.verifyAndActivateTotp(user.id, code);
-    if (!activated) {
+    const recoveryCodes = await this.mfaService.verifyAndActivateTotp(user.id, code);
+    if (!recoveryCodes) {
       return res.redirect(`/realms/${realm.name}/account/totp-setup?error=${encodeURIComponent('Invalid code. Please try again.')}`);
     }
-
-    // Fetch recovery codes to display
-    const recoveryCodes = await this.mfaService.generateRecoveryCodes(user.id);
 
     this.themeRender.render(res, realm, 'account', 'totp-setup', {
       pageTitle: 'Two-Factor Authentication Enabled',

--- a/src/mfa/mfa.controller.spec.ts
+++ b/src/mfa/mfa.controller.spec.ts
@@ -27,20 +27,20 @@ describe('MfaController', () => {
       expect(mockMfaService.isMfaEnabled).toHaveBeenCalledWith('user-1');
     });
 
-    it('should return { mfaEnabled: true } when MFA is enabled', async () => {
+    it('should return { enabled: true } when MFA is enabled', async () => {
       mockMfaService.isMfaEnabled.mockResolvedValue(true);
 
       const result = await controller.getMfaStatus('user-1');
 
-      expect(result).toEqual({ mfaEnabled: true });
+      expect(result).toEqual({ enabled: true });
     });
 
-    it('should return { mfaEnabled: false } when MFA is disabled', async () => {
+    it('should return { enabled: false } when MFA is disabled', async () => {
       mockMfaService.isMfaEnabled.mockResolvedValue(false);
 
       const result = await controller.getMfaStatus('user-2');
 
-      expect(result).toEqual({ mfaEnabled: false });
+      expect(result).toEqual({ enabled: false });
     });
   });
 

--- a/src/mfa/mfa.controller.ts
+++ b/src/mfa/mfa.controller.ts
@@ -21,7 +21,7 @@ export class MfaController {
   @ApiOperation({ summary: 'Check if user has MFA enabled' })
   async getMfaStatus(@Param('userId') userId: string) {
     const enabled = await this.mfaService.isMfaEnabled(userId);
-    return { mfaEnabled: enabled };
+    return { enabled };
   }
 
   @Delete()

--- a/src/prisma/prisma.mock.ts
+++ b/src/prisma/prisma.mock.ts
@@ -190,6 +190,7 @@ export function createMockPrismaService(): MockPrismaService {
     pendingAction: {
       findUnique: jest.fn(),
       create: jest.fn(),
+      update: jest.fn(),
       delete: jest.fn(),
       deleteMany: jest.fn(),
     },


### PR DESCRIPTION
## Summary

Fixes 4 MFA/2FA bugs discovered during a comprehensive security audit of the authentication system:

- **#108** — Admin UI MFA status always showed "Not configured" due to backend/frontend field name mismatch (`mfaEnabled` vs `enabled`)
- **#109** — Recovery codes were silently generated twice during TOTP setup, first set wasted
- **#110** — No brute-force protection on TOTP verification (6-digit codes brute-forceable with unlimited attempts)
- **#111** — Device code grant completely bypassed MFA even for MFA-enabled users

## Changes

| File | Change |
|------|--------|
| `src/mfa/mfa.controller.ts` | Fix response field: `{ mfaEnabled }` → `{ enabled }` |
| `src/mfa/mfa.service.ts` | `verifyAndActivateTotp()` returns codes directly; new `validateMfaChallengeWithAttemptCheck()` and `consumeMfaChallenge()` methods |
| `src/account/account.controller.ts` | Remove duplicate `generateRecoveryCodes()` call |
| `src/login/login.controller.ts` | Use attempt-tracked challenge validation; reuse same token on retry |
| `src/auth/auth.service.ts` | Add MFA check to device code grant; add attempt tracking to `mfa_otp` grant |
| `src/prisma/prisma.mock.ts` | Add `pendingAction.update` mock |
| Tests | 7 new tests, 689 total passing |

## Test plan

- [x] All 689 unit tests pass (`npm test`)
- [ ] Verify admin UI shows correct MFA status for enabled/disabled users
- [ ] Verify TOTP setup shows recovery codes exactly once
- [ ] Verify MFA verification rejects after 5 failed attempts
- [ ] Verify device code grant fails for MFA-enabled users

Closes #108, #109, #110, #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)