### PR TITLE
Fix: Support GET logout and handle missing refresh_token (#182, #183)

### DIFF
--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -72,7 +72,7 @@ describe('TokensController', () => {
   });
 
   describe('logout', () => {
-    it('should call tokensService.logout with realm, refresh_token, and req.ip', () => {
+    it('should call tokensService.logout with realm, ip, and refresh_token', () => {
       const body = { refresh_token: 'rt-123' };
       const req = { ip: '127.0.0.1', headers: {} };
 
@@ -80,8 +80,8 @@ describe('TokensController', () => {
 
       expect(mockTokensService.logout).toHaveBeenCalledWith(
         realm,
-        'rt-123',
         '127.0.0.1',
+        'rt-123',
       );
     });
   });


### PR DESCRIPTION
## Summary
- Added `GET /logout` endpoint supporting OIDC RP-Initiated Logout spec
- Supports `id_token_hint`, `post_logout_redirect_uri`, and `state` query parameters
- Made `refresh_token` optional in `POST /logout` — returns 204 instead of 500 when missing
- Extracted session cleanup into private `endSession()` method to avoid duplication
- `logoutByIdToken()` verifies the ID token and ends the associated session(s)

## Test plan
- [x] `GET /logout` → 204 (previously 404)
- [x] `GET /logout?post_logout_redirect_uri=...&state=abc` → redirects with state
- [x] `POST /logout` without refresh_token → 204 (previously 500)
- [x] All 8 controller unit tests pass

Closes #182
Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)