### PR TITLE
feat: Mobile SDKs — iOS (Swift) & Android (Kotlin)

### DIFF
--- a/packages/authme-android/README.md
+++ b/packages/authme-android/README.md
@@ -1,0 +1,351 @@
+# AuthMe Android SDK
+
+Native Kotlin SDK for the [AuthMe](https://github.com/Islamawad132/Authme) Identity and Access Management server.
+
+Implements the **OAuth 2.0 Authorization Code flow with PKCE** (RFC 7636) using Chrome Custom Tabs. Tokens are stored securely with `EncryptedSharedPreferences` (AES-256-GCM) and optional biometric gating via `BiometricPrompt` is built in.
+
+## Requirements
+
+| Requirement      | Version      |
+|------------------|--------------|
+| Kotlin           | 1.9+         |
+| Android minSdk   | 24 (Android 7.0) |
+| Android targetSdk| 34 (Android 14)  |
+| AGP              | 8.x          |
+
+## Installation
+
+### Gradle (Kotlin DSL)
+
+Add JitPack to your project-level `settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+Add the dependency to your app or library module `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("com.github.Islamawad132:Authme:1.0.0")
+}
+```
+
+### Required permissions in AndroidManifest.xml
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+## Setup
+
+### 1. Register a redirect URI
+
+In your AuthMe admin console, register a custom scheme redirect URI for your app:
+
+```
+com.example.myapp://callback
+```
+
+### 2. Add an intent filter to your Activity
+
+In `AndroidManifest.xml`, register the Activity that will handle the OAuth callback:
+
+```xml
+<activity
+    android:name=".MainActivity"
+    android:launchMode="singleTop"
+    android:exported="true">
+
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data
+            android:scheme="com.example.myapp"
+            android:host="callback" />
+    </intent-filter>
+</activity>
+```
+
+### 3. Create the client
+
+```kotlin
+import com.authme.sdk.AuthConfig
+import com.authme.sdk.AuthMeClient
+
+val authMe = AuthMeClient(
+    context     = applicationContext,
+    serverUrl   = "https://auth.example.com",
+    realm       = "my-realm",
+    clientId    = "my-android-app",
+    redirectUri = "com.example.myapp://callback"
+)
+```
+
+Or using `AuthConfig`:
+
+```kotlin
+val config = AuthConfig(
+    serverUrl    = "https://auth.example.com",
+    realm        = "my-realm",
+    clientId     = "my-android-app",
+    redirectUri  = "com.example.myapp://callback",
+    scopes       = listOf("openid", "profile", "email"),
+    autoRefresh  = true,
+    refreshBuffer = 30
+)
+val authMe = AuthMeClient(applicationContext, config)
+```
+
+## Login flow
+
+```kotlin
+// In your Activity or Fragment:
+binding.signInButton.setOnClickListener {
+    lifecycleScope.launch {
+        try {
+            authMe.login(this@MainActivity)
+            // Browser opens — wait for the redirect callback
+        } catch (e: AuthMeException) {
+            showError(e.message)
+        }
+    }
+}
+```
+
+### Handle the redirect callback
+
+In your `Activity`, override `onNewIntent` (and optionally `onResume`):
+
+```kotlin
+override fun onNewIntent(intent: Intent?) {
+    super.onNewIntent(intent)
+    handleAuthCallback(intent)
+}
+
+override fun onResume() {
+    super.onResume()
+    handleAuthCallback(intent)
+}
+
+private fun handleAuthCallback(intent: Intent?) {
+    lifecycleScope.launch {
+        try {
+            val handled = authMe.handleRedirectIntent(intent)
+            if (handled) {
+                // Login successful — navigate to home screen
+                navigateToHome()
+            }
+        } catch (e: AuthMeException.StateMismatch) {
+            showError("Security error: state mismatch")
+        } catch (e: AuthMeException.CallbackError) {
+            showError("Login failed: ${e.message}")
+        }
+    }
+}
+```
+
+## Checking authentication state
+
+```kotlin
+if (authMe.isAuthenticated) {
+    println("User is logged in")
+}
+```
+
+## Accessing the access token
+
+```kotlin
+val token = authMe.getAccessToken()
+if (token != null) {
+    // Attach to API requests
+    val request = Request.Builder()
+        .url(apiUrl)
+        .header("Authorization", "Bearer $token")
+        .build()
+}
+```
+
+## Fetching user info
+
+```kotlin
+lifecycleScope.launch {
+    try {
+        val user = authMe.getUserInfo()
+        println("Hello, ${user.name ?: user.preferredUsername ?: "User"}")
+        println("Email: ${user.email}")
+    } catch (e: AuthMeException.NotAuthenticated) {
+        redirectToLogin()
+    }
+}
+```
+
+## Token refresh
+
+Token refresh runs automatically in the background when `autoRefresh = true` (default).
+
+To refresh manually:
+
+```kotlin
+lifecycleScope.launch {
+    try {
+        authMe.refreshToken()
+    } catch (e: AuthMeException.NoRefreshToken) {
+        // Prompt user to log in again
+        redirectToLogin()
+    } catch (e: AuthMeException) {
+        showError("Refresh failed: ${e.message}")
+    }
+}
+```
+
+## Biometric authentication
+
+Require fingerprint, face, or device credentials before accessing the token:
+
+```kotlin
+lifecycleScope.launch {
+    try {
+        val token = authMe.getAccessToken(
+            activity = this@MainActivity,
+            title    = "Verify your identity"
+        )
+        // token is non-null only after successful biometric auth
+        useToken(token)
+    } catch (e: AuthMeException.BiometricAuthFailed) {
+        showError("Biometric failed: ${e.message}")
+    }
+}
+```
+
+### Standalone biometric prompt
+
+```kotlin
+val biometric = BiometricAuth(activity)
+
+if (biometric.isBiometricAvailable) {
+    lifecycleScope.launch {
+        try {
+            biometric.authenticate(
+                title       = "Confirm identity",
+                subtitle    = "Access your secure data",
+                description = "Use your fingerprint or face to continue"
+            )
+            // Proceed with sensitive operation
+        } catch (e: AuthMeException.BiometricAuthFailed) {
+            showError(e.message)
+        }
+    }
+}
+```
+
+## Logout
+
+```kotlin
+lifecycleScope.launch {
+    authMe.logout()
+    // Tokens are cleared; server session is terminated
+    redirectToLogin()
+}
+```
+
+## Lifecycle management
+
+Cancel background auto-refresh jobs when the client is no longer needed:
+
+```kotlin
+override fun onDestroy() {
+    super.onDestroy()
+    authMe.destroy()
+}
+```
+
+## Error handling
+
+All SDK errors are subclasses of `AuthMeException`:
+
+```kotlin
+try {
+    authMe.login(activity)
+} catch (e: AuthMeException.StateMismatch) {
+    // Possible CSRF — abort and clear state
+} catch (e: AuthMeException.ServerError) {
+    showError("Server: ${e.message}")
+} catch (e: AuthMeException.NetworkError) {
+    showError("Network: ${e.message}")
+} catch (e: AuthMeException) {
+    showError(e.message)
+}
+```
+
+| Exception | Description |
+|-----------|-------------|
+| `NotAuthenticated` | No valid session exists |
+| `TokenExpired` | Access token has expired |
+| `NoRefreshToken` | No refresh token in storage |
+| `StateMismatch` | OAuth state parameter mismatch (possible CSRF) |
+| `PkceVerifierMissing` | PKCE verifier missing from storage |
+| `NetworkError` | HTTP / IO error |
+| `ServerError` | Non-2xx response from the AuthMe server |
+| `CallbackError` | Error present in the redirect callback URI |
+| `DiscoveryFailed` | OIDC discovery document fetch failed |
+| `BiometricAuthFailed` | Biometric / device credential authentication failed |
+| `LoginCancelled` | User cancelled the login flow |
+
+## Complete ViewModel example
+
+```kotlin
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.authme.sdk.AuthMeClient
+import com.authme.sdk.AuthMeException
+import com.authme.sdk.User
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class AuthViewModel(private val authMe: AuthMeClient) : ViewModel() {
+
+    private val _user = MutableStateFlow<User?>(null)
+    val user: StateFlow<User?> = _user
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
+
+    fun login(activity: androidx.fragment.app.FragmentActivity) {
+        viewModelScope.launch {
+            runCatching { authMe.login(activity) }
+                .onFailure { _error.value = it.message }
+        }
+    }
+
+    fun handleCallback(intent: android.content.Intent?) {
+        viewModelScope.launch {
+            runCatching {
+                val handled = authMe.handleRedirectIntent(intent)
+                if (handled) {
+                    _user.value = authMe.getUserInfo()
+                }
+            }.onFailure { _error.value = it.message }
+        }
+    }
+
+    fun logout() {
+        viewModelScope.launch {
+            authMe.logout()
+            _user.value = null
+        }
+    }
+}
+```
+
+## License
+
+MIT — see the root [LICENSE](../../LICENSE) file.

--- a/packages/authme-android/build.gradle.kts
+++ b/packages/authme-android/build.gradle.kts
@@ -1,0 +1,103 @@
+plugins {
+    id("com.android.library") version "8.2.2"
+    id("org.jetbrains.kotlin.android") version "1.9.22"
+    id("maven-publish")
+}
+
+android {
+    namespace = "com.authme.sdk"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+        targetSdk = 34
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += listOf(
+            "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        )
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
+}
+
+dependencies {
+    // AndroidX Core
+    implementation("androidx.core:core-ktx:1.12.0")
+
+    // Browser — Chrome Custom Tabs for OAuth flow
+    implementation("androidx.browser:browser:1.7.0")
+
+    // Security — EncryptedSharedPreferences
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+
+    // Biometric
+    implementation("androidx.biometric:biometric:1.1.0")
+
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    // JSON serialization
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+
+    // Lifecycle
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+
+    // Test
+    testImplementation("junit:junit:4.13.2")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+
+                groupId    = "com.github.Islamawad132"
+                artifactId = "authme-android"
+                version    = "1.0.0"
+
+                pom {
+                    name.set("AuthMe Android SDK")
+                    description.set("Android SDK for the AuthMe Identity and Access Management Server")
+                    url.set("https://github.com/Islamawad132/Authme")
+                    licenses {
+                        license {
+                            name.set("MIT License")
+                            url.set("https://opensource.org/licenses/MIT")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/authme-android/src/main/kotlin/com/authme/sdk/AuthMeClient.kt
+++ b/packages/authme-android/src/main/kotlin/com/authme/sdk/AuthMeClient.kt
@@ -1,0 +1,463 @@
+package com.authme.sdk
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Base64
+
+/**
+ * Main entry point for the AuthMe Android SDK.
+ *
+ * Manages the full OAuth 2.0 PKCE login flow, secure token storage via
+ * [EncryptedSharedPreferences][androidx.security.crypto.EncryptedSharedPreferences],
+ * automatic token refresh, and optional biometric gating.
+ *
+ * ## Quick start
+ * ```kotlin
+ * val config = AuthConfig(
+ *     serverUrl  = "https://auth.example.com",
+ *     realm      = "my-realm",
+ *     clientId   = "my-android-app",
+ *     redirectUri = "com.example.myapp://callback"
+ * )
+ * val authMe = AuthMeClient(applicationContext, config)
+ *
+ * // In your Activity:
+ * authMe.login(activity)
+ *
+ * // In Activity.onNewIntent / onResume handle the redirect:
+ * authMe.handleRedirectIntent(intent)
+ * ```
+ */
+class AuthMeClient(
+    private val context: Context,
+    private val config: AuthConfig,
+) {
+
+    // -----------------------------------------------------------------------
+    // Internal state
+    // -----------------------------------------------------------------------
+
+    private val storage     = TokenStorage(context, config.realm, config.clientId)
+    private val json        = Json { ignoreUnknownKeys = true }
+    private val scope       = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var oidcConfig  : OIDCConfiguration? = null
+    private var refreshJob  : Job? = null
+
+    // -----------------------------------------------------------------------
+    // Convenience constructor (flat parameters)
+    // -----------------------------------------------------------------------
+
+    constructor(
+        context: Context,
+        serverUrl: String,
+        realm: String,
+        clientId: String,
+        redirectUri: String,
+        scopes: List<String> = listOf("openid", "profile", "email"),
+    ) : this(
+        context,
+        AuthConfig(
+            serverUrl   = serverUrl,
+            realm       = realm,
+            clientId    = clientId,
+            redirectUri = redirectUri,
+            scopes      = scopes,
+        )
+    )
+
+    // -----------------------------------------------------------------------
+    // Authentication state
+    // -----------------------------------------------------------------------
+
+    /** `true` if a valid (non-expired) access token is in storage. */
+    val isAuthenticated: Boolean
+        get() = storage.accessToken?.let { !isTokenExpired(it) } ?: false
+
+    // -----------------------------------------------------------------------
+    // Login
+    // -----------------------------------------------------------------------
+
+    /**
+     * Start the OAuth 2.0 PKCE login flow using Chrome Custom Tabs.
+     *
+     * This opens the AuthMe authorization endpoint in a Chrome Custom Tab.
+     * When the user completes authentication the browser redirects to your
+     * [AuthConfig.redirectUri]. Call [handleRedirectIntent] in your Activity's
+     * `onNewIntent` / `onResume` to complete the flow.
+     *
+     * @param activity The hosting [FragmentActivity].
+     */
+    suspend fun login(activity: FragmentActivity) {
+        val oidc = fetchDiscovery()
+
+        val verifier  = PKCEHelper.generateCodeVerifier()
+        val challenge = PKCEHelper.generateCodeChallenge(verifier)
+        val state     = PKCEHelper.generateState()
+
+        storage.pkceVerifier = verifier
+        storage.authState    = state
+
+        val authUri = Uri.parse(oidc.authorizationEndpoint).buildUpon()
+            .appendQueryParameter("response_type",         "code")
+            .appendQueryParameter("client_id",             config.clientId)
+            .appendQueryParameter("redirect_uri",          config.redirectUri)
+            .appendQueryParameter("scope",                 config.scopes.joinToString(" "))
+            .appendQueryParameter("state",                 state)
+            .appendQueryParameter("code_challenge",        challenge)
+            .appendQueryParameter("code_challenge_method", "S256")
+            .build()
+
+        val customTabsIntent = CustomTabsIntent.Builder()
+            .setShowTitle(true)
+            .build()
+
+        customTabsIntent.launchUrl(activity, authUri)
+    }
+
+    // -----------------------------------------------------------------------
+    // Callback / redirect handling
+    // -----------------------------------------------------------------------
+
+    /**
+     * Handle the redirect Intent sent to your Activity after authorization.
+     *
+     * Call this from `Activity.onNewIntent` and from `Activity.onResume`
+     * (for the case where the Activity was recreated).
+     *
+     * ```kotlin
+     * override fun onNewIntent(intent: Intent?) {
+     *     super.onNewIntent(intent)
+     *     lifecycleScope.launch {
+     *         authMe.handleRedirectIntent(intent)
+     *     }
+     * }
+     * ```
+     *
+     * @param intent The intent received by the Activity.
+     * @return `true` if the intent was an AuthMe callback and was handled successfully.
+     */
+    suspend fun handleRedirectIntent(intent: Intent?): Boolean {
+        val uri = intent?.data ?: return false
+        if (!uri.toString().startsWith(config.redirectUri)) return false
+
+        val oidc = fetchDiscovery()
+
+        val error = uri.getQueryParameter("error")
+        if (error != null) {
+            val description = uri.getQueryParameter("error_description") ?: error
+            throw AuthMeException.CallbackError(description)
+        }
+
+        val code = uri.getQueryParameter("code")
+            ?: throw AuthMeException.CallbackError("Missing authorization code")
+
+        val returnedState = uri.getQueryParameter("state")
+        val storedState   = storage.authState
+        if (storedState == null || returnedState != storedState) {
+            throw AuthMeException.StateMismatch()
+        }
+
+        val verifier = storage.pkceVerifier
+            ?: throw AuthMeException.PkceVerifierMissing()
+
+        val tokens = exchangeCode(code, verifier, oidc.tokenEndpoint)
+        storage.store(tokens)
+        storage.pkceVerifier = null
+        storage.authState    = null
+
+        scheduleAutoRefresh()
+        return true
+    }
+
+    // -----------------------------------------------------------------------
+    // Logout
+    // -----------------------------------------------------------------------
+
+    /**
+     * Clear local tokens and attempt server-side session termination.
+     *
+     * Optionally launches a Custom Tab to the end-session endpoint if the
+     * server requires user interaction for logout.
+     *
+     * @param activity Pass a [FragmentActivity] to open the end-session URL
+     *                 in a Custom Tab, or `null` for a silent back-channel logout.
+     */
+    suspend fun logout(activity: FragmentActivity? = null) {
+        val refreshToken = storage.refreshToken
+        val oidc         = runCatching { fetchDiscovery() }.getOrNull()
+
+        if (refreshToken != null && oidc?.endSessionEndpoint != null) {
+            runCatching {
+                httpPost(
+                    url  = oidc.endSessionEndpoint,
+                    body = "refresh_token=${Uri.encode(refreshToken)}&client_id=${Uri.encode(config.clientId)}",
+                    contentType = "application/x-www-form-urlencoded",
+                )
+            }
+        }
+
+        cancelAutoRefresh()
+        storage.clear()
+    }
+
+    // -----------------------------------------------------------------------
+    // Token access
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the current access token, or `null` if not authenticated or expired.
+     */
+    fun getAccessToken(): String? {
+        val token = storage.accessToken ?: return null
+        return if (isTokenExpired(token)) null else token
+    }
+
+    /**
+     * Returns the current access token gated behind a biometric prompt.
+     *
+     * @param activity The hosting [FragmentActivity].
+     * @param title    Title shown in the biometric dialog.
+     * @throws [AuthMeException.BiometricAuthFailed] if authentication fails.
+     */
+    suspend fun getAccessToken(
+        activity: FragmentActivity,
+        title: String = "Authenticate to access your account",
+    ): String? {
+        BiometricAuth(activity).authenticate(title = title)
+        return getAccessToken()
+    }
+
+    // -----------------------------------------------------------------------
+    // Token refresh
+    // -----------------------------------------------------------------------
+
+    /**
+     * Refresh the access token using the stored refresh token.
+     *
+     * @throws [AuthMeException.NoRefreshToken] if no refresh token is available.
+     * @throws [AuthMeException.ServerError] if the server rejects the refresh.
+     */
+    suspend fun refreshToken() {
+        val oidc          = fetchDiscovery()
+        val refreshToken  = storage.refreshToken ?: throw AuthMeException.NoRefreshToken()
+
+        val body = listOf(
+            "grant_type"    to "refresh_token",
+            "refresh_token" to refreshToken,
+            "client_id"     to config.clientId,
+        ).formEncode()
+
+        val responseBody = httpPost(
+            url         = oidc.tokenEndpoint,
+            body        = body,
+            contentType = "application/x-www-form-urlencoded",
+        )
+
+        val tokens = json.decodeFromString<TokenResponse>(responseBody)
+        storage.store(tokens)
+        scheduleAutoRefresh()
+    }
+
+    // -----------------------------------------------------------------------
+    // User Info
+    // -----------------------------------------------------------------------
+
+    /**
+     * Fetch the current user's profile from the userinfo endpoint.
+     *
+     * @throws [AuthMeException.NotAuthenticated] if no valid token is available.
+     */
+    suspend fun getUserInfo(): User {
+        val accessToken = getAccessToken() ?: throw AuthMeException.NotAuthenticated()
+        val oidc        = fetchDiscovery()
+
+        val responseBody = httpGet(
+            url     = oidc.userinfoEndpoint,
+            headers = mapOf("Authorization" to "Bearer $accessToken"),
+        )
+
+        return json.decodeFromString(responseBody)
+    }
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    /**
+     * Cancel background coroutines (auto-refresh). Call from `Activity.onDestroy`
+     * or when the client is no longer needed.
+     */
+    fun destroy() {
+        scope.cancel()
+    }
+
+    // -----------------------------------------------------------------------
+    // Discovery
+    // -----------------------------------------------------------------------
+
+    private suspend fun fetchDiscovery(): OIDCConfiguration {
+        oidcConfig?.let { return it }
+
+        val body   = httpGet(config.discoveryUrl)
+        val result = json.decodeFromString<OIDCConfiguration>(body)
+        oidcConfig = result
+        return result
+    }
+
+    // -----------------------------------------------------------------------
+    // Code exchange
+    // -----------------------------------------------------------------------
+
+    private suspend fun exchangeCode(
+        code: String,
+        verifier: String,
+        tokenEndpoint: String,
+    ): TokenResponse {
+        val body = listOf(
+            "grant_type"    to "authorization_code",
+            "code"          to code,
+            "redirect_uri"  to config.redirectUri,
+            "client_id"     to config.clientId,
+            "code_verifier" to verifier,
+        ).formEncode()
+
+        val responseBody = httpPost(
+            url         = tokenEndpoint,
+            body        = body,
+            contentType = "application/x-www-form-urlencoded",
+        )
+
+        return json.decodeFromString(responseBody)
+    }
+
+    // -----------------------------------------------------------------------
+    // Auto-refresh
+    // -----------------------------------------------------------------------
+
+    private fun scheduleAutoRefresh() {
+        if (!config.autoRefresh) return
+        cancelAutoRefresh()
+
+        val token  = storage.accessToken ?: return
+        val expiry = jwtExpiry(token) ?: return
+        val now    = System.currentTimeMillis() / 1_000L
+        val delay  = maxOf(0, expiry - now - config.refreshBuffer) * 1_000L
+
+        refreshJob = scope.launch {
+            delay(delay)
+            runCatching { refreshToken() }
+        }
+    }
+
+    private fun cancelAutoRefresh() {
+        refreshJob?.cancel()
+        refreshJob = null
+    }
+
+    // -----------------------------------------------------------------------
+    // JWT helpers
+    // -----------------------------------------------------------------------
+
+    private fun isTokenExpired(token: String): Boolean {
+        val exp = jwtExpiry(token) ?: return true
+        return System.currentTimeMillis() / 1_000L >= exp
+    }
+
+    private fun jwtExpiry(token: String): Long? {
+        val parts = token.split(".")
+        if (parts.size != 3) return null
+
+        return runCatching {
+            val decoded = Base64.getUrlDecoder().decode(parts[1])
+            val payload = String(decoded, Charsets.UTF_8)
+            val json    = org.json.JSONObject(payload)
+            json.getLong("exp")
+        }.getOrNull()
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTP helpers
+    // -----------------------------------------------------------------------
+
+    private suspend fun httpGet(
+        url: String,
+        headers: Map<String, String> = emptyMap(),
+    ): String = kotlinx.coroutines.withContext(Dispatchers.IO) {
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            headers.forEach { (k, v) -> setRequestProperty(k, v) }
+            connectTimeout = 15_000
+            readTimeout    = 15_000
+        }
+
+        try {
+            connection.connect()
+            val code = connection.responseCode
+            val body = connection.inputStream.bufferedReader().readText()
+
+            if (code !in 200..299) {
+                throw AuthMeException.ServerError("HTTP $code: $body")
+            }
+            body
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private suspend fun httpPost(
+        url: String,
+        body: String,
+        contentType: String,
+        headers: Map<String, String> = emptyMap(),
+    ): String = kotlinx.coroutines.withContext(Dispatchers.IO) {
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            doOutput      = true
+            setRequestProperty("Content-Type", contentType)
+            headers.forEach { (k, v) -> setRequestProperty(k, v) }
+            connectTimeout = 15_000
+            readTimeout    = 15_000
+        }
+
+        try {
+            connection.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+
+            val code     = connection.responseCode
+            val stream   = if (code in 200..299) connection.inputStream else connection.errorStream
+            val response = stream?.bufferedReader()?.readText() ?: ""
+
+            if (code !in 200..299) {
+                val message = runCatching {
+                    val jo = org.json.JSONObject(response)
+                    jo.optString("error_description").ifBlank { jo.optString("error") }
+                }.getOrNull() ?: "HTTP $code"
+                throw AuthMeException.ServerError(message)
+            }
+            response
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Form encoding helper
+    // -----------------------------------------------------------------------
+
+    private fun List<Pair<String, String>>.formEncode(): String =
+        joinToString("&") { (k, v) ->
+            "${Uri.encode(k)}=${Uri.encode(v)}"
+        }
+}

--- a/packages/authme-android/src/main/kotlin/com/authme/sdk/BiometricAuth.kt
+++ b/packages/authme-android/src/main/kotlin/com/authme/sdk/BiometricAuth.kt
@@ -1,0 +1,131 @@
+package com.authme.sdk
+
+import android.content.Context
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * Wrapper around [BiometricPrompt] for requiring biometric or device-credential
+ * authentication before granting access to sensitive token data.
+ *
+ * ## Usage
+ * ```kotlin
+ * val biometric = BiometricAuth(activity)
+ * biometric.authenticate(title = "Verify your identity")
+ * // Execution continues here only after successful authentication
+ * val token = client.getAccessToken()
+ * ```
+ */
+class BiometricAuth(private val activity: FragmentActivity) {
+
+    // -----------------------------------------------------------------------
+    // Availability
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns `true` if the device supports biometric authentication AND the
+     * user has enrolled at least one biometric credential.
+     */
+    val isBiometricAvailable: Boolean
+        get() {
+            val manager = BiometricManager.from(activity)
+            return manager.canAuthenticate(
+                Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK
+            ) == BiometricManager.BIOMETRIC_SUCCESS
+        }
+
+    /**
+     * Returns a human-readable description of the biometric type available,
+     * or `null` if biometrics are unavailable.
+     */
+    fun getBiometricType(context: Context): String? {
+        val manager = BiometricManager.from(context)
+        return when (manager.canAuthenticate(Authenticators.BIOMETRIC_STRONG)) {
+            BiometricManager.BIOMETRIC_SUCCESS -> "Strong biometrics (fingerprint / face / iris)"
+            else -> when (manager.canAuthenticate(Authenticators.BIOMETRIC_WEAK)) {
+                BiometricManager.BIOMETRIC_SUCCESS -> "Weak biometrics"
+                else -> null
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Authentication
+    // -----------------------------------------------------------------------
+
+    /**
+     * Show a biometric prompt and suspend until the user successfully authenticates.
+     *
+     * Falls back to device credentials (PIN / pattern / password) if biometrics fail
+     * and [allowDeviceCredential] is `true`.
+     *
+     * @param title              Title shown in the biometric dialog.
+     * @param subtitle           Optional subtitle shown in the dialog.
+     * @param description        Optional description text.
+     * @param negativeButtonText Text for the negative/cancel button (only shown
+     *                           when [allowDeviceCredential] is `false`).
+     * @param allowDeviceCredential Whether to fall back to PIN/pattern/password.
+     *
+     * @throws [AuthMeException.BiometricAuthFailed] if authentication fails or is cancelled.
+     */
+    suspend fun authenticate(
+        title: String = "Authenticate",
+        subtitle: String? = null,
+        description: String? = null,
+        negativeButtonText: String = "Cancel",
+        allowDeviceCredential: Boolean = true,
+    ): Unit = suspendCancellableCoroutine { continuation ->
+
+        val executor = ContextCompat.getMainExecutor(activity)
+
+        val callback = object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                if (continuation.isActive) continuation.resume(Unit)
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                if (continuation.isActive) {
+                    continuation.resumeWithException(
+                        AuthMeException.BiometricAuthFailed(errString.toString())
+                    )
+                }
+            }
+
+            override fun onAuthenticationFailed() {
+                // Called when a biometric is presented but not recognized — the
+                // system handles retry automatically; we only fail on error/cancel.
+            }
+        }
+
+        val prompt = BiometricPrompt(activity, executor, callback)
+
+        val info = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(title)
+            .apply { subtitle?.let { setSubtitle(it) } }
+            .apply { description?.let { setDescription(it) } }
+            .apply {
+                if (allowDeviceCredential) {
+                    setAllowedAuthenticators(
+                        Authenticators.BIOMETRIC_STRONG
+                                or Authenticators.BIOMETRIC_WEAK
+                                or Authenticators.DEVICE_CREDENTIAL
+                    )
+                } else {
+                    setAllowedAuthenticators(
+                        Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK
+                    )
+                    setNegativeButtonText(negativeButtonText)
+                }
+            }
+            .build()
+
+        continuation.invokeOnCancellation { prompt.cancelAuthentication() }
+        prompt.authenticate(info)
+    }
+}

--- a/packages/authme-android/src/main/kotlin/com/authme/sdk/Models.kt
+++ b/packages/authme-android/src/main/kotlin/com/authme/sdk/Models.kt
@@ -1,0 +1,126 @@
+package com.authme.sdk
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// ---------------------------------------------------------------------------
+// AuthConfig
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for creating an [AuthMeClient] instance.
+ *
+ * @param serverUrl   Base URL of the AuthMe server, e.g. "https://auth.example.com"
+ * @param realm       Realm name to authenticate against
+ * @param clientId    OAuth 2.0 client ID (must be a PUBLIC client in AuthMe)
+ * @param redirectUri Custom scheme redirect URI, e.g. "com.example.app://callback"
+ * @param scopes      OAuth 2.0 scopes to request (default: openid, profile, email)
+ * @param autoRefresh Automatically refresh tokens before expiry (default: true)
+ * @param refreshBuffer Seconds before expiry at which to trigger a refresh (default: 30)
+ */
+data class AuthConfig(
+    val serverUrl: String,
+    val realm: String,
+    val clientId: String,
+    val redirectUri: String,
+    val scopes: List<String> = listOf("openid", "profile", "email"),
+    val autoRefresh: Boolean = true,
+    val refreshBuffer: Int = 30,
+) {
+    /** The OIDC discovery URL for this realm. */
+    val discoveryUrl: String
+        get() = "${serverUrl.trimEnd('/')}/realms/$realm/.well-known/openid-configuration"
+}
+
+// ---------------------------------------------------------------------------
+// TokenResponse
+// ---------------------------------------------------------------------------
+
+/** Raw token response from the token endpoint. */
+@Serializable
+data class TokenResponse(
+    @SerialName("access_token")  val accessToken: String,
+    @SerialName("token_type")    val tokenType: String,
+    @SerialName("expires_in")    val expiresIn: Int,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("id_token")      val idToken: String? = null,
+    @SerialName("scope")         val scope: String? = null,
+)
+
+// ---------------------------------------------------------------------------
+// User
+// ---------------------------------------------------------------------------
+
+/** User information returned by the userinfo endpoint. */
+@Serializable
+data class User(
+    val sub: String,
+    @SerialName("preferred_username") val preferredUsername: String? = null,
+    val name: String? = null,
+    @SerialName("given_name")    val givenName: String? = null,
+    @SerialName("family_name")   val familyName: String? = null,
+    val email: String? = null,
+    @SerialName("email_verified") val emailVerified: Boolean? = null,
+)
+
+// ---------------------------------------------------------------------------
+// OIDCConfiguration (internal)
+// ---------------------------------------------------------------------------
+
+@Serializable
+internal data class OIDCConfiguration(
+    val issuer: String,
+    @SerialName("authorization_endpoint") val authorizationEndpoint: String,
+    @SerialName("token_endpoint")         val tokenEndpoint: String,
+    @SerialName("userinfo_endpoint")      val userinfoEndpoint: String,
+    @SerialName("jwks_uri")               val jwksUri: String,
+    @SerialName("end_session_endpoint")   val endSessionEndpoint: String? = null,
+)
+
+// ---------------------------------------------------------------------------
+// AuthMeException
+// ---------------------------------------------------------------------------
+
+/** Sealed hierarchy of exceptions thrown by the AuthMe Android SDK. */
+sealed class AuthMeException(message: String, cause: Throwable? = null) :
+    Exception(message, cause) {
+
+    /** User is not currently authenticated. */
+    class NotAuthenticated : AuthMeException("User is not authenticated")
+
+    /** The stored access token has expired and no refresh token is available. */
+    class TokenExpired : AuthMeException("Access token has expired")
+
+    /** No refresh token is available in storage. */
+    class NoRefreshToken : AuthMeException("No refresh token available")
+
+    /** The redirect URI registered in the app does not match the config. */
+    class InvalidRedirectUri(uri: String) :
+        AuthMeException("Invalid redirect URI: $uri")
+
+    /** The OAuth state parameter did not match — possible CSRF. */
+    class StateMismatch : AuthMeException("State mismatch — possible CSRF attack")
+
+    /** The PKCE code verifier is missing from storage. */
+    class PkceVerifierMissing : AuthMeException("PKCE code verifier is missing")
+
+    /** A network or HTTP error occurred. */
+    class NetworkError(message: String, cause: Throwable? = null) :
+        AuthMeException(message, cause)
+
+    /** The AuthMe server returned an error response. */
+    class ServerError(message: String) : AuthMeException(message)
+
+    /** The authorization callback contained an error. */
+    class CallbackError(message: String) : AuthMeException(message)
+
+    /** Failed to fetch or parse the OIDC discovery document. */
+    class DiscoveryFailed(message: String) : AuthMeException(message)
+
+    /** Biometric authentication failed or was cancelled. */
+    class BiometricAuthFailed(reason: String) :
+        AuthMeException("Biometric authentication failed: $reason")
+
+    /** The login was cancelled by the user. */
+    class LoginCancelled : AuthMeException("Login was cancelled by the user")
+}

--- a/packages/authme-android/src/main/kotlin/com/authme/sdk/PKCEHelper.kt
+++ b/packages/authme-android/src/main/kotlin/com/authme/sdk/PKCEHelper.kt
@@ -1,0 +1,67 @@
+package com.authme.sdk
+
+import android.util.Base64
+import java.security.MessageDigest
+import java.security.SecureRandom
+
+/**
+ * Helpers for generating OAuth 2.0 PKCE parameters (RFC 7636).
+ *
+ * Generates a cryptographically random code verifier and derives
+ * the S256 code challenge via SHA-256.
+ */
+object PKCEHelper {
+
+    private val secureRandom = SecureRandom()
+
+    // -----------------------------------------------------------------------
+    // Code Verifier
+    // -----------------------------------------------------------------------
+
+    /**
+     * Generate a cryptographically random PKCE code verifier.
+     *
+     * The verifier is 32 random bytes encoded as Base64URL without padding,
+     * producing a 43-character string within the RFC 7636 §4.1 bounds (43–128).
+     */
+    fun generateCodeVerifier(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return bytes.base64UrlEncode()
+    }
+
+    // -----------------------------------------------------------------------
+    // Code Challenge
+    // -----------------------------------------------------------------------
+
+    /**
+     * Derive the S256 PKCE code challenge from a verifier string.
+     *
+     * Challenge = BASE64URL(SHA256(ASCII(verifier)))
+     */
+    fun generateCodeChallenge(verifier: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val hash   = digest.digest(verifier.toByteArray(Charsets.US_ASCII))
+        return hash.base64UrlEncode()
+    }
+
+    // -----------------------------------------------------------------------
+    // State
+    // -----------------------------------------------------------------------
+
+    /**
+     * Generate a random state parameter for CSRF protection.
+     */
+    fun generateState(): String {
+        val bytes = ByteArray(16)
+        secureRandom.nextBytes(bytes)
+        return bytes.base64UrlEncode()
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    private fun ByteArray.base64UrlEncode(): String =
+        Base64.encodeToString(this, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+}

--- a/packages/authme-android/src/main/kotlin/com/authme/sdk/TokenStorage.kt
+++ b/packages/authme-android/src/main/kotlin/com/authme/sdk/TokenStorage.kt
@@ -1,0 +1,104 @@
+package com.authme.sdk
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+/**
+ * Secure token storage backed by [EncryptedSharedPreferences].
+ *
+ * All tokens are AES-256-GCM encrypted at rest using a key stored in the
+ * Android Keystore. The preference file is scoped to the realm + clientId
+ * combination so multiple AuthMe realms can coexist without key collisions.
+ */
+internal class TokenStorage(context: Context, realm: String, clientId: String) {
+
+    // -----------------------------------------------------------------------
+    // Keys
+    // -----------------------------------------------------------------------
+
+    private object Key {
+        const val ACCESS_TOKEN  = "access_token"
+        const val REFRESH_TOKEN = "refresh_token"
+        const val ID_TOKEN      = "id_token"
+        const val PKCE_VERIFIER = "pkce_verifier"
+        const val AUTH_STATE    = "auth_state"
+    }
+
+    // -----------------------------------------------------------------------
+    // Encrypted prefs
+    // -----------------------------------------------------------------------
+
+    private val prefs: SharedPreferences
+
+    init {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        val fileName = "authme_${realm}_${clientId}".replace(Regex("[^a-zA-Z0-9_]"), "_")
+
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            fileName,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // Accessors
+    // -----------------------------------------------------------------------
+
+    var accessToken: String?
+        get() = prefs.getString(Key.ACCESS_TOKEN, null)
+        set(value) = put(Key.ACCESS_TOKEN, value)
+
+    var refreshToken: String?
+        get() = prefs.getString(Key.REFRESH_TOKEN, null)
+        set(value) = put(Key.REFRESH_TOKEN, value)
+
+    var idToken: String?
+        get() = prefs.getString(Key.ID_TOKEN, null)
+        set(value) = put(Key.ID_TOKEN, value)
+
+    var pkceVerifier: String?
+        get() = prefs.getString(Key.PKCE_VERIFIER, null)
+        set(value) = put(Key.PKCE_VERIFIER, value)
+
+    var authState: String?
+        get() = prefs.getString(Key.AUTH_STATE, null)
+        set(value) = put(Key.AUTH_STATE, value)
+
+    // -----------------------------------------------------------------------
+    // Bulk operations
+    // -----------------------------------------------------------------------
+
+    /** Store a full token response. */
+    fun store(tokens: TokenResponse) {
+        prefs.edit()
+            .putString(Key.ACCESS_TOKEN,  tokens.accessToken)
+            .apply { if (tokens.refreshToken != null) putString(Key.REFRESH_TOKEN, tokens.refreshToken) }
+            .apply { if (tokens.idToken != null) putString(Key.ID_TOKEN, tokens.idToken) }
+            .apply()
+    }
+
+    /** Remove all stored tokens and PKCE state. */
+    fun clear() {
+        prefs.edit().clear().apply()
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    private fun put(key: String, value: String?) {
+        if (value == null) {
+            prefs.edit().remove(key).apply()
+        } else {
+            prefs.edit().putString(key, value).apply()
+        }
+    }
+}

--- a/packages/authme-android/src/test/kotlin/com/authme/sdk/PKCEHelperTest.kt
+++ b/packages/authme-android/src/test/kotlin/com/authme/sdk/PKCEHelperTest.kt
@@ -1,0 +1,69 @@
+package com.authme.sdk
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Base64
+
+class PKCEHelperTest {
+
+    @Test
+    fun `code verifier length is within RFC 7636 bounds`() {
+        val verifier = PKCEHelper.generateCodeVerifier()
+        // RFC 7636 §4.1: 43–128 unreserved characters
+        assertTrue(
+            "Verifier length ${verifier.length} out of bounds [43, 128]",
+            verifier.length in 43..128
+        )
+    }
+
+    @Test
+    fun `code verifier uses only Base64URL characters`() {
+        val verifier = PKCEHelper.generateCodeVerifier()
+        val allowed  = Regex("^[A-Za-z0-9\\-_]+$")
+        assertTrue("Verifier contains invalid characters: $verifier", allowed.matches(verifier))
+    }
+
+    @Test
+    fun `code verifier has no padding`() {
+        val verifier = PKCEHelper.generateCodeVerifier()
+        assertFalse("Verifier must not contain '='", verifier.contains("="))
+    }
+
+    @Test
+    fun `code verifiers are unique`() {
+        val v1 = PKCEHelper.generateCodeVerifier()
+        val v2 = PKCEHelper.generateCodeVerifier()
+        assertNotEquals("Two verifiers should not be identical", v1, v2)
+    }
+
+    @Test
+    fun `code challenge is Base64URL without padding`() {
+        val verifier  = PKCEHelper.generateCodeVerifier()
+        val challenge = PKCEHelper.generateCodeChallenge(verifier)
+        val allowed   = Regex("^[A-Za-z0-9\\-_]+$")
+        assertTrue("Challenge contains invalid characters: $challenge", allowed.matches(challenge))
+        assertFalse("Challenge must not contain '='", challenge.contains("="))
+    }
+
+    /**
+     * RFC 7636 §B appendix test vector:
+     * verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+     * challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+     */
+    @Test
+    fun `code challenge matches RFC 7636 test vector`() {
+        val verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        val challenge = PKCEHelper.generateCodeChallenge(verifier)
+        assertEquals("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", challenge)
+    }
+
+    @Test
+    fun `state values are unique`() {
+        val s1 = PKCEHelper.generateState()
+        val s2 = PKCEHelper.generateState()
+        assertNotEquals(s1, s2)
+    }
+}

--- a/packages/authme-ios/Package.swift
+++ b/packages/authme-ios/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "AuthMe",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+    ],
+    products: [
+        .library(
+            name: "AuthMe",
+            targets: ["AuthMe"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "AuthMe",
+            dependencies: [],
+            path: "Sources/AuthMe",
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency"),
+            ]
+        ),
+        .testTarget(
+            name: "AuthMeTests",
+            dependencies: ["AuthMe"],
+            path: "Tests/AuthMeTests"
+        ),
+    ]
+)

--- a/packages/authme-ios/README.md
+++ b/packages/authme-ios/README.md
@@ -1,0 +1,290 @@
+# AuthMe iOS SDK
+
+Native Swift SDK for the [AuthMe](https://github.com/Islamawad132/Authme) Identity and Access Management server.
+
+Implements the **OAuth 2.0 Authorization Code flow with PKCE** (RFC 7636) using `ASWebAuthenticationSession`. Tokens are stored securely in the iOS Keychain and optional Face ID / Touch ID gating is built in.
+
+## Requirements
+
+| Requirement | Version |
+|-------------|---------|
+| Swift       | 5.9+    |
+| iOS         | 15.0+   |
+| macOS       | 12.0+   |
+| Xcode       | 15.0+   |
+
+## Installation
+
+### Swift Package Manager
+
+Add the package to your `Package.swift` dependencies:
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/Islamawad132/Authme",
+        from: "1.0.0"
+    )
+]
+```
+
+Or in Xcode: **File › Add Package Dependencies…** and paste the repository URL.
+
+Add `AuthMe` to your target:
+
+```swift
+.target(
+    name: "MyApp",
+    dependencies: [
+        .product(name: "AuthMe", package: "Authme")
+    ]
+)
+```
+
+## Setup
+
+### 1. Register a redirect URI
+
+In your AuthMe admin console, register your app's custom URL scheme as a redirect URI. For example:
+
+```
+com.example.myapp://callback
+```
+
+### 2. Configure URL scheme (for custom scheme redirects)
+
+In `Info.plist`:
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>com.example.myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+### 3. Create the client
+
+```swift
+import AuthMe
+
+let authMe = AuthMeClient(
+    serverUrl: URL(string: "https://auth.example.com")!,
+    realm: "my-realm",
+    clientId: "my-mobile-app",
+    redirectUri: "com.example.myapp://callback"
+)
+```
+
+Or using the full `AuthConfig`:
+
+```swift
+let config = AuthConfig(
+    serverUrl: URL(string: "https://auth.example.com")!,
+    realm: "my-realm",
+    clientId: "my-mobile-app",
+    redirectUri: "com.example.myapp://callback",
+    scopes: ["openid", "profile", "email"],
+    autoRefresh: true,
+    refreshBuffer: 30
+)
+let authMe = AuthMeClient(config: config)
+```
+
+## Login flow
+
+```swift
+// In a SwiftUI view:
+Button("Sign in") {
+    Task {
+        do {
+            try await authMe.login()
+            print("Logged in!")
+        } catch {
+            print("Login error: \(error.localizedDescription)")
+        }
+    }
+}
+```
+
+`login()` opens an `ASWebAuthenticationSession` (Safari-based in-app browser) that navigates to the AuthMe authorization endpoint. When the user completes authentication, the browser redirects back to your app, and the SDK automatically exchanges the authorization code for tokens.
+
+## Checking authentication state
+
+```swift
+if authMe.isAuthenticated {
+    print("User is logged in")
+}
+```
+
+## Accessing the access token
+
+```swift
+if let token = authMe.getAccessToken() {
+    // Attach to API requests
+    var request = URLRequest(url: apiURL)
+    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+}
+```
+
+## Fetching user info
+
+```swift
+do {
+    let user = try await authMe.getUserInfo()
+    print("Hello, \(user.name ?? user.preferredUsername ?? "unknown")")
+    print("Email: \(user.email ?? "n/a")")
+} catch {
+    print("Failed to fetch user info: \(error)")
+}
+```
+
+## Token refresh
+
+Token refresh happens automatically in the background when `autoRefresh: true` (the default).
+
+To refresh manually:
+
+```swift
+do {
+    try await authMe.refreshToken()
+} catch AuthMeError.noRefreshToken {
+    // Prompt user to log in again
+} catch {
+    print("Refresh failed: \(error)")
+}
+```
+
+## Biometric authentication
+
+Require Face ID or Touch ID before granting access to the token:
+
+```swift
+do {
+    let token = try await authMe.getAccessToken(
+        biometricReason: "Authenticate to access your account"
+    )
+    // token is only returned after successful biometric verification
+} catch AuthMeError.biometricAuthFailed(let reason) {
+    print("Biometric failed: \(reason)")
+}
+```
+
+### Checking availability
+
+```swift
+let biometric = BiometricAuth()
+switch biometric.biometryType {
+case .faceID:   print("Face ID available")
+case .touchID:  print("Touch ID available")
+case .opticID:  print("Optic ID available")
+case .none:     print("No biometrics — passcode only")
+}
+```
+
+## Logout
+
+```swift
+await authMe.logout()
+// Tokens are cleared from Keychain and the server session is terminated.
+```
+
+## Error handling
+
+All errors are typed as `AuthMeError`:
+
+```swift
+do {
+    try await authMe.login()
+} catch AuthMeError.stateMismatch {
+    // Possible CSRF — abort
+} catch AuthMeError.serverError(let message) {
+    print("Server returned: \(message)")
+} catch AuthMeError.networkError(let underlying) {
+    print("Network: \(underlying)")
+} catch {
+    print("Unknown error: \(error)")
+}
+```
+
+| Error | Description |
+|-------|-------------|
+| `notAuthenticated` | No valid session exists |
+| `tokenExpired` | Access token has expired |
+| `noRefreshToken` | No refresh token in storage |
+| `stateMismatch` | OAuth state parameter mismatch (possible CSRF) |
+| `pkceVerifierMissing` | PKCE verifier not found in storage |
+| `networkError` | Underlying URLSession / transport error |
+| `serverError` | Non-2xx response from AuthMe server |
+| `biometricAuthFailed` | Face ID / Touch ID / passcode authentication failed |
+| `discoveryFailed` | Could not fetch the OIDC discovery document |
+| `callbackError` | Error received in the authorization callback URL |
+
+## Thread safety
+
+`AuthMeClient` is annotated `@MainActor`. All public methods must be called from the main actor. The SDK internally uses `async/await` for network and biometric operations.
+
+## Complete SwiftUI example
+
+```swift
+import SwiftUI
+import AuthMe
+
+@MainActor
+class AuthViewModel: ObservableObject {
+    let client = AuthMeClient(
+        serverUrl: URL(string: "https://auth.example.com")!,
+        realm: "demo",
+        clientId: "swiftui-app",
+        redirectUri: "com.example.swiftui://callback"
+    )
+
+    @Published var user: User?
+    @Published var errorMessage: String?
+
+    func login() {
+        Task {
+            do {
+                try await client.login()
+                user = try await client.getUserInfo()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func logout() {
+        Task {
+            await client.logout()
+            user = nil
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var vm = AuthViewModel()
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if let user = vm.user {
+                Text("Welcome, \(user.name ?? "User")!")
+                Button("Logout", action: vm.logout)
+            } else {
+                Button("Sign in with AuthMe", action: vm.login)
+            }
+            if let error = vm.errorMessage {
+                Text(error).foregroundColor(.red)
+            }
+        }
+        .padding()
+    }
+}
+```
+
+## License
+
+MIT — see the root [LICENSE](../../LICENSE) file.

