### PR TITLE
Fix login error messages never displayed

### DIFF
--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -19,7 +19,8 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
+    const isOnLoginPage = window.location.pathname === '/console/login';
+    if (error.response?.status === 401 && !isOnLoginPage) {
       sessionStorage.removeItem('adminApiKey');
       sessionStorage.removeItem('adminToken');
       window.location.href = '/console/login';

--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -12,6 +12,7 @@ export function useAuth() {
 
   const login = useCallback(
     async (apiKey: string): Promise<boolean> => {
+      sessionStorage.removeItem('adminToken');
       sessionStorage.setItem('adminApiKey', apiKey);
       try {
         await getAllRealms();
@@ -26,6 +27,8 @@ export function useAuth() {
 
   const loginWithCredentials = useCallback(
     async (username: string, password: string): Promise<boolean> => {
+      sessionStorage.removeItem('adminApiKey');
+      sessionStorage.removeItem('adminToken');
       try {
         const { data } = await apiClient.post('/auth/login', { username, password });
         if (data.access_token) {


### PR DESCRIPTION
## Summary
- Skip 401 redirect in Axios interceptor when user is on the login page, so LoginPage can display error messages
- Clear stale auth state (old tokens) before each login attempt to prevent bypass of API key validation

## Test plan
- [x] Wrong credentials → error message "Invalid username or password" displayed
- [x] Invalid API key → error message "Invalid API key" displayed  
- [x] Valid credentials → redirects to dashboard
- [x] Valid API key → redirects to dashboard

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)