### PR TITLE
Fix /clients/new route conflict with :id segment

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -55,6 +55,7 @@ export default function App() {
           <Route path="/console/realms/:name/users/create" element={<UserCreatePage />} />
           <Route path="/console/realms/:name/users/:id" element={<UserDetailPage />} />
           <Route path="/console/realms/:name/clients" element={<ClientListPage />} />
+          <Route path="/console/realms/:name/clients/new" element={<ClientCreatePage />} />
           <Route path="/console/realms/:name/clients/create" element={<ClientCreatePage />} />
           <Route path="/console/realms/:name/clients/:id" element={<ClientDetailPage />} />
           <Route path="/console/realms/:name/roles" element={<RoleListPage />} />


### PR DESCRIPTION
## Summary
- Added explicit `/clients/new` route before the dynamic `:id` route in `App.tsx`
- Previously, navigating to `/clients/new` was matched by `/clients/:id` with `id="new"`, causing a 404 on client lookup instead of showing the Create Client form

## Test plan
- [x] Navigate to `/console/realms/master/clients/new` → Create Client form renders
- [x] Navigate to `/console/realms/master/clients/create` → Create Client form still works
- [x] Navigate to actual client by ID → Client detail page still works
- [x] No console errors on any route

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)