### PR TITLE
fix: block disabled realms for non-admin endpoints

### DIFF
--- a/src/common/guards/realm.guard.ts
+++ b/src/common/guards/realm.guard.ts
@@ -3,6 +3,7 @@ import {
   ExecutionContext,
   Injectable,
   NotFoundException,
+  ForbiddenException,
 } from '@nestjs/common';
 import type { Request } from 'express';
 import { PrismaService } from '../../prisma/prisma.service.js';
@@ -26,6 +27,11 @@ export class RealmGuard implements CanActivate {
 
     if (!realm) {
       throw new NotFoundException(`Realm '${realmName}' not found`);
+    }
+
+    // Block disabled realms for non-admin endpoints
+    if (!realm.enabled && !request.path.startsWith('/admin/')) {
+      throw new ForbiddenException('Realm is disabled');
     }
 
     (request as any).realm = realm;


### PR DESCRIPTION
## Summary
- Closes #221
- Adds `ForbiddenException('Realm is disabled')` in `RealmGuard` when realm is not enabled
- Excludes admin API paths (`/admin/...`) so admins can still re-enable disabled realms

## Test plan
- [ ] Disable a realm, verify login page returns 403
- [ ] Admin API still works on disabled realm
- [ ] Updated guard spec tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)