### PR TITLE
Fix: Validate theme names and add fallback for nonexistent themes (#188)

### DIFF
--- a/src/theme/theme-template.service.ts
+++ b/src/theme/theme-template.service.ts
@@ -31,6 +31,14 @@ export class ThemeTemplateService {
       }
     }
 
+    // Fallback to the default 'authme' theme to prevent 500 errors
+    if (themeName !== 'authme') {
+      this.logger.warn(
+        `Template "${templateName}" not found for theme "${themeName}/${themeType}", falling back to "authme"`,
+      );
+      return this.resolve('authme', themeType, templateName);
+    }
+
     throw new Error(
       `Template not found: ${templateName} for theme ${themeName}/${themeType}. ` +
       `Searched chain: [${chain.join(' → ')}]`,


### PR DESCRIPTION
## Summary
- Added theme name validation in `RealmsService.update()` — rejects unknown themes with 400 error listing available themes
- Added fallback to default `authme` theme in `ThemeTemplateService.resolve()` — prevents 500 errors if invalid theme is in the database
- Layered defense: upstream validation prevents bad data, downstream fallback ensures graceful degradation

## Test plan
- [x] Setting nonexistent theme → 400 `"Theme 'x' does not exist. Available themes: authme, midnight"`
- [x] Setting valid theme → 200 OK
- [x] Login page with valid theme → 200 OK
- [x] Login page with broken theme in DB → 200 OK (falls back to authme)

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)