### PR TITLE
Fix client scope names not displayed on client detail page

### DIFF
--- a/admin-ui/src/api/clientScopes.ts
+++ b/admin-ui/src/api/clientScopes.ts
@@ -86,14 +86,25 @@ export async function deleteMapper(
 }
 
 // Client scope assignments
+
+// The API returns join records { id, clientScopeId, clientScope: { ... } }.
+// Flatten them into ClientScope objects so the UI can use scope.id / scope.name directly.
+function flattenScopeAssignments(data: any[]): ClientScope[] {
+  return data.map((entry) =>
+    entry.clientScope
+      ? { ...entry.clientScope, assignmentId: entry.id }
+      : entry,
+  );
+}
+
 export async function getClientDefaultScopes(
   realmName: string,
   clientId: string,
 ): Promise<ClientScope[]> {
-  const { data } = await apiClient.get<ClientScope[]>(
+  const { data } = await apiClient.get(
     `/realms/${realmName}/clients/${clientId}/default-client-scopes`,
   );
-  return data;
+  return flattenScopeAssignments(data);
 }
 
 export async function assignClientDefaultScope(
@@ -121,10 +132,10 @@ export async function getClientOptionalScopes(
   realmName: string,
   clientId: string,
 ): Promise<ClientScope[]> {
-  const { data } = await apiClient.get<ClientScope[]>(
+  const { data } = await apiClient.get(
     `/realms/${realmName}/clients/${clientId}/optional-client-scopes`,
   );
-  return data;
+  return flattenScopeAssignments(data);
 }
 
 export async function assignClientOptionalScope(


### PR DESCRIPTION
## Summary
- Added `flattenScopeAssignments` helper in `clientScopes.ts` to transform nested API responses
- API returns `{ id, clientScopeId, clientScope: { id, name, ... } }` but UI expected `{ id, name, ... }`
- Now scope names and remove buttons work correctly on the Client Detail page

## Test plan
- [x] Navigate to a client detail page with assigned default scopes → scope name "test-scope" is displayed
- [x] Remove button (×) works correctly
- [x] Available scopes dropdown correctly filters out already-assigned scopes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)