### PR TITLE
Fix: CLI exits cleanly on errors instead of crashing with libuv assertion

### DIFF
--- a/packages/authme-cli/src/commands/auth.ts
+++ b/packages/authme-cli/src/commands/auth.ts
@@ -36,8 +36,7 @@ export function registerAuthCommands(program: Command): void {
 
       if (!res.ok) {
         const err = await res.json().catch(() => ({ message: res.statusText }));
-        console.error(chalk.red(`Login failed: ${err.message}`));
-        process.exit(1);
+        throw new Error(chalk.red(`Login failed: ${err.message}`));
       }
 
       const data: LoginResponse = await res.json();

--- a/packages/authme-cli/src/commands/init.ts
+++ b/packages/authme-cli/src/commands/init.ts
@@ -34,8 +34,7 @@ export function registerInitCommand(program: Command): void {
         });
 
         if (!res.ok) {
-          console.error(chalk.red('Login failed. Check your credentials and server URL.'));
-          process.exit(1);
+          throw new Error(chalk.red('Login failed. Check your credentials and server URL.'));
         }
 
         const data: LoginResponse = await res.json();

--- a/packages/authme-cli/src/config.ts
+++ b/packages/authme-cli/src/config.ts
@@ -48,8 +48,7 @@ export function requireAuth(): { serverUrl: string; headers: Record<string, stri
     return { serverUrl: config.serverUrl, headers };
   }
 
-  console.error(
+  throw new Error(
     'Not authenticated. Run `authme login` or set AUTHME_SERVER_URL + ADMIN_API_KEY env vars.',
   );
-  process.exit(1);
 }

--- a/packages/authme-cli/src/http.ts
+++ b/packages/authme-cli/src/http.ts
@@ -62,8 +62,9 @@ export class HttpClient {
     if (!res.ok) {
       const msg = json?.message ?? json?.error ?? res.statusText;
       const display = Array.isArray(msg) ? msg.join(', ') : msg;
-      console.error(chalk.red(`Error ${res.status}: ${display}`));
-      process.exit(1);
+      const error = new Error(`Error ${res.status}: ${display}`);
+      error.message = chalk.red(error.message);
+      throw error;
     }
 
     return json as T;

--- a/packages/authme-cli/src/index.ts
+++ b/packages/authme-cli/src/index.ts
@@ -21,6 +21,6 @@ registerRoleCommands(program);
 registerInitCommand(program);
 
 program.parseAsync(process.argv).catch((err) => {
-  console.error(err);
-  process.exit(1);
+  if (err.message) console.error(err.message);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## Summary
- Replaced `process.exit(1)` calls with `throw new Error()` in `http.ts`, `config.ts`, `auth.ts`, and `init.ts`
- Top-level error handler in `index.ts` now uses `process.exitCode = 1` instead of `process.exit(1)`, allowing the event loop to drain naturally
- Eliminates the `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` crash on Windows when async operations are still pending

Closes #206

## Test plan
- [x] CLI builds successfully
- [x] `realm get nonexistent-realm` → clean "Error 404" with exit code 1 (no UV assertion)
- [x] `realm create test-realm` → clean "Error 409" with exit code 1
- [x] Normal commands (`whoami`) still work with exit code 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)