### PR TITLE
Fix removeUserRealmRoles returning 200 instead of 204

### DIFF
--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -98,6 +98,7 @@ export class RolesController {
   }
 
   @Delete('users/:userId/role-mappings/realm')
+  @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Remove realm roles from a user' })
   removeUserRealmRoles(
     @CurrentRealm() realm: Realm,


### PR DESCRIPTION
## Summary
- Add `@HttpCode(HttpStatus.NO_CONTENT)` to the `DELETE users/:userId/role-mappings/realm` handler
- Matches the pattern already used by `deleteRealmRole` in the same controller (line 44)

## Test plan
- [x] Roles controller unit tests pass (10/10)
- [ ] E2E tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)