### PR TITLE
feat: WebAuthn/FIDO2 Passwordless Authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@node-saml/node-saml": "^5.1.0",
         "@prisma/adapter-pg": "^7.4.0",
         "@prisma/client": "^7.4.0",
+        "@simplewebauthn/server": "^13.3.0",
         "argon2": "^0.44.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.3",
@@ -1047,6 +1048,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@hexagon/base64": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
+      "integrity": "sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==",
+      "license": "MIT"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
@@ -2163,6 +2170,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@levischuck/tiny-cbor": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
+      "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2911,6 +2924,165 @@
         "@noble/hashes": "^1.1.5"
       }
     },
+    "node_modules/@peculiar/asn1-android": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-android/-/asn1-android-2.6.0.tgz",
+      "integrity": "sha512-cBRCKtYPF7vJGN76/yG8VbxRcHLPF3HnkoHhKOZeHpoVtbMYfY9ROKtH3DtYUY9m8uI1Mh47PRhHf2hSK3xcSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
+      "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
+      "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
+      "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
+      "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
+      "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
+      "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.1",
+        "@peculiar/asn1-pfx": "^2.6.1",
+        "@peculiar/asn1-pkcs8": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/asn1-x509-attr": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
+      "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+      "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
+      "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "asn1js": "^3.0.6",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
+      "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "asn1js": "^3.0.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+      "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.6.0",
+        "@peculiar/asn1-csr": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.0",
+        "@peculiar/asn1-pkcs9": "^2.6.0",
+        "@peculiar/asn1-rsa": "^2.6.0",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.0",
+        "pvtsutils": "^1.3.6",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.8.1",
+        "tsyringe": "^4.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@phc/format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
@@ -3129,6 +3301,25 @@
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@simplewebauthn/server": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/server/-/server-13.3.0.tgz",
+      "integrity": "sha512-MLHYFrYG8/wK2i+86XMhiecK72nMaHKKt4bo+7Q1TbuG9iGjlSdfkPWKO5ZFE/BX+ygCJ7pr8H/AJeyAj1EaTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hexagon/base64": "^1.1.27",
+        "@levischuck/tiny-cbor": "^0.2.2",
+        "@peculiar/asn1-android": "^2.6.0",
+        "@peculiar/asn1-ecc": "^2.6.1",
+        "@peculiar/asn1-rsa": "^2.6.1",
+        "@peculiar/asn1-schema": "^2.6.0",
+        "@peculiar/asn1-x509": "^2.6.1",
+        "@peculiar/x509": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -4597,6 +4788,20 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -10073,6 +10278,24 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -11615,6 +11838,24 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@node-saml/node-saml": "^5.1.0",
     "@prisma/adapter-pg": "^7.4.0",
     "@prisma/client": "^7.4.0",
+    "@simplewebauthn/server": "^13.3.0",
     "argon2": "^0.44.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",

--- a/prisma/migrations/20260324220000_add_webauthn_credentials/migration.sql
+++ b/prisma/migrations/20260324220000_add_webauthn_credentials/migration.sql
@@ -1,0 +1,36 @@
+-- AlterTable: Add WebAuthn fields to realms
+ALTER TABLE "realms" ADD COLUMN "webauthn_enabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "realms" ADD COLUMN "webauthn_rp_name" TEXT;
+ALTER TABLE "realms" ADD COLUMN "webauthn_rp_id" TEXT;
+
+-- CreateTable: WebAuthn credentials
+CREATE TABLE "webauthn_credentials" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "realm_id" TEXT NOT NULL,
+    "credential_id" TEXT NOT NULL,
+    "public_key" BYTEA NOT NULL,
+    "counter" BIGINT NOT NULL DEFAULT 0,
+    "transports" TEXT[],
+    "device_type" TEXT NOT NULL,
+    "backed_up" BOOLEAN NOT NULL DEFAULT false,
+    "friendly_name" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_used_at" TIMESTAMP(3),
+
+    CONSTRAINT "webauthn_credentials_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "webauthn_credentials_credential_id_key" ON "webauthn_credentials"("credential_id");
+
+-- CreateIndex
+CREATE INDEX "webauthn_credentials_user_id_idx" ON "webauthn_credentials"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "webauthn_credentials" ADD CONSTRAINT "webauthn_credentials_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "webauthn_credentials" ADD CONSTRAINT "webauthn_credentials_realm_id_fkey"
+    FOREIGN KEY ("realm_id") REFERENCES "realms"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -114,6 +114,7 @@ model Realm {
   impersonationSessions ImpersonationSession[]
   policies              Policy[]
   customAttributes      CustomAttribute[]
+  webAuthnCredentials WebAuthnCredential[]
 
   @@map("realms")
 }

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -19,6 +19,7 @@ import { CryptoService } from '../crypto/crypto.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
 import { MfaService } from '../mfa/mfa.service.js';
 import { ThemeRenderService } from '../theme/theme-render.service.js';
+import { WebAuthnService } from '../webauthn/webauthn.service.js';
 
 @ApiExcludeController()
 @Controller('realms/:realmName/account')
