### PR TITLE
feat: Official Kubernetes Helm Chart

### DIFF
--- a/helm/authme/Chart.yaml
+++ b/helm/authme/Chart.yaml
@@ -1,0 +1,33 @@
+apiVersion: v2
+name: authme
+description: A Helm chart for AuthMe — a self-hosted authentication service built with NestJS.
+type: application
+version: 0.1.0
+appVersion: "0.0.1"
+
+keywords:
+  - authme
+  - authentication
+  - sso
+  - oauth
+  - oidc
+  - saml
+  - webauthn
+
+home: https://github.com/Islamawad132/Authme
+sources:
+  - https://github.com/Islamawad132/Authme
+
+maintainers:
+  - name: Islamawad132
+    url: https://github.com/Islamawad132
+
+dependencies:
+  - name: postgresql
+    version: "16.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: redis
+    version: "20.x.x"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled

--- a/helm/authme/templates/NOTES.txt
+++ b/helm/authme/templates/NOTES.txt
@@ -1,0 +1,42 @@
+1. Get the AuthMe application URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "authme.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "AuthMe is available at http://$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be provisioned.
+  Watch the status with:
+    kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "authme.fullname" . }}
+
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "authme.fullname" . }} --template "{{"{{range (index .status.loadBalancer.ingress 0)}}{{.}}{{end}}"}}")
+  echo "AuthMe is available at http://$SERVICE_IP:{{ .Values.service.port }}"
+{{- else if contains "ClusterIP" .Values.service.type }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "authme.fullname" . }} 3000:{{ .Values.service.port }}
+  echo "AuthMe is available at http://127.0.0.1:3000"
+{{- end }}
+
+2. Run the Helm test suite to verify the deployment:
+  helm test {{ .Release.Name }} --namespace {{ .Release.Namespace }}
+
+3. Check pod status:
+  kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "authme.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+4. View application logs:
+  kubectl logs --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "authme.name" . }}" --tail=100 -f
+
+{{- if .Values.secrets.ADMIN_API_KEY | eq "change-me-in-production" }}
+
+WARNING: You are using the default ADMIN_API_KEY value.
+         Please set a strong secret before exposing AuthMe to the internet:
+
+  helm upgrade {{ .Release.Name }} {{ .Chart.Name }} \
+    --namespace {{ .Release.Namespace }} \
+    --reuse-values \
+    --set secrets.ADMIN_API_KEY="<your-strong-api-key>"
+{{- end }}

