### PR TITLE
Fix: Skip dependent API calls when realm does not exist

### DIFF
--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -88,7 +88,7 @@ export default function Layout() {
             </NavLink>
           ))}
 
-          {currentRealm && (
+          {currentRealm && realms?.some((r) => r.name === currentRealm) && (
             <>
               <div className="mt-6 mb-2 px-3 text-xs font-semibold uppercase tracking-wider text-gray-400">
                 {currentRealm}

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -34,25 +34,25 @@ export default function RealmDetailPage() {
   const { data: users } = useQuery({
     queryKey: ['users', name],
     queryFn: () => getUsers(name!),
-    enabled: !!name,
+    enabled: !!name && !!realm,
   });
 
   const { data: clients } = useQuery({
     queryKey: ['clients', name],
     queryFn: () => getClients(name!),
-    enabled: !!name,
+    enabled: !!name && !!realm,
   });
 
   const { data: roles } = useQuery({
     queryKey: ['roles', name],
     queryFn: () => getRealmRoles(name!),
-    enabled: !!name,
+    enabled: !!name && !!realm,
   });
 
   const { data: groups } = useQuery({
     queryKey: ['groups', name],
     queryFn: () => getGroups(name!),
-    enabled: !!name,
+    enabled: !!name && !!realm,
   });
 
   const { data: themes } = useQuery({


### PR DESCRIPTION
## Summary
- Gate `users`, `clients`, `roles`, and `groups` queries on `!!realm` so they only fire after the realm is successfully fetched
- Hide sidebar realm-specific navigation when the realm name is not found in the realms list
- Reduces 10+ 404 requests down to just 1 when visiting a non-existent realm URL

## Test plan
- [x] Navigate to `/console/realms/nonexistent-realm` → only 1 realm fetch (404), no dependent queries
- [x] Sidebar shows only Dashboard and Realms (no realm-specific nav)
- [x] Main content shows "Realm not found."
- [x] Valid realm (`test-realm`) still loads all data and sidebar nav correctly

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)