### PR TITLE
Fix: Prevent email enumeration on registration page

### DIFF
--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -556,7 +556,7 @@ export class LoginController {
       .join('&');
     const oauthSuffix = oauthParams ? `&${oauthParams}` : '';
 
-    const preserveFields = `&username=${encodeURIComponent(username)}&email=${encodeURIComponent(email)}&firstName=${encodeURIComponent(firstName)}&lastName=${encodeURIComponent(lastName)}${oauthSuffix}`;
+    const preserveFields = oauthSuffix;
 
     if (!username || username.length < 2) {
       return res.redirect(
@@ -590,23 +590,16 @@ export class LoginController {
       );
     }
 
-    // Check for duplicate username
+    // Check for duplicate username or email — use a generic message to prevent enumeration
     const existingByUsername = await this.prisma.user.findUnique({
       where: { realmId_username: { realmId: realm.id, username } },
     });
-    if (existingByUsername) {
-      return res.redirect(
-        `/realms/${realm.name}/register?error=${encodeURIComponent('An account with that username already exists.')}${preserveFields}`,
-      );
-    }
-
-    // Check for duplicate email
     const existingByEmail = await this.prisma.user.findUnique({
       where: { realmId_email: { realmId: realm.id, email } },
     });
-    if (existingByEmail) {
+    if (existingByUsername || existingByEmail) {
       return res.redirect(
-        `/realms/${realm.name}/register?error=${encodeURIComponent('An account with that email already exists.')}${preserveFields}`,
+        `/realms/${realm.name}/register?error=${encodeURIComponent('An account with that username or email already exists.')}${preserveFields}`,
       );
     }
 


### PR DESCRIPTION
## Summary
- Merged duplicate username and email checks into a single generic error message: "An account with that username or email already exists"
- Removed user form fields (username, email, firstName, lastName) from redirect URL query parameters — only OAuth params are preserved
- Both changes prevent information leakage that could be used for account enumeration attacks

Closes #201

## Test plan
- [x] Register with existing email → generic error (no email-specific message)
- [x] Register with existing username → same generic error
- [x] URL no longer contains user form fields in query params
- [x] OAuth params still preserved through registration redirects
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)