### PR TITLE
fix: reject empty theme names in realm DTOs

### DIFF
--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsBoolean, IsInt, IsObject, Min, Matches } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsInt, IsObject, Min, MinLength, Matches } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateRealmDto {
@@ -176,6 +176,7 @@ export class CreateRealmDto {
   @ApiPropertyOptional({ default: 'authme', description: 'Name of the theme preset to use' })
   @IsOptional()
   @IsString()
+  @MinLength(1)
   themeName?: string;
 
   @ApiPropertyOptional({ description: 'Realm theme configuration (color overrides)' })
@@ -186,15 +187,18 @@ export class CreateRealmDto {
   @ApiPropertyOptional({ default: 'authme', description: 'Login page theme' })
   @IsOptional()
   @IsString()
+  @MinLength(1)
   loginTheme?: string;
 
   @ApiPropertyOptional({ default: 'authme', description: 'Account page theme' })
   @IsOptional()
   @IsString()
+  @MinLength(1)
   accountTheme?: string;
 
   @ApiPropertyOptional({ default: 'authme', description: 'Email template theme' })
   @IsOptional()
   @IsString()
+  @MinLength(1)
   emailTheme?: string;
 }


### PR DESCRIPTION
## Summary
- Closes #222
- Adds `@MinLength(1)` to `themeName`, `loginTheme`, `accountTheme`, `emailTheme` fields in `CreateRealmDto`
- Empty theme names now return 400 validation error

## Test plan
- [ ] `PUT /admin/realms/test-realm` with `{"loginTheme": ""}` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)