### PR TITLE
Fix SAML Service Provider update rejecting enabled field

### DIFF
--- a/src/saml/dto/create-saml-sp.dto.ts
+++ b/src/saml/dto/create-saml-sp.dto.ts
@@ -23,6 +23,11 @@ export class CreateSamlSpDto {
   @IsUrl({ require_tld: false })
   acsUrl!: string;
 
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
   @ApiPropertyOptional({ example: 'https://sp.example.com/slo' })
   @IsOptional()
   @IsUrl({ require_tld: false })


### PR DESCRIPTION
## Summary
- Added `enabled` (optional boolean) field to `CreateSamlSpDto`
- Since `UpdateSamlSpDto` extends `CreateSamlSpDto` via `PartialType`, the update endpoint now accepts the `enabled` field
- The field already existed in the Prisma model and was used by the frontend form

## Test plan
- [x] Create a SAML Service Provider
- [x] Toggle "Sign assertions" off and click "Save Changes"
- [x] Verify PUT request returns 200 (was 400 before)
- [x] Verify success toast "SAML service provider updated successfully."
- [x] Verify no console errors

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)