### PR TITLE
Fix token and introspect endpoints returning 201 instead of 200

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,6 +5,8 @@ import {
   Param,
   Req,
   UseGuards,
+  HttpCode,
+  HttpStatus,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiConsumes } from '@nestjs/swagger';
 import type { Request } from 'express';
@@ -22,6 +24,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('token')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Token endpoint (password, client_credentials, refresh_token, authorization_code)' })
   @ApiConsumes('application/x-www-form-urlencoded', 'application/json')
   token(

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -24,6 +24,7 @@ export class TokensController {
   constructor(private readonly tokensService: TokensService) {}
 
   @Post('token/introspect')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Token introspection (RFC 7662)' })
   introspect(
     @CurrentRealm() realm: Realm,

--- a/test/oauth-flows.e2e-spec.ts
+++ b/test/oauth-flows.e2e-spec.ts
@@ -40,7 +40,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           client_id: 'test-client',
           client_secret: 'test-client-secret',
         })
-        .expect(201);
+        .expect(200);
 
       expect(res.body).toHaveProperty('access_token');
       expect(res.body).toHaveProperty('token_type', 'Bearer');
@@ -65,7 +65,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           password: 'TestPassword123!',
           scope: 'openid',
         })
-        .expect(201);
+        .expect(200);
 
       expect(res.body).toHaveProperty('access_token');
       expect(res.body).toHaveProperty('refresh_token');
@@ -133,7 +133,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           password: 'TestPassword123!',
           scope: 'openid',
         })
-        .expect(201);
+        .expect(200);
 
       const originalRefreshToken = tokenRes.body.refresh_token;
       expect(originalRefreshToken).toBeDefined();
@@ -148,7 +148,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           client_id: 'test-client',
           client_secret: 'test-client-secret',
         })
-        .expect(201);
+        .expect(200);
 
       expect(refreshRes.body).toHaveProperty('access_token');
       expect(refreshRes.body).toHaveProperty('refresh_token');
@@ -175,7 +175,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           password: 'TestPassword123!',
           scope: 'openid',
         })
-        .expect(201);
+        .expect(200);
 
       const accessToken = tokenRes.body.access_token;
 
@@ -183,7 +183,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
       const introspectRes = await request(app.getHttpServer())
         .post(INTROSPECT_URL)
         .send({ token: accessToken })
-        .expect(201);
+        .expect(200);
 
       expect(introspectRes.body).toHaveProperty('active', true);
       expect(introspectRes.body).toHaveProperty('sub');
@@ -207,7 +207,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           password: 'TestPassword123!',
           scope: 'openid',
         })
-        .expect(201);
+        .expect(200);
 
       const accessToken = tokenRes.body.access_token;
 
@@ -221,7 +221,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
       const introspectRes = await request(app.getHttpServer())
         .post(INTROSPECT_URL)
         .send({ token: accessToken })
-        .expect(201);
+        .expect(200);
 
       expect(introspectRes.body).toHaveProperty('active', false);
     });
@@ -243,7 +243,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           password: 'TestPassword123!',
           scope: 'openid',
         })
-        .expect(201);
+        .expect(200);
 
       const accessToken = tokenRes.body.access_token;
 


### PR DESCRIPTION
## Summary
- Add `@HttpCode(HttpStatus.OK)` to the **token endpoint** (`auth.controller.ts`) to comply with **RFC 6749 Section 5.1**
- Add `@HttpCode(HttpStatus.OK)` to the **introspect endpoint** (`tokens.controller.ts`) to comply with **RFC 7662**
- Update all e2e tests in `oauth-flows.e2e-spec.ts` to expect `200` instead of `201`

## Test plan
- [x] All 689 unit tests pass
- [x] Auth controller unit tests pass
- [x] Tokens controller unit tests pass
- [ ] E2E tests pass (token, introspect, revoke, userinfo flows)

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)