### PR TITLE
fix: add missing scope column to refresh_tokens table

### DIFF
--- a/prisma/migrations/20260301000000_add_refresh_token_scope/migration.sql
+++ b/prisma/migrations/20260301000000_add_refresh_token_scope/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "refresh_tokens" ADD COLUMN "scope" TEXT;


### PR DESCRIPTION
## Summary
- Closes #217
- Creates migration to add the `scope TEXT` column to `refresh_tokens` that was defined in the Prisma schema but never migrated

## Test plan
- [ ] Run `npx prisma migrate deploy` successfully
- [ ] Verify `scope` column exists in `refresh_tokens` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)