--- a/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
+++ b/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
@@ -1,0 +1,422 @@
+import Foundation
+import AuthenticationServices
+
+/// Main entry point for the AuthMe iOS SDK.
+///
+/// `AuthMeClient` manages the full OAuth 2.0 PKCE login flow, secure token storage,
+/// automatic token refresh, and optional biometric gating.
+///
+/// ## Quick start
+/// ```swift
+/// let config = AuthConfig(
+///     serverUrl: URL(string: "https://auth.example.com")!,
+///     realm: "my-realm",
+///     clientId: "my-app",
+///     redirectUri: "com.example.myapp://callback"
+/// )
+/// let client = AuthMeClient(config: config)
+///
+/// // In your SwiftUI view or view controller:
+/// try await client.login()
+/// ```
+@MainActor
+public final class AuthMeClient: NSObject {
+
+    // MARK: - State
+
+    private let config: AuthConfig
+    private let storage: TokenStorage
+    private let urlSession: URLSession
+
+    private var oidcConfig: OIDCConfiguration?
+    private var refreshTask: Task<Void, Never>?
+
+    // MARK: - Init
+
+    /// Create a new AuthMeClient with the given configuration.
+    public init(
+        config: AuthConfig,
+        urlSession: URLSession = .shared
+    ) {
+        self.config = config
+        self.storage = TokenStorage(realm: config.realm, clientId: config.clientId)
+        self.urlSession = urlSession
+        super.init()
+    }
+
+    /// Convenience initialiser matching the documented API surface.
+    public convenience init(
+        serverUrl: URL,
+        realm: String,
+        clientId: String,
+        redirectUri: String,
+        scopes: [String] = ["openid", "profile", "email"]
+    ) {
+        self.init(config: AuthConfig(
+            serverUrl: serverUrl,
+            realm: realm,
+            clientId: clientId,
+            redirectUri: redirectUri,
+            scopes: scopes
+        ))
+    }
+
+    // MARK: - Authentication state
+
+    /// Returns `true` if a non-expired access token is available.
+    public var isAuthenticated: Bool {
+        guard let token = storage.accessToken else { return false }
+        return !isTokenExpired(token)
+    }
+
+    // MARK: - Login
+
+    /// Open an `ASWebAuthenticationSession` to perform the OAuth 2.0 PKCE login flow.
+    ///
+    /// On success the tokens are stored in the Keychain and auto-refresh is scheduled.
+    /// - Parameter presentationContextProvider: The window anchor for the auth session.
+    ///   Defaults to the key window on iOS 15+.
+    public func login(
+        presentationContextProvider: ASWebAuthenticationPresentationContextProviding? = nil
+    ) async throws {
+        let oidc = try await fetchDiscovery()
+
+        let verifier = PKCEHelper.generateCodeVerifier()
+        let challenge = PKCEHelper.generateCodeChallenge(from: verifier)
+        let state     = PKCEHelper.generateState()
+
+        storage.pkceVerifier = verifier
+        storage.authState    = state
+
+        var components = URLComponents(string: oidc.authorizationEndpoint)!
+        components.queryItems = [
+            URLQueryItem(name: "response_type",           value: "code"),
+            URLQueryItem(name: "client_id",               value: config.clientId),
+            URLQueryItem(name: "redirect_uri",            value: config.redirectUri),
+            URLQueryItem(name: "scope",                   value: config.scopes.joined(separator: " ")),
+            URLQueryItem(name: "state",                   value: state),
+            URLQueryItem(name: "code_challenge",          value: challenge),
+            URLQueryItem(name: "code_challenge_method",   value: "S256"),
+        ]
+
+        guard let authURL = components.url else {
+            throw AuthMeError.invalidRedirectURI(config.redirectUri)
+        }
+
+        guard let callbackScheme = URL(string: config.redirectUri)?.scheme else {
+            throw AuthMeError.invalidRedirectURI(config.redirectUri)
+        }
+
+        let callbackURL = try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<URL, Error>) in
+
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: callbackScheme
+            ) { url, error in
+                if let error {
+                    continuation.resume(throwing: AuthMeError.networkError(error))
+                } else if let url {
+                    continuation.resume(returning: url)
+                } else {
+                    continuation.resume(throwing: AuthMeError.callbackError("No callback URL received"))
+                }
+            }
+
+            session.prefersEphemeralWebBrowserSession = false
+
+            if let provider = presentationContextProvider {
+                session.presentationContextProvider = provider
+            } else {
+                session.presentationContextProvider = DefaultPresentationContextProvider()
+            }
+
+            session.start()
+        }
+
+        try await handleCallback(url: callbackURL, oidcConfig: oidc)
+        scheduleAutoRefresh()
+    }
+
+    // MARK: - Callback handling
+
+    /// Handle an inbound redirect URI after authorization — call from your AppDelegate/SceneDelegate
+    /// `openURL` handler if using a custom URL scheme outside of ASWebAuthenticationSession.
+    public func handleRedirectURL(_ url: URL) async throws {
+        let oidc = try await fetchDiscovery()
+        try await handleCallback(url: url, oidcConfig: oidc)
+        scheduleAutoRefresh()
+    }
+
+    private func handleCallback(url: URL, oidcConfig: OIDCConfiguration) async throws {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let params     = Dictionary(
+            uniqueKeysWithValues: (components?.queryItems ?? []).compactMap { item -> (String, String)? in
+                guard let value = item.value else { return nil }
+                return (item.name, value)
+            }
+        )
+
+        if let error = params["error"] {
+            let description = params["error_description"] ?? error
+            throw AuthMeError.callbackError(description)
+        }
+
+        guard let code = params["code"] else {
+            throw AuthMeError.callbackError("Missing authorization code")
+        }
+
+        let returnedState = params["state"]
+        guard let storedState = storage.authState, returnedState == storedState else {
+            throw AuthMeError.stateMismatch
+        }
+
+        guard let verifier = storage.pkceVerifier else {
+            throw AuthMeError.pkceVerifierMissing
+        }
+
+        let tokens = try await exchangeCode(
+            code: code,
+            verifier: verifier,
+            tokenEndpoint: oidcConfig.tokenEndpoint
+        )
+
+        storage.store(tokens)
+        storage.pkceVerifier = nil
+        storage.authState    = nil
+    }
+
+    // MARK: - Logout
+
+    /// Clear local tokens and attempt server-side session termination.
+    public func logout() async {
+        if let refreshToken = storage.refreshToken,
+           let oidc = try? await fetchDiscovery(),
+           let endSessionEndpoint = oidc.endSessionEndpoint
+        {
+            var request = URLRequest(url: URL(string: endSessionEndpoint)!)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try? JSONEncoder().encode(["refresh_token": refreshToken])
+            _ = try? await urlSession.data(for: request)
+        }
+
+        cancelAutoRefresh()
+        storage.clear()
+    }
+
+    // MARK: - Token access
+
+    /// Returns the current access token string, or `nil` if not authenticated / expired.
+    public func getAccessToken() -> String? {
+        guard let token = storage.accessToken, !isTokenExpired(token) else { return nil }
+        return token
+    }
+
+    /// Returns the current access token, gated behind a biometric prompt.
+    ///
+    /// - Parameter reason: The biometric prompt reason string.
+    /// - Throws: `AuthMeError.biometricAuthFailed` if the user cancels or biometrics fail.
+    public func getAccessToken(
+        biometricReason: String,
+        biometricAuth: BiometricAuth = BiometricAuth()
+    ) async throws -> String? {
+        try await biometricAuth.authenticate(reason: biometricReason)
+        return getAccessToken()
+    }
+
+    // MARK: - Token refresh
+
+    /// Refresh the access token using the stored refresh token.
+    public func refreshToken() async throws {
+        let oidc = try await fetchDiscovery()
+
+        guard let refreshTokenValue = storage.refreshToken else {
+            throw AuthMeError.noRefreshToken
+        }
+
+        var request = URLRequest(url: URL(string: oidc.tokenEndpoint)!)
+        request.httpMethod = "POST"
+        request.setValue(
+            "application/x-www-form-urlencoded",
+            forHTTPHeaderField: "Content-Type"
+        )
+        request.httpBody = [
+            "grant_type":    "refresh_token",
+            "refresh_token": refreshTokenValue,
+            "client_id":     config.clientId,
+        ].percentEncoded()
+
+        let (data, response) = try await urlSession.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            storage.clear()
+            let message = parseError(from: data) ?? "Token refresh failed"
+            throw AuthMeError.serverError(message)
+        }
+
+        let tokens = try JSONDecoder().decode(TokenResponse.self, from: data)
+        storage.store(tokens)
+        scheduleAutoRefresh()
+    }
+
+    // MARK: - User Info
+
+    /// Fetch the current user's profile from the userinfo endpoint.
+    public func getUserInfo() async throws -> User {
+        guard let accessToken = getAccessToken() else {
+            throw AuthMeError.notAuthenticated
+        }
+
+        let oidc = try await fetchDiscovery()
+
+        var request = URLRequest(url: URL(string: oidc.userinfoEndpoint)!)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await urlSession.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw AuthMeError.serverError("Failed to fetch user info")
+        }
+
+        return try JSONDecoder().decode(User.self, from: data)
+    }
+
+    // MARK: - Discovery
+
+    private func fetchDiscovery() async throws -> OIDCConfiguration {
+        if let cached = oidcConfig { return cached }
+
+        let (data, response) = try await urlSession.data(from: config.discoveryURL)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw AuthMeError.discoveryFailed("Non-200 response from discovery endpoint")
+        }
+
+        let configuration = try JSONDecoder().decode(OIDCConfiguration.self, from: data)
+        oidcConfig = configuration
+        return configuration
+    }
+
+    // MARK: - Code exchange
+
+    private func exchangeCode(
+        code: String,
+        verifier: String,
+        tokenEndpoint: String
+    ) async throws -> TokenResponse {
+        var request = URLRequest(url: URL(string: tokenEndpoint)!)
+        request.httpMethod = "POST"
+        request.setValue(
+            "application/x-www-form-urlencoded",
+            forHTTPHeaderField: "Content-Type"
+        )
+        request.httpBody = [
+            "grant_type":    "authorization_code",
+            "code":          code,
+            "redirect_uri":  config.redirectUri,
+            "client_id":     config.clientId,
+            "code_verifier": verifier,
+        ].percentEncoded()
+
+        let (data, response) = try await urlSession.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let message = parseError(from: data) ?? "Token exchange failed"
+            throw AuthMeError.serverError(message)
+        }
+
+        return try JSONDecoder().decode(TokenResponse.self, from: data)
+    }
+
+    // MARK: - Auto-refresh scheduling
+
+    private func scheduleAutoRefresh() {
+        guard config.autoRefresh else { return }
+        cancelAutoRefresh()
+
+        guard let token = storage.accessToken,
+              let expiry = jwtExpiry(from: token)
+        else { return }
+
+        let refreshIn = max(0, expiry - Date().timeIntervalSince1970 - config.refreshBuffer)
+
+        refreshTask = Task { [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(nanoseconds: UInt64(refreshIn * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            try? await self.refreshToken()
+        }
+    }
+
+    private func cancelAutoRefresh() {
+        refreshTask?.cancel()
+        refreshTask = nil
+    }
+
+    // MARK: - JWT helpers
+
+    private func isTokenExpired(_ token: String) -> Bool {
+        guard let expiry = jwtExpiry(from: token) else { return true }
+        return Date().timeIntervalSince1970 >= expiry
+    }
+
+    private func jwtExpiry(from token: String) -> TimeInterval? {
+        let parts = token.split(separator: ".")
+        guard parts.count == 3 else { return nil }
+
+        var base64 = String(parts[1])
+        // Pad to a multiple of 4
+        while base64.count % 4 != 0 { base64.append("=") }
+        base64 = base64
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        guard let data = Data(base64Encoded: base64),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let exp  = json["exp"] as? TimeInterval
+        else { return nil }
+
+        return exp
+    }
+
+    private func parseError(from data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return (json["error_description"] as? String) ?? (json["error"] as? String)
+    }
+}
+
+// MARK: - Dictionary helpers
+
+private extension Dictionary where Key == String, Value == String {
+    func percentEncoded() -> Data? {
+        map { key, value in
+            let encodedKey   = key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? key
+            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? value
+            return "\(encodedKey)=\(encodedValue)"
+        }
+        .joined(separator: "&")
+        .data(using: .utf8)
+    }
+}
+
+// MARK: - Default presentation context
+
+/// A minimal `ASWebAuthenticationPresentationContextProviding` implementation that
+/// returns the app's key window.
+private final class DefaultPresentationContextProvider: NSObject,
+    ASWebAuthenticationPresentationContextProviding
+{
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        #if os(iOS)
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+        return scene?.windows.first(where: \.isKeyWindow)
+            ?? UIWindow()
+        #else
+        return ASPresentationAnchor()
+        #endif
+    }
+}

--- a/packages/authme-ios/Sources/AuthMe/BiometricAuth.swift
+++ b/packages/authme-ios/Sources/AuthMe/BiometricAuth.swift
@@ -1,0 +1,80 @@
+import Foundation
+import LocalAuthentication
+
+/// Wrapper around LocalAuthentication for Face ID / Touch ID gating of sensitive operations.
+///
+/// Use `BiometricAuth` to require biometric (or device passcode fallback) confirmation
+/// before exposing tokens to the app. The prompt is shown each time `authenticate()` is called.
+public final class BiometricAuth: @unchecked Sendable {
+
+    // MARK: - Biometric type
+
+    /// The biometric modality available on the current device.
+    public enum BiometryType: Sendable {
+        case faceID
+        case touchID
+        case opticID
+        case none
+    }
+
+    // MARK: - Policy
+
+    /// Whether to fall back to the device passcode when biometrics fail.
+    public var allowPasscodeFallback: Bool
+
+    public init(allowPasscodeFallback: Bool = true) {
+        self.allowPasscodeFallback = allowPasscodeFallback
+    }
+
+    // MARK: - Capabilities
+
+    /// Returns the biometric type available on this device, or `.none` if unavailable.
+    public var biometryType: BiometryType {
+        let context = LAContext()
+        var error: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+        else { return .none }
+
+        switch context.biometryType {
+        case .faceID:   return .faceID
+        case .touchID:  return .touchID
+        case .opticID:  return .opticID
+        default:        return .none
+        }
+    }
+
+    /// Returns `true` if the device supports any biometric modality.
+    public var isBiometricAvailable: Bool {
+        biometryType != .none
+    }
+
+    // MARK: - Authentication
+
+    /// Prompt the user to authenticate via biometrics (or passcode if enabled).
+    ///
+    /// - Parameter reason: A human-readable string shown in the system prompt.
+    /// - Throws: `AuthMeError.biometricAuthFailed` if authentication is denied or unavailable.
+    public func authenticate(reason: String = "Authenticate to access your account") async throws {
+        let context = LAContext()
+        context.localizedCancelTitle = "Cancel"
+
+        let policy: LAPolicy = allowPasscodeFallback
+            ? .deviceOwnerAuthentication
+            : .deviceOwnerAuthenticationWithBiometrics
+
+        var canEvalError: NSError?
+        guard context.canEvaluatePolicy(policy, error: &canEvalError) else {
+            let message = canEvalError?.localizedDescription ?? "Biometrics not available"
+            throw AuthMeError.biometricAuthFailed(message)
+        }
+
+        do {
+            let success = try await context.evaluatePolicy(policy, localizedReason: reason)
+            guard success else {
+                throw AuthMeError.biometricAuthFailed("Authentication was not successful")
+            }
+        } catch let laError as LAError {
+            throw AuthMeError.biometricAuthFailed(laError.localizedDescription)
+        }
+    }
+}

--- a/packages/authme-ios/Sources/AuthMe/Models.swift
+++ b/packages/authme-ios/Sources/AuthMe/Models.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+// MARK: - AuthConfig
+
+/// Configuration for creating an AuthMeClient instance.
+public struct AuthConfig: Sendable {
+    /// Base URL of the AuthMe server (e.g. "https://auth.example.com")
+    public let serverUrl: URL
+    /// Realm name to authenticate against
+    public let realm: String
+    /// OAuth2 client ID (must be registered in AuthMe as a PUBLIC client)
+    public let clientId: String
+    /// Custom URL scheme redirect URI (e.g. "com.example.app://callback")
+    public let redirectUri: String
+    /// OAuth2 scopes to request (default: ["openid", "profile", "email"])
+    public let scopes: [String]
+    /// Automatically refresh tokens before expiry (default: true)
+    public let autoRefresh: Bool
+    /// Seconds before expiry to trigger a refresh (default: 30)
+    public let refreshBuffer: TimeInterval
+
+    public init(
+        serverUrl: URL,
+        realm: String,
+        clientId: String,
+        redirectUri: String,
+        scopes: [String] = ["openid", "profile", "email"],
+        autoRefresh: Bool = true,
+        refreshBuffer: TimeInterval = 30
+    ) {
+        self.serverUrl = serverUrl
+        self.realm = realm
+        self.clientId = clientId
+        self.redirectUri = redirectUri
+        self.scopes = scopes
+        self.autoRefresh = autoRefresh
+        self.refreshBuffer = refreshBuffer
+    }
+
+    /// The OIDC discovery URL for this realm.
+    var discoveryURL: URL {
+        serverUrl
+            .appendingPathComponent("realms")
+            .appendingPathComponent(realm)
+            .appendingPathComponent(".well-known/openid-configuration")
+    }
+}
+
+// MARK: - TokenResponse
+
+/// Raw token response from the token endpoint.
+public struct TokenResponse: Codable, Sendable {
+    public let accessToken: String
+    public let tokenType: String
+    public let expiresIn: Int
+    public let refreshToken: String?
+    public let idToken: String?
+    public let scope: String?
+
+    enum CodingKeys: String, CodingKey {
+        case accessToken = "access_token"
+        case tokenType = "token_type"
+        case expiresIn = "expires_in"
+        case refreshToken = "refresh_token"
+        case idToken = "id_token"
+        case scope
+    }
+}
+
+// MARK: - User
+
+/// User information returned by the userinfo endpoint.
+public struct User: Codable, Sendable {
+    public let sub: String
+    public let preferredUsername: String?
+    public let name: String?
+    public let givenName: String?
+    public let familyName: String?
+    public let email: String?
+    public let emailVerified: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case sub
+        case preferredUsername = "preferred_username"
+        case name
+        case givenName = "given_name"
+        case familyName = "family_name"
+        case email
+        case emailVerified = "email_verified"
+    }
+}
+
+// MARK: - OIDCConfiguration
+
+/// OIDC Discovery document.
+struct OIDCConfiguration: Codable {
+    let issuer: String
+    let authorizationEndpoint: String
+    let tokenEndpoint: String
+    let userinfoEndpoint: String
+    let jwksUri: String
+    let endSessionEndpoint: String?
+
+    enum CodingKeys: String, CodingKey {
+        case issuer
+        case authorizationEndpoint = "authorization_endpoint"
+        case tokenEndpoint = "token_endpoint"
+        case userinfoEndpoint = "userinfo_endpoint"
+        case jwksUri = "jwks_uri"
+        case endSessionEndpoint = "end_session_endpoint"
+    }
+}
+
+// MARK: - AuthMeError
+
+/// Errors thrown by the AuthMe SDK.
+public enum AuthMeError: LocalizedError, Sendable {
+    case notAuthenticated
+    case tokenExpired
+    case noRefreshToken
+    case invalidRedirectURI(String)
+    case stateMismatch
+    case pkceVerifierMissing
+    case networkError(Error)
+    case serverError(String)
+    case tokenParseError
+    case biometricAuthFailed(String)
+    case discoveryFailed(String)
+    case callbackError(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "User is not authenticated."
+        case .tokenExpired:
+            return "The access token has expired."
+        case .noRefreshToken:
+            return "No refresh token available."
+        case .invalidRedirectURI(let uri):
+            return "Invalid redirect URI: \(uri)"
+        case .stateMismatch:
+            return "State parameter mismatch — possible CSRF attack."
+        case .pkceVerifierMissing:
+            return "PKCE code verifier is missing."
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        case .serverError(let message):
+            return "Server error: \(message)"
+        case .tokenParseError:
+            return "Failed to parse token."
+        case .biometricAuthFailed(let reason):
+            return "Biometric authentication failed: \(reason)"
+        case .discoveryFailed(let message):
+            return "Failed to fetch OIDC discovery document: \(message)"
+        case .callbackError(let message):
+            return "Authorization callback error: \(message)"
+        }
+    }
+}

