### PR TITLE
Fix: Make admin console sidebar scrollable

### DIFF
--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -61,7 +61,7 @@ export default function Layout() {
 
       {/* Sidebar */}
       <aside
-        className={`fixed inset-y-0 left-0 z-40 w-64 transform bg-gray-900 text-white transition-transform lg:relative lg:translate-x-0 ${
+        className={`fixed inset-y-0 left-0 z-40 flex w-64 transform flex-col bg-gray-900 text-white transition-transform lg:relative lg:translate-x-0 ${
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
@@ -69,7 +69,7 @@ export default function Layout() {
           <img src="/console/authme-logo.png" alt="AuthMe" className="h-8 w-auto" />
         </div>
 
-        <nav className="mt-4 space-y-1 px-3">
+        <nav className="mt-4 flex-1 space-y-1 overflow-y-auto px-3 pb-4">
           {globalNav.map((item) => (
             <NavLink
               key={item.to}


### PR DESCRIPTION
## Summary
- Added `flex flex-col` to the sidebar `<aside>` so it uses column layout
- Added `flex-1 overflow-y-auto pb-4` to the `<nav>` element so it scrolls when content overflows the viewport
- Bottom links (Identity Providers, SAML Providers) are now accessible on all screen sizes

Closes #199

## Test plan
- [x] Navigate to a realm with all nav items visible
- [x] Resize viewport to 600px height — sidebar scrolls properly
- [x] Click "SAML Providers" (bottom-most link) — navigates successfully
- [x] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)