### PR TITLE
Fix: Include client default scopes in authorization code flow tokens

### DIFF
--- a/src/oauth/oauth.service.spec.ts
+++ b/src/oauth/oauth.service.spec.ts
@@ -66,9 +66,15 @@ describe('OAuthService', () => {
     state: 'abc123',
   };
 
+  const mockScopesService = {
+    parseAndValidate: jest.fn((s?: string) => s ? s.split(' ').filter(Boolean) : []),
+    getClientEffectiveScopes: jest.fn(async () => ['openid']),
+    toString: jest.fn((scopes: string[]) => scopes.join(' ')),
+  };
+
   beforeEach(() => {
     prisma = createMockPrismaService();
-    service = new OAuthService(prisma as any);
+    service = new OAuthService(prisma as any, mockScopesService as any);
   });
 
   describe('validateAuthRequest', () => {


### PR DESCRIPTION
## Summary
- Fixes #180: Default client scopes (like `roles`) were not included in access tokens issued via the authorization code flow
- The `authorizeWithUser()` method now resolves effective scopes by merging client default scopes with requested scopes using `ScopesService.getClientEffectiveScopes()`

## Test plan
- [x] Authorization code flow tokens now include `realm_access` and `resource_access` claims
- [x] The `roles` default scope is automatically included even when not explicitly requested
- [x] Password grant continues to work as before
- [x] Updated unit test mock to match new constructor signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)