### PR TITLE
Add DELETE endpoint for client role-mappings

### DIFF
--- a/src/roles/roles.controller.spec.ts
+++ b/src/roles/roles.controller.spec.ts
@@ -16,6 +16,7 @@ describe('RolesController', () => {
     removeUserRealmRoles: jest.Mock;
     assignClientRoles: jest.Mock;
     getUserClientRoles: jest.Mock;
+    removeUserClientRoles: jest.Mock;
   };
 
   const realm = {
@@ -36,6 +37,7 @@ describe('RolesController', () => {
       removeUserRealmRoles: jest.fn(),
       assignClientRoles: jest.fn(),
       getUserClientRoles: jest.fn(),
+      removeUserClientRoles: jest.fn(),
     };
 
     controller = new RolesController(mockRolesService as any);
@@ -159,6 +161,18 @@ describe('RolesController', () => {
 
       expect(mockRolesService.getUserClientRoles).toHaveBeenCalledWith(realm, 'user-1', 'client-1');
       expect(result).toEqual(expected);
+    });
+  });
+
+  describe('removeUserClientRoles', () => {
+    it('should call rolesService.removeUserClientRoles with realm, userId, clientId, and roleNames', () => {
+      const dto = { roleNames: ['editor'] };
+      mockRolesService.removeUserClientRoles.mockReturnValue(undefined);
+
+      const result = controller.removeUserClientRoles(realm, 'user-1', 'client-1', dto as any);
+
+      expect(mockRolesService.removeUserClientRoles).toHaveBeenCalledWith(realm, 'user-1', 'client-1', ['editor']);
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -138,4 +138,21 @@ export class RolesController {
   ) {
     return this.rolesService.getUserClientRoles(realm, userId, clientId);
   }
+
+  @Delete('users/:userId/role-mappings/clients/:clientId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Remove client roles from a user' })
+  removeUserClientRoles(
+    @CurrentRealm() realm: Realm,
+    @Param('userId') userId: string,
+    @Param('clientId') clientId: string,
+    @Body() dto: AssignRolesDto,
+  ) {
+    return this.rolesService.removeUserClientRoles(
+      realm,
+      userId,
+      clientId,
+      dto.roleNames,
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- Add `removeUserClientRoles` method to `RolesService`
- Add `DELETE /admin/realms/:realmName/users/:userId/role-mappings/clients/:clientId` endpoint
- Returns 204 No Content on success
- Previously, client roles could be assigned and listed but **not removed** via the API

## Test plan
- [x] New controller unit test: `removeUserClientRoles` (1 test)
- [x] New service unit tests: `removeUserClientRoles` (3 tests: success, client not found, non-existent roles)
- [x] All 36 roles tests pass
- [ ] E2E tests pass

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)