### PR TITLE
fix: block stored XSS in account profile update endpoint

### DIFF
--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -79,11 +79,19 @@ export class AccountController {
       return res.redirect(`/realms/${realm.name}/login`);
     }
 
+    const firstName = (body['firstName'] ?? '').trim();
+    const lastName = (body['lastName'] ?? '').trim();
+
+    const htmlPattern = /[<>]/;
+    if (htmlPattern.test(firstName) || htmlPattern.test(lastName)) {
+      return res.redirect(`/realms/${realm.name}/account?error=${encodeURIComponent('Fields must not contain HTML tags or angle brackets.')}`);
+    }
+
     await this.prisma.user.update({
       where: { id: user.id },
       data: {
-        firstName: body['firstName'] || null,
-        lastName: body['lastName'] || null,
+        firstName: firstName || null,
+        lastName: lastName || null,
       },
     });
 


### PR DESCRIPTION
## Summary
- Added HTML tag validation (`/[<>]/` pattern) to the account profile update endpoint (`POST /realms/:realmName/account/profile`)
- Rejects firstName and lastName fields containing angle brackets with error: "Fields must not contain HTML tags or angle brackets."
- Matches the same validation already used in the registration endpoint

## Test plan
- [x] Submit XSS payload `<script>alert(1)</script>` in firstName → blocked with error message
- [x] Submit valid name without HTML tags → accepted, "Profile updated successfully."
- [x] Original field values preserved when XSS payload is rejected

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)