### PR TITLE
Fix: Preserve OAuth params through registration flow (#185)

### DIFF
--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -518,6 +518,14 @@ export class LoginController {
       lastName: query['lastName'] ?? '',
       error: query['error'] ?? '',
       info: query['info'] ?? '',
+      client_id: query['client_id'] ?? '',
+      redirect_uri: query['redirect_uri'] ?? '',
+      response_type: query['response_type'] ?? '',
+      scope: query['scope'] ?? '',
+      state: query['state'] ?? '',
+      nonce: query['nonce'] ?? '',
+      code_challenge: query['code_challenge'] ?? '',
+      code_challenge_method: query['code_challenge_method'] ?? '',
     });
   }
 
@@ -540,7 +548,15 @@ export class LoginController {
     const password = body['password'] ?? '';
     const confirmPassword = body['confirmPassword'] ?? '';
 
-    const preserveFields = `&username=${encodeURIComponent(username)}&email=${encodeURIComponent(email)}&firstName=${encodeURIComponent(firstName)}&lastName=${encodeURIComponent(lastName)}`;
+    // Preserve OAuth params through registration redirects
+    const oauthParamNames = ['client_id', 'redirect_uri', 'response_type', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method'];
+    const oauthParams = oauthParamNames
+      .filter(p => body[p])
+      .map(p => `${p}=${encodeURIComponent(body[p])}`)
+      .join('&');
+    const oauthSuffix = oauthParams ? `&${oauthParams}` : '';
+
+    const preserveFields = `&username=${encodeURIComponent(username)}&email=${encodeURIComponent(email)}&firstName=${encodeURIComponent(firstName)}&lastName=${encodeURIComponent(lastName)}${oauthSuffix}`;
 
     if (!username || username.length < 2) {
       return res.redirect(
@@ -644,7 +660,7 @@ export class LoginController {
     }
 
     const info = encodeURIComponent('Account created successfully! Please check your email to verify your account, then sign in.');
-    res.redirect(`/realms/${realm.name}/login?info=${info}`);
+    res.redirect(`/realms/${realm.name}/login?info=${info}${oauthSuffix}`);
   }
 
   // ─── EMAIL VERIFICATION ─────────────────────────────────

--- a/themes/authme/login/templates/login.hbs
+++ b/themes/authme/login/templates/login.hbs
@@ -40,6 +40,6 @@
 
 {{#if registrationAllowed}}
 <div style="text-align: center; margin-top: 1rem;">
-  <a href="/realms/{{realmName}}/register" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "loginNoAccount"}}</a>
+  <a href="/realms/{{realmName}}/register?client_id={{client_id}}&redirect_uri={{redirect_uri}}&response_type={{response_type}}&scope={{scope}}&state={{state}}&nonce={{nonce}}&code_challenge={{code_challenge}}&code_challenge_method={{code_challenge_method}}" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "loginNoAccount"}}</a>
 </div>
 {{/if}}

--- a/themes/authme/login/templates/register.hbs
+++ b/themes/authme/login/templates/register.hbs
@@ -7,6 +7,15 @@
 {{/if}}
 
 <form method="POST" action="/realms/{{realmName}}/register" class="auth-form">
+  <input type="hidden" name="client_id" value="{{client_id}}">
+  <input type="hidden" name="redirect_uri" value="{{redirect_uri}}">
+  <input type="hidden" name="response_type" value="{{response_type}}">
+  <input type="hidden" name="scope" value="{{scope}}">
+  <input type="hidden" name="state" value="{{state}}">
+  <input type="hidden" name="nonce" value="{{nonce}}">
+  <input type="hidden" name="code_challenge" value="{{code_challenge}}">
+  <input type="hidden" name="code_challenge_method" value="{{code_challenge_method}}">
+
   <div class="form-group">
     <label for="username">{{msg "registerUsername"}}</label>
     <input type="text" id="username" name="username" required autocomplete="username" autofocus value="{{username}}">
@@ -44,5 +53,5 @@
 </form>
 
 <div style="text-align: center; margin-top: 1rem;">
-  <a href="/realms/{{realmName}}/login" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "registerSignInPrompt"}}</a>
+  <a href="/realms/{{realmName}}/login?client_id={{client_id}}&redirect_uri={{redirect_uri}}&response_type={{response_type}}&scope={{scope}}&state={{state}}&nonce={{nonce}}&code_challenge={{code_challenge}}&code_challenge_method={{code_challenge_method}}" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "registerSignInPrompt"}}</a>
 </div>

--- a/themes/midnight/login/templates/login.hbs
+++ b/themes/midnight/login/templates/login.hbs
@@ -39,6 +39,6 @@
 
 {{#if registrationAllowed}}
 <div class="auth-footer-link">
-  <a href="/realms/{{realmName}}/register">{{msg "loginNoAccount"}}</a>
+  <a href="/realms/{{realmName}}/register?client_id={{client_id}}&redirect_uri={{redirect_uri}}&response_type={{response_type}}&scope={{scope}}&state={{state}}&nonce={{nonce}}&code_challenge={{code_challenge}}&code_challenge_method={{code_challenge_method}}">{{msg "loginNoAccount"}}</a>
 </div>
 {{/if}}

--- a/themes/midnight/login/templates/register.hbs
+++ b/themes/midnight/login/templates/register.hbs
@@ -7,6 +7,15 @@
 {{/if}}
 
 <form method="POST" action="/realms/{{realmName}}/register" class="auth-form">
+  <input type="hidden" name="client_id" value="{{client_id}}">
+  <input type="hidden" name="redirect_uri" value="{{redirect_uri}}">
+  <input type="hidden" name="response_type" value="{{response_type}}">
+  <input type="hidden" name="scope" value="{{scope}}">
+  <input type="hidden" name="state" value="{{state}}">
+  <input type="hidden" name="nonce" value="{{nonce}}">
+  <input type="hidden" name="code_challenge" value="{{code_challenge}}">
+  <input type="hidden" name="code_challenge_method" value="{{code_challenge_method}}">
+
   <div class="form-group">
     <label for="username">{{msg "registerUsername"}}</label>
     <input type="text" id="username" name="username" required autocomplete="username" autofocus value="{{username}}" placeholder="{{msg "registerUsername"}}">
@@ -46,5 +55,5 @@
 </form>
 
 <div class="auth-footer-link">
-  <a href="/realms/{{realmName}}/login">{{msg "registerSignInPrompt"}}</a>
+  <a href="/realms/{{realmName}}/login?client_id={{client_id}}&redirect_uri={{redirect_uri}}&response_type={{response_type}}&scope={{scope}}&state={{state}}&nonce={{nonce}}&code_challenge={{code_challenge}}&code_challenge_method={{code_challenge_method}}">{{msg "registerSignInPrompt"}}</a>
 </div>


### PR DESCRIPTION
## Summary
- Added hidden form fields for OAuth params to both `authme` and `midnight` registration templates
- Controller now passes OAuth params to the register template context
- All registration redirect URLs (validation errors, success) preserve OAuth params
- Updated "Create Account" and "Sign in" links to carry OAuth params between login and register pages

## Test plan
- [x] Register page hidden fields contain OAuth params from query string
- [x] Login "Create Account" link carries OAuth params to register page
- [x] Registration success redirect to login preserves OAuth params
- [x] Both `authme` and `midnight` themes updated

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)