### PR TITLE
fix: block public access to template and config files

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -78,6 +78,17 @@ async function bootstrap() {
   // Handlebars template engine — templates live in themes/ and are resolved by ThemeRenderService
   app.setBaseViewsDir(join(__dirname, '..', 'themes'));
   app.setViewEngine('hbs');
+
+  // Block access to template sources, config files, and message bundles
+  const expressInstance = app.getHttpAdapter().getInstance();
+  expressInstance.use('/themes', (req: { path: string }, res: { status: (code: number) => { json: (body: object) => void } }, next: () => void) => {
+    if (/\.(hbs|properties)$/.test(req.path) || req.path.includes('theme.json')) {
+      res.status(403).json({ statusCode: 403, message: 'Forbidden' });
+      return;
+    }
+    next();
+  });
+
   app.useStaticAssets(join(__dirname, '..', 'themes'), { prefix: '/themes' });
 
   // Register theme engine Handlebars helpers ({{msg}}, {{msgArgs}})


### PR DESCRIPTION
## Summary
- Closes #223
- Adds Express middleware that returns 403 for `.hbs`, `.properties`, and `theme.json` files served under `/themes`
- Only CSS/resource files remain publicly accessible

## Test plan
- [ ] `curl /themes/authme/login/templates/login.hbs` returns 403
- [ ] `curl /themes/authme/login/resources/css/auth.css` still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)