### PR TITLE
fix(security): persist token blacklist to database with Redis caching

### DIFF
--- a/prisma/migrations/20260324950000_add_revoked_tokens/migration.sql
+++ b/prisma/migrations/20260324950000_add_revoked_tokens/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "revoked_tokens" (
+    "jti" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "revoked_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "revoked_tokens_pkey" PRIMARY KEY ("jti")
+);
+
+-- CreateIndex
+CREATE INDEX "revoked_tokens_expires_at_idx" ON "revoked_tokens"("expires_at");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1157,3 +1157,12 @@ model OrganizationSsoConnection {
 
   @@map("organization_sso_connections")
 }
+
+model RevokedToken {
+  jti       String   @id
+  expiresAt DateTime @map("expires_at")
+  revokedAt DateTime @default(now()) @map("revoked_at")
+
+  @@index([expiresAt])
+  @@map("revoked_tokens")
+}

--- a/src/tokens/token-blacklist.service.ts
+++ b/src/tokens/token-blacklist.service.ts
@@ -1,30 +1,132 @@
-import { Injectable, OnModuleDestroy } from '@nestjs/common';
+import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
+import { RedisService } from '../redis/redis.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const BLACKLIST_PREFIX = 'token:blacklist:';
 
 @Injectable()
-export class TokenBlacklistService implements OnModuleDestroy {
-  private readonly blacklist = new Map<string, number>(); // jti -> exp timestamp
-  private cleanupInterval: ReturnType<typeof setInterval>;
+export class TokenBlacklistService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(TokenBlacklistService.name);
+  /** In-memory fallback used only when Redis is unavailable. */
+  private readonly memoryFallback = new Map<string, number>();
+  private cleanupInterval: ReturnType<typeof setInterval> | undefined;
 
-  constructor() {
+  constructor(
+    private readonly redis: RedisService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async onModuleInit() {
+    // Periodically clean up expired tokens from DB and memory fallback
     this.cleanupInterval = setInterval(() => this.cleanup(), 60_000);
+
+    // On startup, load persisted revoked tokens into Redis (if Redis is up)
+    await this.rehydrateFromDatabase();
   }
 
   onModuleDestroy() {
-    clearInterval(this.cleanupInterval);
+    if (this.cleanupInterval) clearInterval(this.cleanupInterval);
   }
 
-  blacklistToken(jti: string, exp: number): void {
-    this.blacklist.set(jti, exp);
+  async blacklistToken(jti: string, exp: number): Promise<void> {
+    const ttl = exp - Math.floor(Date.now() / 1000);
+    if (ttl <= 0) return; // Already expired, no need to blacklist
+
+    // 1. Persist to database for durability across restarts
+    try {
+      await this.prisma.revokedToken.upsert({
+        where: { jti },
+        create: { jti, expiresAt: new Date(exp * 1000) },
+        update: {},
+      });
+    } catch (err) {
+      this.logger.warn(`Failed to persist revoked token to DB: ${(err as Error).message}`);
+    }
+
+    // 2. Store in Redis for fast cross-instance lookup
+    if (this.redis.isAvailable()) {
+      try {
+        await this.redis.set(`${BLACKLIST_PREFIX}${jti}`, '1', ttl);
+        return;
+      } catch (err) {
+        this.logger.warn(`Failed to blacklist token in Redis: ${(err as Error).message}`);
+      }
+    }
+
+    // 3. In-memory fallback
+    this.memoryFallback.set(jti, exp);
   }
 
-  isBlacklisted(jti: string): boolean {
-    return this.blacklist.has(jti);
+  async isBlacklisted(jti: string): Promise<boolean> {
+    // 1. Check Redis first (fastest, shared across instances)
+    if (this.redis.isAvailable()) {
+      try {
+        const exists = await this.redis.exists(`${BLACKLIST_PREFIX}${jti}`);
+        if (exists) return true;
+      } catch {
+        // Fall through to other checks
+      }
+    }
+
+    // 2. Check in-memory fallback
+    if (this.memoryFallback.has(jti)) return true;
+
+    // 3. Check database as last resort
+    try {
+      const record = await this.prisma.revokedToken.findUnique({ where: { jti } });
+      if (record) {
+        // Re-populate Redis/memory if found in DB
+        const ttl = Math.floor(record.expiresAt.getTime() / 1000) - Math.floor(Date.now() / 1000);
+        if (ttl > 0 && this.redis.isAvailable()) {
+          await this.redis.set(`${BLACKLIST_PREFIX}${jti}`, '1', ttl).catch(() => {});
+        }
+        return true;
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to check DB for revoked token: ${(err as Error).message}`);
+    }
+
+    return false;
   }
 
-  private cleanup(): void {
+  private async rehydrateFromDatabase(): Promise<void> {
+    if (!this.redis.isAvailable()) return;
+    try {
+      const now = new Date();
+      const tokens = await this.prisma.revokedToken.findMany({
+        where: { expiresAt: { gt: now } },
+      });
+      for (const token of tokens) {
+        const ttl = Math.floor(token.expiresAt.getTime() / 1000) - Math.floor(now.getTime() / 1000);
+        if (ttl > 0) {
+          await this.redis.set(`${BLACKLIST_PREFIX}${token.jti}`, '1', ttl).catch(() => {});
+        }
+      }
+      if (tokens.length > 0) {
+        this.logger.log(`Rehydrated ${tokens.length} revoked tokens from database into Redis`);
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to rehydrate blacklist from DB: ${(err as Error).message}`);
+    }
+  }
+
+  private async cleanup(): Promise<void> {
+    // Clean memory fallback
     const now = Math.floor(Date.now() / 1000);
-    for (const [jti, exp] of this.blacklist) {
-      if (exp < now) this.blacklist.delete(jti);
+    for (const [jti, exp] of this.memoryFallback) {
+      if (exp < now) this.memoryFallback.delete(jti);
+    }
+
+    // Clean expired entries from database
+    try {
+      const { count } = await this.prisma.revokedToken.deleteMany({
+        where: { expiresAt: { lt: new Date() } },
+      });
+      if (count > 0) {
+        this.logger.debug(`Cleaned up ${count} expired revoked tokens from database`);
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to clean expired tokens from DB: ${(err as Error).message}`);
     }
   }
 }

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -42,7 +42,7 @@ export class TokensService {
 
       // Check token blacklist
       const jti = payload['jti'] as string | undefined;
-      if (jti && this.blacklist.isBlacklisted(jti)) {
+      if (jti && await this.blacklist.isBlacklisted(jti)) {
         return { active: false };
       }
 
@@ -101,7 +101,7 @@ export class TokensService {
           const jti = payload['jti'] as string | undefined;
           const exp = payload.exp as number | undefined;
           if (jti && exp) {
-            this.blacklist.blacklistToken(jti, exp);
+            await this.blacklist.blacklistToken(jti, exp);
           }
         }
       } catch {
@@ -212,7 +212,7 @@ export class TokensService {
 
     // Check blacklist
     const jti = payload['jti'] as string | undefined;
-    if (jti && this.blacklist.isBlacklisted(jti)) {
+    if (jti && await this.blacklist.isBlacklisted(jti)) {
       throw new UnauthorizedException('Token has been revoked');
     }
 


### PR DESCRIPTION
## Summary
- **Critical security fix**: Revoked tokens now survive server restarts
- Tokens persisted to new `revoked_tokens` database table
- Redis used as fast cache layer for cross-instance visibility
- In-memory fallback when Redis is unavailable
- Automatic rehydration from DB on startup
- Periodic cleanup of expired entries

## Test plan
- [x] TypeScript compilation passes
- [x] Prisma schema generates successfully
- [ ] Manual: revoke token, restart server, verify token stays revoked
- [ ] Manual: revoke on instance A, verify instance B sees it (via Redis)

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)