### PR TITLE
Add client role mappings UI to admin console

### DIFF
--- a/admin-ui/src/api/roles.ts
+++ b/admin-ui/src/api/roles.ts
@@ -57,3 +57,50 @@ export async function removeUserRealmRoles(
     { data: { roleNames } },
   );
 }
+
+// ─── Client Roles ────────────────────────────────────────
+
+export async function getClientRoles(
+  realmName: string,
+  clientId: string,
+): Promise<Role[]> {
+  const { data } = await apiClient.get<Role[]>(
+    `/realms/${realmName}/clients/${clientId}/roles`,
+  );
+  return data;
+}
+
+export async function getUserClientRoles(
+  realmName: string,
+  userId: string,
+  clientId: string,
+): Promise<Role[]> {
+  const { data } = await apiClient.get<Role[]>(
+    `/realms/${realmName}/users/${userId}/role-mappings/clients/${clientId}`,
+  );
+  return data;
+}
+
+export async function assignUserClientRoles(
+  realmName: string,
+  userId: string,
+  clientId: string,
+  roleNames: string[],
+): Promise<void> {
+  await apiClient.post(
+    `/realms/${realmName}/users/${userId}/role-mappings/clients/${clientId}`,
+    { roleNames },
+  );
+}
+
+export async function removeUserClientRoles(
+  realmName: string,
+  userId: string,
+  clientId: string,
+  roleNames: string[],
+): Promise<void> {
+  await apiClient.delete(
+    `/realms/${realmName}/users/${userId}/role-mappings/clients/${clientId}`,
+    { data: { roleNames } },
+  );
+}


### PR DESCRIPTION
## Summary
- Add 4 API functions to `admin-ui/src/api/roles.ts`: `getClientRoles`, `getUserClientRoles`, `assignUserClientRoles`, `removeUserClientRoles`
- Add "Client Role Mappings" section to User Detail page with:
  - Client selector dropdown (lists all clients in the realm)
  - Assigned client roles displayed as violet chips with remove button
  - Role assignment dropdown that filters out already-assigned roles
  - Assign button with violet theme to distinguish from realm roles (indigo)

This completes the admin UI for the client role-mapping endpoints added in PR #137.

## Test plan
- [x] `npm run build` passes in `admin-ui/`
- [ ] Navigate to User Detail page → verify "Client Role Mappings" section appears
- [ ] Select a client → verify its assigned roles load as violet chips
- [ ] Assign a client role → verify chip appears and dropdown updates
- [ ] Remove a client role → verify chip disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)