@@ -32,6 +33,7 @@ export class AccountController {
     private readonly passwordPolicyService: PasswordPolicyService,
     private readonly mfaService: MfaService,
     private readonly themeRender: ThemeRenderService,
+    private readonly webAuthnService: WebAuthnService,
   ) {}
 
   private async getSessionUser(realm: Realm, req: Request) {
@@ -53,6 +55,21 @@ export class AccountController {
 
     const query = req.query as Record<string, string>;
     const mfaEnabled = await this.mfaService.isMfaEnabled(user.id);
+    const webAuthnEnabled = (realm as any).webAuthnEnabled ?? false;
+
+    let webAuthnCredentials: any[] = [];
+    if (webAuthnEnabled) {
+      const rawCredentials = await this.webAuthnService.getUserCredentials(user.id);
+      webAuthnCredentials = rawCredentials.map((c) => ({
+        id: c.id,
+        friendlyName: c.friendlyName,
+        deviceType: c.deviceType,
+        backedUp: c.backedUp,
+        transports: c.transports,
+        createdAt: c.createdAt.toLocaleDateString(),
+        lastUsedAt: c.lastUsedAt ? c.lastUsedAt.toLocaleDateString() : null,
+      }));
+    }
 
     this.themeRender.render(res, realm, 'account', 'account', {
       pageTitle: 'My Account',
@@ -62,6 +79,8 @@ export class AccountController {
       firstName: user.firstName ?? '',
       lastName: user.lastName ?? '',
       mfaEnabled,
+      webAuthnEnabled,
+      webAuthnCredentials: webAuthnCredentials.length > 0 ? webAuthnCredentials : null,
       success: query['success'] ?? '',
       error: query['error'] ?? '',
     }, req);

--- a/src/account/account.module.ts
+++ b/src/account/account.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { AccountController } from './account.controller.js';
 import { LoginModule } from '../login/login.module.js';
 import { ThemeModule } from '../theme/theme.module.js';
+import { WebAuthnModule } from '../webauthn/webauthn.module.js';
 
 @Module({
-  imports: [LoginModule, ThemeModule],
+  imports: [LoginModule, ThemeModule, WebAuthnModule],
   controllers: [AccountController],
 })
 export class AccountModule {}

--- a/src/login/login.service.ts
+++ b/src/login/login.service.ts
@@ -132,4 +132,10 @@ export class LoginService {
   async findUserById(userId: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { id: userId } });
   }
+
+  async findUserByUsername(realm: Realm, username: string): Promise<User | null> {
+    return this.prisma.user.findUnique({
+      where: { realmId_username: { realmId: realm.id, username } },
+    });
+  }
 }

--- a/src/webauthn/webauthn.controller.ts
+++ b/src/webauthn/webauthn.controller.ts
@@ -1,0 +1,225 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Body,
+  Param,
+  Req,
+  Res,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
+import type { Realm } from '@prisma/client';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+import { Public } from '../common/decorators/public.decorator.js';
+import { WebAuthnService } from './webauthn.service.js';
+import { LoginService } from '../login/login.service.js';
+import { OAuthService } from '../oauth/oauth.service.js';
+import { ConsentService } from '../consent/consent.service.js';
+import {
+  StartRegistrationDto,
+  VerifyRegistrationDto,
+  StartAuthenticationDto,
+  VerifyAuthenticationDto,
+} from './webauthn.dto.js';
+import type {
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+} from '@simplewebauthn/server';
+
+@ApiExcludeController()
+@Controller('realms/:realmName')
+@UseGuards(RealmGuard)
+@Public()
+export class WebAuthnController {
+  constructor(
+    private readonly webAuthnService: WebAuthnService,
+    private readonly loginService: LoginService,
+    private readonly oauthService: OAuthService,
+    private readonly consentService: ConsentService,
+  ) {}
+
+  private async getSessionUser(realm: Realm, req: Request) {
+    const sessionToken = req.cookies?.['AUTHME_SESSION'];
+    if (!sessionToken) return null;
+    return this.loginService.validateLoginSession(realm, sessionToken);
+  }
+
+  // ─── Registration ──────────────────────────────────────────────
+
+  @Post('webauthn/register/options')
+  @HttpCode(HttpStatus.OK)
+  async startRegistration(
+    @CurrentRealm() realm: Realm,
+    @Body() body: StartRegistrationDto,
+    @Req() req: Request,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      throw new BadRequestException('You must be signed in to register a passkey');
+    }
+
+    return this.webAuthnService.generateRegistrationOptions(user, realm);
+  }
+
+  @Post('webauthn/register/verify')
+  @HttpCode(HttpStatus.OK)
+  async completeRegistration(
+    @CurrentRealm() realm: Realm,
+    @Body() body: VerifyRegistrationDto,
+    @Req() req: Request,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      throw new BadRequestException('You must be signed in to register a passkey');
+    }
+
+    const credential = await this.webAuthnService.verifyRegistration(
+      user,
+      realm,
+      body.response as RegistrationResponseJSON,
+      body.friendlyName,
+    );
+
+    return {
+      id: credential.id,
+      credentialId: credential.credentialId,
+      friendlyName: credential.friendlyName,
+      deviceType: credential.deviceType,
+      createdAt: credential.createdAt,
+    };
+  }
+
+  // ─── Authentication ────────────────────────────────────────────
+
+  @Post('webauthn/authenticate/options')
+  @HttpCode(HttpStatus.OK)
+  async startAuthentication(
+    @CurrentRealm() realm: Realm,
+    @Body() body: StartAuthenticationDto,
+    @Req() req: Request,
+  ) {
+    // Look up userId if username given (for autofill / non-resident-key flow)
+    let userId: string | undefined;
+    if (body.username) {
+      const user = await this.loginService.findUserByUsername(realm, body.username);
+      userId = user?.id;
+    }
+
+    return this.webAuthnService.generateAuthenticationOptions(realm, userId);
+  }
+
+  @Post('webauthn/authenticate/verify')
+  @HttpCode(HttpStatus.OK)
+  async completeAuthentication(
+    @CurrentRealm() realm: Realm,
+    @Body() body: VerifyAuthenticationDto,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const { user } = await this.webAuthnService.verifyAuthentication(
+      realm,
+      body.response as AuthenticationResponseJSON,
+    );
+
+    // Build OAuth params from request body
+    const oauthParams: Record<string, string> = {};
+    for (const key of ['response_type', 'client_id', 'redirect_uri', 'scope', 'state', 'nonce', 'code_challenge', 'code_challenge_method']) {
+      if ((body as any)[key]) oauthParams[key] = (body as any)[key];
+    }
+
+    // Create session
+    const sessionToken = await this.loginService.createLoginSession(
+      realm,
+      user,
+      req.ip,
+      req.headers['user-agent'],
+    );
+
+    res.cookie('AUTHME_SESSION', sessionToken, {
+      httpOnly: true,
+      secure: process.env['NODE_ENV'] === 'production',
+      sameSite: 'lax',
+      path: `/realms/${realm.name}`,
+    });
+
+    // Determine redirect
+    if (!oauthParams['client_id']) {
+      return res.json({ redirectUrl: `/realms/${realm.name}/account` });
+    }
+
+    try {
+      const client = await this.oauthService.validateAuthRequest(realm, oauthParams as any);
+
+      if (client.requireConsent) {
+        const scopes = (oauthParams['scope'] ?? 'openid').split(' ').filter(Boolean);
+        const hasConsent = await this.consentService.hasConsent(user.id, client.id, scopes);
+
+        if (!hasConsent) {
+          const reqId = await this.consentService.storeConsentRequest({
+            userId: user.id,
+            clientId: client.id,
+            clientName: client.name ?? client.clientId,
+            realmName: realm.name,
+            scopes,
+            oauthParams,
+          });
+          return res.json({ redirectUrl: `/realms/${realm.name}/consent?req=${reqId}` });
+        }
+      }
+
+      const result = await this.oauthService.authorizeWithUser(realm, user, oauthParams as any);
+      return res.json({ redirectUrl: result.redirectUrl });
+    } catch (err: any) {
+      return res.json({ redirectUrl: `/realms/${realm.name}/login?error=${encodeURIComponent(err.message)}` });
+    }
+  }
+
+  // ─── Account — Credential Management ──────────────────────────
+
+  @Get('account/webauthn/credentials')
+  async listCredentials(
+    @CurrentRealm() realm: Realm,
+    @Req() req: Request,
+    @Res() res: Response,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      return res.redirect(`/realms/${realm.name}/login`);
+    }
+
+    const credentials = await this.webAuthnService.getUserCredentials(user.id);
+    return res.json(
+      credentials.map((c) => ({
+        id: c.id,
+        friendlyName: c.friendlyName,
+        deviceType: c.deviceType,
+        backedUp: c.backedUp,
+        transports: c.transports,
+        createdAt: c.createdAt,
+        lastUsedAt: c.lastUsedAt,
+      })),
+    );
+  }
+
+  @Delete('account/webauthn/credentials/:credentialId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async removeCredential(
+    @CurrentRealm() realm: Realm,
+    @Param('credentialId') credentialId: string,
+    @Req() req: Request,
+  ) {
+    const user = await this.getSessionUser(realm, req);
+    if (!user) {
+      throw new BadRequestException('You must be signed in to remove a passkey');
+    }
+
+    await this.webAuthnService.removeCredential(user.id, credentialId);
+  }
+}

--- a/src/webauthn/webauthn.dto.ts
+++ b/src/webauthn/webauthn.dto.ts
@@ -1,0 +1,60 @@
+import { IsString, IsOptional, IsObject } from 'class-validator';
+
+export class StartRegistrationDto {
+  @IsOptional()
+  @IsString()
+  friendlyName?: string;
+}
+
+export class VerifyRegistrationDto {
+  @IsObject()
+  response: Record<string, any>;
+
+  @IsOptional()
+  @IsString()
+  friendlyName?: string;
+}
+
+export class StartAuthenticationDto {
+  @IsOptional()
+  @IsString()
+  username?: string;
+}
+
+export class VerifyAuthenticationDto {
+  @IsObject()
+  response: Record<string, any>;
+
+  // OAuth params carried through the passkey login flow
+  @IsOptional()
+  @IsString()
+  client_id?: string;
+
+  @IsOptional()
+  @IsString()
+  redirect_uri?: string;
+
+  @IsOptional()
+  @IsString()
+  response_type?: string;
+
+  @IsOptional()
+  @IsString()
+  scope?: string;
+
+  @IsOptional()
+  @IsString()
+  state?: string;
+
+  @IsOptional()
+  @IsString()
+  nonce?: string;
+
+  @IsOptional()
+  @IsString()
+  code_challenge?: string;
+
+  @IsOptional()
+  @IsString()
+  code_challenge_method?: string;
+}