--- a/helm/authme/templates/_helpers.tpl
+++ b/helm/authme/templates/_helpers.tpl
@@ -1,0 +1,112 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "authme.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "authme.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label value — used in the "helm.sh/chart" label.
+*/}}
+{{- define "authme.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels applied to every resource.
+*/}}
+{{- define "authme.labels" -}}
+helm.sh/chart: {{ include "authme.chart" . }}
+{{ include "authme.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels — used in matchLabels and Service selectors.
+*/}}
+{{- define "authme.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "authme.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "authme.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "authme.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the PostgreSQL host.
+When the bundled sub-chart is enabled, derive the host from the sub-chart's
+fully-qualified service name. Otherwise leave it empty so the caller must
+supply DATABASE_URL directly via secrets.DATABASE_URL.
+*/}}
+{{- define "authme.postgresqlHost" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "%s-postgresql" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Construct the DATABASE_URL from the sub-chart credentials when postgresql is
+enabled and no explicit DATABASE_URL secret value has been provided.
+*/}}
+{{- define "authme.databaseURL" -}}
+{{- if .Values.postgresql.enabled }}
+{{- printf "postgresql://%s:%s@%s:5432/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password (include "authme.postgresqlHost" .) .Values.postgresql.auth.database }}
+{{- else }}
+{{- .Values.secrets.DATABASE_URL }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the Redis host derived from the bundled sub-chart service name.
+*/}}
+{{- define "authme.redisHost" -}}
+{{- if .Values.redis.enabled }}
+{{- printf "%s-redis-master" .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Construct the REDIS_URL from the sub-chart credentials when redis is enabled
+and no explicit REDIS_URL secret value has been provided.
+*/}}
+{{- define "authme.redisURL" -}}
+{{- if .Values.redis.enabled }}
+{{- if .Values.redis.auth.enabled }}
+{{- printf "redis://:%s@%s:6379" .Values.redis.auth.password (include "authme.redisHost" .) }}
+{{- else }}
+{{- printf "redis://%s:6379" (include "authme.redisHost" .) }}
+{{- end }}
+{{- else }}
+{{- .Values.secrets.REDIS_URL }}
+{{- end }}
+{{- end }}

--- a/helm/authme/templates/configmap.yaml
+++ b/helm/authme/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "authme.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+data:
+  PORT: {{ .Values.env.PORT | quote }}
+  NODE_ENV: {{ .Values.env.NODE_ENV | quote }}
+  BASE_URL: {{ .Values.env.BASE_URL | quote }}
+  THROTTLE_TTL: {{ .Values.env.THROTTLE_TTL | quote }}
+  THROTTLE_LIMIT: {{ .Values.env.THROTTLE_LIMIT | quote }}
+  SESSION_STORE: {{ .Values.env.SESSION_STORE | quote }}

--- a/helm/authme/templates/deployment.yaml
+++ b/helm/authme/templates/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "authme.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "authme.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "authme.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "authme.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.env.PORT | default 3000 }}
+              protocol: TCP
+          # ── Environment: non-sensitive values from ConfigMap ──────────────
+          envFrom:
+            - configMapRef:
+                name: {{ include "authme.fullname" . }}
+            - secretRef:
+                name: {{ include "authme.fullname" . }}
+          # ── Startup probe — gives the container time to run migrations ────
+          startupProbe:
+            httpGet:
+              path: {{ .Values.startupProbe.httpGet.path }}
+              port: {{ .Values.startupProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          # ── Liveness probe — restarts the container if the app deadlocks ──
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.livenessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          # ── Readiness probe — removes the pod from Service endpoints ──────
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.readinessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/authme/templates/hpa.yaml
+++ b/helm/authme/templates/hpa.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "authme.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "authme.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/authme/templates/ingress.yaml
+++ b/helm/authme/templates/ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "authme.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/authme/templates/pdb.yaml
+++ b/helm/authme/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "authme.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "authme.selectorLabels" . | nindent 6 }}
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/helm/authme/templates/secret.yaml
+++ b/helm/authme/templates/secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "authme.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+  annotations:
+    # Helm will not diff secret values in plain text.
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  ADMIN_API_KEY: {{ .Values.secrets.ADMIN_API_KEY | quote }}
+  DATABASE_URL: {{ include "authme.databaseURL" . | quote }}
+  {{- $redisURL := include "authme.redisURL" . }}
+  {{- if $redisURL }}
+  REDIS_URL: {{ $redisURL | quote }}
+  {{- end }}
+  {{- if .Values.secrets.REDIS_SENTINEL_HOSTS }}
+  REDIS_SENTINEL_HOSTS: {{ .Values.secrets.REDIS_SENTINEL_HOSTS | quote }}
+  {{- end }}
+  {{- if .Values.secrets.REDIS_SENTINEL_NAME }}
+  REDIS_SENTINEL_NAME: {{ .Values.secrets.REDIS_SENTINEL_NAME | quote }}
+  {{- end }}

--- a/helm/authme/templates/service.yaml
+++ b/helm/authme/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "authme.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "authme.selectorLabels" . | nindent 4 }}

--- a/helm/authme/templates/serviceaccount.yaml
+++ b/helm/authme/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "authme.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/authme/templates/tests/test-connection.yaml
+++ b/helm/authme/templates/tests/test-connection.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "authme.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "authme.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: wget
+      image: busybox:1.36
+      command:
+        - wget
+      args:
+        - --spider
+        - --timeout=10
+        - "http://{{ include "authme.fullname" . }}:{{ .Values.service.port }}/health"

--- a/helm/authme/values.production.yaml
+++ b/helm/authme/values.production.yaml
@@ -1,0 +1,115 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# AuthMe Helm Chart — Production Overrides
+#
+# Usage:
+#   helm upgrade --install authme ./helm/authme \
+#     -f helm/authme/values.production.yaml \
+#     --set secrets.ADMIN_API_KEY="<strong-key>" \
+#     --set env.BASE_URL="https://auth.example.com"
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Run 3 pods by default; the HPA below will scale between 2 and 10.
+replicaCount: 3
+
+# ── Resources ─────────────────────────────────────────────────────────────────
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# ── Horizontal Pod Autoscaler ─────────────────────────────────────────────────
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 70
+
+# ── Pod Disruption Budget ─────────────────────────────────────────────────────
+# Ensures at least (replicaCount - 1) pods remain available during voluntary
+# disruptions such as node drains or rolling upgrades.
+podDisruptionBudget:
+  enabled: true
+  maxUnavailable: 1
+
+# ── Ingress ───────────────────────────────────────────────────────────────────
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+  hosts:
+    - host: auth.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: authme-tls
+      hosts:
+        - auth.example.com
+
+# ── Application Environment ───────────────────────────────────────────────────
+env:
+  NODE_ENV: "production"
+  BASE_URL: "https://auth.example.com"
+  SESSION_STORE: "database"
+  THROTTLE_TTL: "60000"
+  THROTTLE_LIMIT: "100"
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+# Override these values at deploy time; never commit real secrets to source
+# control. Example:
+#   --set secrets.ADMIN_API_KEY="$(openssl rand -hex 32)"
+secrets:
+  ADMIN_API_KEY: "REPLACE_WITH_STRONG_SECRET"
+  DATABASE_URL: ""   # auto-constructed from postgresql sub-chart when enabled
+
+# ── PostgreSQL Sub-chart ──────────────────────────────────────────────────────
+postgresql:
+  enabled: true
+  auth:
+    username: authme
+    # Override at deploy time: --set postgresql.auth.password="..."
+    password: "REPLACE_WITH_STRONG_DB_PASSWORD"
+    database: authme
+  primary:
+    persistence:
+      enabled: true
+      size: 20Gi
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+
+# ── Pod Security ──────────────────────────────────────────────────────────────
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# ── Affinity: spread pods across nodes for HA ─────────────────────────────────
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: authme
+          topologyKey: kubernetes.io/hostname

--- a/helm/authme/values.yaml
+++ b/helm/authme/values.yaml
@@ -1,0 +1,234 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# AuthMe Helm Chart — Default Values
+# Override any value with --set key=value or a custom values file.
+# ──────────────────────────────────────────────────────────────────────────────
+
+# Number of AuthMe pod replicas.
+replicaCount: 1
+
+# ── Image ─────────────────────────────────────────────────────────────────────
+image:
+  repository: islamawad/authme
+  # Overrides the image tag. Defaults to Chart.appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# List of references to secrets in the same namespace to use for pulling the
+# container image from a private registry.
+imagePullSecrets: []
+
+# Override the chart name used in resource labels and names.
+nameOverride: ""
+fullnameOverride: ""
+
+# ── Service Account ───────────────────────────────────────────────────────────
+serviceAccount:
+  # Create a dedicated ServiceAccount for the AuthMe pods.
+  create: true
+  # Automatically mount the ServiceAccount API credentials.
+  automount: true
+  # Extra annotations to add to the ServiceAccount resource.
+  annotations: {}
+  # Override the generated ServiceAccount name.
+  name: ""
+
+# ── Pod Annotations & Labels ──────────────────────────────────────────────────
+podAnnotations: {}
+podLabels: {}
+
+# ── Pod Security Context ──────────────────────────────────────────────────────
+podSecurityContext:
+  fsGroup: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# ── Container Security Context ────────────────────────────────────────────────
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# ── Service ───────────────────────────────────────────────────────────────────
+service:
+  type: ClusterIP
+  port: 3000
+  # Override the target container port (defaults to service.port).
+  targetPort: ""
+  annotations: {}
+
+# ── Ingress ───────────────────────────────────────────────────────────────────
+ingress:
+  enabled: false
+  # Ingress class name (e.g., "nginx", "traefik").
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: authme.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: authme-tls
+  #    hosts:
+  #      - authme.example.com
+
+# ── Resources ─────────────────────────────────────────────────────────────────
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# ── Liveness / Readiness / Startup Probes ────────────────────────────────────
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health/ready
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  # Allow up to 5 minutes (30 * 10s) for the container to start.
+  failureThreshold: 30
+
+# ── Horizontal Pod Autoscaler ─────────────────────────────────────────────────
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# ── Pod Disruption Budget ─────────────────────────────────────────────────────
+podDisruptionBudget:
+  enabled: false
+  # Exactly one of minAvailable or maxUnavailable must be set.
+  # minAvailable: 1
+  maxUnavailable: 1
+
+# ── Node Scheduling ───────────────────────────────────────────────────────────
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+# ── Additional Volumes & Mounts ───────────────────────────────────────────────
+volumes: []
+volumeMounts: []
+
+# ── AuthMe Application Configuration ─────────────────────────────────────────
+env:
+  # ── Server ────────────────────────────────────────────────────────────────
+  # TCP port the AuthMe process listens on inside the container.
+  PORT: "3000"
+
+  # Node environment. Use "production" in live deployments.
+  NODE_ENV: "production"
+
+  # Public URL of the AuthMe instance (used for redirect URIs, emails, etc.).
+  BASE_URL: "http://authme.example.com"
+
+  # ── Rate Limiting ─────────────────────────────────────────────────────────
+  # Time-to-live window for the throttle limiter in milliseconds.
+  THROTTLE_TTL: "60000"
+
+  # Maximum number of requests allowed within THROTTLE_TTL.
+  THROTTLE_LIMIT: "100"
+
+  # ── Session Store ─────────────────────────────────────────────────────────
+  # Backend used to store sessions: "database" (default) or "redis".
+  # Switch to "redis" when redis.enabled is true for horizontal scalability.
+  SESSION_STORE: "database"
+
+# ── Sensitive / Secret Environment Variables ─────────────────────────────────
+# Values in this section are stored in a Kubernetes Secret.
+secrets:
+  # Admin API key used to access protected administrative endpoints.
+  # REQUIRED — change before deploying to production.
+  ADMIN_API_KEY: "change-me-in-production"
+
+  # Database connection string. When postgresql.enabled is true the chart
+  # auto-constructs this from the postgresql sub-chart credentials; set an
+  # explicit value only when connecting to an external database.
+  DATABASE_URL: ""
+
+  # Redis connection string. Required when redis.enabled is true or when
+  # SESSION_STORE is "redis". Leave empty to disable Redis.
+  REDIS_URL: ""
+
+  # Redis Sentinel — comma-separated host:port pairs.
+  REDIS_SENTINEL_HOSTS: ""
+
+  # Redis Sentinel master name.
+  REDIS_SENTINEL_NAME: ""
+
+# ── PostgreSQL Sub-chart (Bitnami) ────────────────────────────────────────────
+# https://artifacthub.io/packages/helm/bitnami/postgresql
+# Set enabled: false and configure secrets.DATABASE_URL to use an external DB.
+postgresql:
+  enabled: true
+  auth:
+    username: authme
+    password: authme
+    database: authme
+    # Existing Kubernetes Secret that holds the postgres passwords.
+    # When set, the password fields above are ignored.
+    existingSecret: ""
+  primary:
+    persistence:
+      enabled: true
+      size: 8Gi
+  # Adjust resources for the PostgreSQL pod.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# ── Redis Sub-chart (Bitnami) ─────────────────────────────────────────────────
+# https://artifacthub.io/packages/helm/bitnami/redis
+# Enable when you want a managed Redis instance for caching / session storage.
+redis:
+  enabled: false
+  auth:
+    enabled: true
+    password: authme-redis
+    existingSecret: ""
+  architecture: standalone
+  master:
+    persistence:
+      enabled: true
+      size: 2Gi
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi


### PR DESCRIPTION
## Summary
- Implements **Feature 16: Official Kubernetes Helm Chart** (closes #275)
- Production-ready Helm chart at `helm/authme/`
- PostgreSQL and Redis as optional Bitnami sub-chart dependencies
- HPA, PDB, Ingress (Nginx/Traefik), TLS, health probes
- Auto-constructed DATABASE_URL and REDIS_URL from sub-chart credentials
- Production values overlay with HA settings
- Helm test for health endpoint

## Key Files
- `helm/authme/Chart.yaml` — Chart metadata with dependencies
- `helm/authme/values.yaml` — 234 lines of documented defaults
- `helm/authme/values.production.yaml` — HA production overlay
- `helm/authme/templates/` — Deployment, Service, Ingress, HPA, PDB, ConfigMap, Secret, ServiceAccount, NOTES.txt, test

## Usage
```bash
helm install authme ./helm/authme
# Production:
helm install authme ./helm/authme -f helm/authme/values.production.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)