### PR TITLE
Fix service-account-user 404 console errors

### DIFF
--- a/admin-ui/src/pages/clients/ClientDetailPage.tsx
+++ b/admin-ui/src/pages/clients/ClientDetailPage.tsx
@@ -51,7 +51,7 @@ export default function ClientDetailPage() {
   const { data: serviceAccount } = useQuery({
     queryKey: ['serviceAccount', name, id],
     queryFn: () => getServiceAccountUser(name!, id!),
-    enabled: !!name && !!id && !!hasClientCredentials,
+    enabled: !!name && !!id && !!client?.serviceAccountUserId,
   });
 
   const [form, setForm] = useState({


### PR DESCRIPTION
## Summary
- Only fetch the service account user when `client.serviceAccountUserId` is non-null
- Prevents unnecessary 404 network requests and console errors

## Test plan
- [x] Navigate to test-client detail page → no console errors
- [x] Service Account section still shows "No service account user found" text correctly

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)