### PR TITLE
Add pagination to Users list page

### DIFF
--- a/admin-ui/src/api/users.ts
+++ b/admin-ui/src/api/users.ts
@@ -4,13 +4,13 @@ import type { User, OfflineSession } from '../types';
 export async function getUsers(
   realmName: string,
   page = 1,
-  limit = 50,
-): Promise<User[]> {
+  limit = 20,
+): Promise<{ users: User[]; total: number }> {
   const { data } = await apiClient.get<{ users: User[]; total: number }>(
     `/realms/${realmName}/users`,
     { params: { page, limit } },
   );
-  return data.users;
+  return data;
 }
 
 export async function getUserById(


### PR DESCRIPTION
## Summary
- Updated `getUsers` API function to return `{ users, total }` instead of just the users array
- Added Previous/Next pagination controls to UserListPage with "Showing X–Y of Z users" summary
- Uses `keepPreviousData` from TanStack Query for smooth page transitions
- Pagination bar auto-hides when total fits in a single page
- Shows total user count in the page subtitle

## Test plan
- [x] Users list loads correctly with total count displayed
- [x] Pagination controls hidden when users fit on one page (< 20)
- [x] No console errors
- [x] Clicking user rows still navigates to user detail

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)