### PR TITLE
Fix: Preserve scopes when refreshing tokens (#181)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -225,6 +225,7 @@ model RefreshToken {
   id        String  @id @default(uuid())
   sessionId String  @map("session_id")
   tokenHash String  @unique @map("token_hash")
+  scope     String?
   revoked   Boolean @default(false)
   isOffline Boolean @default(false) @map("is_offline")
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -312,7 +312,7 @@ export class AuthService {
       user,
       client_id,
       storedToken.sessionId,
-      scope,
+      scope || storedToken.scope || undefined,
     );
   }
 
@@ -677,6 +677,7 @@ export class AuthService {
       data: {
         sessionId,
         tokenHash: refreshTokenHash,
+        scope: validatedScope,
         expiresAt: new Date(Date.now() + refreshLifespan * 1000),
         isOffline,
       },


### PR DESCRIPTION
## Summary
- Added `scope` field to the `RefreshToken` Prisma model to persist the original scope
- `issueTokens()` now stores `validatedScope` in the refresh token record
- `handleRefreshTokenGrant()` falls back to the stored scope when the client omits the `scope` parameter
- Per OAuth 2.0 spec (RFC 6749 Section 6): if scope is omitted on refresh, the original scope should be used

## Test plan
- [x] Get tokens with `openid profile email` scope via password grant
- [x] Refresh without `scope` parameter → scope preserved as `openid profile email`
- [x] Previously scope dropped to just `openid`

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)