### PR TITLE
feat: Non-Human Identity Management (Service Accounts & API Keys)

### DIFF
--- a/prisma/migrations/20260324600000_add_non_human_identity/migration.sql
+++ b/prisma/migrations/20260324600000_add_non_human_identity/migration.sql
@@ -1,0 +1,43 @@
+-- CreateTable: service_accounts — lightweight non-human identity entities
+CREATE TABLE "service_accounts" (
+    "id" TEXT NOT NULL,
+    "realm_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "service_accounts_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "service_accounts_realm_id_name_key" ON "service_accounts"("realm_id", "name");
+
+ALTER TABLE "service_accounts"
+    ADD CONSTRAINT "service_accounts_realm_id_fkey"
+    FOREIGN KEY ("realm_id") REFERENCES "realms"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateTable: api_keys — hashed API keys scoped to a service account
+CREATE TABLE "api_keys" (
+    "id" TEXT NOT NULL,
+    "service_account_id" TEXT NOT NULL,
+    "key_prefix" TEXT NOT NULL,
+    "key_hash" TEXT NOT NULL,
+    "name" TEXT,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "expires_at" TIMESTAMP(3),
+    "last_used_at" TIMESTAMP(3),
+    "request_count" INTEGER NOT NULL DEFAULT 0,
+    "revoked" BOOLEAN NOT NULL DEFAULT false,
+    "revoked_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "api_keys_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "api_keys_key_prefix_idx" ON "api_keys"("key_prefix");
+CREATE INDEX "api_keys_service_account_id_idx" ON "api_keys"("service_account_id");
+
+ALTER TABLE "api_keys"
+    ADD CONSTRAINT "api_keys_service_account_id_fkey"
+    FOREIGN KEY ("service_account_id") REFERENCES "service_accounts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -49,6 +49,7 @@ import { WebAuthnModule } from './webauthn/webauthn.module.js';
 import { AuthorizationModule } from './authorization/authorization.module.js';
 import { CustomAttributesModule } from './custom-attributes/custom-attributes.module.js';
 import { PluginsModule } from './plugins/plugins.module.js';
+import { AuthFlowModule } from './auth-flow/auth-flow.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -108,6 +109,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     AuthorizationModule,
     CustomAttributesModule,
     PluginsModule,
+    AuthFlowModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/prisma/prisma.mock.ts
+++ b/src/prisma/prisma.mock.ts
@@ -276,6 +276,21 @@ export function createMockPrismaService(): MockPrismaService {
       upsert: jest.fn(),
       deleteMany: jest.fn(),
     },
+    serviceAccount: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    apiKey: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
     $connect: jest.fn(),
     $disconnect: jest.fn(),
   } as any;

--- a/src/service-accounts/api-key.guard.ts
+++ b/src/service-accounts/api-key.guard.ts
@@ -1,0 +1,38 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Request } from 'express';
+import { ServiceAccountsService } from './service-accounts.service.js';
+
+/**
+ * Guard that validates API keys passed via the `X-Api-Key` header.
+ * The header value must be the full plain key returned at creation time.
+ * The first 8 characters are used as a lookup prefix; the full value is
+ * verified against the stored Argon2 hash.
+ *
+ * On success the resolved ApiKey record (with its ServiceAccount) is
+ * attached to `request.apiKey` for downstream use.
+ */
+@Injectable()
+export class ApiKeyGuard implements CanActivate {
+  constructor(private readonly serviceAccountsService: ServiceAccountsService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const header = request.headers['x-api-key'];
+    const plainKey = Array.isArray(header) ? header[0] : header;
+
+    if (!plainKey || plainKey.length < 8) {
+      throw new UnauthorizedException('Missing or malformed X-Api-Key header');
+    }
+
+    const keyPrefix = plainKey.slice(0, 8);
+    const apiKey = await this.serviceAccountsService.validateApiKey(keyPrefix, plainKey);
+
+    (request as any).apiKey = apiKey;
+    return true;
+  }
+}

