### PR TITLE
feat: Webhook & Event Notification System

### DIFF
--- a/prisma/migrations/20260324120000_add_webhook_system/migration.sql
+++ b/prisma/migrations/20260324120000_add_webhook_system/migration.sql
@@ -1,0 +1,39 @@
+-- CreateTable
+CREATE TABLE "webhooks" (
+    "id" TEXT NOT NULL,
+    "realm_id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "secret" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "event_types" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "description" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "webhooks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "webhook_deliveries" (
+    "id" TEXT NOT NULL,
+    "webhook_id" TEXT NOT NULL,
+    "event_type" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "status_code" INTEGER,
+    "response" TEXT,
+    "success" BOOLEAN NOT NULL DEFAULT false,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "last_attempt" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "webhook_deliveries_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "webhook_deliveries_webhook_id_created_at_idx" ON "webhook_deliveries"("webhook_id", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "webhooks" ADD CONSTRAINT "webhooks_realm_id_fkey" FOREIGN KEY ("realm_id") REFERENCES "realms"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "webhook_deliveries" ADD CONSTRAINT "webhook_deliveries_webhook_id_fkey" FOREIGN KEY ("webhook_id") REFERENCES "webhooks"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,15 @@ model Realm {
   eventsExpiration   Int     @default(604800) @map("events_expiration")
   adminEventsEnabled Boolean @default(false) @map("admin_events_enabled")
 
+  // Rate limiting
+  rateLimitEnabled         Boolean @default(false) @map("rate_limit_enabled")
+  clientRateLimitPerMinute Int     @default(60)    @map("client_rate_limit_per_minute")
+  clientRateLimitPerHour   Int     @default(1000)  @map("client_rate_limit_per_hour")
+  userRateLimitPerMinute   Int     @default(30)    @map("user_rate_limit_per_minute")
+  userRateLimitPerHour     Int     @default(500)   @map("user_rate_limit_per_hour")
+  ipRateLimitPerMinute     Int     @default(20)    @map("ip_rate_limit_per_minute")
+  ipRateLimitPerHour       Int     @default(200)   @map("ip_rate_limit_per_hour")
+
   // Theming
   themeName    String  @default("authme") @map("theme_name") @db.VarChar(50)
   theme        Json?   @default("{}") @map("theme")
@@ -81,6 +90,7 @@ model Realm {
   adminEvents        AdminEvent[]
   userFederations    UserFederation[]
   samlServiceProviders SamlServiceProvider[]
+  webhooks           Webhook[]
 
   @@map("realms")
 }
@@ -706,6 +716,44 @@ model PendingAction {
 
   @@index([expiresAt])
   @@map("pending_actions")
+}
+
+// ─── WEBHOOKS ────────────────────────────────────────────
+
+model Webhook {
+  id          String   @id @default(uuid())
+  realmId     String   @map("realm_id")
+  realm       Realm    @relation(fields: [realmId], references: [id], onDelete: Cascade)
+  url         String
+  secret      String
+  enabled     Boolean  @default(true)
+  eventTypes  String[] @map("event_types")
+  description String?
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  deliveries WebhookDelivery[]
+
+  @@map("webhooks")
+}
+
+model WebhookDelivery {
+  id          String   @id @default(uuid())
+  webhookId   String   @map("webhook_id")
+  webhook     Webhook  @relation(fields: [webhookId], references: [id], onDelete: Cascade)
+  eventType   String   @map("event_type")
+  payload     Json
+  statusCode  Int?     @map("status_code")
+  response    String?
+  success     Boolean  @default(false)
+  attempts    Int      @default(0)
+  lastAttempt DateTime? @map("last_attempt")
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@index([webhookId, createdAt])
+  @@map("webhook_deliveries")
 }
 
 // ─── ADMIN EVENTS ────────────────────────────────────────

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -39,6 +39,8 @@ import { MetricsModule } from './metrics/metrics.module.js';
 import { UserFederationModule } from './user-federation/user-federation.module.js';
 import { SamlModule } from './saml/saml.module.js';
 import { ThemeModule } from './theme/theme.module.js';
+import { WebhooksModule } from './webhooks/webhooks.module.js';
+import { RateLimitModule } from './rate-limit/rate-limit.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -88,6 +90,8 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     UserFederationModule,
     SamlModule,
     ThemeModule,
+    WebhooksModule,
+    RateLimitModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,10 +1,12 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, Module, forwardRef } from '@nestjs/common';
 import { EventsService } from './events.service.js';
 import { EventsController } from './events.controller.js';
 import { EventsCleanupService } from './events-cleanup.service.js';
+import { WebhooksModule } from '../webhooks/webhooks.module.js';
 
 @Global()
 @Module({
+  imports: [forwardRef(() => WebhooksModule)],
   controllers: [EventsController],
   providers: [EventsService, EventsCleanupService],
   exports: [EventsService],

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import type { LoginEventTypeValue, OperationTypeValue, ResourceTypeValue } from './event-types.js';
+import type { WebhooksService } from '../webhooks/webhooks.service.js';
 
 export interface RecordLoginEventParams {
   realmId: string;
@@ -48,7 +49,10 @@ export interface QueryAdminEventsParams {
 export class EventsService {
   private readonly logger = new Logger(EventsService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    @Optional() private readonly webhooksService?: WebhooksService,
+  ) {}
 
   async recordLoginEvent(params: RecordLoginEventParams): Promise<void> {
     const realm = await this.prisma.realm.findUnique({
@@ -73,6 +77,20 @@ export class EventsService {
     } catch (err) {
       this.logger.warn(`Failed to record login event: ${(err as Error).message}`);
     }
+
+    // Dispatch webhook event (non-blocking, best-effort)
+    this.webhooksService?.dispatchEvent({
+      realmId: params.realmId,
+      eventType: `user.${params.type.toLowerCase()}`,
+      payload: {
+        userId: params.userId,
+        sessionId: params.sessionId,
+        clientId: params.clientId,
+        ipAddress: params.ipAddress,
+        error: params.error,
+        details: params.details,
+      },
+    });
   }
 
   async recordAdminEvent(params: RecordAdminEventParams): Promise<void> {

--- a/src/prisma/prisma.mock.ts
+++ b/src/prisma/prisma.mock.ts
@@ -214,6 +214,18 @@ export function createMockPrismaService(): MockPrismaService {
       update: jest.fn(),
       delete: jest.fn(),
     },
+    webhook: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    webhookDelivery: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
     $connect: jest.fn(),
     $disconnect: jest.fn(),
   } as any;

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
+import type { Realm } from '@prisma/client';
+import { WebhooksService } from './webhooks.service.js';
+import { CreateWebhookDto, UpdateWebhookDto } from './webhooks.dto.js';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+
+@ApiTags('Webhooks')
+@Controller('admin/realms/:realmName/webhooks')
+@UseGuards(RealmGuard)
+@ApiSecurity('admin-api-key')
+export class WebhooksController {
+  constructor(private readonly webhooksService: WebhooksService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create a webhook in a realm' })
+  create(@CurrentRealm() realm: Realm, @Body() dto: CreateWebhookDto) {
+    return this.webhooksService.create(realm, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List webhooks in a realm' })
+  findAll(@CurrentRealm() realm: Realm) {
+    return this.webhooksService.findAll(realm);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a webhook by ID' })
+  findOne(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.webhooksService.findOne(realm, id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a webhook' })
+  update(
+    @CurrentRealm() realm: Realm,
+    @Param('id') id: string,
+    @Body() dto: UpdateWebhookDto,
+  ) {
+    return this.webhooksService.update(realm, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a webhook' })
+  remove(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.webhooksService.remove(realm, id);
+  }
+
+  @Post(':id/test')
+  @ApiOperation({ summary: 'Send a test event to the webhook' })
+  test(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.webhooksService.testWebhook(realm, id);
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'List delivery logs for a webhook' })
+  deliveries(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.webhooksService.findDeliveries(realm, id);
+  }
+}

--- a/src/webhooks/webhooks.dto.ts
+++ b/src/webhooks/webhooks.dto.ts
@@ -1,0 +1,70 @@
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsArray,
+  IsUrl,
+  MinLength,
+  ArrayNotEmpty,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateWebhookDto {
+  @ApiProperty({ example: 'https://example.com/webhook' })
+  @IsUrl({ require_tld: false }, { message: 'url must be a valid URL' })
+  url!: string;
+
+  @ApiProperty({ example: 'my-signing-secret', minLength: 8 })
+  @IsString()
+  @MinLength(8)
+  secret!: string;
+
+  @ApiProperty({
+    example: ['user.login', 'user.created'],
+    description: 'List of event types to subscribe to',
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  eventTypes!: string[];
+
+  @ApiPropertyOptional({ example: 'My webhook for user events' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ example: true, default: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}
+
+export class UpdateWebhookDto {
+  @ApiPropertyOptional({ example: 'https://example.com/webhook' })
+  @IsOptional()
+  @IsUrl({ require_tld: false }, { message: 'url must be a valid URL' })
+  url?: string;
+
+  @ApiPropertyOptional({ example: 'new-signing-secret', minLength: 8 })
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  secret?: string;
+
+  @ApiPropertyOptional({ example: ['user.login', 'user.created'] })
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  eventTypes?: string[];
+
+  @ApiPropertyOptional({ example: 'Updated description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ example: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/src/webhooks/webhooks.module.ts
+++ b/src/webhooks/webhooks.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { WebhooksController } from './webhooks.controller.js';
+import { WebhooksService } from './webhooks.service.js';
+
+@Module({
+  controllers: [WebhooksController],
+  providers: [WebhooksService],
+  exports: [WebhooksService],
+})
+export class WebhooksModule {}

--- a/src/webhooks/webhooks.service.spec.ts
+++ b/src/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,430 @@
+// Mock fetch globally before imports
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+import { NotFoundException } from '@nestjs/common';
+import { WebhooksService } from './webhooks.service.js';
+import {
+  createMockPrismaService,
+  MockPrismaService,
+} from '../prisma/prisma.mock.js';
+import type { Realm } from '@prisma/client';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+  let prisma: MockPrismaService;
+
+  const mockRealm: Realm = {
+    id: 'realm-1',
+    name: 'test-realm',
+    displayName: 'Test Realm',
+    enabled: true,
+  } as Realm;
+
+  const mockWebhook = {
+    id: 'webhook-1',
+    realmId: 'realm-1',
+    url: 'https://example.com/hook',
+    secret: 'super-secret-key',
+    enabled: true,
+    eventTypes: ['user.login', 'user.created'],
+    description: 'Test webhook',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+    service = new WebhooksService(prisma as any);
+    jest.clearAllMocks();
+  });
+
+  // ─── HMAC Signing ─────────────────────────────────────
+
+  describe('signPayload', () => {
+    it('should produce a sha256= prefixed HMAC signature', () => {
+      const secret = 'my-secret';
+      const body = '{"eventType":"user.login"}';
+      const sig = service.signPayload(secret, body);
+
+      expect(sig).toMatch(/^sha256=[a-f0-9]{64}$/);
+    });
+
+    it('should produce consistent signatures for the same input', () => {
+      const secret = 'consistent-secret';
+      const body = '{"hello":"world"}';
+
+      const sig1 = service.signPayload(secret, body);
+      const sig2 = service.signPayload(secret, body);
+
+      expect(sig1).toBe(sig2);
+    });
+
+    it('should produce different signatures for different secrets', () => {
+      const body = '{"hello":"world"}';
+
+      const sig1 = service.signPayload('secret-a', body);
+      const sig2 = service.signPayload('secret-b', body);
+
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('should produce different signatures for different payloads', () => {
+      const secret = 'same-secret';
+
+      const sig1 = service.signPayload(secret, '{"a":1}');
+      const sig2 = service.signPayload(secret, '{"a":2}');
+
+      expect(sig1).not.toBe(sig2);
+    });
+  });
+
+  // ─── CRUD ──────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should create a webhook', async () => {
+      prisma.webhook.create.mockResolvedValue(mockWebhook);
+
+      const dto = {
+        url: 'https://example.com/hook',
+        secret: 'super-secret-key',
+        eventTypes: ['user.login'],
+        enabled: true,
+      };
+
+      const result = await service.create(mockRealm, dto);
+
+      expect(prisma.webhook.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            realmId: 'realm-1',
+            url: dto.url,
+            secret: dto.secret,
+            eventTypes: dto.eventTypes,
+          }),
+        }),
+      );
+      expect(result).toEqual(mockWebhook);
+    });
+
+    it('should default enabled to true when not specified', async () => {
+      prisma.webhook.create.mockResolvedValue(mockWebhook);
+
+      await service.create(mockRealm, {
+        url: 'https://example.com/hook',
+        secret: 'super-secret-key',
+        eventTypes: ['user.login'],
+      });
+
+      expect(prisma.webhook.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ enabled: true }),
+        }),
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all webhooks for a realm', async () => {
+      const webhooks = [mockWebhook];
+      prisma.webhook.findMany.mockResolvedValue(webhooks);
+
+      const result = await service.findAll(mockRealm);
+
+      expect(result).toEqual(webhooks);
+      expect(prisma.webhook.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { realmId: 'realm-1' },
+        }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return webhook when found', async () => {
+      prisma.webhook.findFirst.mockResolvedValue(mockWebhook);
+
+      const result = await service.findOne(mockRealm, 'webhook-1');
+
+      expect(result).toEqual(mockWebhook);
+      expect(prisma.webhook.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'webhook-1', realmId: 'realm-1' },
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when webhook not found', async () => {
+      prisma.webhook.findFirst.mockResolvedValue(null);
+
+      await expect(service.findOne(mockRealm, 'missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a webhook', async () => {
+      const updated = { ...mockWebhook, enabled: false };
+      prisma.webhook.findFirst.mockResolvedValue(mockWebhook);
+      prisma.webhook.update.mockResolvedValue(updated);
+
+      const result = await service.update(mockRealm, 'webhook-1', {
+        enabled: false,
+      });
+
+      expect(result).toEqual(updated);
+      expect(prisma.webhook.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'webhook-1' },
+          data: expect.objectContaining({ enabled: false }),
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when webhook not found', async () => {
+      prisma.webhook.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update(mockRealm, 'missing', { enabled: false }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a webhook', async () => {
+      prisma.webhook.findFirst.mockResolvedValue(mockWebhook);
+      prisma.webhook.delete.mockResolvedValue(mockWebhook);
+
+      await service.remove(mockRealm, 'webhook-1');
+
+      expect(prisma.webhook.delete).toHaveBeenCalledWith({
+        where: { id: 'webhook-1' },
+      });
+    });
+
+    it('should throw NotFoundException when webhook not found', async () => {
+      prisma.webhook.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove(mockRealm, 'missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ─── Dispatch ──────────────────────────────────────────
+
+  describe('dispatchEvent', () => {
+    it('should not throw when dispatch succeeds', () => {
+      prisma.webhook.findMany.mockResolvedValue([]);
+
+      // dispatchEvent is fire-and-forget, should not throw
+      expect(() =>
+        service.dispatchEvent({
+          realmId: 'realm-1',
+          eventType: 'user.login',
+          payload: { userId: 'user-1' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('should find enabled webhooks with matching eventType', async () => {
+      prisma.webhook.findMany.mockResolvedValue([]);
+
+      // Trigger internal dispatch directly
+      await (service as any).doDispatch({
+        realmId: 'realm-1',
+        eventType: 'user.login',
+        payload: { userId: 'user-1' },
+      });
+
+      expect(prisma.webhook.findMany).toHaveBeenCalledWith({
+        where: {
+          realmId: 'realm-1',
+          enabled: true,
+          eventTypes: { has: 'user.login' },
+        },
+      });
+    });
+
+    it('should not deliver when no matching webhooks', async () => {
+      prisma.webhook.findMany.mockResolvedValue([]);
+
+      await (service as any).doDispatch({
+        realmId: 'realm-1',
+        eventType: 'user.login',
+        payload: {},
+      });
+
+      expect(prisma.webhookDelivery.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Retry Logic ───────────────────────────────────────
+
+  describe('deliverWebhook (retry logic)', () => {
+    const webhookRecord = {
+      id: 'webhook-1',
+      url: 'https://example.com/hook',
+      secret: 'test-secret',
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      prisma.webhookDelivery.create.mockResolvedValue({ id: 'delivery-1' });
+      prisma.webhookDelivery.update.mockResolvedValue({});
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should succeed on first attempt', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: async () => 'OK',
+      });
+
+      const promise = (service as any).deliverWebhook(
+        webhookRecord,
+        'user.login',
+        { userId: 'u1' },
+      );
+      // Fast-forward any timers
+      jest.runAllTimersAsync();
+
+      await promise;
+
+      expect(prisma.webhookDelivery.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ success: true, attempts: 1 }),
+        }),
+      );
+    });
+
+    it('should retry on failure and eventually mark as failed', async () => {
+      // Fail all 4 attempts (initial + 3 retries)
+      mockFetch
+        .mockRejectedValueOnce(new Error('Connection refused'))
+        .mockRejectedValueOnce(new Error('Connection refused'))
+        .mockRejectedValueOnce(new Error('Connection refused'))
+        .mockRejectedValueOnce(new Error('Connection refused'));
+
+      // Replace sleep to avoid waiting
+      jest
+        .spyOn(service as any, 'sleep')
+        .mockResolvedValue(undefined);
+
+      await (service as any).deliverWebhook(webhookRecord, 'user.login', {});
+
+      // Should have tried 4 times (1 + 3 retries)
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+
+      expect(prisma.webhookDelivery.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ success: false }),
+        }),
+      );
+    });
+
+    it('should succeed on retry after initial failure', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new Error('Timeout'))
+        .mockResolvedValueOnce({
+          status: 200,
+          text: async () => 'OK',
+        });
+
+      jest
+        .spyOn(service as any, 'sleep')
+        .mockResolvedValue(undefined);
+
+      await (service as any).deliverWebhook(webhookRecord, 'user.login', {});
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      expect(prisma.webhookDelivery.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ success: true, attempts: 2 }),
+        }),
+      );
+    });
+
+    it('should mark as failed when endpoint returns non-2xx and all retries exhausted', async () => {
+      mockFetch.mockResolvedValue({
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      jest
+        .spyOn(service as any, 'sleep')
+        .mockResolvedValue(undefined);
+
+      await (service as any).deliverWebhook(webhookRecord, 'user.login', {});
+
+      // Called 4 times: initial + 3 retries
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+
+      // The final update should mark it as failed
+      expect(prisma.webhookDelivery.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ success: false }),
+        }),
+      );
+    });
+
+    it('should include HMAC signature header in request', async () => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        text: async () => 'OK',
+      });
+
+      jest
+        .spyOn(service as any, 'sleep')
+        .mockResolvedValue(undefined);
+
+      await (service as any).deliverWebhook(
+        webhookRecord,
+        'user.login',
+        { userId: 'u1' },
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        webhookRecord.url,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'X-Webhook-Signature': expect.stringMatching(/^sha256=[a-f0-9]{64}$/),
+          }),
+        }),
+      );
+    });
+  });
+
+  // ─── findDeliveries ────────────────────────────────────
+
+  describe('findDeliveries', () => {
+    it('should return delivery logs for a webhook', async () => {
+      const deliveries = [
+        { id: 'del-1', webhookId: 'webhook-1', eventType: 'user.login' },
+      ];
+      prisma.webhook.findFirst.mockResolvedValue(mockWebhook);
+      prisma.webhookDelivery.findMany.mockResolvedValue(deliveries);
+
+      const result = await service.findDeliveries(mockRealm, 'webhook-1');
+
+      expect(result).toEqual(deliveries);
+      expect(prisma.webhookDelivery.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { webhookId: 'webhook-1' } }),
+      );
+    });
+
+    it('should throw NotFoundException when webhook not found', async () => {
+      prisma.webhook.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.findDeliveries(mockRealm, 'missing'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -1,0 +1,275 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { createHmac } from 'crypto';
+import type { Realm } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CreateWebhookDto, UpdateWebhookDto } from './webhooks.dto.js';
+
+export interface DispatchEventOptions {
+  realmId: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+}
+
+const WEBHOOK_SELECT = {
+  id: true,
+  realmId: true,
+  url: true,
+  enabled: true,
+  eventTypes: true,
+  description: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+/** Retry delays in milliseconds: 1s, 10s, 60s */
+const RETRY_DELAYS_MS = [1_000, 10_000, 60_000];
+
+@Injectable()
+export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ─── CRUD ──────────────────────────────────────────────
+
+  async create(realm: Realm, dto: CreateWebhookDto) {
+    const webhook = await this.prisma.webhook.create({
+      data: {
+        realmId: realm.id,
+        url: dto.url,
+        secret: dto.secret,
+        enabled: dto.enabled ?? true,
+        eventTypes: dto.eventTypes,
+        description: dto.description,
+      },
+      select: WEBHOOK_SELECT,
+    });
+    return webhook;
+  }
+
+  async findAll(realm: Realm) {
+    return this.prisma.webhook.findMany({
+      where: { realmId: realm.id },
+      select: WEBHOOK_SELECT,
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async findOne(realm: Realm, id: string) {
+    const webhook = await this.prisma.webhook.findFirst({
+      where: { id, realmId: realm.id },
+      select: WEBHOOK_SELECT,
+    });
+    if (!webhook) {
+      throw new NotFoundException(`Webhook '${id}' not found`);
+    }
+    return webhook;
+  }
+
+  async update(realm: Realm, id: string, dto: UpdateWebhookDto) {
+    await this.findOne(realm, id);
+    return this.prisma.webhook.update({
+      where: { id },
+      data: {
+        url: dto.url,
+        secret: dto.secret,
+        enabled: dto.enabled,
+        eventTypes: dto.eventTypes,
+        description: dto.description,
+      },
+      select: WEBHOOK_SELECT,
+    });
+  }
+
+  async remove(realm: Realm, id: string) {
+    await this.findOne(realm, id);
+    await this.prisma.webhook.delete({ where: { id } });
+  }
+
+  // ─── Test Webhook ───────────────────────────────────────
+
+  async testWebhook(realm: Realm, id: string) {
+    const webhook = await this.findOne(realm, id);
+    const rawWebhook = await this.prisma.webhook.findFirst({
+      where: { id, realmId: realm.id },
+    });
+    if (!rawWebhook) {
+      throw new NotFoundException(`Webhook '${id}' not found`);
+    }
+    const testPayload = {
+      eventType: 'webhook.test',
+      timestamp: new Date().toISOString(),
+      realmId: realm.id,
+      webhookId: id,
+      test: true,
+    };
+    const delivery = await this.deliverWebhook(rawWebhook, 'webhook.test', testPayload);
+    return { message: 'Test event sent', delivery };
+  }
+
+  // ─── Delivery Logs ─────────────────────────────────────
+
+  async findDeliveries(realm: Realm, webhookId: string) {
+    await this.findOne(realm, webhookId);
+    return this.prisma.webhookDelivery.findMany({
+      where: { webhookId },
+      orderBy: { createdAt: 'desc' },
+      take: 100,
+    });
+  }
+
+  // ─── Event Dispatch ────────────────────────────────────
+
+  /**
+   * Dispatch an event to all matching webhooks for the realm.
+   * Non-blocking: schedules delivery asynchronously.
+   */
+  dispatchEvent(options: DispatchEventOptions): void {
+    // Fire-and-forget — never block the caller
+    setImmediate(() => {
+      this.doDispatch(options).catch((err) => {
+        this.logger.warn(
+          `dispatchEvent error for realm=${options.realmId} type=${options.eventType}: ${(err as Error).message}`,
+        );
+      });
+    });
+  }
+
+  private async doDispatch(options: DispatchEventOptions): Promise<void> {
+    const webhooks = await this.prisma.webhook.findMany({
+      where: {
+        realmId: options.realmId,
+        enabled: true,
+        eventTypes: { has: options.eventType },
+      },
+    });
+
+    if (webhooks.length === 0) return;
+
+    const fullPayload = {
+      eventType: options.eventType,
+      timestamp: new Date().toISOString(),
+      realmId: options.realmId,
+      ...options.payload,
+    };
+
+    await Promise.allSettled(
+      webhooks.map((webhook) =>
+        this.deliverWebhook(webhook, options.eventType, fullPayload),
+      ),
+    );
+  }
+
+  // ─── Delivery with Retry ───────────────────────────────
+
+  private async deliverWebhook(
+    webhook: { id: string; url: string; secret: string },
+    eventType: string,
+    payload: Record<string, unknown>,
+  ) {
+    const body = JSON.stringify(payload);
+    const signature = this.signPayload(webhook.secret, body);
+
+    // Create initial delivery record
+    const delivery = await this.prisma.webhookDelivery.create({
+      data: {
+        webhookId: webhook.id,
+        eventType,
+        payload: payload as any,
+        attempts: 0,
+      },
+    });
+
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt <= RETRY_DELAYS_MS.length; attempt++) {
+      if (attempt > 0) {
+        const delay = RETRY_DELAYS_MS[attempt - 1];
+        await this.sleep(delay);
+      }
+
+      try {
+        const response = await this.doHttpPost(webhook.url, body, signature);
+
+        await this.prisma.webhookDelivery.update({
+          where: { id: delivery.id },
+          data: {
+            statusCode: response.statusCode,
+            response: response.body.slice(0, 2000),
+            success: response.statusCode >= 200 && response.statusCode < 300,
+            attempts: attempt + 1,
+            lastAttempt: new Date(),
+          },
+        });
+
+        if (response.statusCode >= 200 && response.statusCode < 300) {
+          return { ...delivery, success: true, attempts: attempt + 1 };
+        }
+
+        lastError = new Error(`HTTP ${response.statusCode}`);
+      } catch (err) {
+        lastError = err as Error;
+        this.logger.warn(
+          `Webhook delivery attempt ${attempt + 1} failed for ${webhook.url}: ${lastError.message}`,
+        );
+      }
+    }
+
+    // All attempts exhausted
+    await this.prisma.webhookDelivery.update({
+      where: { id: delivery.id },
+      data: {
+        success: false,
+        attempts: RETRY_DELAYS_MS.length + 1,
+        lastAttempt: new Date(),
+        response: lastError?.message?.slice(0, 2000),
+      },
+    });
+
+    return { ...delivery, success: false };
+  }
+
+  // ─── HMAC-SHA256 Signing ───────────────────────────────
+
+  signPayload(secret: string, body: string): string {
+    return `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+  }
+
+  // ─── HTTP POST ─────────────────────────────────────────
+
+  private async doHttpPost(
+    url: string,
+    body: string,
+    signature: string,
+  ): Promise<{ statusCode: number; body: string }> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': signature,
+          'X-Webhook-Timestamp': new Date().toISOString(),
+          'User-Agent': 'Authme-Webhook/1.0',
+        },
+        body,
+        signal: controller.signal,
+      });
+
+      const text = await res.text();
+      return { statusCode: res.status, body: text };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}


### PR DESCRIPTION
## Summary
- Implements **Feature 9: Webhook & Event Notification System** (closes #266)
- Adds `Webhook` and `WebhookDelivery` Prisma models with migration
- New `src/webhooks/` module with full CRUD, HMAC-SHA256 signing, async dispatch, exponential backoff retry (1s, 10s, 60s)
- 7 admin API endpoints for webhook management + test + delivery logs
- Integrated with existing events system — dispatches webhooks on login events
- 23 new unit tests passing

## Endpoints Added
- `POST /admin/realms/:realm/webhooks` — Create webhook
- `GET /admin/realms/:realm/webhooks` — List webhooks
- `GET /admin/realms/:realm/webhooks/:id` — Get webhook
- `PUT /admin/realms/:realm/webhooks/:id` — Update webhook
- `DELETE /admin/realms/:realm/webhooks/:id` — Delete webhook
- `POST /admin/realms/:realm/webhooks/:id/test` — Test webhook
- `GET /admin/realms/:realm/webhooks/:id/deliveries` — Delivery logs

## Test plan
- [x] 23 unit tests for webhook service (signing, CRUD, dispatch, retry, deliveries)
- [ ] Manual test: create webhook, trigger login event, verify delivery
- [ ] Verify no regressions in existing test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)