### PR TITLE
fix(security): timing-safe comparison, logout redirect validation, password hashing

### DIFF
--- a/src/common/guards/admin-api-key.guard.ts
+++ b/src/common/guards/admin-api-key.guard.ts
@@ -7,6 +7,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import type { Request } from 'express';
 import { Reflector } from '@nestjs/core';
+import { timingSafeEqual } from 'crypto';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator.js';
 import { AdminAuthService } from '../../admin-auth/admin-auth.service.js';
 
@@ -49,7 +50,11 @@ export class AdminApiKeyGuard implements CanActivate {
     const expectedKey = this.configService.get<string>('ADMIN_API_KEY');
     if (expectedKey) {
       const apiKey = request.headers['x-admin-api-key'];
-      if (typeof apiKey === 'string' && apiKey === expectedKey) {
+      if (
+        typeof apiKey === 'string' &&
+        apiKey.length === expectedKey.length &&
+        timingSafeEqual(Buffer.from(apiKey), Buffer.from(expectedKey))
+      ) {
         (request as any)['adminUser'] = { userId: 'api-key', roles: ['super-admin'] };
         return true;
       }

--- a/src/migration/keycloak-importer.service.ts
+++ b/src/migration/keycloak-importer.service.ts
@@ -265,7 +265,8 @@ export class KeycloakImporterService {
           continue;
         }
 
-        const { hash, algorithm } = this.extractKeycloakPassword(user);
+        const { hash: rawHash, algorithm, needsHashing } = this.extractKeycloakPassword(user);
+        const hash = (needsHashing && rawHash) ? await this.crypto.hashPassword(rawHash) : rawHash;
 
         if (!dryRun) {
           const created = await this.prisma.user.create({
@@ -304,7 +305,7 @@ export class KeycloakImporterService {
     }
   }
 
-  private extractKeycloakPassword(user: KeycloakUser): { hash: string | null; algorithm: string } {
+  private extractKeycloakPassword(user: KeycloakUser): { hash: string | null; algorithm: string; needsHashing?: boolean } {
     const passwordCred = user.credentials?.find(c => c.type === 'password');
     if (!passwordCred) return { hash: null, algorithm: 'argon2' };
 
@@ -317,7 +318,7 @@ export class KeycloakImporterService {
 
     if (passwordCred.value) {
       // Plain text password (rare) — hash it with Argon2
-      return { hash: passwordCred.value, algorithm: 'plaintext' };
+      return { hash: passwordCred.value, algorithm: 'argon2', needsHashing: true };
     }
 
     return { hash: null, algorithm: 'argon2' };

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -68,6 +68,17 @@ export class TokensController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    if (postLogoutRedirectUri) {
+      // Validate post_logout_redirect_uri against the client's registered
+      // redirect URIs *before* performing any session teardown so that an
+      // attacker cannot abuse the endpoint as an open redirector.
+      await this.tokensService.validatePostLogoutRedirectUri(
+        realm,
+        postLogoutRedirectUri,
+        idTokenHint,
+      );
+    }
+
     await this.tokensService.logoutByIdToken(realm, req.ip, idTokenHint);
 
     if (postLogoutRedirectUri) {

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   UnauthorizedException,
+  BadRequestException,
 } from '@nestjs/common';
 import type { Realm } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
@@ -13,6 +14,7 @@ import { TokenBlacklistService } from './token-blacklist.service.js';
 import { BackchannelLogoutService } from './backchannel-logout.service.js';
 import { EventsService } from '../events/events.service.js';
 import { LoginEventType } from '../events/event-types.js';
+import { matchesRedirectUri } from '../common/redirect-uri.utils.js';
 
 @Injectable()
 export class TokensService {
@@ -161,6 +163,71 @@ export class TokensService {
       }
     } catch {
       // Invalid or expired id_token — best-effort logout, don't throw
+    }
+  }
+
+  /**
+   * Validate a post_logout_redirect_uri against the client's registered
+   * redirectUris, derived from the id_token_hint (azp / aud claim).
+   *
+   * Throws BadRequestException if:
+   * - no id_token_hint is provided (no client context to validate against)
+   * - the client cannot be found in this realm
+   * - the URI does not match any of the client's registered redirectUris
+   */
+  async validatePostLogoutRedirectUri(
+    realm: Realm,
+    postLogoutRedirectUri: string,
+    idTokenHint?: string,
+  ): Promise<void> {
+    if (!idTokenHint) {
+      throw new BadRequestException(
+        'id_token_hint is required when post_logout_redirect_uri is specified',
+      );
+    }
+
+    // Decode the id_token_hint to obtain the client identifier (azp or aud).
+    // We do a best-effort decode — if the token is expired but otherwise well-
+    // formed we still extract the client id so the redirect can be validated.
+    let clientId: string | undefined;
+    try {
+      const signingKey = await this.prisma.realmSigningKey.findFirst({
+        where: { realmId: realm.id, active: true },
+        orderBy: { createdAt: 'desc' },
+      });
+      if (signingKey) {
+        const payload = await this.jwkService.verifyJwt(idTokenHint, signingKey.publicKey);
+        const p = payload as Record<string, unknown>;
+        // azp (authorized party) is the canonical client identifier in OIDC id_tokens
+        clientId =
+          (p['azp'] as string | undefined) ??
+          (Array.isArray(p['aud']) ? (p['aud'] as string[])[0] : (p['aud'] as string | undefined));
+      }
+    } catch {
+      // Token may be expired — fall through; clientId stays undefined
+    }
+
+    if (!clientId) {
+      throw new BadRequestException(
+        'Unable to determine client from id_token_hint',
+      );
+    }
+
+    const client = await this.prisma.client.findUnique({
+      where: { realmId_clientId: { realmId: realm.id, clientId } },
+      select: { redirectUris: true },
+    });
+
+    if (!client) {
+      throw new BadRequestException(
+        `Client '${clientId}' not found in this realm`,
+      );
+    }
+
+    if (!matchesRedirectUri(postLogoutRedirectUri, client.redirectUris)) {
+      throw new BadRequestException(
+        'post_logout_redirect_uri does not match any registered redirect URI for this client',
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- **#355**: Admin API key compared with `timingSafeEqual` instead of `===`
- **#359**: `post_logout_redirect_uri` validated against client's registered URIs
- **#362**: Keycloak importer hashes plaintext passwords with Argon2

## Test plan
- [x] TypeScript compilation passes
- [ ] Manual: API key timing attack no longer possible
- [ ] Manual: logout with unregistered redirect URI is rejected
- [ ] Manual: imported Keycloak users have hashed passwords

Closes #355, #359, #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)