### PR TITLE
Fix user creation failing when email field is left empty

### DIFF
--- a/admin-ui/src/pages/users/UserCreatePage.tsx
+++ b/admin-ui/src/pages/users/UserCreatePage.tsx
@@ -20,7 +20,15 @@ export default function UserCreatePage() {
   });
 
   const mutation = useMutation({
-    mutationFn: () => createUser(name!, form),
+    mutationFn: () => {
+      const payload = {
+        ...form,
+        email: form.email.trim() || undefined,
+        firstName: form.firstName.trim() || undefined,
+        lastName: form.lastName.trim() || undefined,
+      };
+      return createUser(name!, payload);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['users', name] });
       navigate(`/console/realms/${name}/users`);


### PR DESCRIPTION
## Summary
- Frontend now strips empty optional string fields (email, firstName, lastName) before sending the create user request
- Empty strings are converted to `undefined` so they are omitted from the JSON payload
- Backend `@IsOptional()` + `@IsEmail()` validation now correctly skips these fields

## Test plan
- [x] Create user with only username + password (leave email empty)
- [x] Verify user is created successfully (POST returns 201)
- [x] Verify user appears in list with "-" for email
- [x] Verify no console errors
- [x] Create user with valid email still works

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)