### PR TITLE
fix: replace process.exit with thrown errors in CLI prompt

### DIFF
--- a/packages/authme-cli/package.json
+++ b/packages/authme-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authme-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "CLI tool for managing an AuthMe IAM server",
   "type": "module",
   "bin": {

--- a/packages/authme-cli/src/prompt.ts
+++ b/packages/authme-cli/src/prompt.ts
@@ -32,7 +32,11 @@ export async function askPassword(question: string): Promise<string> {
         }
       } else if (ch === '\u0003') {
         // Ctrl+C
-        process.exit(0);
+        if (stdin.setRawMode) stdin.setRawMode(false);
+        stdin.pause();
+        stdin.removeListener('data', onData);
+        console.log();
+        throw new Error('Interrupted');
       } else {
         password += ch;
         process.stdout.write('*');
@@ -53,8 +57,7 @@ export async function select(question: string, options: string[]): Promise<strin
   const answer = await ask('Choice: ');
   const idx = parseInt(answer, 10) - 1;
   if (idx < 0 || idx >= options.length) {
-    console.error('Invalid selection.');
-    process.exit(1);
+    throw new Error('Invalid selection');
   }
   return options[idx];
 }


### PR DESCRIPTION
## Summary
- Closes #226
- Replaces `process.exit(0)` on Ctrl+C with `throw new Error('Interrupted')`
- Replaces `process.exit(1)` on invalid selection with `throw new Error('Invalid selection')`
- Bumps CLI version to 0.1.2

## Test plan
- [ ] Ctrl+C during password prompt throws instead of crashing
- [ ] Invalid menu selection throws instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)