### PR TITLE
Fix: Reset toast notifications when switching realm detail tabs

### DIFF
--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -164,6 +164,13 @@ export default function RealmDetailPage() {
     mutationFn: () => sendTestEmail(name!, testEmailTo),
   });
 
+  // Clear toast messages when switching tabs
+  useEffect(() => {
+    updateMutation.reset();
+    testEmailMutation.reset();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     updateMutation.mutate();


### PR DESCRIPTION
## Summary
- Reset `updateMutation` and `testEmailMutation` state via `useEffect` when `activeTab` changes
- Prevents success/error toasts from one tab persisting when switching to another tab

## Test plan
- [x] Save realm settings on General tab → success toast appears
- [x] Switch to Tokens tab → toast disappears
- [x] No regressions on saving from any tab

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)