### PR TITLE
Add publishConfig to SDK package.json

### DIFF
--- a/packages/authme-js/package.json
+++ b/packages/authme-js/package.json
@@ -66,5 +66,8 @@
     "type": "git",
     "url": "https://github.com/Islamawad132/Authme.git",
     "directory": "packages/authme-js"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- Add `"publishConfig": { "access": "public" }` to `packages/authme-js/package.json`
- Ensures the SDK is always published as a public package on npm
- Verified the package is currently accessible: `npm view authme-sdk` returns v0.1.2

## Test plan
- [x] Package is verified accessible on npm
- [ ] Future `npm publish` uses public access by default

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)