### PR TITLE
fix: prevent 500 on offline sessions with null session

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -213,13 +213,15 @@ export class UsersService {
       include: { session: { select: { id: true, userId: true, createdAt: true } } },
       orderBy: { createdAt: 'desc' },
     });
-    return tokens.map((t) => ({
-      id: t.id,
-      sessionId: t.session.id,
-      sessionStarted: t.session.createdAt,
-      expiresAt: t.expiresAt,
-      createdAt: t.createdAt,
-    }));
+    return tokens
+      .filter((t) => t.session !== null)
+      .map((t) => ({
+        id: t.id,
+        sessionId: t.session.id,
+        sessionStarted: t.session.createdAt,
+        expiresAt: t.expiresAt,
+        createdAt: t.createdAt,
+      }));
   }
 
   async revokeOfflineSession(realm: Realm, userId: string, tokenId: string) {


### PR DESCRIPTION
## Summary
- Closes #215
- Adds `.filter((t) => t.session !== null)` to the offline sessions query to prevent crashes from orphaned tokens

## Test plan
- [ ] `GET /admin/realms/{realm}/users/{id}/offline-sessions` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)