### PR TITLE
fix: register msg helper for email templates to fix test email 500 error

### DIFF
--- a/src/theme/theme-email.service.ts
+++ b/src/theme/theme-email.service.ts
@@ -55,10 +55,30 @@ export class ThemeEmailService {
     let compiled = this.compiledTemplates.get(templatePath);
     if (!compiled) {
       const source = readFileSync(templatePath, 'utf-8');
-      // Create a standalone Handlebars instance with the msg helper
+      this.registerHelpers();
       compiled = Handlebars.compile(source);
       this.compiledTemplates.set(templatePath, compiled);
     }
     return compiled;
+  }
+
+  private helpersRegistered = false;
+
+  private registerHelpers(): void {
+    if (this.helpersRegistered) return;
+    Handlebars.registerHelper('msg', function (key: string, options: any) {
+      const messages: Record<string, string> = options?.data?.root?._messages ?? {};
+      return messages[key] ?? key;
+    });
+    Handlebars.registerHelper('msgArgs', function (key: string, ...args: any[]) {
+      const options = args.pop();
+      const messages: Record<string, string> = options?.data?.root?._messages ?? {};
+      let text = messages[key] ?? key;
+      for (let i = 0; i < args.length; i++) {
+        text = text.replace(`{${i}}`, String(args[i] ?? ''));
+      }
+      return text;
+    });
+    this.helpersRegistered = true;
   }
 }


### PR DESCRIPTION
## Summary
- The "Send Test Email" feature in the admin console returned HTTP 500 with `Error: Missing helper: "msg"`
- Root cause: `ThemeEmailService` uses standalone `Handlebars` which didn't have the `msg`/`msgArgs` helpers registered — only the `hbs` view engine (for SSR login pages) had them
- Fix: register both helpers on the standalone Handlebars instance used by email rendering, with a one-time registration guard

## Test plan
- [x] All 6 theme-email tests pass
- [x] Build compiles successfully
- [ ] Send test email from admin console on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)