### PR TITLE
Fix: Admin password reset now unlocks brute-force locked accounts

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -12,6 +12,7 @@ import { VerificationService } from '../verification/verification.service.js';
 import { EmailService } from '../email/email.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
 import { ThemeEmailService } from '../theme/theme-email.service.js';
+import { BruteForceService } from '../brute-force/brute-force.service.js';
 import { CreateUserDto } from './dto/create-user.dto.js';
 import { UpdateUserDto } from './dto/update-user.dto.js';
 import type { Realm } from '@prisma/client';
@@ -41,6 +42,7 @@ export class UsersService {
     private readonly config: ConfigService,
     private readonly passwordPolicyService: PasswordPolicyService,
     private readonly themeEmail: ThemeEmailService,
+    private readonly bruteForceService: BruteForceService,
   ) {}
 
   async create(realm: Realm, dto: CreateUserDto) {
@@ -194,6 +196,9 @@ export class UsersService {
       where: { id: userId },
       data: { passwordHash, passwordChangedAt: new Date() },
     });
+
+    // Unlock brute-force locked account and clear failure records
+    await this.bruteForceService.resetFailures(realm.id, userId);
 
     // Record password history
     await this.passwordPolicyService.recordHistory(


### PR DESCRIPTION
## Summary
- Inject `BruteForceService` into `UsersService` and call `resetFailures()` after a successful admin password reset
- This clears login failure records and sets `lockedUntil` to null, fully unlocking the account

Closes #202

## Test plan
- [x] Lock account via 5 failed login attempts
- [x] Verify account is locked (correct password returns "Account is temporarily locked")
- [x] Admin resets password via PUT /admin/realms/:realm/users/:id/reset-password
- [x] Verify account is unlocked and login succeeds with new password

🤖 Generated with [Claude Code](https://claude.com/claude-code)