### PR TITLE
Remove deprecated version field from docker-compose files

### DIFF
--- a/docker-compose.cluster.yml
+++ b/docker-compose.cluster.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   db:
     image: postgres:16-alpine

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     image: postgres:16-alpine


### PR DESCRIPTION
## Summary
- Remove `version: "3.8"` from `docker-compose.yml`, `docker-compose.dev.yml`, and `docker-compose.cluster.yml`
- Docker Compose V2 ignores this field and emits a deprecation warning

## Test plan
- [ ] `docker compose config` succeeds without warnings
- [ ] `docker compose up` works as expected

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)