### PR TITLE
Fix: Enforce PKCE for public clients (#187)

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -359,6 +359,13 @@ export class AuthService {
       throw new BadRequestException('redirect_uri mismatch');
     }
 
+    // PKCE enforcement: public clients must always use PKCE (OAuth 2.1 / RFC 7636)
+    if (client.clientType === 'PUBLIC' && !authCode.codeChallenge) {
+      throw new BadRequestException(
+        'PKCE (code_challenge) is required for public clients',
+      );
+    }
+
     // PKCE verification
     if (authCode.codeChallenge) {
       if (!code_verifier) {

--- a/src/oauth/oauth.service.ts
+++ b/src/oauth/oauth.service.ts
@@ -66,6 +66,13 @@ export class OAuthService {
       throw new BadRequestException('Only S256 code_challenge_method is supported');
     }
 
+    // PKCE is required for public clients (OAuth 2.1 / RFC 7636)
+    if (client.clientType === 'PUBLIC' && !params.code_challenge) {
+      throw new BadRequestException(
+        'PKCE (code_challenge) is required for public clients',
+      );
+    }
+
     return client;
   }
 


### PR DESCRIPTION
## Summary
- Public clients must provide `code_challenge` (PKCE) per OAuth 2.1 / RFC 7636
- Enforcement added at **authorization endpoint** (`oauth.service.ts`) — rejects public clients without `code_challenge`
- Enforcement added at **token exchange** (`auth.service.ts`) — rejects if stored auth code lacks `codeChallenge` for public clients
- Confidential clients remain unaffected (PKCE optional)
- Added 3 new unit tests covering public client PKCE enforcement

## Test plan
- [x] Public client without `code_challenge` → 400 error
- [x] Public client with `code_challenge` → redirects to login (success)
- [x] Confidential client without `code_challenge` → not blocked by PKCE
- [x] All 18 unit tests pass

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)