### PR TITLE
Fix: SDK CSRF state validation now fails closed

### DIFF
--- a/packages/authme-js/src/client.ts
+++ b/packages/authme-js/src/client.ts
@@ -152,9 +152,9 @@ export class AuthmeClient {
       return false;
     }
 
-    // Verify state
+    // Verify state — fail-closed: reject if stored state is missing or mismatched
     const storedState = this.storage.get('auth_state');
-    if (storedState && state !== storedState) {
+    if (!storedState || state !== storedState) {
       this.events.emit('error', new Error('State mismatch — possible CSRF attack'));
       return false;
     }


### PR DESCRIPTION
## Summary
- Changed state validation in `handleCallback()` from `if (storedState && state !== storedState)` to `if (!storedState || state !== storedState)`
- Previously, if stored state was cleared (e.g. by another tab or storage expiry), the CSRF check was silently skipped
- Now the check fails closed: missing stored state = reject the callback

Closes #203

## Test plan
- [x] SDK builds successfully
- [x] Verified built output contains the fail-closed check

🤖 Generated with [Claude Code](https://claude.com/claude-code)