### PR TITLE
fix(security): admin login rate limiting and token revocation cap fix

### DIFF
--- a/src/admin-auth/admin-auth.controller.spec.ts
+++ b/src/admin-auth/admin-auth.controller.spec.ts
@@ -1,44 +1,97 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException, HttpException, HttpStatus } from '@nestjs/common';
 import { AdminAuthController } from './admin-auth.controller.js';
+
+/** Build a minimal Express-like mock for req / res used by the login handler. */
+function makeReqRes(overrides: Partial<{ ip: string; forwardedFor: string }> = {}) {
+  const req: any = {
+    headers: overrides.forwardedFor ? { 'x-forwarded-for': overrides.forwardedFor } : {},
+    socket: { remoteAddress: overrides.ip ?? '127.0.0.1' },
+  };
+  const headers: Record<string, string> = {};
+  const res: any = {
+    setHeader: (name: string, value: string) => { headers[name] = value; },
+    _headers: headers,
+  };
+  return { req, res };
+}
 
 describe('AdminAuthController', () => {
   let controller: AdminAuthController;
   let adminAuthService: {
     login: jest.Mock;
+    revokeToken: jest.Mock;
   };
 
   beforeEach(() => {
     adminAuthService = {
       login: jest.fn(),
+      revokeToken: jest.fn(),
     };
     controller = new AdminAuthController(adminAuthService as any);
   });
 
   describe('login', () => {
-    it('should call adminAuthService.login and return token', async () => {
-      const tokenResponse = {
+    it('should call adminAuthService.login with username, password, and extracted IP', async () => {
+      const serviceResponse = {
         access_token: 'jwt-token',
         token_type: 'Bearer',
         expires_in: 3600,
+        rateLimitHeaders: {
+          'X-RateLimit-Limit': '5',
+          'X-RateLimit-Remaining': '4',
+          'X-RateLimit-Reset': '1700000060',
+        },
       };
-      adminAuthService.login.mockResolvedValue(tokenResponse);
+      adminAuthService.login.mockResolvedValue(serviceResponse);
+      const { req, res } = makeReqRes({ ip: '10.0.0.1' });
 
-      const result = await controller.login({
-        username: 'admin',
-        password: 'password',
+      const result = await controller.login({ username: 'admin', password: 'password' }, req, res);
+
+      expect(adminAuthService.login).toHaveBeenCalledWith('admin', 'password', '10.0.0.1');
+      // rateLimitHeaders must be forwarded to the response but NOT returned in body
+      expect(result).toEqual({
+        access_token: 'jwt-token',
+        token_type: 'Bearer',
+        expires_in: 3600,
       });
-
-      expect(result).toEqual(tokenResponse);
-      expect(adminAuthService.login).toHaveBeenCalledWith('admin', 'password');
+      expect(res._headers['X-RateLimit-Limit']).toBe('5');
+      expect(res._headers['X-RateLimit-Remaining']).toBe('4');
     });
 
-    it('should propagate errors from service', async () => {
+    it('should prefer x-forwarded-for header over socket address', async () => {
+      adminAuthService.login.mockResolvedValue({
+        access_token: 'tok',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        rateLimitHeaders: {},
+      });
+      const { req, res } = makeReqRes({ forwardedFor: '203.0.113.5, 10.0.0.1' });
+
+      await controller.login({ username: 'admin', password: 'pass' }, req, res);
+
+      // Should use first value from x-forwarded-for
+      expect(adminAuthService.login).toHaveBeenCalledWith('admin', 'pass', '203.0.113.5');
+    });
+
+    it('should propagate rate-limit errors from service', async () => {
+      adminAuthService.login.mockRejectedValue(
+        new HttpException('Too Many Requests', HttpStatus.TOO_MANY_REQUESTS),
+      );
+      const { req, res } = makeReqRes();
+
+      await expect(
+        controller.login({ username: 'admin', password: 'pass' }, req, res),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should propagate UnauthorizedException from service', async () => {
       adminAuthService.login.mockRejectedValue(
         new UnauthorizedException('Invalid credentials'),
       );
+      const { req, res } = makeReqRes();
 
       await expect(
-        controller.login({ username: 'admin', password: 'wrong' }),
+        controller.login({ username: 'admin', password: 'wrong' }, req, res),
       ).rejects.toThrow(UnauthorizedException);
     });
   });

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -1,6 +1,6 @@
-import { Controller, Post, Get, Body, Req, UnauthorizedException } from '@nestjs/common';
+import { Controller, Post, Get, Body, Req, Res, UnauthorizedException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
-import type { Request } from 'express';
+import type { Request, Response } from 'express';
 import { Public } from '../common/decorators/public.decorator.js';
 import { AdminAuthService } from './admin-auth.service.js';
 
@@ -13,8 +13,27 @@ export class AdminAuthController {
   @Post('login')
   @Public()
   @ApiOperation({ summary: 'Admin login' })
-  async login(@Body() body: { username: string; password: string }) {
-    return this.adminAuthService.login(body.username, body.password);
+  async login(
+    @Body() body: { username: string; password: string },
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const ip =
+      (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
+      req.socket?.remoteAddress ??
+      'unknown';
+
+    const { rateLimitHeaders, ...tokenResponse } = await this.adminAuthService.login(
+      body.username,
+      body.password,
+      ip,
+    );
+
+    for (const [name, value] of Object.entries(rateLimitHeaders)) {
+      res.setHeader(name, value);
+    }
+
+    return tokenResponse;
   }
 
   @Post('logout')

--- a/src/admin-auth/admin-auth.service.spec.ts
+++ b/src/admin-auth/admin-auth.service.spec.ts
@@ -1,4 +1,4 @@
-import { UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException, HttpException, HttpStatus } from '@nestjs/common';
 
 jest.mock('../crypto/jwk.service.js', () => ({
   JwkService: jest.fn(),
@@ -14,6 +14,11 @@ const masterRealm = {
   id: 'master-id',
   name: 'master',
   enabled: true,
+  bruteForceEnabled: true,
+  maxLoginFailures: 5,
+  lockoutDuration: 900,
+  failureResetTime: 600,
+  permanentLockoutAfter: 0,
 };
 
 const signingKey = {
@@ -33,13 +38,21 @@ const adminUser = {
   username: 'admin',
   enabled: true,
   passwordHash: 'hashed-password',
+  lockedUntil: null,
 };
+
+/** Allowed rate-limit result (not exhausted). */
+const rlAllowed = { allowed: true, limit: 5, remaining: 4, resetAt: 9999999999 };
+/** Denied rate-limit result (exhausted). */
+const rlDenied = { allowed: false, limit: 5, remaining: 0, resetAt: 9999999999, retryAfter: 30 };
 
 describe('AdminAuthService', () => {
   let service: AdminAuthService;
   let prisma: MockPrismaService;
   let crypto: { hashPassword: jest.Mock; verifyPassword: jest.Mock };
   let jwkService: { signJwt: jest.Mock; verifyJwt: jest.Mock };
+  let rateLimitService: { checkAdminIpLimit: jest.Mock; computeHeaders: jest.Mock };
+  let bruteForceService: { checkLocked: jest.Mock; recordFailure: jest.Mock; resetFailures: jest.Mock };
 
   beforeEach(() => {
     prisma = createMockPrismaService();
@@ -51,8 +64,27 @@ describe('AdminAuthService', () => {
       signJwt: jest.fn(),
       verifyJwt: jest.fn(),
     };
+    rateLimitService = {
+      checkAdminIpLimit: jest.fn().mockResolvedValue(rlAllowed),
+      computeHeaders: jest.fn().mockReturnValue({
+        'X-RateLimit-Limit': '5',
+        'X-RateLimit-Remaining': '4',
+        'X-RateLimit-Reset': '9999999999',
+      }),
+    };
+    bruteForceService = {
+      checkLocked: jest.fn().mockReturnValue({ locked: false }),
+      recordFailure: jest.fn().mockResolvedValue(undefined),
+      resetFailures: jest.fn().mockResolvedValue(undefined),
+    };
 
-    service = new AdminAuthService(prisma as any, crypto as any, jwkService as any);
+    service = new AdminAuthService(
+      prisma as any,
+      crypto as any,
+      jwkService as any,
+      rateLimitService as any,
+      bruteForceService as any,
+    );
   });
 
   // ─── login ─────────────────────────────────────────────
@@ -68,24 +100,90 @@ describe('AdminAuthService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(signingKey);
       jwkService.signJwt.mockResolvedValue('jwt-token');
 
-      const result = await service.login('admin', 'password');
+      const result = await service.login('admin', 'password', '127.0.0.1');
 
-      expect(result).toEqual({
-        access_token: 'jwt-token',
-        token_type: 'Bearer',
-        expires_in: 3600,
-      });
+      expect(result.access_token).toBe('jwt-token');
+      expect(result.token_type).toBe('Bearer');
+      expect(result.expires_in).toBe(3600);
+      expect(result.rateLimitHeaders).toBeDefined();
       expect(prisma.realm.findUnique).toHaveBeenCalledWith({ where: { name: 'master' } });
       expect(crypto.verifyPassword).toHaveBeenCalledWith('hashed-password', 'password');
+    });
+
+    it('should pass the caller IP to checkAdminIpLimit', async () => {
+      prisma.realm.findUnique.mockResolvedValue(masterRealm);
+      prisma.user.findUnique.mockResolvedValue(adminUser);
+      crypto.verifyPassword.mockResolvedValue(true);
+      prisma.userRole.findMany.mockResolvedValue([{ role: { name: 'super-admin' } }]);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(signingKey);
+      jwkService.signJwt.mockResolvedValue('tok');
+
+      await service.login('admin', 'password', '203.0.113.10');
+
+      expect(rateLimitService.checkAdminIpLimit).toHaveBeenCalledWith('203.0.113.10');
+    });
+
+    it('should throw 429 when IP rate limit is exceeded', async () => {
+      rateLimitService.checkAdminIpLimit.mockResolvedValue(rlDenied);
+
+      await expect(service.login('admin', 'password', '1.2.3.4')).rejects.toThrow(HttpException);
+      await expect(service.login('admin', 'password', '1.2.3.4')).rejects.toMatchObject({
+        status: HttpStatus.TOO_MANY_REQUESTS,
+      });
+      // Should NOT reach the DB when rate limited
+      expect(prisma.realm.findUnique).not.toHaveBeenCalled();
+    });
+
+    it('should throw 429 when account is brute-force locked', async () => {
+      prisma.realm.findUnique.mockResolvedValue(masterRealm);
+      prisma.user.findUnique.mockResolvedValue(adminUser);
+      bruteForceService.checkLocked.mockReturnValue({
+        locked: true,
+        lockedUntil: new Date('2099-01-01T00:00:00Z'),
+      });
+
+      await expect(service.login('admin', 'password', '1.2.3.4')).rejects.toMatchObject({
+        status: HttpStatus.TOO_MANY_REQUESTS,
+      });
+      // Password must NOT be verified when account is locked
+      expect(crypto.verifyPassword).not.toHaveBeenCalled();
+    });
+
+    it('should record brute-force failure on wrong password', async () => {
+      prisma.realm.findUnique.mockResolvedValue(masterRealm);
+      prisma.user.findUnique.mockResolvedValue(adminUser);
+      crypto.verifyPassword.mockResolvedValue(false);
+
+      await expect(service.login('admin', 'wrong', '5.5.5.5')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(bruteForceService.recordFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'master-id' }),
+        'user-1',
+        '5.5.5.5',
+      );
+    });
+
+    it('should reset brute-force counters on successful login', async () => {
+      prisma.realm.findUnique.mockResolvedValue(masterRealm);
+      prisma.user.findUnique.mockResolvedValue(adminUser);
+      crypto.verifyPassword.mockResolvedValue(true);
+      prisma.userRole.findMany.mockResolvedValue([{ role: { name: 'super-admin' } }]);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(signingKey);
+      jwkService.signJwt.mockResolvedValue('jwt-token');
+
+      await service.login('admin', 'password', '127.0.0.1');
+
+      expect(bruteForceService.resetFailures).toHaveBeenCalledWith('master-id', 'user-1');
     });
 
     it('should throw if master realm does not exist', async () => {
       prisma.realm.findUnique.mockResolvedValue(null);
 
-      await expect(service.login('admin', 'password')).rejects.toThrow(
+      await expect(service.login('admin', 'password', '127.0.0.1')).rejects.toThrow(
         UnauthorizedException,
       );
-      await expect(service.login('admin', 'password')).rejects.toThrow(
+      await expect(service.login('admin', 'password', '127.0.0.1')).rejects.toThrow(
         'Admin system not initialized',
       );
     });
@@ -94,7 +192,7 @@ describe('AdminAuthService', () => {
       prisma.realm.findUnique.mockResolvedValue(masterRealm);
       prisma.user.findUnique.mockResolvedValue(null);
 
-      await expect(service.login('unknown', 'password')).rejects.toThrow(
+      await expect(service.login('unknown', 'password', '127.0.0.1')).rejects.toThrow(
         UnauthorizedException,
       );
     });
@@ -103,7 +201,7 @@ describe('AdminAuthService', () => {
       prisma.realm.findUnique.mockResolvedValue(masterRealm);
       prisma.user.findUnique.mockResolvedValue({ ...adminUser, enabled: false });
 
-      await expect(service.login('admin', 'password')).rejects.toThrow(
+      await expect(service.login('admin', 'password', '127.0.0.1')).rejects.toThrow(
         'Invalid credentials',
       );
     });
@@ -112,7 +210,7 @@ describe('AdminAuthService', () => {
       prisma.realm.findUnique.mockResolvedValue(masterRealm);
       prisma.user.findUnique.mockResolvedValue({ ...adminUser, passwordHash: null });
 
-      await expect(service.login('admin', 'password')).rejects.toThrow(
+      await expect(service.login('admin', 'password', '127.0.0.1')).rejects.toThrow(
         'Invalid credentials',
       );
     });
@@ -122,7 +220,7 @@ describe('AdminAuthService', () => {
       prisma.user.findUnique.mockResolvedValue(adminUser);
       crypto.verifyPassword.mockResolvedValue(false);
 
-      await expect(service.login('admin', 'wrong')).rejects.toThrow(
+      await expect(service.login('admin', 'wrong', '127.0.0.1')).rejects.toThrow(
         'Invalid credentials',
       );
     });
@@ -135,7 +233,7 @@ describe('AdminAuthService', () => {
         { role: { name: 'regular-user' } },
       ]);
 
-      await expect(service.login('admin', 'password')).rejects.toThrow(
+      await expect(service.login('admin', 'password', '127.0.0.1')).rejects.toThrow(
         'User does not have admin access',
       );
     });
@@ -149,7 +247,7 @@ describe('AdminAuthService', () => {
       ]);
       prisma.realmSigningKey.findFirst.mockResolvedValue(null);
 
-      await expect(service.login('admin', 'password')).rejects.toThrow(
+      await expect(service.login('admin', 'password', '127.0.0.1')).rejects.toThrow(
         'No signing key found for master realm',
       );
     });
@@ -164,7 +262,7 @@ describe('AdminAuthService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(signingKey);
       jwkService.signJwt.mockResolvedValue('jwt-token');
 
-      const result = await service.login('admin', 'password');
+      const result = await service.login('admin', 'password', '127.0.0.1');
       expect(result.access_token).toBe('jwt-token');
     });
 
@@ -178,7 +276,7 @@ describe('AdminAuthService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(signingKey);
       jwkService.signJwt.mockResolvedValue('jwt-token');
 
-      const result = await service.login('admin', 'password');
+      const result = await service.login('admin', 'password', '127.0.0.1');
       expect(result.access_token).toBe('jwt-token');
     });
   });

--- a/src/admin-auth/admin-auth.service.ts
+++ b/src/admin-auth/admin-auth.service.ts
@@ -1,20 +1,51 @@
-import { Injectable, UnauthorizedException, Logger } from '@nestjs/common';
+import { Injectable, UnauthorizedException, Logger, HttpException, HttpStatus } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { JwkService } from '../crypto/jwk.service.js';
+import { RateLimitService } from '../rate-limit/rate-limit.service.js';
+import { BruteForceService } from '../brute-force/brute-force.service.js';
 
 @Injectable()
 export class AdminAuthService {
   private readonly logger = new Logger(AdminAuthService.name);
-  private readonly revokedTokens = new Set<string>();
+  /**
+   * Maps a raw admin token string to its expiry unix timestamp (seconds).
+   * Using a Map instead of a Set lets us evict only truly expired entries
+   * rather than clearing the entire collection when it grows large.
+   */
+  private readonly revokedTokens = new Map<string, number>();
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly crypto: CryptoService,
     private readonly jwkService: JwkService,
+    private readonly rateLimitService: RateLimitService,
+    private readonly bruteForceService: BruteForceService,
   ) {}
 
-  async login(username: string, password: string) {
+  async login(username: string, password: string, ip: string = 'unknown'): Promise<{
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+    rateLimitHeaders: Record<string, string>;
+  }> {
+    // ── IP-based rate limiting ────────────────────────────────────────────────
+    // Applied before any DB work so it protects at network-edge cost.
+    const rlResult = await this.rateLimitService.checkAdminIpLimit(ip);
+    const rateLimitHeaders = this.rateLimitService.computeHeaders(rlResult);
+
+    if (!rlResult.allowed) {
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          error: 'Too Many Requests',
+          message: 'Admin login rate limit exceeded. Please slow down.',
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    // ── Realm & user lookup ───────────────────────────────────────────────────
     const masterRealm = await this.prisma.realm.findUnique({
       where: { name: 'master' },
     });
@@ -31,8 +62,25 @@ export class AdminAuthService {
       throw new UnauthorizedException('Invalid credentials');
     }
 
+    // ── Brute-force lockout check ─────────────────────────────────────────────
+    const lockStatus = this.bruteForceService.checkLocked(masterRealm as any, user as any);
+    if (lockStatus.locked) {
+      const lockedUntil = lockStatus.lockedUntil?.toISOString() ?? 'indefinitely';
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          error: 'Too Many Requests',
+          message: `Account locked due to too many failed login attempts. Locked until: ${lockedUntil}`,
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    // ── Password verification ─────────────────────────────────────────────────
     const valid = await this.crypto.verifyPassword(user.passwordHash, password);
     if (!valid) {
+      // Record the failure so brute-force protection can lock the account.
+      await this.bruteForceService.recordFailure(masterRealm as any, user.id, ip);
       throw new UnauthorizedException('Invalid credentials');
     }
 
@@ -48,6 +96,9 @@ export class AdminAuthService {
     if (!roles.some((r) => ['super-admin', 'realm-admin', 'view-only'].includes(r))) {
       throw new UnauthorizedException('User does not have admin access');
     }
+
+    // ── Reset brute-force counters on successful login ────────────────────────
+    await this.bruteForceService.resetFailures(masterRealm.id, user.id);
 
     // Sign admin JWT with master realm signing key
     const signingKey = await this.prisma.realmSigningKey.findFirst({
@@ -77,21 +128,32 @@ export class AdminAuthService {
       access_token: token,
       token_type: 'Bearer',
       expires_in: 3600,
+      rateLimitHeaders,
     };
   }
 
-  revokeToken(token: string): void {
-    this.revokedTokens.add(token);
-    // Clean up expired tokens periodically to prevent unbounded growth
-    if (this.revokedTokens.size > 1000) {
-      this.revokedTokens.clear();
+  revokeToken(token: string, expiresInSeconds = 3600): void {
+    const expiresAt = Math.floor(Date.now() / 1000) + expiresInSeconds;
+    this.revokedTokens.set(token, expiresAt);
+    // Evict only expired entries to prevent unbounded growth.
+    // Never clear the whole map — that would make revoked tokens valid again.
+    this.evictExpiredRevokedTokens();
+  }
+
+  private evictExpiredRevokedTokens(): void {
+    const now = Math.floor(Date.now() / 1000);
+    for (const [token, expiresAt] of this.revokedTokens) {
+      if (expiresAt <= now) {
+        this.revokedTokens.delete(token);
+      }
     }
   }
 
   async validateAdminToken(
     token: string,
   ): Promise<{ userId: string; roles: string[] }> {
-    if (this.revokedTokens.has(token)) {
+    const revokedExpiry = this.revokedTokens.get(token);
+    if (revokedExpiry !== undefined && revokedExpiry > Math.floor(Date.now() / 1000)) {
       throw new UnauthorizedException('Token has been revoked');
     }
 

--- a/src/rate-limit/rate-limit.service.ts
+++ b/src/rate-limit/rate-limit.service.ts
@@ -70,6 +70,17 @@ export class RateLimitService {
     );
   }
 
+  /**
+   * IP-based rate limit for the admin login endpoint.
+   * Uses fixed conservative limits (5 req/min, 50 req/hour) with a
+   * dedicated key namespace — no realm DB lookup required.
+   */
+  async checkAdminIpLimit(ip: string): Promise<RateLimitResult> {
+    const ADMIN_LIMIT_PER_MINUTE = 5;
+    const ADMIN_LIMIT_PER_HOUR = 50;
+    return this.check(`admin:ip:${ip}`, ADMIN_LIMIT_PER_MINUTE, ADMIN_LIMIT_PER_HOUR);
+  }
+
   async checkIpLimit(ip: string, realmId: string): Promise<RateLimitResult> {
     const realm = await this.prisma.realm.findUnique({
       where: { id: realmId },


### PR DESCRIPTION
## Summary
- **#356**: Admin login endpoint now has IP-based rate limiting (5/min, 50/hr) and brute-force lockout
- **#358**: Admin revoked token set uses TTL-based eviction instead of clearing all at 1000 entries

## Test plan
- [x] Unit tests updated and passing
- [ ] Manual: admin login blocked after 5 rapid failures
- [ ] Manual: revoking >1000 admin tokens doesn't clear previous revocations

Closes #356, #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)