--- a/src/webauthn/webauthn.module.ts
+++ b/src/webauthn/webauthn.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { WebAuthnService } from './webauthn.service.js';
+import { WebAuthnController } from './webauthn.controller.js';
+import { LoginModule } from '../login/login.module.js';
+import { OAuthModule } from '../oauth/oauth.module.js';
+import { ConsentModule } from '../consent/consent.module.js';
+
+@Module({
+  imports: [LoginModule, OAuthModule, ConsentModule],
+  controllers: [WebAuthnController],
+  providers: [WebAuthnService],
+  exports: [WebAuthnService],
+})
+export class WebAuthnModule {}

--- a/src/webauthn/webauthn.service.spec.ts
+++ b/src/webauthn/webauthn.service.spec.ts
@@ -1,0 +1,576 @@
+import { WebAuthnService } from './webauthn.service.js';
+import { createMockPrismaService, type MockPrismaService } from '../prisma/prisma.mock.js';
+import { ForbiddenException, BadRequestException, NotFoundException } from '@nestjs/common';
+
+// ── Module-level mocks ────────────────────────────────────────────────
+
+jest.mock('@simplewebauthn/server', () => ({
+  generateRegistrationOptions: jest.fn(),
+  verifyRegistrationResponse: jest.fn(),
+  generateAuthenticationOptions: jest.fn(),
+  verifyAuthenticationResponse: jest.fn(),
+}));
+
+import * as simpleWebAuthn from '@simplewebauthn/server';
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+function createMockCryptoService() {
+  return {
+    sha256: jest.fn().mockImplementation((input: string) => `hash:${input}`),
+    generateSecret: jest.fn().mockReturnValue('MOCK_SECRET'),
+  };
+}
+
+function makeRealm(overrides: Record<string, any> = {}) {
+  return {
+    id: 'realm-1',
+    name: 'test-realm',
+    displayName: 'Test Realm',
+    webAuthnEnabled: true,
+    webAuthnRpId: 'localhost',
+    webAuthnRpName: 'Test Realm',
+    ...overrides,
+  } as any;
+}
+
+function makeUser(overrides: Record<string, any> = {}) {
+  return {
+    id: 'user-1',
+    username: 'alice',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    email: 'alice@example.com',
+    ...overrides,
+  } as any;
+}
+
+function makeCredential(overrides: Record<string, any> = {}) {
+  return {
+    id: 'cred-db-1',
+    userId: 'user-1',
+    realmId: 'realm-1',
+    credentialId: 'credId123',
+    publicKey: Buffer.from([1, 2, 3]),
+    counter: BigInt(5),
+    transports: ['internal'],
+    deviceType: 'singleDevice',
+    backedUp: false,
+    friendlyName: 'My Phone',
+    createdAt: new Date('2025-01-01'),
+    lastUsedAt: null,
+    user: makeUser(),
+    ...overrides,
+  };
+}
+
+// ── Test Suite ────────────────────────────────────────────────────────
+
+describe('WebAuthnService', () => {
+  let service: WebAuthnService;
+  let prisma: MockPrismaService;
+  let crypto: ReturnType<typeof createMockCryptoService>;
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+    crypto = createMockCryptoService();
+    service = new WebAuthnService(prisma as any, crypto as any);
+    jest.clearAllMocks();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // generateRegistrationOptions
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('generateRegistrationOptions', () => {
+    it('should throw ForbiddenException when WebAuthn is disabled', async () => {
+      const realm = makeRealm({ webAuthnEnabled: false });
+
+      await expect(service.generateRegistrationOptions(makeUser(), realm))
+        .rejects.toThrow(ForbiddenException);
+    });
+
+    it('should call generateRegistrationOptions with correct rpId and rpName', async () => {
+      const realm = makeRealm();
+      prisma.webAuthnCredential.findMany.mockResolvedValue([]);
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      const mockOptions = { challenge: 'mock-challenge', user: { id: 'user-1' } };
+      (simpleWebAuthn.generateRegistrationOptions as jest.Mock).mockResolvedValue(mockOptions);
+
+      const result = await service.generateRegistrationOptions(makeUser(), realm);
+
+      expect(simpleWebAuthn.generateRegistrationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rpID: 'localhost',
+          rpName: 'Test Realm',
+        }),
+      );
+      expect(result).toBe(mockOptions);
+    });
+
+    it('should exclude existing credentials', async () => {
+      const realm = makeRealm();
+      const existingCred = makeCredential();
+      prisma.webAuthnCredential.findMany.mockResolvedValue([existingCred]);
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      const mockOptions = { challenge: 'mock-challenge' };
+      (simpleWebAuthn.generateRegistrationOptions as jest.Mock).mockResolvedValue(mockOptions);
+
+      await service.generateRegistrationOptions(makeUser(), realm);
+
+      expect(simpleWebAuthn.generateRegistrationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          excludeCredentials: [
+            expect.objectContaining({ id: 'credId123' }),
+          ],
+        }),
+      );
+    });
+
+    it('should store the challenge in PendingAction', async () => {
+      const realm = makeRealm();
+      prisma.webAuthnCredential.findMany.mockResolvedValue([]);
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      const mockOptions = { challenge: 'challenge-abc' };
+      (simpleWebAuthn.generateRegistrationOptions as jest.Mock).mockResolvedValue(mockOptions);
+
+      await service.generateRegistrationOptions(makeUser(), realm);
+
+      expect(prisma.pendingAction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: 'webauthn_registration_challenge',
+            data: expect.objectContaining({ challenge: 'challenge-abc' }),
+          }),
+        }),
+      );
+    });
+
+    it('should use realm name as rpName when webAuthnRpName is null', async () => {
+      const realm = makeRealm({ webAuthnRpName: null, displayName: null, name: 'my-realm' });
+      prisma.webAuthnCredential.findMany.mockResolvedValue([]);
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      const mockOptions = { challenge: 'c' };
+      (simpleWebAuthn.generateRegistrationOptions as jest.Mock).mockResolvedValue(mockOptions);
+
+      await service.generateRegistrationOptions(makeUser(), realm);
+
+      expect(simpleWebAuthn.generateRegistrationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ rpName: 'my-realm' }),
+      );
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // verifyRegistration
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('verifyRegistration', () => {
+    const mockResponse = { id: 'credId-new', rawId: 'credId-new' } as any;
+
+    it('should throw ForbiddenException when WebAuthn is disabled', async () => {
+      const realm = makeRealm({ webAuthnEnabled: false });
+
+      await expect(service.verifyRegistration(makeUser(), realm, mockResponse))
+        .rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw BadRequestException when challenge not found', async () => {
+      const realm = makeRealm();
+      // pendingAction not found
+      prisma.pendingAction.findUnique.mockResolvedValue(null);
+
+      await expect(service.verifyRegistration(makeUser(), realm, mockResponse))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when verification fails', async () => {
+      const realm = makeRealm();
+
+      // Provide a valid pending action
+      prisma.pendingAction.findUnique.mockResolvedValue({
+        id: 'action-1',
+        type: 'webauthn_registration_challenge',
+        data: { challenge: 'expected-challenge' } as any,
+        expiresAt: new Date(Date.now() + 60_000),
+      } as any);
+      prisma.pendingAction.delete.mockResolvedValue({} as any);
+
+      (simpleWebAuthn.verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: false,
+        registrationInfo: null,
+      });
+
+      await expect(service.verifyRegistration(makeUser(), realm, mockResponse))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should store credential and return it on success', async () => {
+      const realm = makeRealm();
+
+      prisma.pendingAction.findUnique.mockResolvedValue({
+        id: 'action-1',
+        type: 'webauthn_registration_challenge',
+        data: { challenge: 'expected-challenge' } as any,
+        expiresAt: new Date(Date.now() + 60_000),
+      } as any);
+      prisma.pendingAction.delete.mockResolvedValue({} as any);
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(null); // no duplicate
+      prisma.webAuthnCredential.create.mockResolvedValue(makeCredential() as any);
+
+      (simpleWebAuthn.verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: 'credId-new',
+            publicKey: new Uint8Array([1, 2, 3]),
+            counter: 0,
+            transports: ['internal'],
+          },
+          credentialDeviceType: 'singleDevice',
+          credentialBackedUp: false,
+        },
+      });
+
+      const result = await service.verifyRegistration(makeUser(), realm, mockResponse, 'My Phone');
+
+      expect(prisma.webAuthnCredential.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId: 'user-1',
+            realmId: 'realm-1',
+            credentialId: 'credId-new',
+            friendlyName: 'My Phone',
+          }),
+        }),
+      );
+      expect(result).toEqual(makeCredential());
+    });
+
+    it('should throw BadRequestException when credential is already registered', async () => {
+      const realm = makeRealm();
+
+      prisma.pendingAction.findUnique.mockResolvedValue({
+        id: 'action-1',
+        type: 'webauthn_registration_challenge',
+        data: { challenge: 'expected-challenge' } as any,
+        expiresAt: new Date(Date.now() + 60_000),
+      } as any);
+      prisma.pendingAction.delete.mockResolvedValue({} as any);
+
+      (simpleWebAuthn.verifyRegistrationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        registrationInfo: {
+          credential: {
+            id: 'credId-new',
+            publicKey: new Uint8Array([1, 2, 3]),
+            counter: 0,
+            transports: [],
+          },
+          credentialDeviceType: 'singleDevice',
+          credentialBackedUp: false,
+        },
+      });
+
+      // Duplicate credential
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(makeCredential() as any);
+
+      await expect(service.verifyRegistration(makeUser(), realm, mockResponse))
+        .rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // generateAuthenticationOptions
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('generateAuthenticationOptions', () => {
+    it('should throw ForbiddenException when WebAuthn is disabled', async () => {
+      const realm = makeRealm({ webAuthnEnabled: false });
+
+      await expect(service.generateAuthenticationOptions(realm))
+        .rejects.toThrow(ForbiddenException);
+    });
+
+    it('should generate options without allowCredentials for usernameless flow', async () => {
+      const realm = makeRealm();
+      const mockOptions = { challenge: 'auth-challenge' };
+      (simpleWebAuthn.generateAuthenticationOptions as jest.Mock).mockResolvedValue(mockOptions);
+
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      const result = await service.generateAuthenticationOptions(realm);
+
+      expect(simpleWebAuthn.generateAuthenticationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({ rpID: 'localhost' }),
+      );
+      expect(result).toBe(mockOptions);
+    });
+
+    it('should set allowCredentials when userId is provided', async () => {
+      const realm = makeRealm();
+      const cred = makeCredential();
+      prisma.webAuthnCredential.findMany.mockResolvedValue([cred]);
+
+      const mockOptions = { challenge: 'auth-challenge' };
+      (simpleWebAuthn.generateAuthenticationOptions as jest.Mock).mockResolvedValue(mockOptions);
+
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      await service.generateAuthenticationOptions(realm, 'user-1');
+
+      expect(simpleWebAuthn.generateAuthenticationOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowCredentials: [expect.objectContaining({ id: 'credId123' })],
+        }),
+      );
+    });
+
+    it('should store challenge in PendingAction with realm key for usernameless flow', async () => {
+      const realm = makeRealm();
+      (simpleWebAuthn.generateAuthenticationOptions as jest.Mock).mockResolvedValue({ challenge: 'ch' });
+
+      prisma.pendingAction.deleteMany.mockResolvedValue({ count: 0 });
+      prisma.pendingAction.create.mockResolvedValue({} as any);
+
+      await service.generateAuthenticationOptions(realm);
+
+      expect(prisma.pendingAction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            type: 'webauthn_authentication_challenge',
+            data: expect.objectContaining({ challenge: 'ch', key: 'realm:realm-1' }),
+          }),
+        }),
+      );
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // verifyAuthentication
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('verifyAuthentication', () => {
+    const mockResponse = { id: 'credId123', rawId: 'credId123' } as any;
+
+    it('should throw ForbiddenException when WebAuthn is disabled', async () => {
+      const realm = makeRealm({ webAuthnEnabled: false });
+
+      await expect(service.verifyAuthentication(realm, mockResponse))
+        .rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException when credential is not found', async () => {
+      const realm = makeRealm();
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(null);
+
+      await expect(service.verifyAuthentication(realm, mockResponse))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when credential belongs to different realm', async () => {
+      const realm = makeRealm();
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(
+        makeCredential({ realmId: 'other-realm' }) as any,
+      );
+
+      await expect(service.verifyAuthentication(realm, mockResponse))
+        .rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw BadRequestException when no challenge found', async () => {
+      const realm = makeRealm();
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(makeCredential() as any);
+      // No pending action found
+      prisma.pendingAction.findUnique.mockResolvedValue(null);
+
+      await expect(service.verifyAuthentication(realm, mockResponse))
+        .rejects.toThrow(BadRequestException);
+    });
+
+    it('should verify assertion and update counter on success', async () => {
+      const realm = makeRealm();
+      const cred = makeCredential();
+
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(cred as any);
+
+      // Provide challenge via pending action
+      prisma.pendingAction.findUnique.mockResolvedValue({
+        id: 'action-1',
+        type: 'webauthn_authentication_challenge',
+        data: { challenge: 'expected-challenge' } as any,
+        expiresAt: new Date(Date.now() + 60_000),
+      } as any);
+      prisma.pendingAction.delete.mockResolvedValue({} as any);
+      prisma.webAuthnCredential.update.mockResolvedValue(cred as any);
+
+      (simpleWebAuthn.verifyAuthenticationResponse as jest.Mock).mockResolvedValue({
+        verified: true,
+        authenticationInfo: { newCounter: 6 },
+      });
+
+      const result = await service.verifyAuthentication(realm, mockResponse);
+
+      expect(result.user).toEqual(cred.user);
+      expect(result.credential).toBe(cred);
+      expect(prisma.webAuthnCredential.update).toHaveBeenCalledWith({
+        where: { id: cred.id },
+        data: expect.objectContaining({
+          counter: BigInt(6),
+          lastUsedAt: expect.any(Date),
+        }),
+      });
+    });
+
+    it('should throw BadRequestException when verification returns verified=false', async () => {
+      const realm = makeRealm();
+      const cred = makeCredential();
+
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(cred as any);
+      prisma.pendingAction.findUnique.mockResolvedValue({
+        id: 'action-1',
+        type: 'webauthn_authentication_challenge',
+        data: { challenge: 'expected-challenge' } as any,
+        expiresAt: new Date(Date.now() + 60_000),
+      } as any);
+      prisma.pendingAction.delete.mockResolvedValue({} as any);
+
+      (simpleWebAuthn.verifyAuthenticationResponse as jest.Mock).mockResolvedValue({
+        verified: false,
+        authenticationInfo: {},
+      });
+
+      await expect(service.verifyAuthentication(realm, mockResponse))
+        .rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // getUserCredentials
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('getUserCredentials', () => {
+    it('should return credentials ordered by createdAt ascending', async () => {
+      const creds = [makeCredential(), makeCredential({ id: 'cred-db-2' })];
+      prisma.webAuthnCredential.findMany.mockResolvedValue(creds as any);
+
+      const result = await service.getUserCredentials('user-1');
+
+      expect(prisma.webAuthnCredential.findMany).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        orderBy: { createdAt: 'asc' },
+      });
+      expect(result).toBe(creds);
+    });
+
+    it('should return empty array when user has no credentials', async () => {
+      prisma.webAuthnCredential.findMany.mockResolvedValue([]);
+
+      const result = await service.getUserCredentials('user-1');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // removeCredential
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('removeCredential', () => {
+    it('should throw NotFoundException when credential does not exist', async () => {
+      prisma.webAuthnCredential.findFirst.mockResolvedValue(null);
+
+      await expect(service.removeCredential('user-1', 'cred-db-1'))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw NotFoundException when credential belongs to different user', async () => {
+      // findFirst returns null when userId does not match
+      prisma.webAuthnCredential.findFirst.mockResolvedValue(null);
+
+      await expect(service.removeCredential('user-1', 'cred-db-1'))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('should delete the credential when it belongs to the user', async () => {
+      const cred = makeCredential();
+      prisma.webAuthnCredential.findFirst.mockResolvedValue(cred as any);
+      prisma.webAuthnCredential.delete.mockResolvedValue(cred as any);
+
+      await service.removeCredential('user-1', 'cred-db-1');
+
+      expect(prisma.webAuthnCredential.delete).toHaveBeenCalledWith({
+        where: { id: 'cred-db-1' },
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // hasCredentials
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('hasCredentials', () => {
+    it('should return true when user has credentials', async () => {
+      prisma.webAuthnCredential.count.mockResolvedValue(2);
+
+      const result = await service.hasCredentials('user-1', 'realm-1');
+
+      expect(result).toBe(true);
+      expect(prisma.webAuthnCredential.count).toHaveBeenCalledWith({
+        where: { userId: 'user-1', realmId: 'realm-1' },
+      });
+    });
+
+    it('should return false when user has no credentials', async () => {
+      prisma.webAuthnCredential.count.mockResolvedValue(0);
+
+      const result = await service.hasCredentials('user-1', 'realm-1');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────
+  // challenge TTL / expiry
+  // ──────────────────────────────────────────────────────────────────────
+
+  describe('challenge expiry', () => {
+    it('should return null and delete the pending action when challenge is expired', async () => {
+      const realm = makeRealm();
+      const cred = makeCredential();
+
+      prisma.webAuthnCredential.findUnique.mockResolvedValue(cred as any);
+      prisma.pendingAction.findUnique.mockResolvedValue({
+        id: 'action-1',
+        type: 'webauthn_authentication_challenge',
+        data: { challenge: 'old-challenge' } as any,
+        expiresAt: new Date(Date.now() - 60_000), // expired
+      } as any);
+      prisma.pendingAction.delete.mockResolvedValue({} as any);
+
+      // Both user-specific and realm-wide lookups return null
+      // (second call also returns null because pendingAction.findUnique is called twice)
+      prisma.pendingAction.findUnique.mockResolvedValueOnce({
+        id: 'action-1',
+        type: 'webauthn_authentication_challenge',
+        data: { challenge: 'old-challenge' } as any,
+        expiresAt: new Date(Date.now() - 60_000),
+      } as any).mockResolvedValueOnce(null);
+
+      await expect(service.verifyAuthentication(realm, { id: 'credId123' } as any))
+        .rejects.toThrow(BadRequestException);
+
+      expect(prisma.pendingAction.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/webauthn/webauthn.service.ts
+++ b/src/webauthn/webauthn.service.ts
@@ -1,0 +1,364 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+  Inject,
+  forwardRef,
+} from '@nestjs/common';
+import {
+  generateRegistrationOptions,
+  verifyRegistrationResponse,
+  generateAuthenticationOptions,
+  verifyAuthenticationResponse,
+} from '@simplewebauthn/server';
+import type {
+  PublicKeyCredentialCreationOptionsJSON,
+  PublicKeyCredentialRequestOptionsJSON,
+  RegistrationResponseJSON,
+  AuthenticationResponseJSON,
+  AuthenticatorTransportFuture,
+} from '@simplewebauthn/server';
+import type { Realm, User, WebAuthnCredential } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
+
+export interface WebAuthnRegistrationChallenge {
+  options: PublicKeyCredentialCreationOptionsJSON;
+}
+
+export interface WebAuthnAuthenticationChallenge {
+  options: PublicKeyCredentialRequestOptionsJSON;
+}
+
+@Injectable()
+export class WebAuthnService {
+  private readonly logger = new Logger(WebAuthnService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  // ─── Helpers ──────────────────────────────────────────────────────────
+
+  private getRpId(realm: Realm): string {
+    return realm.webAuthnRpId ?? 'localhost';
+  }
+
+  private getRpName(realm: Realm): string {
+    return realm.webAuthnRpName ?? realm.displayName ?? realm.name;
+  }
+
+  private getOrigin(rpId: string): string {
+    const baseUrl = process.env['BASE_URL'] ?? 'http://localhost:3000';
+    try {
+      const url = new URL(baseUrl);
+      // Use rpId with protocol from BASE_URL
+      return `${url.protocol}//${rpId}${url.port && url.port !== '80' && url.port !== '443' ? ':' + url.port : ''}`;
+    } catch {
+      return `https://${rpId}`;
+    }
+  }
+
+  // ─── Registration ─────────────────────────────────────────────────────
+
+  async generateRegistrationOptions(
+    user: User,
+    realm: Realm,
+  ): Promise<PublicKeyCredentialCreationOptionsJSON> {
+    if (!realm.webAuthnEnabled) {
+      throw new ForbiddenException('WebAuthn is not enabled for this realm');
+    }
+
+    const rpId = this.getRpId(realm);
+    const rpName = this.getRpName(realm);
+
+    // Get existing credentials to exclude
+    const existingCredentials = await this.prisma.webAuthnCredential.findMany({
+      where: { userId: user.id },
+    });
+
+    const options = await generateRegistrationOptions({
+      rpName,
+      rpID: rpId,
+      userID: Buffer.from(user.id),
+      userName: user.username,
+      userDisplayName: [user.firstName, user.lastName].filter(Boolean).join(' ') || user.username,
+      attestationType: 'none',
+      excludeCredentials: existingCredentials.map((cred) => ({
+        id: cred.credentialId,
+        transports: cred.transports as AuthenticatorTransportFuture[],
+      })),
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'preferred',
+      },
+    });
+
+    // Store challenge in PendingAction for later verification
+    await this.storeWebAuthnChallenge(user.id, realm.id, 'registration', options.challenge);
+
+    return options;
+  }
+
+  async verifyRegistration(
+    user: User,
+    realm: Realm,
+    response: RegistrationResponseJSON,
+    friendlyName?: string,
+  ): Promise<WebAuthnCredential> {
+    if (!realm.webAuthnEnabled) {
+      throw new ForbiddenException('WebAuthn is not enabled for this realm');
+    }
+
+    const rpId = this.getRpId(realm);
+    const expectedChallenge = await this.consumeWebAuthnChallenge(user.id, realm.id, 'registration');
+
+    if (!expectedChallenge) {
+      throw new BadRequestException('Registration challenge expired or not found. Please try again.');
+    }
+
+    let verification;
+    try {
+      verification = await verifyRegistrationResponse({
+        response,
+        expectedChallenge,
+        expectedOrigin: this.getOrigin(rpId),
+        expectedRPID: rpId,
+        requireUserVerification: false,
+      });
+    } catch (err: any) {
+      this.logger.warn(`WebAuthn registration verification failed: ${err.message}`);
+      throw new BadRequestException('Registration verification failed: ' + err.message);
+    }
+
+    if (!verification.verified || !verification.registrationInfo) {
+      throw new BadRequestException('Registration verification failed');
+    }
+
+    const { credential, credentialDeviceType, credentialBackedUp } = verification.registrationInfo;
+
+    // Check for duplicate credential
+    const existing = await this.prisma.webAuthnCredential.findUnique({
+      where: { credentialId: credential.id },
+    });
+    if (existing) {
+      throw new BadRequestException('This passkey is already registered');
+    }
+
+    const stored = await this.prisma.webAuthnCredential.create({
+      data: {
+        userId: user.id,
+        realmId: realm.id,
+        credentialId: credential.id,
+        publicKey: Buffer.from(credential.publicKey),
+        counter: credential.counter,
+        transports: (credential.transports ?? []) as string[],
+        deviceType: credentialDeviceType,
+        backedUp: credentialBackedUp,
+        friendlyName: friendlyName ?? null,
+      },
+    });
+
+    this.logger.log(`WebAuthn credential registered for user ${user.id} in realm ${realm.id}`);
+    return stored;
+  }
+
+  // ─── Authentication ────────────────────────────────────────────────────
+
+  async generateAuthenticationOptions(
+    realm: Realm,
+    userId?: string,
+  ): Promise<PublicKeyCredentialRequestOptionsJSON> {
+    if (!realm.webAuthnEnabled) {
+      throw new ForbiddenException('WebAuthn is not enabled for this realm');
+    }
+
+    const rpId = this.getRpId(realm);
+
+    let allowCredentials: { id: string; transports: AuthenticatorTransportFuture[] }[] | undefined;
+    if (userId) {
+      const credentials = await this.prisma.webAuthnCredential.findMany({
+        where: { userId, realmId: realm.id },
+      });
+      if (credentials.length > 0) {
+        allowCredentials = credentials.map((c) => ({
+          id: c.credentialId,
+          transports: c.transports as AuthenticatorTransportFuture[],
+        }));
+      }
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: rpId,
+      allowCredentials,
+      userVerification: 'preferred',
+    });
+
+    // Store challenge — keyed by realm for usernameless flow, or by user for user-specific
+    const challengeKey = userId ?? `realm:${realm.id}`;
+    await this.storeWebAuthnChallenge(challengeKey, realm.id, 'authentication', options.challenge);
+
+    return options;
+  }
+
+  async verifyAuthentication(
+    realm: Realm,
+    response: AuthenticationResponseJSON,
+  ): Promise<{ user: User; credential: WebAuthnCredential }> {
+    if (!realm.webAuthnEnabled) {
+      throw new ForbiddenException('WebAuthn is not enabled for this realm');
+    }
+
+    const rpId = this.getRpId(realm);
+
+    // Find the credential being used
+    const credential = await this.prisma.webAuthnCredential.findUnique({
+      where: { credentialId: response.id },
+      include: { user: true },
+    });
+
+    if (!credential) {
+      throw new NotFoundException('Passkey not found');
+    }
+
+    if (credential.realmId !== realm.id) {
+      throw new ForbiddenException('Passkey does not belong to this realm');
+    }
+
+    // Try user-specific challenge first, then realm-level (usernameless)
+    let expectedChallenge = await this.consumeWebAuthnChallenge(
+      credential.userId,
+      realm.id,
+      'authentication',
+    );
+
+    if (!expectedChallenge) {
+      expectedChallenge = await this.consumeWebAuthnChallenge(
+        `realm:${realm.id}`,
+        realm.id,
+        'authentication',
+      );
+    }
+
+    if (!expectedChallenge) {
+      throw new BadRequestException('Authentication challenge expired or not found. Please try again.');
+    }
+
+    let verification;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response,
+        expectedChallenge,
+        expectedOrigin: this.getOrigin(rpId),
+        expectedRPID: rpId,
+        credential: {
+          id: credential.credentialId,
+          publicKey: new Uint8Array(credential.publicKey),
+          counter: Number(credential.counter),
+          transports: credential.transports as AuthenticatorTransportFuture[],
+        },
+        requireUserVerification: false,
+      });
+    } catch (err: any) {
+      this.logger.warn(`WebAuthn authentication verification failed: ${err.message}`);
+      throw new BadRequestException('Authentication verification failed: ' + err.message);
+    }
+
+    if (!verification.verified) {
+      throw new BadRequestException('Authentication verification failed');
+    }
+
+    // Update counter and lastUsedAt
+    await this.prisma.webAuthnCredential.update({
+      where: { id: credential.id },
+      data: {
+        counter: BigInt(verification.authenticationInfo.newCounter),
+        lastUsedAt: new Date(),
+      },
+    });
+
+    return { user: credential.user, credential };
+  }
+
+  // ─── Credential management ────────────────────────────────────────────
+
+  async getUserCredentials(userId: string): Promise<WebAuthnCredential[]> {
+    return this.prisma.webAuthnCredential.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async removeCredential(userId: string, credentialId: string): Promise<void> {
+    const credential = await this.prisma.webAuthnCredential.findFirst({
+      where: { id: credentialId, userId },
+    });
+
+    if (!credential) {
+      throw new NotFoundException('Credential not found');
+    }
+
+    await this.prisma.webAuthnCredential.delete({ where: { id: credentialId } });
+    this.logger.log(`WebAuthn credential ${credentialId} removed for user ${userId}`);
+  }
+
+  async hasCredentials(userId: string, realmId: string): Promise<boolean> {
+    const count = await this.prisma.webAuthnCredential.count({
+      where: { userId, realmId },
+    });
+    return count > 0;
+  }
+
+  // ─── Challenge store (via PendingAction) ──────────────────────────────
+
+  private async storeWebAuthnChallenge(
+    key: string,
+    realmId: string,
+    type: 'registration' | 'authentication',
+    challenge: string,
+  ): Promise<void> {
+    const actionType = `webauthn_${type}_challenge`;
+    const tokenHash = this.crypto.sha256(`${key}:${realmId}:${actionType}`);
+
+    // Upsert (delete old, create new) to handle repeated requests
+    await this.prisma.pendingAction.deleteMany({
+      where: { tokenHash },
+    });
+
+    await this.prisma.pendingAction.create({
+      data: {
+        tokenHash,
+        type: actionType,
+        data: { key, realmId, challenge } as any,
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000), // 5-minute TTL
+      },
+    });
+  }
+
+  private async consumeWebAuthnChallenge(
+    key: string,
+    realmId: string,
+    type: 'registration' | 'authentication',
+  ): Promise<string | null> {
+    const actionType = `webauthn_${type}_challenge`;
+    const tokenHash = this.crypto.sha256(`${key}:${realmId}:${actionType}`);
+
+    const action = await this.prisma.pendingAction.findUnique({
+      where: { tokenHash },
+    });
+
+    if (!action || action.type !== actionType) return null;
+    if (action.expiresAt < new Date()) {
+      await this.prisma.pendingAction.delete({ where: { id: action.id } });
+      return null;
+    }
+
+    await this.prisma.pendingAction.delete({ where: { id: action.id } });
+
+    const data = action.data as any;
+    return data.challenge as string;
+  }
+}

--- a/src/well-known/well-known.controller.ts
+++ b/src/well-known/well-known.controller.ts
@@ -74,6 +74,10 @@ export class WellKnownController {
       code_challenge_methods_supported: ['S256'],
       backchannel_logout_supported: true,
       backchannel_logout_session_supported: true,
+      // WebAuthn / FIDO2 support
+      webauthn_registration_endpoint: `${realmUrl}/webauthn/register/options`,
+      webauthn_authentication_endpoint: `${realmUrl}/webauthn/authenticate/options`,
+      ...((realm as any).webAuthnEnabled ? { passkey_endpoint: `${realmUrl}/webauthn` } : {}),
     };
   }
 

--- a/themes/authme/account/templates/account.hbs
+++ b/themes/authme/account/templates/account.hbs
@@ -89,3 +89,179 @@
   </a>
   {{/if}}
 </div>
+
+{{#if webAuthnEnabled}}
+<div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 1.5rem;" id="passkeys-section">
+  <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 0.5rem;">Passkeys (Passwordless)</h3>
+  <p style="color: #6b7280; font-size: 0.85rem; margin-bottom: 1rem;">Passkeys let you sign in using your device's biometrics (fingerprint, face, or PIN) without a password.</p>
+
+  <div id="passkeys-list" style="margin-bottom: 1rem;">
+    {{#if webAuthnCredentials}}
+      {{#each webAuthnCredentials}}
+      <div style="display: flex; align-items: center; justify-content: space-between; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 0.5rem;">
+        <div>
+          <div style="font-weight: 500; color: #111827;">
+            {{#if this.friendlyName}}{{this.friendlyName}}{{else}}Passkey{{/if}}
+            {{#if this.backedUp}}<span style="font-size: 0.7rem; color: #166534; background: #f0fdf4; border: 1px solid #bbf7d0; border-radius: 3px; padding: 0.1rem 0.3rem; margin-left: 0.4rem;">Synced</span>{{/if}}
+          </div>
+          <div style="font-size: 0.8rem; color: #6b7280; margin-top: 0.2rem;">
+            Added {{this.createdAt}}
+            {{#if this.lastUsedAt}} &middot; Last used {{this.lastUsedAt}}{{/if}}
+          </div>
+        </div>
+        <button
+          type="button"
+          onclick="removePasskey('{{this.id}}')"
+          style="background: none; border: 1px solid #fca5a5; color: #dc2626; border-radius: 4px; padding: 0.3rem 0.75rem; cursor: pointer; font-size: 0.85rem;"
+        >Remove</button>
+      </div>
+      {{/each}}
+    {{else}}
+      <p style="color: #6b7280; font-size: 0.875rem; font-style: italic;">No passkeys registered yet.</p>
+    {{/if}}
+  </div>
+
+  <div id="passkey-status" style="margin-bottom: 0.75rem; display: none;"></div>
+
+  <button type="button" id="register-passkey-btn" class="btn-primary" style="display: inline-flex; align-items: center; gap: 0.4rem;">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    Add a passkey
+  </button>
+
+  <div id="passkey-name-form" style="display: none; margin-top: 1rem;">
+    <div class="form-group">
+      <label for="passkey-name">Passkey name (optional)</label>
+      <input type="text" id="passkey-name" placeholder="e.g. MacBook Touch ID, iPhone Face ID" style="margin-bottom: 0.5rem;">
+    </div>
+    <button type="button" id="confirm-register-passkey-btn" class="btn-primary">Register passkey</button>
+    <button type="button" id="cancel-register-passkey-btn" style="background: none; border: 1px solid #d1d5db; color: #374151; border-radius: 6px; padding: 0.6rem 1.25rem; margin-left: 0.5rem; cursor: pointer;">Cancel</button>
+  </div>
+</div>
+
+<script>
+(function() {
+  const realmName = '{{realmName}}';
+
+  function showStatus(msg, isError) {
+    const el = document.getElementById('passkey-status');
+    el.style.display = 'block';
+    el.style.background = isError ? '#fef2f2' : '#f0fdf4';
+    el.style.border = '1px solid ' + (isError ? '#fca5a5' : '#bbf7d0');
+    el.style.color = isError ? '#dc2626' : '#166534';
+    el.style.borderRadius = '6px';
+    el.style.padding = '0.6rem 1rem';
+    el.textContent = msg;
+  }
+
+  // Show name form when "Add passkey" clicked
+  document.getElementById('register-passkey-btn').addEventListener('click', function() {
+    document.getElementById('passkey-name-form').style.display = 'block';
+    this.style.display = 'none';
+  });
+
+  document.getElementById('cancel-register-passkey-btn').addEventListener('click', function() {
+    document.getElementById('passkey-name-form').style.display = 'none';
+    document.getElementById('register-passkey-btn').style.display = 'inline-flex';
+    document.getElementById('passkey-status').style.display = 'none';
+  });
+
+  document.getElementById('confirm-register-passkey-btn').addEventListener('click', async function() {
+    const friendlyName = document.getElementById('passkey-name').value.trim();
+    const btn = this;
+    btn.disabled = true;
+    btn.textContent = 'Waiting for device...';
+
+    try {
+      // Get options from server
+      const optRes = await fetch('/realms/' + realmName + '/webauthn/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ friendlyName }),
+        credentials: 'same-origin',
+      });
+      if (!optRes.ok) throw new Error((await optRes.json()).message || 'Failed to get registration options');
+      const options = await optRes.json();
+
+      // Convert base64url strings to ArrayBuffers as required by WebAuthn API
+      options.user.id = base64urlToBuffer(options.user.id);
+      options.challenge = base64urlToBuffer(options.challenge);
+      if (options.excludeCredentials) {
+        options.excludeCredentials = options.excludeCredentials.map(function(c) {
+          return Object.assign({}, c, { id: base64urlToBuffer(c.id) });
+        });
+      }
+
+      // Create credential via browser API
+      const credential = await navigator.credentials.create({ publicKey: options });
+      if (!credential) throw new Error('Passkey creation was cancelled');
+
+      // Encode response for server
+      const response = encodeCredential(credential);
+
+      // Send to server for verification
+      const verifyRes = await fetch('/realms/' + realmName + '/webauthn/register/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ response, friendlyName: friendlyName || undefined }),
+        credentials: 'same-origin',
+      });
+      if (!verifyRes.ok) throw new Error((await verifyRes.json()).message || 'Verification failed');
+
+      showStatus('Passkey registered successfully! Reloading...', false);
+      setTimeout(function() { window.location.reload(); }, 1200);
+    } catch (err) {
+      showStatus('Error: ' + (err.message || 'Registration failed'), true);
+      btn.disabled = false;
+      btn.textContent = 'Register passkey';
+    }
+  });
+
+  window.removePasskey = async function(credentialId) {
+    if (!confirm('Remove this passkey? You will no longer be able to use it to sign in.')) return;
+    try {
+      const res = await fetch('/realms/' + realmName + '/account/webauthn/credentials/' + credentialId, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      if (!res.ok) throw new Error('Failed to remove passkey');
+      window.location.reload();
+    } catch (err) {
+      showStatus('Error removing passkey: ' + err.message, true);
+    }
+  };
+
+  // Helpers
+  function base64urlToBuffer(base64url) {
+    if (base64url instanceof ArrayBuffer) return base64url;
+    const b64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    const bin = atob(b64);
+    const buf = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+    return buf.buffer;
+  }
+
+  function bufferToBase64url(buffer) {
+    const bytes = new Uint8Array(buffer);
+    let str = '';
+    for (let i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+    return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  }
+
+  function encodeCredential(credential) {
+    const response = credential.response;
+    const obj = {
+      id: credential.id,
+      rawId: bufferToBase64url(credential.rawId),
+      type: credential.type,
+      response: {
+        clientDataJSON: bufferToBase64url(response.clientDataJSON),
+        attestationObject: bufferToBase64url(response.attestationObject),
+      },
+    };
+    if (response.getTransports) obj.response.transports = response.getTransports();
+    if (credential.authenticatorAttachment) obj.authenticatorAttachment = credential.authenticatorAttachment;
+    return obj;
+  }
+})();
+</script>
+{{/if}}

--- a/themes/authme/login/templates/login.hbs
+++ b/themes/authme/login/templates/login.hbs
@@ -38,6 +38,142 @@
   <button type="submit" class="btn-primary">{{msg "loginSignIn"}}</button>
 </form>
 
+{{#if webAuthnEnabled}}
+<div style="margin-top: 1rem; text-align: center;">
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;">
+    <div style="flex: 1; height: 1px; background: #e5e7eb;"></div>
+    <span style="color: #9ca3af; font-size: 0.8rem;">or</span>
+    <div style="flex: 1; height: 1px; background: #e5e7eb;"></div>
+  </div>
+  <div id="passkey-login-status" style="display: none; margin-bottom: 0.75rem;"></div>
+  <button
+    type="button"
+    id="passkey-login-btn"
+    style="width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; background: #ffffff; color: #374151; border: 1px solid #d1d5db; border-radius: 6px; padding: 0.65rem 1.25rem; font-size: 0.95rem; cursor: pointer; font-weight: 500;"
+    onclick="passkeyLogin()"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/>
+    </svg>
+    Sign in with a passkey
+  </button>
+</div>
+
+<script>
+(function() {
+  var realmName = '{{realmName}}';
+  var oauthParams = {
+    client_id: '{{client_id}}',
+    redirect_uri: '{{redirect_uri}}',
+    response_type: '{{response_type}}',
+    scope: '{{scope}}',
+    state: '{{state}}',
+    nonce: '{{nonce}}',
+    code_challenge: '{{code_challenge}}',
+    code_challenge_method: '{{code_challenge_method}}'
+  };
+
+  function showPasskeyStatus(msg, isError) {
+    var el = document.getElementById('passkey-login-status');
+    el.style.display = 'block';
+    el.style.background = isError ? '#fef2f2' : '#f0fdf4';
+    el.style.border = '1px solid ' + (isError ? '#fca5a5' : '#bbf7d0');
+    el.style.color = isError ? '#dc2626' : '#166534';
+    el.style.borderRadius = '6px';
+    el.style.padding = '0.5rem 1rem';
+    el.style.fontSize = '0.875rem';
+    el.textContent = msg;
+  }
+
+  window.passkeyLogin = async function() {
+    var btn = document.getElementById('passkey-login-btn');
+    btn.disabled = true;
+    btn.textContent = 'Waiting for device...';
+
+    try {
+      // Get authentication options (usernameless / resident key flow)
+      var optRes = await fetch('/realms/' + realmName + '/webauthn/authenticate/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+        credentials: 'same-origin',
+      });
+      if (!optRes.ok) throw new Error((await optRes.json()).message || 'Failed to get options');
+      var options = await optRes.json();
+
+      options.challenge = base64urlToBuffer(options.challenge);
+      if (options.allowCredentials) {
+        options.allowCredentials = options.allowCredentials.map(function(c) {
+          return Object.assign({}, c, { id: base64urlToBuffer(c.id) });
+        });
+      }
+
+      var assertion = await navigator.credentials.get({ publicKey: options });
+      if (!assertion) throw new Error('Passkey authentication was cancelled');
+
+      var response = encodeAssertion(assertion);
+      var body = Object.assign({}, oauthParams, { response: response });
+
+      var verifyRes = await fetch('/realms/' + realmName + '/webauthn/authenticate/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        credentials: 'same-origin',
+      });
+
+      if (!verifyRes.ok) {
+        var errData = await verifyRes.json();
+        throw new Error(errData.message || 'Authentication failed');
+      }
+
+      var data = await verifyRes.json();
+      if (data.redirectUrl) {
+        window.location.href = data.redirectUrl;
+      } else {
+        showPasskeyStatus('Signed in! Redirecting...', false);
+        window.location.href = '/realms/' + realmName + '/account';
+      }
+    } catch (err) {
+      showPasskeyStatus(err.message || 'Passkey authentication failed', true);
+      btn.disabled = false;
+      btn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg> Sign in with a passkey';
+    }
+  };
+
+  function base64urlToBuffer(base64url) {
+    if (base64url instanceof ArrayBuffer) return base64url;
+    var b64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+    var bin = atob(b64);
+    var buf = new Uint8Array(bin.length);
+    for (var i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+    return buf.buffer;
+  }
+
+  function bufferToBase64url(buffer) {
+    var bytes = new Uint8Array(buffer);
+    var str = '';
+    for (var i = 0; i < bytes.length; i++) str += String.fromCharCode(bytes[i]);
+    return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  }
+
+  function encodeAssertion(assertion) {
+    var response = assertion.response;
+    return {
+      id: assertion.id,
+      rawId: bufferToBase64url(assertion.rawId),
+      type: assertion.type,
+      response: {
+        clientDataJSON: bufferToBase64url(response.clientDataJSON),
+        authenticatorData: bufferToBase64url(response.authenticatorData),
+        signature: bufferToBase64url(response.signature),
+        userHandle: response.userHandle ? bufferToBase64url(response.userHandle) : null,
+      },
+    };
+  }
+})();
+</script>
+{{/if}}
+
 {{#if registrationAllowed}}
 <div style="text-align: center; margin-top: 1rem;">
   <a href="/realms/{{realmName}}/register?client_id={{client_id}}&redirect_uri={{redirect_uri}}&response_type={{response_type}}&scope={{scope}}&state={{state}}&nonce={{nonce}}&code_challenge={{code_challenge}}&code_challenge_method={{code_challenge_method}}" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "loginNoAccount"}}</a>


### PR DESCRIPTION
## Summary
- Implements **Feature 2: WebAuthn/FIDO2 Passwordless Auth** (closes #259)
- Full passkey support using `@simplewebauthn/server`
- Registration and authentication ceremonies following W3C spec
- Passkey management in account portal (register, list, remove)
- "Sign in with a passkey" button on login page with browser credential API
- OIDC discovery advertises WebAuthn endpoints
- Per-realm `webAuthnEnabled`, `webAuthnRpName`, `webAuthnRpId` settings
- 28 unit tests passing

## Endpoints
- `POST /realms/:realm/webauthn/register/options` — Registration challenge
- `POST /realms/:realm/webauthn/register/verify` — Complete registration
- `POST /realms/:realm/webauthn/authenticate/options` — Auth challenge
- `POST /realms/:realm/webauthn/authenticate/verify` — Complete auth
- `GET /realms/:realm/account/webauthn/credentials` — List credentials
- `DELETE /realms/:realm/account/webauthn/credentials/:id` — Remove credential

## Test plan
- [x] 28 unit tests (registration, authentication, challenge TTL, counter updates, CRUD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)