### PR TITLE
fix(docker): run as non-root user and fix npm prune stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN npx prisma generate
 RUN npm run build
 # Copy admin-ui build output into dist
 RUN cp -r admin-ui/dist dist/admin-ui
-RUN npm prune --production
 
 # Stage 3: Production
 FROM node:22-alpine AS production
@@ -34,13 +33,24 @@ COPY --from=build /app/dist ./dist
 COPY --from=build /app/prisma ./prisma
 COPY --from=build /app/themes ./themes
 COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
 
 # Prisma config needed for migrate deploy
 COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+
+# Remove dev dependencies in production stage (not build stage)
+RUN npm prune --production
+
+RUN addgroup -g 1001 -S authme && adduser -S authme -u 1001
 
 ENV NODE_ENV=production
 EXPOSE 3000
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh
+
+# Ensure the app directory is owned by the non-root user
+RUN chown -R authme:authme /app
+
+USER authme
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Run production container as non-root user `authme:1001`
- Move `npm prune --production` from build stage to production stage
- Production image no longer includes dev dependencies

## Test plan
- [x] Dockerfile syntax valid
- [ ] `docker build` succeeds
- [ ] Container starts as non-root (`whoami` returns `authme`)

Closes #348
Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)