### PR TITLE
Fix: Return 409 for duplicate email instead of 500 (#178)

### DIFF
--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -132,6 +132,17 @@ describe('UsersService', () => {
         service.create(mockRealm, { username: 'testuser' }),
       ).rejects.toThrow(ConflictException);
     });
+
+    it('should throw ConflictException when email already exists', async () => {
+      // First call (username check) returns null, second call (email check) returns existing user
+      prisma.user.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockUser);
+
+      await expect(
+        service.create(mockRealm, { username: 'newuser', email: 'test@example.com' }),
+      ).rejects.toThrow(ConflictException);
+    });
   });
 
   describe('findAll', () => {


### PR DESCRIPTION
## Summary
- Added duplicate email check in `users.service.ts` `create()` method before `prisma.user.create()`
- Added duplicate email check in `update()` method when email changes
- Returns proper 409 Conflict with message instead of unhandled Prisma P2002 error (500)
- Added unit test for duplicate email scenario

## Test plan
- [x] Duplicate email on create → 409 Conflict
- [x] Unique email on create → 201 Created
- [x] All 14 unit tests pass

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)