--- a/packages/authme-ios/Sources/AuthMe/PKCEHelper.swift
+++ b/packages/authme-ios/Sources/AuthMe/PKCEHelper.swift
@@ -1,0 +1,57 @@
+import Foundation
+import CryptoKit
+
+/// Helpers for generating OAuth 2.0 PKCE parameters (RFC 7636).
+public enum PKCEHelper {
+
+    // MARK: - Code Verifier
+
+    /// Generate a cryptographically random PKCE code verifier.
+    ///
+    /// The verifier is a high-entropy random string of 43–128 characters,
+    /// Base64URL-encoded without padding, as required by RFC 7636.
+    public static func generateCodeVerifier() -> String {
+        var buffer = [UInt8](repeating: 0, count: 32)
+        let result = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
+        guard result == errSecSuccess else {
+            // Fallback to Swift's built-in random if SecRandom fails
+            buffer = (0..<32).map { _ in UInt8.random(in: 0...255) }
+            return Data(buffer).base64URLEncodedString()
+        }
+        return Data(buffer).base64URLEncodedString()
+    }
+
+    // MARK: - Code Challenge
+
+    /// Derive the S256 PKCE code challenge from a verifier.
+    ///
+    /// Challenge = BASE64URL(SHA256(ASCII(verifier)))
+    public static func generateCodeChallenge(from verifier: String) -> String {
+        guard let data = verifier.data(using: .ascii) else {
+            preconditionFailure("Code verifier must be ASCII")
+        }
+        let digest = SHA256.hash(data: data)
+        return Data(digest).base64URLEncodedString()
+    }
+
+    // MARK: - State
+
+    /// Generate a random state parameter for CSRF protection.
+    public static func generateState() -> String {
+        var buffer = [UInt8](repeating: 0, count: 16)
+        _ = SecRandomCopyBytes(kSecRandomDefault, buffer.count, &buffer)
+        return Data(buffer).base64URLEncodedString()
+    }
+}
+
+// MARK: - Data + Base64URL
+
+private extension Data {
+    /// Encode as Base64URL without padding characters (RFC 4648 §5).
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/packages/authme-ios/Sources/AuthMe/TokenStorage.swift
+++ b/packages/authme-ios/Sources/AuthMe/TokenStorage.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Security
+
+/// Secure token storage backed by the iOS Keychain.
+///
+/// Tokens are stored under a service name derived from the realm and client ID,
+/// so multiple AuthMe realms can coexist without key collisions.
+final class TokenStorage: @unchecked Sendable {
+
+    // MARK: - Keys
+
+    private let servicePrefix: String
+
+    init(realm: String, clientId: String) {
+        self.servicePrefix = "com.authme.sdk.\(realm).\(clientId)"
+    }
+
+    // MARK: - Stored Keys
+
+    private enum Key: String {
+        case accessToken  = "access_token"
+        case refreshToken = "refresh_token"
+        case idToken      = "id_token"
+        case pkceVerifier = "pkce_verifier"
+        case authState    = "auth_state"
+    }
+
+    // MARK: - Convenience accessors
+
+    var accessToken: String? {
+        get { read(key: .accessToken) }
+        set { newValue == nil ? delete(key: .accessToken) : write(newValue!, key: .accessToken) }
+    }
+
+    var refreshToken: String? {
+        get { read(key: .refreshToken) }
+        set { newValue == nil ? delete(key: .refreshToken) : write(newValue!, key: .refreshToken) }
+    }
+
+    var idToken: String? {
+        get { read(key: .idToken) }
+        set { newValue == nil ? delete(key: .idToken) : write(newValue!, key: .idToken) }
+    }
+
+    var pkceVerifier: String? {
+        get { read(key: .pkceVerifier) }
+        set { newValue == nil ? delete(key: .pkceVerifier) : write(newValue!, key: .pkceVerifier) }
+    }
+
+    var authState: String? {
+        get { read(key: .authState) }
+        set { newValue == nil ? delete(key: .authState) : write(newValue!, key: .authState) }
+    }
+
+    // MARK: - Bulk operations
+
+    /// Store a full token response.
+    func store(_ tokens: TokenResponse) {
+        accessToken  = tokens.accessToken
+        refreshToken = tokens.refreshToken
+        idToken      = tokens.idToken
+    }
+
+    /// Remove all stored tokens and PKCE state.
+    func clear() {
+        Key.allCases.forEach { delete(key: $0) }
+    }
+
+    // MARK: - Keychain primitives
+
+    private func serviceName(for key: Key) -> String {
+        "\(servicePrefix).\(key.rawValue)"
+    }
+
+    @discardableResult
+    private func write(_ value: String, key: Key) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+
+        let service = serviceName(for: key)
+
+        // Delete existing item first so we can add a fresh one
+        delete(key: key)
+
+        let query: [String: Any] = [
+            kSecClass as String:            kSecClassGenericPassword,
+            kSecAttrService as String:      service,
+            kSecAttrAccessible as String:   kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String:        data,
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    private func read(key: Key) -> String? {
+        let service = serviceName(for: key)
+
+        let query: [String: Any] = [
+            kSecClass as String:       kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecReturnData as String:  true,
+            kSecMatchLimit as String:  kSecMatchLimitOne,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let string = String(data: data, encoding: .utf8)
+        else { return nil }
+
+        return string
+    }
+
+    @discardableResult
+    private func delete(key: Key) -> Bool {
+        let service = serviceName(for: key)
+
+        let query: [String: Any] = [
+            kSecClass as String:       kSecClassGenericPassword,
+            kSecAttrService as String: service,
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}
+
+// MARK: - CaseIterable conformance for Key
+
+extension TokenStorage.Key: CaseIterable {}

--- a/packages/authme-ios/Tests/AuthMeTests/PKCEHelperTests.swift
+++ b/packages/authme-ios/Tests/AuthMeTests/PKCEHelperTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import AuthMe
+
+final class PKCEHelperTests: XCTestCase {
+
+    func testCodeVerifierLength() {
+        let verifier = PKCEHelper.generateCodeVerifier()
+        // RFC 7636 §4.1: 43–128 characters
+        XCTAssertGreaterThanOrEqual(verifier.count, 43)
+        XCTAssertLessThanOrEqual(verifier.count, 128)
+    }
+
+    func testCodeVerifierIsBase64URL() {
+        let verifier = PKCEHelper.generateCodeVerifier()
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        XCTAssertTrue(verifier.unicodeScalars.allSatisfy { allowed.contains($0) })
+    }
+
+    func testCodeVerifierIsUnique() {
+        let v1 = PKCEHelper.generateCodeVerifier()
+        let v2 = PKCEHelper.generateCodeVerifier()
+        XCTAssertNotEqual(v1, v2)
+    }
+
+    func testCodeChallengeIsBase64URL() {
+        let verifier  = PKCEHelper.generateCodeVerifier()
+        let challenge = PKCEHelper.generateCodeChallenge(from: verifier)
+        let allowed   = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        XCTAssertTrue(challenge.unicodeScalars.allSatisfy { allowed.contains($0) })
+    }
+
+    func testCodeChallengeHasNoPadding() {
+        let verifier  = PKCEHelper.generateCodeVerifier()
+        let challenge = PKCEHelper.generateCodeChallenge(from: verifier)
+        XCTAssertFalse(challenge.contains("="))
+    }
+
+    /// RFC 7636 §4.2 test vector (SHA-256 of "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+    func testCodeChallengeKnownVector() {
+        let verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        let challenge = PKCEHelper.generateCodeChallenge(from: verifier)
+        XCTAssertEqual(challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    func testStateIsUnique() {
+        let s1 = PKCEHelper.generateState()
+        let s2 = PKCEHelper.generateState()
+        XCTAssertNotEqual(s1, s2)
+    }
+}


### PR DESCRIPTION
## Summary
- Implements **Feature 22: Mobile SDKs** (closes #280)
- Native iOS SDK (Swift 5.9+, iOS 15+) with ASWebAuthenticationSession, Keychain, Face ID/Touch ID
- Native Android SDK (Kotlin 1.9+, minSdk 24) with Chrome Custom Tabs, EncryptedSharedPreferences, BiometricPrompt
- Both implement OAuth 2.0 PKCE with RFC 7636 test vectors
- Auto token refresh, biometric-gated token access, back-channel logout

## iOS SDK (`packages/authme-ios/`)
- Swift Package Manager distribution
- AuthMeClient, TokenStorage (Keychain), BiometricAuth, PKCEHelper
- Full README with SwiftUI ViewModel example

## Android SDK (`packages/authme-android/`)
- Gradle/Maven publish configuration
- AuthMeClient, TokenStorage (EncryptedSharedPreferences), BiometricAuth, PKCEHelper
- Full README with ViewModel example

🤖 Generated with [Claude Code](https://claude.com/claude-code)