### PR TITLE
fix(security): default JS SDK to memory storage to prevent XSS token theft

### DIFF
--- a/packages/authme-js/src/client.ts
+++ b/packages/authme-js/src/client.ts
@@ -56,7 +56,10 @@ export class AuthmeClient {
       onError: config.onError,
       onTokenRefresh: config.onTokenRefresh,
     };
-    this.storage = createStorage(config.storage ?? 'sessionStorage');
+    // Default to in-memory storage to prevent XSS token theft.
+    // sessionStorage/localStorage are accessible to any JS on the page.
+    // Users can opt-in to persistent storage if they accept the risk.
+    this.storage = createStorage(config.storage ?? 'memory');
 
     // Wire up callback-style config options to the event system
     if (config.onLogin) {


### PR DESCRIPTION
## Summary
- Default token storage changed from `sessionStorage` to `memory`
- Prevents XSS attacks from stealing tokens via DOM storage APIs
- Users can explicitly opt-in to `sessionStorage`/`localStorage` if desired

## Test plan
- [x] Code change is minimal and safe
- [ ] Manual: tokens not visible in browser DevTools Storage tab by default

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)