### PR TITLE
fix: add id and name attributes to admin UI form inputs

### DIFF
--- a/admin-ui/src/pages/clients/ClientCreatePage.tsx
+++ b/admin-ui/src/pages/clients/ClientCreatePage.tsx
@@ -107,10 +107,12 @@ export default function ClientCreatePage() {
       <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="clientId" className="mb-1.5 block text-sm font-medium text-gray-700">
               Client ID
             </label>
             <input
+              id="clientId"
+              name="clientId"
               type="text"
               required
               value={form.clientId}
@@ -120,10 +122,12 @@ export default function ClientCreatePage() {
             />
           </div>
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="clientName" className="mb-1.5 block text-sm font-medium text-gray-700">
               Name
             </label>
             <input
+              id="clientName"
+              name="name"
               type="text"
               value={form.name}
               onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -134,10 +138,12 @@ export default function ClientCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="description" className="mb-1.5 block text-sm font-medium text-gray-700">
             Description
           </label>
           <textarea
+            id="description"
+            name="description"
             value={form.description}
             onChange={(e) => setForm({ ...form, description: e.target.value })}
             rows={2}
@@ -146,10 +152,12 @@ export default function ClientCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="clientType" className="mb-1.5 block text-sm font-medium text-gray-700">
             Client Type
           </label>
           <select
+            id="clientType"
+            name="clientType"
             value={form.clientType}
             onChange={(e) =>
               setForm({ ...form, clientType: e.target.value as 'CONFIDENTIAL' | 'PUBLIC' })
@@ -165,10 +173,12 @@ export default function ClientCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="redirectUris" className="mb-1.5 block text-sm font-medium text-gray-700">
             Redirect URIs (one per line)
           </label>
           <textarea
+            id="redirectUris"
+            name="redirectUris"
             value={form.redirectUris}
             onChange={(e) => setForm({ ...form, redirectUris: e.target.value })}
             rows={3}
@@ -178,10 +188,12 @@ export default function ClientCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="webOrigins" className="mb-1.5 block text-sm font-medium text-gray-700">
             Web Origins (one per line)
           </label>
           <textarea
+            id="webOrigins"
+            name="webOrigins"
             value={form.webOrigins}
             onChange={(e) => setForm({ ...form, webOrigins: e.target.value })}
             rows={2}
@@ -191,10 +203,12 @@ export default function ClientCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="grantTypes" className="mb-1.5 block text-sm font-medium text-gray-700">
             Grant Types (comma-separated)
           </label>
           <input
+            id="grantTypes"
+            name="grantTypes"
             type="text"
             value={form.grantTypes}
             onChange={(e) => setForm({ ...form, grantTypes: e.target.value })}

--- a/admin-ui/src/pages/realms/RealmCreatePage.tsx
+++ b/admin-ui/src/pages/realms/RealmCreatePage.tsx
@@ -40,10 +40,12 @@ export default function RealmCreatePage() {
 
       <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="realmName" className="mb-1.5 block text-sm font-medium text-gray-700">
             Name
           </label>
           <input
+            id="realmName"
+            name="name"
             type="text"
             required
             value={form.name}
@@ -57,10 +59,12 @@ export default function RealmCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="displayName" className="mb-1.5 block text-sm font-medium text-gray-700">
             Display Name
           </label>
           <input
+            id="displayName"
+            name="displayName"
             type="text"
             value={form.displayName}
             onChange={(e) => setForm({ ...form, displayName: e.target.value })}
@@ -71,10 +75,12 @@ export default function RealmCreatePage() {
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="accessTokenLifespan" className="mb-1.5 block text-sm font-medium text-gray-700">
               Access Token Lifespan (seconds)
             </label>
             <input
+              id="accessTokenLifespan"
+              name="accessTokenLifespan"
               type="number"
               min={1}
               value={form.accessTokenLifespan}
@@ -85,10 +91,12 @@ export default function RealmCreatePage() {
             />
           </div>
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="refreshTokenLifespan" className="mb-1.5 block text-sm font-medium text-gray-700">
               Refresh Token Lifespan (seconds)
             </label>
             <input
+              id="refreshTokenLifespan"
+              name="refreshTokenLifespan"
               type="number"
               min={1}
               value={form.refreshTokenLifespan}

--- a/admin-ui/src/pages/users/UserCreatePage.tsx
+++ b/admin-ui/src/pages/users/UserCreatePage.tsx
@@ -52,10 +52,12 @@ export default function UserCreatePage() {
       <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="username" className="mb-1.5 block text-sm font-medium text-gray-700">
               Username
             </label>
             <input
+              id="username"
+              name="username"
               type="text"
               required
               value={form.username}
@@ -64,10 +66,12 @@ export default function UserCreatePage() {
             />
           </div>
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="email" className="mb-1.5 block text-sm font-medium text-gray-700">
               Email
             </label>
             <input
+              id="email"
+              name="email"
               type="email"
               value={form.email}
               onChange={(e) => setForm({ ...form, email: e.target.value })}
@@ -78,10 +82,12 @@ export default function UserCreatePage() {
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="firstName" className="mb-1.5 block text-sm font-medium text-gray-700">
               First Name
             </label>
             <input
+              id="firstName"
+              name="firstName"
               type="text"
               value={form.firstName}
               onChange={(e) => setForm({ ...form, firstName: e.target.value })}
@@ -89,10 +95,12 @@ export default function UserCreatePage() {
             />
           </div>
           <div>
-            <label className="mb-1.5 block text-sm font-medium text-gray-700">
+            <label htmlFor="lastName" className="mb-1.5 block text-sm font-medium text-gray-700">
               Last Name
             </label>
             <input
+              id="lastName"
+              name="lastName"
               type="text"
               value={form.lastName}
               onChange={(e) => setForm({ ...form, lastName: e.target.value })}
@@ -102,10 +110,12 @@ export default function UserCreatePage() {
         </div>
 
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-gray-700">
+          <label htmlFor="password" className="mb-1.5 block text-sm font-medium text-gray-700">
             Password
           </label>
           <PasswordInput
+            id="password"
+            name="password"
             required
             value={form.password}
             onChange={(e) => setForm({ ...form, password: e.target.value })}


### PR DESCRIPTION
## Summary
- Closes #216
- Adds `id` and `name` attributes to all form inputs in UserCreatePage, ClientCreatePage, RealmCreatePage
- Links `<label>` elements via `htmlFor` for accessibility and autofill support

## Test plan
- [ ] Verify form inputs have proper id/name attributes in browser DevTools
- [ ] Labels focus the correct input when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)