### PR TITLE
fix(security): derive admin identity from auth context in impersonation

### DIFF
--- a/src/impersonation/dto/end-impersonation.dto.ts
+++ b/src/impersonation/dto/end-impersonation.dto.ts
@@ -1,14 +1,9 @@
 import { IsString, IsNotEmpty } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
-export class EndImpersonationDto {
+export class EndImpersonationBodyDto {
   @ApiProperty({ description: 'The impersonation session ID to end' })
   @IsString()
   @IsNotEmpty()
   impersonationSessionId!: string;
-
-  @ApiProperty({ description: 'The admin user ID ending the impersonation' })
-  @IsString()
-  @IsNotEmpty()
-  adminUserId!: string;
 }

--- a/src/impersonation/dto/start-impersonation.dto.ts
+++ b/src/impersonation/dto/start-impersonation.dto.ts
@@ -1,9 +1,3 @@
-import { IsString, IsNotEmpty } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
-
-export class StartImpersonationDto {
-  @ApiProperty({ description: 'The ID of the admin user initiating impersonation' })
-  @IsString()
-  @IsNotEmpty()
-  adminUserId!: string;
-}
+// StartImpersonation no longer requires a request body.
+// The admin identity is derived from the authenticated session.
+// This file is kept for potential future fields (e.g., reason, scope).

--- a/src/impersonation/impersonation.controller.ts
+++ b/src/impersonation/impersonation.controller.ts
@@ -7,15 +7,23 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import type { Request } from 'express';
 import type { Realm } from '@prisma/client';
 import { ImpersonationService } from './impersonation.service.js';
-import { StartImpersonationDto } from './dto/start-impersonation.dto.js';
-import { EndImpersonationDto } from './dto/end-impersonation.dto.js';
+import { EndImpersonationBodyDto } from './dto/end-impersonation.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+
+function getAdminUserId(req: Request): string {
+  const adminUser = (req as any)['adminUser'];
+  if (!adminUser?.userId) {
+    throw new UnauthorizedException('Admin identity could not be determined');
+  }
+  return adminUser.userId;
+}
 
 @ApiTags('Impersonation')
 @Controller('admin/realms/:realmName')
@@ -31,18 +39,19 @@ export class ImpersonationController {
     description:
       'Generates access/refresh tokens for the target user with impersonation claims. ' +
       'The resulting tokens carry an `act.sub` claim (RFC 8693) identifying the admin, ' +
-      'and an `impersonated: true` claim. Requires impersonation to be enabled on the realm.',
+      'and an `impersonated: true` claim. Requires impersonation to be enabled on the realm. ' +
+      'The admin identity is derived from the authenticated session, not the request body.',
   })
   startImpersonation(
     @CurrentRealm() realm: Realm,
     @Param('userId') targetUserId: string,
-    @Body() dto: StartImpersonationDto,
     @Req() req: Request,
   ) {
+    const adminUserId = getAdminUserId(req);
     const ip = req.ip;
     return this.impersonationService.startImpersonation(
       realm,
-      dto.adminUserId,
+      adminUserId,
       targetUserId,
       ip,
     );
@@ -54,18 +63,19 @@ export class ImpersonationController {
     summary: 'End an impersonation session',
     description:
       'Revokes the impersonation session tokens and marks the session as ended. ' +
-      'Logs an IMPERSONATION_END event.',
+      'Logs an IMPERSONATION_END event. The admin identity is derived from the authenticated session.',
   })
   async endImpersonation(
     @CurrentRealm() realm: Realm,
-    @Body() dto: EndImpersonationDto,
+    @Body() dto: EndImpersonationBodyDto,
     @Req() req: Request,
   ) {
+    const adminUserId = getAdminUserId(req);
     const ip = req.ip;
     await this.impersonationService.endImpersonation(
       realm,
       dto.impersonationSessionId,
-      dto.adminUserId,
+      adminUserId,
       ip,
     );
   }


### PR DESCRIPTION
## Summary
- **Critical security fix**: Impersonation endpoints no longer accept `adminUserId` from request body
- Admin identity is now extracted from the authenticated session (`req.adminUser`) set by `AdminApiKeyGuard`
- Prevents audit trail manipulation and identity spoofing

## Test plan
- [x] TypeScript compilation passes (no new errors)
- [x] Impersonation controller no longer accepts adminUserId in body
- [ ] Manual test: verify impersonation uses authenticated admin identity

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)