### PR TITLE
Add server-side token revocation on admin logout

### DIFF
--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -43,7 +43,12 @@ export function useAuth() {
     [],
   );
 
-  const logout = useCallback(() => {
+  const logout = useCallback(async () => {
+    try {
+      await apiClient.post('/auth/logout');
+    } catch {
+      // Best-effort: clear locally even if server call fails
+    }
     sessionStorage.removeItem('adminApiKey');
     sessionStorage.removeItem('adminToken');
     navigate('/console/login');

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -17,6 +17,16 @@ export class AdminAuthController {
     return this.adminAuthService.login(body.username, body.password);
   }
 
+  @Post('logout')
+  @ApiOperation({ summary: 'Admin logout – revoke current token' })
+  async logout(@Req() req: Request) {
+    const authHeader = req.headers['authorization'];
+    if (authHeader?.startsWith('Bearer ')) {
+      this.adminAuthService.revokeToken(authHeader.slice(7));
+    }
+    return { message: 'Logged out' };
+  }
+
   @Get('me')
   @ApiOperation({ summary: 'Get current admin user info' })
   async getMe(@Req() req: Request) {


### PR DESCRIPTION
## Summary
- Added `POST /admin/auth/logout` endpoint to revoke the current admin JWT token
- Backend stores revoked tokens in an in-memory set and rejects them during validation
- Frontend logout hook now calls the server endpoint before clearing sessionStorage
- Previously, logout only cleared client-side storage, leaving the JWT valid until natural expiry (1 hour)

## Test plan
- [x] Click Logout → `POST /admin/auth/logout` returns 201
- [x] Redirected to login page after logout
- [x] Can log back in after logout
- [x] No console errors

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)