### PR TITLE
Add test suite for authme-sdk (30 tests)

### DIFF
--- a/packages/authme-js/package.json
+++ b/packages/authme-js/package.json
@@ -39,13 +39,16 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",
-    "react": "^19.0.0",
-    "@types/react": "^19.0.0"
+    "vitest": "^4.0.18"
   },
   "files": [
     "dist",

--- a/packages/authme-js/src/__tests__/events.test.ts
+++ b/packages/authme-js/src/__tests__/events.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventEmitter } from '../events.js';
+
+type TestEvents = {
+  login: string;
+  logout: void;
+  error: Error;
+};
+
+describe('EventEmitter', () => {
+  it('should emit events to registered handlers', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const handler = vi.fn();
+
+    emitter.on('login', handler);
+    emitter.emit('login', 'user-1');
+
+    expect(handler).toHaveBeenCalledWith('user-1');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should support multiple handlers for the same event', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+
+    emitter.on('login', handler1);
+    emitter.on('login', handler2);
+    emitter.emit('login', 'user-1');
+
+    expect(handler1).toHaveBeenCalledWith('user-1');
+    expect(handler2).toHaveBeenCalledWith('user-1');
+  });
+
+  it('should unsubscribe a handler with off()', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const handler = vi.fn();
+
+    emitter.on('login', handler);
+    emitter.off('login', handler);
+    emitter.emit('login', 'user-1');
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('should handle void events', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const handler = vi.fn();
+
+    emitter.on('logout', handler);
+    emitter.emit('logout');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not throw when emitting an event with no listeners', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    expect(() => emitter.emit('login', 'user-1')).not.toThrow();
+  });
+
+  it('should not let listener errors break the emitter', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const badHandler = vi.fn(() => { throw new Error('boom'); });
+    const goodHandler = vi.fn();
+
+    emitter.on('login', badHandler);
+    emitter.on('login', goodHandler);
+    emitter.emit('login', 'user-1');
+
+    expect(badHandler).toHaveBeenCalled();
+    expect(goodHandler).toHaveBeenCalled();
+  });
+
+  it('should handle Error event payloads', () => {
+    const emitter = new EventEmitter<TestEvents>();
+    const handler = vi.fn();
+    const error = new Error('auth failed');
+
+    emitter.on('error', handler);
+    emitter.emit('error', error);
+
+    expect(handler).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/authme-js/src/__tests__/pkce.test.ts
+++ b/packages/authme-js/src/__tests__/pkce.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { generateCodeVerifier, generateCodeChallenge, generateState } from '../pkce.js';
+
+describe('generateCodeVerifier', () => {
+  it('should generate a base64url-encoded string', () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('should generate a string of expected length (43 chars for 32 bytes)', () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier.length).toBe(43);
+  });
+
+  it('should generate unique values each time', () => {
+    const v1 = generateCodeVerifier();
+    const v2 = generateCodeVerifier();
+    expect(v1).not.toBe(v2);
+  });
+});
+
+describe('generateCodeChallenge', () => {
+  it('should generate a base64url-encoded challenge from a verifier', async () => {
+    const verifier = generateCodeVerifier();
+    const challenge = await generateCodeChallenge(verifier);
+
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(challenge.length).toBe(43);
+  });
+
+  it('should produce a deterministic challenge for the same verifier', async () => {
+    const verifier = 'test-verifier-12345678901234567890123';
+    const c1 = await generateCodeChallenge(verifier);
+    const c2 = await generateCodeChallenge(verifier);
+    expect(c1).toBe(c2);
+  });
+
+  it('should produce different challenges for different verifiers', async () => {
+    const c1 = await generateCodeChallenge('verifier-1-abcdefghijklmnopqrstuvwxyz');
+    const c2 = await generateCodeChallenge('verifier-2-abcdefghijklmnopqrstuvwxyz');
+    expect(c1).not.toBe(c2);
+  });
+});
+
+describe('generateState', () => {
+  it('should generate a base64url-encoded string', () => {
+    const state = generateState();
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('should generate a string of expected length (22 chars for 16 bytes)', () => {
+    const state = generateState();
+    expect(state.length).toBe(22);
+  });
+
+  it('should generate unique values each time', () => {
+    const s1 = generateState();
+    const s2 = generateState();
+    expect(s1).not.toBe(s2);
+  });
+});

--- a/packages/authme-js/src/__tests__/storage.test.ts
+++ b/packages/authme-js/src/__tests__/storage.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStorage } from '../storage.js';
+
+describe('MemoryStorage', () => {
+  it('should store and retrieve a value', () => {
+    const storage = new MemoryStorage();
+    storage.set('token', 'abc123');
+    expect(storage.get('token')).toBe('abc123');
+  });
+
+  it('should return null for missing keys', () => {
+    const storage = new MemoryStorage();
+    expect(storage.get('nonexistent')).toBeNull();
+  });
+
+  it('should remove a value', () => {
+    const storage = new MemoryStorage();
+    storage.set('token', 'abc123');
+    storage.remove('token');
+    expect(storage.get('token')).toBeNull();
+  });
+
+  it('should clear all values', () => {
+    const storage = new MemoryStorage();
+    storage.set('token', 'abc123');
+    storage.set('refresh', 'xyz789');
+    storage.clear();
+    expect(storage.get('token')).toBeNull();
+    expect(storage.get('refresh')).toBeNull();
+  });
+
+  it('should overwrite existing values', () => {
+    const storage = new MemoryStorage();
+    storage.set('token', 'old');
+    storage.set('token', 'new');
+    expect(storage.get('token')).toBe('new');
+  });
+
+  it('should use the authme_ prefix internally', () => {
+    const storage = new MemoryStorage();
+    storage.set('token', 'abc');
+    // Trying to get without prefix should return null
+    expect(storage.get('authme_token')).toBeNull();
+    // The intended key works
+    expect(storage.get('token')).toBe('abc');
+  });
+});

--- a/packages/authme-js/src/__tests__/token.test.ts
+++ b/packages/authme-js/src/__tests__/token.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parseJwt, isTokenExpired, getTokenExpiresIn } from '../token.js';
+
+// Helper: create a fake JWT with the given payload (handles unicode)
+function createJwt(payload: Record<string, unknown>): string {
+  const encode = (obj: unknown) => {
+    const json = JSON.stringify(obj);
+    const bytes = new TextEncoder().encode(json);
+    let binary = '';
+    for (const b of bytes) binary += String.fromCharCode(b);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  };
+  const header = encode({ alg: 'RS256', typ: 'JWT' });
+  const body = encode(payload);
+  return `${header}.${body}.fake-signature`;
+}
+
+describe('parseJwt', () => {
+  it('should parse a valid JWT and return the payload', () => {
+    const jwt = createJwt({ sub: 'user-1', exp: 9999999999, iss: 'authme' });
+    const claims = parseJwt(jwt);
+
+    expect(claims.sub).toBe('user-1');
+    expect(claims.exp).toBe(9999999999);
+    expect(claims.iss).toBe('authme');
+  });
+
+  it('should handle unicode characters in the payload', () => {
+    const jwt = createJwt({ sub: 'user-1', name: 'أحمد', exp: 9999999999 });
+    const claims = parseJwt(jwt);
+
+    expect(claims.name).toBe('أحمد');
+  });
+
+  it('should throw on invalid JWT format (not 3 parts)', () => {
+    expect(() => parseJwt('not-a-jwt')).toThrow('Invalid JWT format');
+    expect(() => parseJwt('a.b')).toThrow('Invalid JWT format');
+    expect(() => parseJwt('a.b.c.d')).toThrow('Invalid JWT format');
+  });
+});
+
+describe('isTokenExpired', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should return false for a non-expired token', () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    expect(isTokenExpired({ exp: futureExp } as any)).toBe(false);
+  });
+
+  it('should return true for an expired token', () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 60;
+    expect(isTokenExpired({ exp: pastExp } as any)).toBe(true);
+  });
+
+  it('should account for clock skew', () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    // Without skew: not expired
+    expect(isTokenExpired({ exp } as any, 0)).toBe(false);
+    // With 30s skew: expired (since exp - now = 10, and 10 <= 30)
+    expect(isTokenExpired({ exp } as any, 30)).toBe(true);
+  });
+});
+
+describe('getTokenExpiresIn', () => {
+  it('should return seconds until expiry for a valid token', () => {
+    const exp = Math.floor(Date.now() / 1000) + 300;
+    const expiresIn = getTokenExpiresIn({ exp } as any);
+
+    // Allow 1 second tolerance
+    expect(expiresIn).toBeGreaterThanOrEqual(299);
+    expect(expiresIn).toBeLessThanOrEqual(300);
+  });
+
+  it('should return 0 for an expired token', () => {
+    const exp = Math.floor(Date.now() / 1000) - 60;
+    expect(getTokenExpiresIn({ exp } as any)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Add comprehensive test coverage for the SDK utility modules using Vitest:

- **token.ts** (8 tests): JWT parsing, expiry check, time-to-expiry, unicode support
- **storage.ts** (6 tests): MemoryStorage get/set/remove/clear, prefix handling
- **events.ts** (7 tests): EventEmitter subscribe, unsubscribe, void events, error isolation
- **pkce.ts** (9 tests): Code verifier/challenge generation, state generation, determinism

## Test plan
- [x] `npm test` passes in `packages/authme-js/` (30/30)
- [x] All tests run in under 1 second

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)