### PR TITLE
fix(cli): add missing exports in http.ts for migrate command

### DIFF
--- a/packages/authme-cli/src/commands/migrate.ts
+++ b/packages/authme-cli/src/commands/migrate.ts
@@ -68,7 +68,7 @@ export function registerMigrateCommand(program: Command): void {
 
       try {
         const http = createHttpClient(config);
-        const { data: report } = await http.post<MigrationReport>('/admin/migration/keycloak', {
+        const report = await http.post<MigrationReport>('/admin/migration/keycloak', {
           data, dryRun: opts.dryRun, targetRealm: opts.realm,
         });
         if (opts.json) {
@@ -104,7 +104,7 @@ export function registerMigrateCommand(program: Command): void {
 
       try {
         const http = createHttpClient(config);
-        const { data: report } = await http.post<MigrationReport>('/admin/migration/auth0', {
+        const report = await http.post<MigrationReport>('/admin/migration/auth0', {
           data, dryRun: opts.dryRun, targetRealm: opts.realm,
         });
         if (opts.json) {

--- a/packages/authme-cli/src/http.ts
+++ b/packages/authme-cli/src/http.ts
@@ -1,17 +1,26 @@
 import chalk from 'chalk';
 import { requireAuth } from './config.js';
+import type { CliConfig } from './types.js';
 
 export class HttpClient {
   private serverUrl: string;
   private headers: Record<string, string>;
 
-  constructor() {
-    const auth = requireAuth();
-    this.serverUrl = auth.serverUrl.replace(/\/$/, '');
-    this.headers = {
-      'Content-Type': 'application/json',
-      ...auth.headers,
-    };
+  constructor(config?: { serverUrl: string; headers?: Record<string, string> }) {
+    if (config) {
+      this.serverUrl = config.serverUrl.replace(/\/$/, '');
+      this.headers = {
+        'Content-Type': 'application/json',
+        ...config.headers,
+      };
+    } else {
+      const auth = requireAuth();
+      this.serverUrl = auth.serverUrl.replace(/\/$/, '');
+      this.headers = {
+        'Content-Type': 'application/json',
+        ...auth.headers,
+      };
+    }
   }
 
   private url(path: string): string {
@@ -69,4 +78,23 @@ export class HttpClient {
 
     return json as T;
   }
+}
+
+export function createHttpClient(config: CliConfig): HttpClient {
+  const headers: Record<string, string> = {};
+  if (config.apiKey) {
+    headers['x-admin-api-key'] = config.apiKey;
+  } else if (config.accessToken) {
+    headers['Authorization'] = `Bearer ${config.accessToken}`;
+  }
+  return new HttpClient({ serverUrl: config.serverUrl, headers });
+}
+
+export function handleApiError(error: unknown): never {
+  if (error instanceof Error) {
+    console.error(chalk.red(error.message));
+  } else {
+    console.error(chalk.red('An unexpected error occurred'));
+  }
+  process.exit(1);
 }

--- a/packages/authme-cli/src/types.ts
+++ b/packages/authme-cli/src/types.ts
@@ -78,3 +78,30 @@ export interface BulkUserInput {
   password?: string;
   enabled?: boolean;
 }
+
+export interface MigrationEntityStats {
+  created: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface MigrationError {
+  entity: string;
+  name: string;
+  error: string;
+}
+
+export interface MigrationWarning {
+  entity: string;
+  message: string;
+}
+
+export interface MigrationReport {
+  source: 'keycloak' | 'auth0';
+  dryRun: boolean;
+  startedAt: string;
+  completedAt: string;
+  summary: Record<string, MigrationEntityStats>;
+  errors: MigrationError[];
+  warnings: MigrationWarning[];
+}


### PR DESCRIPTION
## Summary
- Adds `createHttpClient` and `handleApiError` exports to `packages/authme-cli/src/http.ts`
- Adds `MigrationReport` and related types to `packages/authme-cli/src/types.ts`
- Fixes `migrate.ts` destructure pattern to match `HttpClient.post` return type

## Test plan
- [x] `npm run build` in `packages/authme-cli` now succeeds
- [x] All existing CLI tests still pass

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)