### PR TITLE
fix: add Cache-Control no-store to token endpoint

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -18,6 +18,10 @@ describe('AuthController', () => {
     headers: { 'user-agent': 'test-agent' },
   };
 
+  const res = {
+    set: jest.fn(),
+  };
+
   beforeEach(() => {
     mockAuthService = {
       handleTokenRequest: jest.fn(),
@@ -30,7 +34,7 @@ describe('AuthController', () => {
     it('should call authService.handleTokenRequest with correct arguments', () => {
       const body = { grant_type: 'password', username: 'user', password: 'pass' };
 
-      controller.token(realm, body, req as any);
+      controller.token(realm, body, req as any, res as any);
 
       expect(mockAuthService.handleTokenRequest).toHaveBeenCalledWith(
         realm,
@@ -44,7 +48,7 @@ describe('AuthController', () => {
       const expected = { access_token: 'tok', token_type: 'Bearer' };
       mockAuthService.handleTokenRequest.mockResolvedValue(expected);
 
-      const result = await controller.token(realm, {}, req as any);
+      const result = await controller.token(realm, {}, req as any, res as any);
 
       expect(result).toEqual(expected);
     });
@@ -52,7 +56,7 @@ describe('AuthController', () => {
     it('should pass the exact body object without modification', () => {
       const body = { grant_type: 'client_credentials', client_id: 'my-client', client_secret: 's3cret' };
 
-      controller.token(realm, body, req as any);
+      controller.token(realm, body, req as any, res as any);
 
       expect(mockAuthService.handleTokenRequest).toHaveBeenCalledTimes(1);
       const [passedRealm, passedBody] = mockAuthService.handleTokenRequest.mock.calls[0];

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,12 +4,13 @@ import {
   Body,
   Param,
   Req,
+  Res,
   UseGuards,
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiConsumes, ApiBody } from '@nestjs/swagger';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import type { Realm } from '@prisma/client';
 import { AuthService } from './auth.service.js';
 import { TokenRequestDto } from './dto/token-request.dto.js';
@@ -29,11 +30,14 @@ export class AuthController {
   @ApiOperation({ summary: 'Token endpoint (password, client_credentials, refresh_token, authorization_code)' })
   @ApiConsumes('application/x-www-form-urlencoded', 'application/json')
   @ApiBody({ type: TokenRequestDto })
-  token(
+  async token(
     @CurrentRealm() realm: Realm,
     @Body() body: Record<string, string>,
     @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
   ) {
+    res.set('Cache-Control', 'no-store');
+    res.set('Pragma', 'no-cache');
     return this.authService.handleTokenRequest(
       realm,
       body,


### PR DESCRIPTION
## Summary
- Closes #219
- Sets `Cache-Control: no-store` and `Pragma: no-cache` on the OAuth token endpoint response per RFC 6749 Section 5.1

## Test plan
- [ ] `curl -v POST /realms/{realm}/protocol/openid-connect/token` shows Cache-Control and Pragma headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)