### PR TITLE
Add server-side SDK for NestJS/Express token validation

### DIFF
--- a/packages/authme-js/package.json
+++ b/packages/authme-js/package.json
@@ -26,13 +26,27 @@
         "types": "./dist/react.d.cts",
         "default": "./dist/react.cjs"
       }
+    },
+    "./server": {
+      "import": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      },
+      "require": {
+        "types": "./dist/server.d.cts",
+        "default": "./dist/server.cjs"
+      }
     }
   },
   "peerDependencies": {
+    "jose": ">=5.0.0",
     "react": ">=18.0.0"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "jose": {
       "optional": true
     }
   },
@@ -42,10 +56,11 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "tsup": "^8.4.0",
-    "typescript": "^5.7.0",
+    "@types/react": "^19.0.0",
+    "jose": "^6.1.3",
     "react": "^19.0.0",
-    "@types/react": "^19.0.0"
+    "tsup": "^8.4.0",
+    "typescript": "^5.7.0"
   },
   "files": [
     "dist",

--- a/packages/authme-js/src/server.ts
+++ b/packages/authme-js/src/server.ts
@@ -1,0 +1,208 @@
+/**
+ * Server-side utilities for AuthMe token validation.
+ *
+ * Provides middleware for Express and guard for NestJS
+ * that validate JWT access tokens using JWKS.
+ *
+ * @example
+ * ```typescript
+ * import { createAuthmeMiddleware } from 'authme-sdk/server';
+ *
+ * app.use('/api', createAuthmeMiddleware({
+ *   issuerUrl: 'http://localhost:3000',
+ *   realm: 'my-realm',
+ * }));
+ * ```
+ */
+
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+
+export interface AuthmeServerConfig {
+  /** AuthMe server base URL (e.g., 'http://localhost:3000') */
+  issuerUrl: string;
+  /** Realm name */
+  realm: string;
+  /** Optional: required roles to access (realm roles) */
+  requiredRoles?: string[];
+  /** Optional: custom claim to extract roles from (default: 'realm_access.roles') */
+  rolesClaimPath?: string;
+}
+
+export interface AuthmeTokenPayload extends JWTPayload {
+  preferred_username?: string;
+  email?: string;
+  name?: string;
+  realm_access?: { roles: string[] };
+  resource_access?: Record<string, { roles: string[] }>;
+}
+
+// Cache JWKS instances per issuer to avoid creating new ones on every request
+const jwksCache = new Map<string, ReturnType<typeof createRemoteJWKSet>>();
+
+function getJWKS(issuerUrl: string, realm: string) {
+  const url = `${issuerUrl}/realms/${realm}/protocol/openid-connect/certs`;
+  if (!jwksCache.has(url)) {
+    jwksCache.set(url, createRemoteJWKSet(new URL(url)));
+  }
+  return jwksCache.get(url)!;
+}
+
+/**
+ * Verify an AuthMe JWT access token and return the decoded payload.
+ */
+export async function verifyToken(
+  token: string,
+  config: AuthmeServerConfig,
+): Promise<AuthmeTokenPayload> {
+  const JWKS = getJWKS(config.issuerUrl, config.realm);
+  const issuer = `${config.issuerUrl}/realms/${config.realm}`;
+
+  const { payload } = await jwtVerify(token, JWKS, { issuer });
+  return payload as AuthmeTokenPayload;
+}
+
+/**
+ * Check if a token payload has the required realm roles.
+ */
+export function hasRealmRoles(
+  payload: AuthmeTokenPayload,
+  requiredRoles: string[],
+): boolean {
+  const userRoles = payload.realm_access?.roles ?? [];
+  return requiredRoles.every((role) => userRoles.includes(role));
+}
+
+/**
+ * Check if a token payload has the required client roles.
+ */
+export function hasClientRoles(
+  payload: AuthmeTokenPayload,
+  clientId: string,
+  requiredRoles: string[],
+): boolean {
+  const userRoles = payload.resource_access?.[clientId]?.roles ?? [];
+  return requiredRoles.every((role) => userRoles.includes(role));
+}
+
+// ─── Express Middleware ────────────────────────────────────
+
+export interface AuthmeRequest {
+  user?: AuthmeTokenPayload;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+/**
+ * Create an Express middleware that validates AuthMe JWT access tokens.
+ *
+ * @example
+ * ```typescript
+ * import express from 'express';
+ * import { createAuthmeMiddleware } from 'authme-sdk/server';
+ *
+ * const app = express();
+ * const authme = createAuthmeMiddleware({
+ *   issuerUrl: 'http://localhost:3000',
+ *   realm: 'my-realm',
+ * });
+ *
+ * app.get('/api/profile', authme, (req, res) => {
+ *   res.json(req.user);
+ * });
+ * ```
+ */
+export function createAuthmeMiddleware(config: AuthmeServerConfig) {
+  return async (
+    req: AuthmeRequest,
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    const authHeader = req.headers['authorization'] ?? req.headers['Authorization'];
+    const header = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+
+    if (!header?.startsWith('Bearer ')) {
+      return res.status(401).json({ error: 'unauthorized', message: 'Missing Bearer token' });
+    }
+
+    const token = header.slice(7);
+
+    try {
+      const payload = await verifyToken(token, config);
+
+      if (config.requiredRoles?.length) {
+        if (!hasRealmRoles(payload, config.requiredRoles)) {
+          return res.status(403).json({ error: 'forbidden', message: 'Insufficient roles' });
+        }
+      }
+
+      req.user = payload;
+      next();
+    } catch {
+      return res.status(401).json({ error: 'unauthorized', message: 'Invalid or expired token' });
+    }
+  };
+}
+
+// ─── NestJS Guard ─────────────────────────────────────────
+
+/**
+ * NestJS-compatible guard factory for AuthMe token validation.
+ *
+ * @example
+ * ```typescript
+ * import { createAuthmeGuard } from 'authme-sdk/server';
+ *
+ * const AuthmeGuard = createAuthmeGuard({
+ *   issuerUrl: 'http://localhost:3000',
+ *   realm: 'my-realm',
+ * });
+ *
+ * @Controller('api')
+ * export class AppController {
+ *   @Get('profile')
+ *   @UseGuards(AuthmeGuard)
+ *   getProfile(@Req() req) {
+ *     return req.user;
+ *   }
+ * }
+ * ```
+ */
+export function createAuthmeGuard(config: AuthmeServerConfig) {
+  return class AuthmeGuard {
+    async canActivate(context: {
+      switchToHttp: () => { getRequest: () => AuthmeRequest };
+    }): Promise<boolean> {
+      const request = context.switchToHttp().getRequest();
+      const authHeader = request.headers['authorization'] ?? request.headers['Authorization'];
+      const header = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+
+      if (!header?.startsWith('Bearer ')) {
+        throw new Error('Missing Bearer token');
+      }
+
+      const token = header.slice(7);
+      const payload = await verifyToken(token, config);
+
+      if (config.requiredRoles?.length) {
+        if (!hasRealmRoles(payload, config.requiredRoles)) {
+          throw new Error('Insufficient roles');
+        }
+      }
+
+      request.user = payload;
+      return true;
+    }
+  };
+}
+
+/**
+ * Helper to extract roles from an AuthMe token payload.
+ */
+export function getRolesFromToken(
+  payload: AuthmeTokenPayload,
+  clientId?: string,
+): string[] {
+  if (clientId) {
+    return payload.resource_access?.[clientId]?.roles ?? [];
+  }
+  return payload.realm_access?.roles ?? [];
+}

--- a/packages/authme-js/tsup.config.ts
+++ b/packages/authme-js/tsup.config.ts
@@ -4,10 +4,11 @@ export default defineConfig({
   entry: {
     index: 'src/index.ts',
     react: 'src/react.ts',
+    server: 'src/server.ts',
   },
   format: ['esm', 'cjs'],
   dts: true,
   clean: true,
   splitting: true,
-  external: ['react'],
+  external: ['react', 'jose'],
 });


### PR DESCRIPTION
## Summary
Add \`authme-sdk/server\` entry point for backend token validation:

- **verifyToken()** — Validate JWT access tokens using JWKS
- **createAuthmeMiddleware()** — Express middleware (401 for invalid, 403 for insufficient roles)
- **createAuthmeGuard()** — NestJS-compatible guard factory
- **hasRealmRoles() / hasClientRoles()** — Role-based access control helpers
- **getRolesFromToken()** — Extract roles from token payload
- JWKS response caching for performance

Uses \`jose\` as optional peer dependency.

## Test plan
- [x] SDK builds successfully with new server entry point
- [x] TypeScript declarations generated
- [ ] Express middleware validates tokens correctly
- [ ] NestJS guard validates tokens correctly

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)