### PR TITLE
Fix protocol mapper type column showing wrong value

### DIFF
--- a/admin-ui/src/pages/client-scopes/ClientScopeDetailPage.tsx
+++ b/admin-ui/src/pages/client-scopes/ClientScopeDetailPage.tsx
@@ -245,7 +245,7 @@ export default function ClientScopeDetailPage() {
                       {mapper.name}
                     </td>
                     <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
-                      {mapper.protocol}
+                      {mapper.mapperType}
                     </td>
                     <td className="whitespace-nowrap px-6 py-4 text-right text-sm">
                       <button


### PR DESCRIPTION
## Summary
- Changed `mapper.protocol` to `mapper.mapperType` in the protocol mappers table on the Client Scope detail page
- Type column now correctly shows the mapper type (e.g. "oidc-usermodel-attribute-mapper") instead of the protocol (e.g. "openid-connect")

## Test plan
- [x] Navigate to a client scope with a protocol mapper → Type column shows correct mapper type

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)