### PR TITLE
fix: reject HTML tags in username and name fields (#239)

### DIFF
--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -564,6 +564,13 @@ export class LoginController {
       );
     }
 
+    const htmlPattern = /[<>]/;
+    if (htmlPattern.test(username) || htmlPattern.test(firstName) || htmlPattern.test(lastName)) {
+      return res.redirect(
+        `/realms/${realm.name}/register?error=${encodeURIComponent('Fields must not contain HTML tags or angle brackets.')}${preserveFields}`,
+      );
+    }
+
     if (!email) {
       return res.redirect(
         `/realms/${realm.name}/register?error=${encodeURIComponent('Email is required.')}${preserveFields}`,

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,10 +1,14 @@
-import { IsString, IsOptional, IsBoolean, IsEmail, MinLength } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsEmail, MinLength, Matches } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+const NO_HTML = /^[^<>]*$/;
+const NO_HTML_MSG = 'must not contain HTML tags or angle brackets';
 
 export class CreateUserDto {
   @ApiProperty({ example: 'johndoe' })
   @IsString()
   @MinLength(2)
+  @Matches(NO_HTML, { message: `username ${NO_HTML_MSG}` })
   username!: string;
 
   @ApiPropertyOptional({ example: 'john@example.com' })
@@ -15,11 +19,13 @@ export class CreateUserDto {
   @ApiPropertyOptional({ example: 'John' })
   @IsOptional()
   @IsString()
+  @Matches(NO_HTML, { message: `firstName ${NO_HTML_MSG}` })
   firstName?: string;
 
   @ApiPropertyOptional({ example: 'Doe' })
   @IsOptional()
   @IsString()
+  @Matches(NO_HTML, { message: `lastName ${NO_HTML_MSG}` })
   lastName?: string;
 
   @ApiPropertyOptional({ default: true })

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,5 +1,8 @@
-import { IsString, IsOptional, IsBoolean, IsEmail } from 'class-validator';
+import { IsString, IsOptional, IsBoolean, IsEmail, Matches } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+
+const NO_HTML = /^[^<>]*$/;
+const NO_HTML_MSG = 'must not contain HTML tags or angle brackets';
 
 export class UpdateUserDto {
   @ApiPropertyOptional({ example: 'john@example.com' })
@@ -10,11 +13,13 @@ export class UpdateUserDto {
   @ApiPropertyOptional({ example: 'John' })
   @IsOptional()
   @IsString()
+  @Matches(NO_HTML, { message: `firstName ${NO_HTML_MSG}` })
   firstName?: string;
 
   @ApiPropertyOptional({ example: 'Doe' })
   @IsOptional()
   @IsString()
+  @Matches(NO_HTML, { message: `lastName ${NO_HTML_MSG}` })
   lastName?: string;
 
   @ApiPropertyOptional()


### PR DESCRIPTION
## Summary
- Adds `@Matches` validation to `CreateUserDto` and `UpdateUserDto` to reject `<` and `>` characters in username, firstName, and lastName fields
- Adds the same validation to the SSR registration form handler in `LoginController`
- Returns 400 Bad Request with clear error message when HTML tags are detected

Closes #239

## Test plan
- [x] Verified bug: HTML tags like `<b>`, `<script>`, `<img>` accepted in username/name fields
- [x] Admin API: HTML in username → 400 rejected
- [x] Admin API: HTML in firstName → 400 rejected
- [x] Admin API: HTML in lastName → 400 rejected
- [x] Admin API: Clean input → 201 created (no false positives)
- [x] Registration form: HTML in fields → redirect with error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)