### PR TITLE
fix: register BruteForceController in BruteForceModule

### DIFF
--- a/src/brute-force/brute-force.module.ts
+++ b/src/brute-force/brute-force.module.ts
@@ -1,8 +1,10 @@
 import { Global, Module } from '@nestjs/common';
+import { BruteForceController } from './brute-force.controller.js';
 import { BruteForceService } from './brute-force.service.js';
 
 @Global()
 @Module({
+  controllers: [BruteForceController],
   providers: [BruteForceService],
   exports: [BruteForceService],
 })


### PR DESCRIPTION
## Summary
- Added `BruteForceController` to the `controllers` array in `BruteForceModule`
- The controller was defined but never registered, causing all admin brute-force endpoints (`GET /locked-users`, `POST /users/:id/unlock`) to return 404

## Test plan
- [x] `GET /admin/realms/:realm/brute-force/locked-users` now returns `200 OK` with empty array
- [x] `POST /admin/realms/:realm/brute-force/users/:id/unlock` now returns `204 No Content`
- [x] Build passes with no errors

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)