### PR TITLE
Fix favicon paths doubled by Vite base config

### DIFF
--- a/admin-ui/index.html
+++ b/admin-ui/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/console/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/console/favicon-16x16.png" />
-    <link rel="icon" type="image/x-icon" href="/console/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/console/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/console/" />
     <title>Authme Admin Console</title>


### PR DESCRIPTION
## Summary
- Favicon `<link>` hrefs used absolute `/console/` paths which Vite's `base: '/console/'` config prepended again, resulting in requests to `/console/console/favicon.ico` (double prefix)
- Changed to relative paths (`favicon.ico` instead of `/console/favicon.ico`) so the existing `<base href="/console/">` tag resolves them correctly

## Test plan
- [x] Hard reload → `GET /console/favicon.ico` returns 200 (not `/console/console/favicon.ico`)
- [x] All icon link hrefs resolve to correct `/console/` paths
- [x] No console errors

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)