### PR TITLE
Fix Realm Overview showing dash for Users count

### DIFF
--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -195,7 +195,7 @@ export default function RealmDetailPage() {
   ];
 
   const quickLinks = [
-    { to: `/console/realms/${name}/users`, label: 'Users', count: users?.length },
+    { to: `/console/realms/${name}/users`, label: 'Users', count: users?.total },
     { to: `/console/realms/${name}/clients`, label: 'Clients', count: clients?.length },
     { to: `/console/realms/${name}/roles`, label: 'Roles', count: roles?.length },
     { to: `/console/realms/${name}/groups`, label: 'Groups', count: groups?.length },


### PR DESCRIPTION
## Summary
- Changed `users?.length` to `users?.total` in the Realm Overview quick links
- The `getUsers()` API returns `{ users: User[], total: number }` (paginated), not a plain array
- Using `.length` on the object returned `undefined`, so the count displayed as "-"

## Test plan
- [x] Navigate to realm overview (test-realm)
- [x] Verify Users card shows "2" (actual count) instead of "-"
- [x] Other counts (Clients, Roles, Groups) still display correctly

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)