### PR TITLE
Add TokenRequestDto for Swagger documentation of token endpoint

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,10 +6,11 @@ import {
   Req,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiConsumes } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiConsumes, ApiBody } from '@nestjs/swagger';
 import type { Request } from 'express';
 import type { Realm } from '@prisma/client';
 import { AuthService } from './auth.service.js';
+import { TokenRequestDto } from './dto/token-request.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
@@ -24,6 +25,7 @@ export class AuthController {
   @Post('token')
   @ApiOperation({ summary: 'Token endpoint (password, client_credentials, refresh_token, authorization_code)' })
   @ApiConsumes('application/x-www-form-urlencoded', 'application/json')
+  @ApiBody({ type: TokenRequestDto })
   token(
     @CurrentRealm() realm: Realm,
     @Body() body: Record<string, string>,

--- a/src/auth/dto/token-request.dto.ts
+++ b/src/auth/dto/token-request.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TokenRequestDto {
+  @ApiProperty({
+    description: 'OAuth2 grant type',
+    enum: [
+      'password',
+      'client_credentials',
+      'refresh_token',
+      'authorization_code',
+      'urn:ietf:params:oauth:grant-type:device_code',
+    ],
+    example: 'client_credentials',
+  })
+  grant_type!: string;
+
+  @ApiPropertyOptional({
+    description: 'Client identifier',
+    example: 'my-app',
+  })
+  client_id?: string;
+
+  @ApiPropertyOptional({
+    description: 'Client secret',
+    example: 'my-client-secret',
+  })
+  client_secret?: string;
+
+  @ApiPropertyOptional({
+    description: 'Username (for password grant)',
+    example: 'john',
+  })
+  username?: string;
+
+  @ApiPropertyOptional({
+    description: 'Password (for password grant)',
+    example: 'secret',
+  })
+  password?: string;
+
+  @ApiPropertyOptional({
+    description: 'Refresh token (for refresh_token grant)',
+  })
+  refresh_token?: string;
+
+  @ApiPropertyOptional({
+    description: 'Authorization code (for authorization_code grant)',
+  })
+  code?: string;
+
+  @ApiPropertyOptional({
+    description: 'Redirect URI (for authorization_code grant)',
+    example: 'http://localhost:3000/callback',
+  })
+  redirect_uri?: string;
+
+  @ApiPropertyOptional({
+    description: 'PKCE code verifier (for authorization_code grant with PKCE)',
+  })
+  code_verifier?: string;
+
+  @ApiPropertyOptional({
+    description: 'Device code (for device_code grant)',
+  })
+  device_code?: string;
+
+  @ApiPropertyOptional({
+    description: 'Requested scopes (space-separated)',
+    example: 'openid profile email',
+  })
+  scope?: string;
+
+  @ApiPropertyOptional({
+    description: 'TOTP code (when MFA is required)',
+    example: '123456',
+  })
+  totp?: string;
+
+  @ApiPropertyOptional({
+    description: 'MFA token (when MFA is required, returned from initial auth attempt)',
+  })
+  mfa_token?: string;
+}


### PR DESCRIPTION
## Summary
- Create `TokenRequestDto` with `@ApiProperty` decorators documenting all token request fields
- Add `@ApiBody({ type: TokenRequestDto })` to the token endpoint
- Swagger UI now shows all fields: `grant_type`, `client_id`, `client_secret`, `username`, `password`, `refresh_token`, `code`, `redirect_uri`, `code_verifier`, `device_code`, `scope`, `totp`, `mfa_token`
- Runtime behavior unchanged — still accepts `Record<string, string>`

## Test plan
- [x] Auth controller unit tests pass (3/3)
- [ ] Swagger UI at /api shows documented fields
- [ ] All grant types still work

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)