--- a/src/service-accounts/dto/create-api-key.dto.ts
+++ b/src/service-accounts/dto/create-api-key.dto.ts
@@ -1,0 +1,25 @@
+import {
+  IsString,
+  IsOptional,
+  IsArray,
+  IsDateString,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateApiKeyDto {
+  @ApiPropertyOptional({ example: 'ci-pipeline-key' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ example: ['read:users', 'write:tokens'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  scopes?: string[];
+
+  @ApiPropertyOptional({ example: '2027-01-01T00:00:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+}

--- a/src/service-accounts/dto/create-service-account.dto.ts
+++ b/src/service-accounts/dto/create-service-account.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsOptional, IsBoolean, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateServiceAccountDto {
+  @ApiProperty({ example: 'my-service' })
+  @IsString()
+  @MinLength(2)
+  name!: string;
+
+  @ApiPropertyOptional({ example: 'Service account for CI/CD pipeline' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/src/service-accounts/dto/update-service-account.dto.ts
+++ b/src/service-accounts/dto/update-service-account.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsOptional, IsBoolean } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateServiceAccountDto {
+  @ApiPropertyOptional({ example: 'updated-service-name' })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ example: 'Updated description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+}

--- a/src/service-accounts/service-accounts.controller.ts
+++ b/src/service-accounts/service-accounts.controller.ts
@@ -1,0 +1,109 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
+import type { Realm } from '@prisma/client';
+import { ServiceAccountsService } from './service-accounts.service.js';
+import { CreateServiceAccountDto } from './dto/create-service-account.dto.js';
+import { UpdateServiceAccountDto } from './dto/update-service-account.dto.js';
+import { CreateApiKeyDto } from './dto/create-api-key.dto.js';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+
+@ApiTags('Service Accounts')
+@Controller('admin/realms/:realmName/service-accounts')
+@UseGuards(RealmGuard)
+@ApiSecurity('admin-api-key')
+export class ServiceAccountsController {
+  constructor(private readonly serviceAccountsService: ServiceAccountsService) {}
+
+  // ── Service Account endpoints ──────────────────────────────────────────────
+
+  @Post()
+  @ApiOperation({ summary: 'Create a service account in a realm' })
+  create(@CurrentRealm() realm: Realm, @Body() dto: CreateServiceAccountDto) {
+    return this.serviceAccountsService.create(realm, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List service accounts in a realm' })
+  findAll(@CurrentRealm() realm: Realm) {
+    return this.serviceAccountsService.findAll(realm);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a service account by ID' })
+  findOne(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.serviceAccountsService.findById(realm, id);
+  }
+
+  @Put(':id')
+  @ApiOperation({ summary: 'Update a service account' })
+  update(
+    @CurrentRealm() realm: Realm,
+    @Param('id') id: string,
+    @Body() dto: UpdateServiceAccountDto,
+  ) {
+    return this.serviceAccountsService.update(realm, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a service account' })
+  remove(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.serviceAccountsService.remove(realm, id);
+  }
+
+  // ── API Key endpoints ──────────────────────────────────────────────────────
+
+  @Post(':id/api-keys')
+  @ApiOperation({ summary: 'Create an API key for a service account' })
+  createApiKey(
+    @CurrentRealm() realm: Realm,
+    @Param('id') id: string,
+    @Body() dto: CreateApiKeyDto,
+  ) {
+    return this.serviceAccountsService.createApiKey(realm, id, dto);
+  }
+
+  @Get(':id/api-keys')
+  @ApiOperation({ summary: 'List API keys for a service account' })
+  listApiKeys(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.serviceAccountsService.listApiKeys(realm, id);
+  }
+
+  @Post(':id/api-keys/:keyId/revoke')
+  @ApiOperation({ summary: 'Revoke an API key' })
+  revokeApiKey(
+    @CurrentRealm() realm: Realm,
+    @Param('id') id: string,
+    @Param('keyId') keyId: string,
+  ) {
+    return this.serviceAccountsService.revokeApiKey(realm, id, keyId);
+  }
+
+  @Post(':id/api-keys/:keyId/rotate')
+  @ApiOperation({ summary: 'Rotate an API key (creates new key, keeps old active for grace period)' })
+  rotateApiKey(
+    @CurrentRealm() realm: Realm,
+    @Param('id') id: string,
+    @Param('keyId') keyId: string,
+  ) {
+    return this.serviceAccountsService.rotateApiKey(realm, id, keyId);
+  }
+
+  @Get(':id/metrics')
+  @ApiOperation({ summary: 'Get usage metrics for a service account' })
+  getUsageMetrics(@CurrentRealm() realm: Realm, @Param('id') id: string) {
+    return this.serviceAccountsService.getUsageMetrics(realm, id);
+  }
+}

--- a/src/service-accounts/service-accounts.module.ts
+++ b/src/service-accounts/service-accounts.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ServiceAccountsController } from './service-accounts.controller.js';
+import { ServiceAccountsService } from './service-accounts.service.js';
+import { ApiKeyGuard } from './api-key.guard.js';
+
+@Module({
+  controllers: [ServiceAccountsController],
+  providers: [ServiceAccountsService, ApiKeyGuard],
+  exports: [ServiceAccountsService, ApiKeyGuard],
+})
+export class ServiceAccountsModule {}

--- a/src/service-accounts/service-accounts.service.spec.ts
+++ b/src/service-accounts/service-accounts.service.spec.ts
@@ -1,0 +1,434 @@
+import {
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ServiceAccountsService } from './service-accounts.service.js';
+import {
+  createMockPrismaService,
+  MockPrismaService,
+} from '../prisma/prisma.mock.js';
+import type { Realm } from '@prisma/client';
+
+describe('ServiceAccountsService', () => {
+  let service: ServiceAccountsService;
+  let prisma: MockPrismaService;
+  let cryptoService: {
+    generateSecret: jest.Mock;
+    hashPassword: jest.Mock;
+    verifyPassword: jest.Mock;
+    sha256: jest.Mock;
+  };
+
+  const mockRealm: Realm = {
+    id: 'realm-1',
+    name: 'test-realm',
+    displayName: 'Test Realm',
+    enabled: true,
+    accessTokenLifespan: 300,
+    refreshTokenLifespan: 1800,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as Realm;
+
+  const mockServiceAccount = {
+    id: 'sa-uuid-1',
+    realmId: 'realm-1',
+    name: 'my-service',
+    description: 'Test service account',
+    enabled: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+
+  const mockApiKey = {
+    id: 'key-uuid-1',
+    serviceAccountId: 'sa-uuid-1',
+    keyPrefix: 'abcd1234',
+    keyHash: '$argon2id$hash',
+    name: 'test-key',
+    scopes: ['read:users'],
+    expiresAt: null,
+    lastUsedAt: null,
+    requestCount: 0,
+    revoked: false,
+    revokedAt: null,
+    createdAt: new Date(),
+    serviceAccount: { ...mockServiceAccount },
+  };
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+    cryptoService = {
+      generateSecret: jest.fn(),
+      hashPassword: jest.fn(),
+      verifyPassword: jest.fn(),
+      sha256: jest.fn(),
+    };
+    service = new ServiceAccountsService(prisma as any, cryptoService as any);
+  });
+
+  // ── Service Account CRUD ─────────────────────────────────────────────────
+
+  describe('create', () => {
+    it('should create a service account', async () => {
+      prisma.serviceAccount.findUnique.mockResolvedValue(null);
+      prisma.serviceAccount.create.mockResolvedValue(mockServiceAccount);
+
+      const result = await service.create(mockRealm, {
+        name: 'my-service',
+        description: 'Test service account',
+      });
+
+      expect(result).toEqual(mockServiceAccount);
+      expect(prisma.serviceAccount.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            realmId: 'realm-1',
+            name: 'my-service',
+            description: 'Test service account',
+            enabled: true,
+          }),
+        }),
+      );
+    });
+
+    it('should default enabled to true when not specified', async () => {
+      prisma.serviceAccount.findUnique.mockResolvedValue(null);
+      prisma.serviceAccount.create.mockResolvedValue(mockServiceAccount);
+
+      await service.create(mockRealm, { name: 'my-service' });
+
+      expect(prisma.serviceAccount.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ enabled: true }),
+        }),
+      );
+    });
+
+    it('should throw ConflictException when name already exists in realm', async () => {
+      prisma.serviceAccount.findUnique.mockResolvedValue(mockServiceAccount);
+
+      await expect(
+        service.create(mockRealm, { name: 'my-service' }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all service accounts for a realm', async () => {
+      prisma.serviceAccount.findMany.mockResolvedValue([mockServiceAccount]);
+
+      const result = await service.findAll(mockRealm);
+
+      expect(result).toEqual([mockServiceAccount]);
+      expect(prisma.serviceAccount.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { realmId: 'realm-1' } }),
+      );
+    });
+  });
+
+  describe('findById', () => {
+    it('should return service account when found', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+
+      const result = await service.findById(mockRealm, 'sa-uuid-1');
+
+      expect(result).toEqual(mockServiceAccount);
+    });
+
+    it('should throw NotFoundException when not found', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.findById(mockRealm, 'nonexistent'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a service account', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.serviceAccount.findUnique.mockResolvedValue(null);
+      const updated = { ...mockServiceAccount, description: 'Updated' };
+      prisma.serviceAccount.update.mockResolvedValue(updated);
+
+      const result = await service.update(mockRealm, 'sa-uuid-1', {
+        description: 'Updated',
+      });
+
+      expect(result).toEqual(updated);
+    });
+
+    it('should throw ConflictException when new name is already taken by another account', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      // Another account with the same name
+      prisma.serviceAccount.findUnique.mockResolvedValue({
+        ...mockServiceAccount,
+        id: 'sa-uuid-other',
+      });
+
+      await expect(
+        service.update(mockRealm, 'sa-uuid-1', { name: 'taken-name' }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('should throw NotFoundException when service account does not exist', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update(mockRealm, 'nonexistent', { name: 'x' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a service account', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.serviceAccount.delete.mockResolvedValue(mockServiceAccount);
+
+      await service.remove(mockRealm, 'sa-uuid-1');
+
+      expect(prisma.serviceAccount.delete).toHaveBeenCalledWith({
+        where: { id: 'sa-uuid-1' },
+      });
+    });
+
+    it('should throw NotFoundException when service account does not exist', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(null);
+
+      await expect(service.remove(mockRealm, 'nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ── API Key management ───────────────────────────────────────────────────
+
+  describe('createApiKey', () => {
+    it('should generate a key, store only its hash, and return the plain key once', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      cryptoService.generateSecret.mockReturnValue('abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890');
+      cryptoService.hashPassword.mockResolvedValue('$argon2id$v=19$...');
+      prisma.apiKey.create.mockResolvedValue({
+        ...mockApiKey,
+        keyPrefix: 'abcd1234',
+      });
+
+      const result = await service.createApiKey(mockRealm, 'sa-uuid-1', {
+        name: 'test-key',
+        scopes: ['read:users'],
+      });
+
+      expect(result.plainKey).toBe('abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890');
+      expect(result.keyWarning).toBeDefined();
+      expect(cryptoService.generateSecret).toHaveBeenCalledWith(32);
+      expect(cryptoService.hashPassword).toHaveBeenCalledWith(
+        'abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890',
+      );
+      expect(prisma.apiKey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            serviceAccountId: 'sa-uuid-1',
+            keyPrefix: 'abcd1234',
+            keyHash: '$argon2id$v=19$...',
+          }),
+        }),
+      );
+    });
+
+    it('should throw NotFoundException when service account does not exist', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.createApiKey(mockRealm, 'nonexistent', {}),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should set expiresAt when provided', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      cryptoService.generateSecret.mockReturnValue('abcd1234ef567890abcd1234ef567890abcd1234ef567890abcd1234ef567890');
+      cryptoService.hashPassword.mockResolvedValue('hash');
+      prisma.apiKey.create.mockResolvedValue({ ...mockApiKey, expiresAt: new Date('2027-01-01') });
+
+      const result = await service.createApiKey(mockRealm, 'sa-uuid-1', {
+        expiresAt: '2027-01-01T00:00:00.000Z',
+      });
+
+      expect(prisma.apiKey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            expiresAt: new Date('2027-01-01T00:00:00.000Z'),
+          }),
+        }),
+      );
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('validateApiKey', () => {
+    it('should return the api key record when credentials are valid', async () => {
+      prisma.apiKey.findMany.mockResolvedValue([mockApiKey]);
+      cryptoService.verifyPassword.mockResolvedValue(true);
+      prisma.apiKey.update.mockResolvedValue({});
+
+      const result = await service.validateApiKey('abcd1234', 'abcd1234ef567890...');
+
+      expect(result).toEqual(mockApiKey);
+      expect(cryptoService.verifyPassword).toHaveBeenCalledWith(
+        '$argon2id$hash',
+        'abcd1234ef567890...',
+      );
+    });
+
+    it('should throw UnauthorizedException when no candidates match the prefix', async () => {
+      prisma.apiKey.findMany.mockResolvedValue([]);
+
+      await expect(
+        service.validateApiKey('badpref', 'badprefxxxxxxxx'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should throw UnauthorizedException when hash verification fails', async () => {
+      prisma.apiKey.findMany.mockResolvedValue([mockApiKey]);
+      cryptoService.verifyPassword.mockResolvedValue(false);
+
+      await expect(
+        service.validateApiKey('abcd1234', 'wrong-plain-key'),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should skip expired keys', async () => {
+      const expiredKey = {
+        ...mockApiKey,
+        expiresAt: new Date(Date.now() - 1000),
+      };
+      prisma.apiKey.findMany.mockResolvedValue([expiredKey]);
+
+      await expect(
+        service.validateApiKey('abcd1234', 'abcd1234plainkey'),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(cryptoService.verifyPassword).not.toHaveBeenCalled();
+    });
+
+    it('should skip keys whose service account is disabled', async () => {
+      const disabledSaKey = {
+        ...mockApiKey,
+        serviceAccount: { ...mockServiceAccount, enabled: false },
+      };
+      prisma.apiKey.findMany.mockResolvedValue([disabledSaKey]);
+
+      await expect(
+        service.validateApiKey('abcd1234', 'abcd1234plainkey'),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(cryptoService.verifyPassword).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeApiKey', () => {
+    it('should revoke an active key', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.apiKey.findFirst.mockResolvedValue(mockApiKey);
+      prisma.apiKey.update.mockResolvedValue({ ...mockApiKey, revoked: true });
+
+      const result = await service.revokeApiKey(mockRealm, 'sa-uuid-1', 'key-uuid-1');
+
+      expect(result.message).toMatch(/revoked successfully/i);
+      expect(prisma.apiKey.update).toHaveBeenCalledWith({
+        where: { id: 'key-uuid-1' },
+        data: expect.objectContaining({ revoked: true, revokedAt: expect.any(Date) }),
+      });
+    });
+
+    it('should return a message when key is already revoked', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.apiKey.findFirst.mockResolvedValue({ ...mockApiKey, revoked: true });
+
+      const result = await service.revokeApiKey(mockRealm, 'sa-uuid-1', 'key-uuid-1');
+
+      expect(result.message).toMatch(/already revoked/i);
+      expect(prisma.apiKey.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when key does not exist', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.apiKey.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.revokeApiKey(mockRealm, 'sa-uuid-1', 'nonexistent'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('rotateApiKey', () => {
+    it('should create a new key and schedule the old key for expiry', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.apiKey.findFirst.mockResolvedValue(mockApiKey);
+      cryptoService.generateSecret.mockReturnValue('newkey1234567890newkey1234567890newkey1234567890newkey1234567890');
+      cryptoService.hashPassword.mockResolvedValue('$argon2id$newhash');
+      const newKeyRecord = {
+        ...mockApiKey,
+        id: 'key-uuid-2',
+        keyPrefix: 'newkey12',
+        keyHash: '$argon2id$newhash',
+      };
+      prisma.apiKey.create.mockResolvedValue(newKeyRecord);
+      prisma.apiKey.update.mockResolvedValue({});
+
+      const result = await service.rotateApiKey(mockRealm, 'sa-uuid-1', 'key-uuid-1');
+
+      expect(result.newKey.plainKey).toBe('newkey1234567890newkey1234567890newkey1234567890newkey1234567890');
+      expect(result.newKey.keyWarning).toBeDefined();
+      expect(result.oldKeyId).toBe('key-uuid-1');
+      expect(result.gracePeriodEndsAt).toBeInstanceOf(Date);
+
+      // Old key should have been updated with a grace-period expiry
+      expect(prisma.apiKey.update).toHaveBeenCalledWith({
+        where: { id: 'key-uuid-1' },
+        data: expect.objectContaining({ expiresAt: expect.any(Date) }),
+      });
+    });
+
+    it('should throw NotFoundException when key does not exist', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.apiKey.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.rotateApiKey(mockRealm, 'sa-uuid-1', 'nonexistent'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getUsageMetrics', () => {
+    it('should return aggregated usage metrics', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      const usedDate = new Date('2026-01-01');
+      const keys = [
+        { ...mockApiKey, requestCount: 10, lastUsedAt: usedDate },
+        { ...mockApiKey, id: 'key-uuid-2', requestCount: 5, lastUsedAt: null },
+      ];
+      prisma.apiKey.findMany.mockResolvedValue(keys);
+
+      const result = await service.getUsageMetrics(mockRealm, 'sa-uuid-1');
+
+      expect(result.serviceAccountId).toBe('sa-uuid-1');
+      expect(result.totalRequests).toBe(15);
+      expect(result.lastUsedAt).toEqual(usedDate);
+      expect(result.keys).toHaveLength(2);
+    });
+
+    it('should return null lastUsedAt when no keys have been used', async () => {
+      prisma.serviceAccount.findFirst.mockResolvedValue(mockServiceAccount);
+      prisma.apiKey.findMany.mockResolvedValue([
+        { ...mockApiKey, requestCount: 0, lastUsedAt: null },
+      ]);
+
+      const result = await service.getUsageMetrics(mockRealm, 'sa-uuid-1');
+
+      expect(result.lastUsedAt).toBeNull();
+      expect(result.totalRequests).toBe(0);
+    });
+  });
+});

--- a/src/service-accounts/service-accounts.service.ts
+++ b/src/service-accounts/service-accounts.service.ts
@@ -1,0 +1,288 @@
+import {
+  Injectable,
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { Realm } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
+import { CreateServiceAccountDto } from './dto/create-service-account.dto.js';
+import { UpdateServiceAccountDto } from './dto/update-service-account.dto.js';
+import { CreateApiKeyDto } from './dto/create-api-key.dto.js';
+
+const SERVICE_ACCOUNT_SELECT = {
+  id: true,
+  realmId: true,
+  name: true,
+  description: true,
+  enabled: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+const API_KEY_SELECT = {
+  id: true,
+  serviceAccountId: true,
+  keyPrefix: true,
+  name: true,
+  scopes: true,
+  expiresAt: true,
+  lastUsedAt: true,
+  requestCount: true,
+  revoked: true,
+  revokedAt: true,
+  createdAt: true,
+} as const;
+
+// Grace period (seconds) during which a rotated-out key keeps working
+const ROTATION_GRACE_SECONDS = 3600;
+
+@Injectable()
+export class ServiceAccountsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  // ── Service Account CRUD ───────────────────────────────────────────────────
+
+  async create(realm: Realm, dto: CreateServiceAccountDto) {
+    const existing = await this.prisma.serviceAccount.findUnique({
+      where: { realmId_name: { realmId: realm.id, name: dto.name } },
+    });
+    if (existing) {
+      throw new ConflictException(
+        `Service account '${dto.name}' already exists in realm '${realm.name}'`,
+      );
+    }
+
+    return this.prisma.serviceAccount.create({
+      data: {
+        realmId: realm.id,
+        name: dto.name,
+        description: dto.description,
+        enabled: dto.enabled ?? true,
+      },
+      select: SERVICE_ACCOUNT_SELECT,
+    });
+  }
+
+  async findAll(realm: Realm) {
+    return this.prisma.serviceAccount.findMany({
+      where: { realmId: realm.id },
+      select: SERVICE_ACCOUNT_SELECT,
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async findById(realm: Realm, id: string) {
+    const sa = await this.prisma.serviceAccount.findFirst({
+      where: { id, realmId: realm.id },
+      select: SERVICE_ACCOUNT_SELECT,
+    });
+    if (!sa) {
+      throw new NotFoundException(`Service account '${id}' not found`);
+    }
+    return sa;
+  }
+
+  async update(realm: Realm, id: string, dto: UpdateServiceAccountDto) {
+    await this.findById(realm, id);
+
+    if (dto.name) {
+      const conflict = await this.prisma.serviceAccount.findUnique({
+        where: { realmId_name: { realmId: realm.id, name: dto.name } },
+      });
+      if (conflict && conflict.id !== id) {
+        throw new ConflictException(
+          `Service account name '${dto.name}' already taken in realm '${realm.name}'`,
+        );
+      }
+    }
+
+    return this.prisma.serviceAccount.update({
+      where: { id },
+      data: {
+        name: dto.name,
+        description: dto.description,
+        enabled: dto.enabled,
+      },
+      select: SERVICE_ACCOUNT_SELECT,
+    });
+  }
+
+  async remove(realm: Realm, id: string) {
+    await this.findById(realm, id);
+    await this.prisma.serviceAccount.delete({ where: { id } });
+  }
+
+  // ── API Key management ─────────────────────────────────────────────────────
+
+  async createApiKey(realm: Realm, serviceAccountId: string, dto: CreateApiKeyDto) {
+    await this.findById(realm, serviceAccountId);
+
+    // Generate a cryptographically random key: prefix (8 hex chars) + full key (64 hex chars)
+    const rawKey = this.crypto.generateSecret(32); // 64 hex chars
+    const keyPrefix = rawKey.slice(0, 8);
+    const keyHash = await this.crypto.hashPassword(rawKey);
+
+    const apiKey = await this.prisma.apiKey.create({
+      data: {
+        serviceAccountId,
+        keyPrefix,
+        keyHash,
+        name: dto.name,
+        scopes: dto.scopes ?? [],
+        expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : undefined,
+      },
+      select: API_KEY_SELECT,
+    });
+
+    return {
+      ...apiKey,
+      plainKey: rawKey,
+      keyWarning: 'Store this key securely. It will not be shown again.',
+    };
+  }
+
+  async listApiKeys(realm: Realm, serviceAccountId: string) {
+    await this.findById(realm, serviceAccountId);
+    return this.prisma.apiKey.findMany({
+      where: { serviceAccountId },
+      select: API_KEY_SELECT,
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  async revokeApiKey(realm: Realm, serviceAccountId: string, apiKeyId: string) {
+    await this.findById(realm, serviceAccountId);
+    const key = await this.prisma.apiKey.findFirst({
+      where: { id: apiKeyId, serviceAccountId },
+    });
+    if (!key) {
+      throw new NotFoundException(`API key '${apiKeyId}' not found`);
+    }
+    if (key.revoked) {
+      return { message: 'API key is already revoked' };
+    }
+
+    await this.prisma.apiKey.update({
+      where: { id: apiKeyId },
+      data: { revoked: true, revokedAt: new Date() },
+    });
+
+    return { message: 'API key revoked successfully' };
+  }
+
+  async rotateApiKey(realm: Realm, serviceAccountId: string, apiKeyId: string) {
+    await this.findById(realm, serviceAccountId);
+    const oldKey = await this.prisma.apiKey.findFirst({
+      where: { id: apiKeyId, serviceAccountId },
+    });
+    if (!oldKey) {
+      throw new NotFoundException(`API key '${apiKeyId}' not found`);
+    }
+
+    // Create a new key with the same settings
+    const newRaw = this.crypto.generateSecret(32);
+    const newPrefix = newRaw.slice(0, 8);
+    const newHash = await this.crypto.hashPassword(newRaw);
+
+    const newKey = await this.prisma.apiKey.create({
+      data: {
+        serviceAccountId,
+        keyPrefix: newPrefix,
+        keyHash: newHash,
+        name: oldKey.name ? `${oldKey.name} (rotated)` : undefined,
+        scopes: oldKey.scopes,
+        expiresAt: oldKey.expiresAt,
+      },
+      select: API_KEY_SELECT,
+    });
+
+    // Schedule old key for expiry after grace period (mark via expiresAt)
+    const graceExpiry = new Date(Date.now() + ROTATION_GRACE_SECONDS * 1000);
+    await this.prisma.apiKey.update({
+      where: { id: apiKeyId },
+      data: { expiresAt: graceExpiry },
+    });
+
+    return {
+      newKey: {
+        ...newKey,
+        plainKey: newRaw,
+        keyWarning: 'Store this key securely. It will not be shown again.',
+      },
+      oldKeyId: apiKeyId,
+      gracePeriodEndsAt: graceExpiry,
+    };
+  }
+
+  async validateApiKey(keyPrefix: string, plainKey: string) {
+    const candidates = await this.prisma.apiKey.findMany({
+      where: { keyPrefix, revoked: false },
+      include: { serviceAccount: true },
+    });
+
+    for (const candidate of candidates) {
+      // Skip expired keys
+      if (candidate.expiresAt && candidate.expiresAt < new Date()) continue;
+      // Skip disabled service accounts
+      if (!candidate.serviceAccount.enabled) continue;
+
+      const valid = await this.crypto.verifyPassword(candidate.keyHash, plainKey);
+      if (valid) {
+        // Update usage statistics (fire-and-forget — don't block the request)
+        this.prisma.apiKey
+          .update({
+            where: { id: candidate.id },
+            data: {
+              lastUsedAt: new Date(),
+              requestCount: { increment: 1 },
+            },
+          })
+          .catch(() => {
+            // Non-critical — ignore failures
+          });
+
+        return candidate;
+      }
+    }
+
+    throw new UnauthorizedException('Invalid or expired API key');
+  }
+
+  async getUsageMetrics(realm: Realm, serviceAccountId: string) {
+    await this.findById(realm, serviceAccountId);
+
+    const keys = await this.prisma.apiKey.findMany({
+      where: { serviceAccountId },
+      select: {
+        id: true,
+        name: true,
+        keyPrefix: true,
+        revoked: true,
+        expiresAt: true,
+        lastUsedAt: true,
+        requestCount: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const totalRequests = keys.reduce((sum, k) => sum + k.requestCount, 0);
+    const lastUsedAt = keys
+      .filter((k) => k.lastUsedAt !== null)
+      .sort((a, b) =>
+        (b.lastUsedAt as Date).getTime() - (a.lastUsedAt as Date).getTime(),
+      )[0]?.lastUsedAt ?? null;
+
+    return {
+      serviceAccountId,
+      totalRequests,
+      lastUsedAt,
+      keys,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Implements **Feature 18: Non-Human Identity Management** (closes #277)
- `ServiceAccount` and `ApiKey` Prisma models with Argon2id key hashing
- API key generation (returned once), validation by prefix lookup, rotation with 1-hour grace period
- Usage metrics (request count, last used, per-key stats)
- `ApiKeyGuard` for protecting endpoints with `X-Api-Key` header
- 26 unit tests passing

## Endpoints
- `POST/GET/PUT/DELETE /admin/realms/:realm/service-accounts` — CRUD
- `POST /admin/realms/:realm/service-accounts/:id/api-keys` — Create key
- `GET /admin/realms/:realm/service-accounts/:id/api-keys` — List keys
- `POST .../api-keys/:keyId/rotate` — Rotate with grace period
- `POST .../api-keys/:keyId/revoke` — Immediate revoke
- `GET .../metrics` — Usage metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)