### PR TITLE
fix: log unhandled exceptions in GlobalExceptionFilter

### DIFF
--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -4,11 +4,14 @@ import {
   ArgumentsHost,
   HttpException,
   HttpStatus,
+  Logger,
 } from '@nestjs/common';
 import type { Response } from 'express';
 
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger('ExceptionFilter');
+
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
@@ -22,6 +25,13 @@ export class GlobalExceptionFilter implements ExceptionFilter {
       exception instanceof HttpException
         ? exception.getResponse()
         : 'Internal server error';
+
+    if (!(exception instanceof HttpException)) {
+      this.logger.error(
+        'Unhandled exception',
+        exception instanceof Error ? exception.stack : String(exception),
+      );
+    }
 
     response.status(status).json({
       statusCode: status,


### PR DESCRIPTION
## Summary
- Closes #218
- Adds `Logger` to the global exception filter to log stack traces for non-HTTP exceptions
- Previously these 500 errors were silently swallowed with no server-side logging

## Test plan
- [ ] Trigger a 500 error and verify stack trace appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)