### PR TITLE
fix: show correct registration success message based on email verification setting

### DIFF
--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -663,7 +663,10 @@ export class LoginController {
       }
     }
 
-    const info = encodeURIComponent('Account created successfully! Please check your email to verify your account, then sign in.');
+    const message = realm.requireEmailVerification
+      ? 'Account created successfully! Please check your email to verify your account, then sign in.'
+      : 'Account created successfully! You can now sign in.';
+    const info = encodeURIComponent(message);
     res.redirect(`/realms/${realm.name}/login?info=${info}${oauthSuffix}`);
   }
 


### PR DESCRIPTION
## Summary
- Fixes #253
- When `requireEmailVerification` is `false`, the registration success message now says **"Account created successfully! You can now sign in."** instead of misleadingly telling users to check their email
- When `requireEmailVerification` is `true`, the original message is preserved

## Test plan
- [x] Register with `requireEmailVerification: false` → message says "You can now sign in."
- [x] Verified compiled output has correct ternary conditional
- [x] All 41 existing login tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)