### PR TITLE
Fix Vite base URL mismatch on page refresh at /console

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -81,7 +81,7 @@ export default function App() {
       </Route>
 
       {/* Catch-all: redirect to console */}
-      <Route path="*" element={<Navigate to="/console" replace />} />
+      <Route path="*" element={<Navigate to="/console/" replace />} />
     </Routes>
   );
 }

--- a/admin-ui/src/pages/LoginPage.tsx
+++ b/admin-ui/src/pages/LoginPage.tsx
@@ -32,7 +32,7 @@ export default function LoginPage() {
     }
 
     if (success) {
-      navigate('/console');
+      navigate('/console/');
     }
     setLoading(false);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,8 +68,13 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document);
 
-  // SPA fallback: serve index.html for /console/* navigation routes (skip static files)
+  // Redirect /console → /console/ to match Vite's base URL
   const expressApp = app.getHttpAdapter().getInstance();
+  expressApp.get('/console', (_req: unknown, res: { redirect: (url: string) => void }) => {
+    res.redirect('/console/');
+  });
+
+  // SPA fallback: serve index.html for /console/* navigation routes (skip static files)
   const adminUiIndex = join(__dirname, 'admin-ui', 'index.html');
   expressApp.get(
     '/console/{*path}',


### PR DESCRIPTION
## Summary
- Added backend redirect: `/console` → `/console/` (302) in `main.ts`
- Updated `LoginPage.tsx` to navigate to `/console/` after login
- Updated `App.tsx` catch-all route to redirect to `/console/`
- All three changes ensure URLs match Vite's `base: '/console/'` config

## Test plan
- [x] Backend: `curl http://localhost:3000/console` returns 302 → `/console/`
- [x] Frontend: After login, URL is `/console/` (with trailing slash)
- [x] Dashboard loads correctly at `/console/`
- [x] No Vite base URL mismatch warning shown

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)