### PR TITLE
fix(backend): add cleanup schedulers for expired sessions and auth codes

### DIFF
--- a/src/oauth/oauth.service.spec.ts
+++ b/src/oauth/oauth.service.spec.ts
@@ -320,4 +320,22 @@ describe('OAuthService', () => {
       expect(createCall.data.codeChallengeMethod).toBe('S256');
     });
   });
+
+  describe('cleanupExpiredCodes', () => {
+    it('should delete authorization codes whose expiresAt is in the past', async () => {
+      prisma.authorizationCode.deleteMany.mockResolvedValue({ count: 3 });
+
+      await service.cleanupExpiredCodes();
+
+      expect(prisma.authorizationCode.deleteMany).toHaveBeenCalledTimes(1);
+      const callArg = prisma.authorizationCode.deleteMany.mock.calls[0][0];
+      expect(callArg.where.expiresAt.lt).toBeInstanceOf(Date);
+    });
+
+    it('should not throw when no expired codes exist', async () => {
+      prisma.authorizationCode.deleteMany.mockResolvedValue({ count: 0 });
+
+      await expect(service.cleanupExpiredCodes()).resolves.toBeUndefined();
+    });
+  });
 });

--- a/src/oauth/oauth.service.ts
+++ b/src/oauth/oauth.service.ts
@@ -1,8 +1,10 @@
 import {
   Injectable,
   BadRequestException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
 import { randomBytes } from 'crypto';
 import type { Realm, User, Client } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
@@ -24,6 +26,8 @@ export interface AuthorizeParams {
 
 @Injectable()
 export class OAuthService {
+  private readonly logger = new Logger(OAuthService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly scopesService: ScopesService,
@@ -125,5 +129,15 @@ export class OAuthService {
     }
 
     return { redirectUrl: redirectUrl.toString() };
+  }
+
+  @Interval(300_000) // every 5 minutes
+  async cleanupExpiredCodes(): Promise<void> {
+    const { count } = await this.prisma.authorizationCode.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+    if (count > 0) {
+      this.logger.debug(`Cleaned up ${count} expired authorization code(s)`);
+    }
   }
 }

--- a/src/prisma/prisma.mock.ts
+++ b/src/prisma/prisma.mock.ts
@@ -61,6 +61,7 @@ export function createMockPrismaService(): MockPrismaService {
       findUnique: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      deleteMany: jest.fn(),
     },
     realmSigningKey: {
       findFirst: jest.fn(),

--- a/src/sessions/sessions-cleanup.service.spec.ts
+++ b/src/sessions/sessions-cleanup.service.spec.ts
@@ -1,0 +1,98 @@
+import { SessionsCleanupService } from './sessions-cleanup.service.js';
+import {
+  createMockPrismaService,
+  type MockPrismaService,
+} from '../prisma/prisma.mock.js';
+
+describe('SessionsCleanupService', () => {
+  let service: SessionsCleanupService;
+  let prisma: MockPrismaService;
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+
+    // Add deleteMany overloads that are missing from the shared mock
+    prisma.refreshToken.deleteMany = jest.fn();
+    prisma.authorizationCode.deleteMany = jest.fn();
+    prisma.impersonationSession.deleteMany = jest.fn();
+
+    service = new SessionsCleanupService(prisma as any);
+  });
+
+  describe('cleanupExpiredSessions', () => {
+    it('should delete expired records across all session-related tables', async () => {
+      prisma.session.deleteMany.mockResolvedValue({ count: 3 });
+      (prisma.loginSession.deleteMany as jest.Mock).mockResolvedValue({ count: 2 });
+      prisma.refreshToken.deleteMany.mockResolvedValue({ count: 5 });
+      (prisma.authorizationCode.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.impersonationSession.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      const before = new Date();
+      await service.cleanupExpiredSessions();
+      const after = new Date();
+
+      // Each deleteMany should have been called with expiresAt < now
+      expect(prisma.session.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: expect.any(Date) } },
+      });
+      const oauthCall = (prisma.session.deleteMany as jest.Mock).mock.calls[0][0];
+      expect(oauthCall.where.expiresAt.lt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(oauthCall.where.expiresAt.lt.getTime()).toBeLessThanOrEqual(after.getTime());
+
+      expect(prisma.loginSession.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: expect.any(Date) } },
+      });
+
+      expect(prisma.refreshToken.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: expect.any(Date) } },
+      });
+
+      expect(prisma.authorizationCode.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: expect.any(Date) } },
+      });
+
+      expect(prisma.impersonationSession.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: expect.any(Date) } },
+      });
+    });
+
+    it('should not throw when all tables return zero deleted rows', async () => {
+      prisma.session.deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.loginSession.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+      prisma.refreshToken.deleteMany.mockResolvedValue({ count: 0 });
+      (prisma.authorizationCode.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+      (prisma.impersonationSession.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
+
+      await expect(service.cleanupExpiredSessions()).resolves.toBeUndefined();
+    });
+
+    it('should use a consistent timestamp across all delete calls', async () => {
+      const fixedNow = new Date('2026-03-24T12:00:00.000Z').getTime();
+      jest.spyOn(Date, 'now').mockReturnValue(fixedNow);
+
+      prisma.session.deleteMany.mockResolvedValue({ count: 1 });
+      (prisma.loginSession.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      prisma.refreshToken.deleteMany.mockResolvedValue({ count: 1 });
+      (prisma.authorizationCode.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+      (prisma.impersonationSession.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await service.cleanupExpiredSessions();
+
+      const timestamps = [
+        (prisma.session.deleteMany as jest.Mock).mock.calls[0][0].where.expiresAt.lt,
+        (prisma.loginSession.deleteMany as jest.Mock).mock.calls[0][0].where.expiresAt.lt,
+        (prisma.refreshToken.deleteMany as jest.Mock).mock.calls[0][0].where.expiresAt.lt,
+        (prisma.authorizationCode.deleteMany as jest.Mock).mock.calls[0][0].where.expiresAt.lt,
+        (prisma.impersonationSession.deleteMany as jest.Mock).mock.calls[0][0].where.expiresAt.lt,
+      ];
+
+      // All five calls must use the exact same Date instance / value
+      const referenceTime = timestamps[0].getTime();
+      for (const ts of timestamps) {
+        expect(ts.getTime()).toBe(referenceTime);
+      }
+
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/src/sessions/sessions-cleanup.service.ts
+++ b/src/sessions/sessions-cleanup.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Interval } from '@nestjs/schedule';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+@Injectable()
+export class SessionsCleanupService {
+  private readonly logger = new Logger(SessionsCleanupService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Interval(3_600_000) // every hour
+  async cleanupExpiredSessions(): Promise<void> {
+    const now = new Date();
+
+    // Delete expired OAuth sessions.  RefreshTokens are deleted automatically
+    // via the onDelete: Cascade relation defined in the Prisma schema.
+    const oauthResult = await this.prisma.session.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+
+    // Delete expired SSO / browser login sessions.
+    const ssoResult = await this.prisma.loginSession.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+
+    // Delete any refresh tokens that have individually expired but whose
+    // parent session is still alive (e.g. offline tokens with a shorter TTL).
+    const refreshResult = await this.prisma.refreshToken.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+
+    // Delete expired authorization codes that were never exchanged.
+    const authCodeResult = await this.prisma.authorizationCode.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+
+    // Delete expired impersonation sessions.
+    const impersonationResult = await this.prisma.impersonationSession.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+
+    const total =
+      oauthResult.count +
+      ssoResult.count +
+      refreshResult.count +
+      authCodeResult.count +
+      impersonationResult.count;
+
+    if (total > 0) {
+      this.logger.debug(
+        `Session cleanup removed ${oauthResult.count} OAuth session(s), ` +
+        `${ssoResult.count} SSO session(s), ` +
+        `${refreshResult.count} refresh token(s), ` +
+        `${authCodeResult.count} authorization code(s), ` +
+        `${impersonationResult.count} impersonation session(s)`,
+      );
+    }
+  }
+}

--- a/src/sessions/sessions.module.ts
+++ b/src/sessions/sessions.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SessionsService } from './sessions.service.js';
 import { SessionsController } from './sessions.controller.js';
+import { SessionsCleanupService } from './sessions-cleanup.service.js';
 
 @Module({
   controllers: [SessionsController],
-  providers: [SessionsService],
+  providers: [SessionsService, SessionsCleanupService],
   exports: [SessionsService],
 })
 export class SessionsModule {}


### PR DESCRIPTION
## Summary
- New `SessionsCleanupService` runs hourly to remove expired sessions, login sessions, refresh tokens, auth codes, and impersonation sessions
- `OAuthService` gets `@Interval` cleanup for expired authorization codes (every 5 min)
- Prevents indefinite database accumulation of stale entries

## Test plan
- [x] Unit tests pass for both new cleanup methods
- [x] TypeScript compilation passes

Closes #340
Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)