### PR TITLE
fix: return HTTP 401 for missing Bearer token in UserInfo endpoint

### DIFF
--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
+  UnauthorizedException,
 } from '@nestjs/common';
 import type { Response } from 'express';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
@@ -85,7 +86,10 @@ export class TokensController {
   userinfo(@CurrentRealm() realm: Realm, @Req() req: Request) {
     const authHeader = req.headers['authorization'];
     if (!authHeader?.startsWith('Bearer ')) {
-      return { error: 'invalid_token', error_description: 'Missing Bearer token' };
+      throw new UnauthorizedException({
+        error: 'invalid_token',
+        error_description: 'Missing Bearer token',
+      });
     }
     const token = authHeader.slice(7);
     return this.tokensService.userinfo(realm, token);


### PR DESCRIPTION
## Summary
- Fixed UserInfo endpoint (`/realms/{realm}/protocol/openid-connect/userinfo`) returning HTTP 200 instead of 401 when Bearer token is missing
- Now throws `UnauthorizedException` per RFC 6750 Section 3.1 instead of returning a plain error object with 200 status

## Test plan
- [x] `curl` UserInfo with no Authorization header → HTTP 401 with error body
- [x] `curl` UserInfo with invalid Bearer token → HTTP 401 (unchanged)
- [x] `curl` UserInfo with valid Bearer token → HTTP 200 with user claims (unchanged)

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)