### PR TITLE
Fix race condition during API key login sending stale credentials

### DIFF
--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -10,9 +10,14 @@ export function useAuth() {
     !!sessionStorage.getItem('adminApiKey') ||
     !!sessionStorage.getItem('adminToken');
 
+  const clearAuthState = useCallback(() => {
+    sessionStorage.removeItem('adminApiKey');
+    sessionStorage.removeItem('adminToken');
+  }, []);
+
   const login = useCallback(
     async (apiKey: string): Promise<boolean> => {
-      sessionStorage.removeItem('adminToken');
+      clearAuthState();
       sessionStorage.setItem('adminApiKey', apiKey);
       try {
         await getAllRealms();
@@ -22,13 +27,12 @@ export function useAuth() {
         return false;
       }
     },
-    [],
+    [clearAuthState],
   );
 
   const loginWithCredentials = useCallback(
     async (username: string, password: string): Promise<boolean> => {
-      sessionStorage.removeItem('adminApiKey');
-      sessionStorage.removeItem('adminToken');
+      clearAuthState();
       try {
         const { data } = await apiClient.post('/auth/login', { username, password });
         if (data.access_token) {
@@ -40,7 +44,7 @@ export function useAuth() {
         return false;
       }
     },
-    [],
+    [clearAuthState],
   );
 
   const logout = useCallback(async () => {
@@ -49,10 +53,9 @@ export function useAuth() {
     } catch {
       // Best-effort: clear locally even if server call fails
     }
-    sessionStorage.removeItem('adminApiKey');
-    sessionStorage.removeItem('adminToken');
+    clearAuthState();
     navigate('/console/login');
-  }, [navigate]);
+  }, [clearAuthState, navigate]);
 
-  return { isAuthenticated, login, loginWithCredentials, logout };
+  return { isAuthenticated, login, loginWithCredentials, logout, clearAuthState };
 }

--- a/admin-ui/src/pages/LoginPage.tsx
+++ b/admin-ui/src/pages/LoginPage.tsx
@@ -10,7 +10,7 @@ export default function LoginPage() {
   const [apiKey, setApiKey] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const { login, loginWithCredentials } = useAuth();
+  const { login, loginWithCredentials, clearAuthState } = useAuth();
   const navigate = useNavigate();
 
   async function handleSubmit(e: FormEvent) {
@@ -39,6 +39,7 @@ export default function LoginPage() {
 
   function toggleMode() {
     setError('');
+    clearAuthState();
     setMode(mode === 'credentials' ? 'apikey' : 'credentials');
   }
 


### PR DESCRIPTION
## Summary
- Extracted `clearAuthState()` helper in `useAuth` that removes both `adminApiKey` and `adminToken` from sessionStorage
- Both `login()` and `loginWithCredentials()` now call `clearAuthState()` before setting new credentials
- `toggleMode()` in LoginPage now clears auth state when switching between credential and API key modes
- Prevents the axios interceptor from sending stale headers from a previous auth method

## Test plan
- [x] Enter invalid API key → error shown
- [x] Enter valid API key → login succeeds, navigates to dashboard
- [x] Verify the successful request has only `x-admin-api-key` header (no stale `Authorization`)
- [x] No console errors
- [x] Credential login still works after switching modes

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)