### PR TITLE
fix(tests): add missing CacheService mocks to 7 test suites

### DIFF
--- a/src/clients/clients.service.spec.ts
+++ b/src/clients/clients.service.spec.ts
@@ -9,6 +9,30 @@ import {
 } from '../prisma/prisma.mock.js';
 import type { Realm } from '@prisma/client';
 
+function createMockCacheService() {
+  return {
+    getCachedClientConfig: jest.fn().mockResolvedValue(null),
+    cacheClientConfig: jest.fn().mockResolvedValue(undefined),
+    invalidateClientCache: jest.fn().mockResolvedValue(undefined),
+    getCachedRealmConfig: jest.fn().mockResolvedValue(null),
+    cacheRealmConfig: jest.fn().mockResolvedValue(undefined),
+    invalidateRealmCache: jest.fn().mockResolvedValue(undefined),
+    getCachedRealmByName: jest.fn().mockResolvedValue(null),
+    cacheRealmByName: jest.fn().mockResolvedValue(undefined),
+    getCachedJWKS: jest.fn().mockResolvedValue(null),
+    cacheJWKS: jest.fn().mockResolvedValue(undefined),
+    cacheCorsOrigins: jest.fn().mockResolvedValue(undefined),
+    getCachedCorsOrigins: jest.fn().mockResolvedValue(null),
+    invalidateCorsOrigins: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockCorsOriginService() {
+  return {
+    invalidateLocalCache: jest.fn(),
+  };
+}
+
 describe('ClientsService', () => {
   let service: ClientsService;
   let prisma: MockPrismaService;
@@ -23,6 +47,8 @@ describe('ClientsService', () => {
     getOptionalScopeNames: jest.Mock;
     seedDefaultScopes: jest.Mock;
   };
+  let cacheService: ReturnType<typeof createMockCacheService>;
+  let corsOriginService: ReturnType<typeof createMockCorsOriginService>;
 
   const mockRealm: Realm = {
     id: 'realm-1',
@@ -63,6 +89,8 @@ describe('ClientsService', () => {
       getOptionalScopeNames: jest.fn().mockReturnValue(['web-origins', 'offline_access']),
       seedDefaultScopes: jest.fn().mockResolvedValue(undefined),
     };
+    cacheService = createMockCacheService();
+    corsOriginService = createMockCorsOriginService();
     prisma.clientScope.findFirst.mockResolvedValue(null);
     prisma.clientScope.findMany.mockResolvedValue([
       { id: 'scope-1', name: 'openid', realmId: 'realm-1' },
@@ -77,7 +105,7 @@ describe('ClientsService', () => {
     prisma.user.create.mockResolvedValue({ id: 'sa-user-1' });
     prisma.clientDefaultScope.create.mockResolvedValue({});
     prisma.clientOptionalScope.create.mockResolvedValue({});
-    service = new ClientsService(prisma as any, cryptoService as any, scopeSeedService as any);
+    service = new ClientsService(prisma as any, cryptoService as any, scopeSeedService as any, cacheService as any, corsOriginService as any);
   });
 
   describe('create', () => {

--- a/src/health/health.controller.spec.ts
+++ b/src/health/health.controller.spec.ts
@@ -7,6 +7,7 @@ describe('HealthController', () => {
   let healthCheckService: { check: jest.Mock };
   let prismaHealth: { isHealthy: jest.Mock };
   let memoryHealth: { checkHeap: jest.Mock };
+  let redisHealth: { isHealthy: jest.Mock };
 
   beforeEach(() => {
     healthCheckService = {
@@ -14,11 +15,13 @@ describe('HealthController', () => {
     };
     prismaHealth = { isHealthy: jest.fn() };
     memoryHealth = { checkHeap: jest.fn() };
+    redisHealth = { isHealthy: jest.fn() };
 
     controller = new HealthController(
       healthCheckService as any,
       memoryHealth as any,
       prismaHealth as any,
+      redisHealth as any,
     );
   });
 

--- a/src/realms/realms.service.spec.ts
+++ b/src/realms/realms.service.spec.ts
@@ -14,10 +14,34 @@ import {
   MockPrismaService,
 } from '../prisma/prisma.mock.js';
 
+function createMockCacheService() {
+  return {
+    getCachedClientConfig: jest.fn().mockResolvedValue(null),
+    cacheClientConfig: jest.fn().mockResolvedValue(undefined),
+    invalidateClientCache: jest.fn().mockResolvedValue(undefined),
+    getCachedRealmConfig: jest.fn().mockResolvedValue(null),
+    cacheRealmConfig: jest.fn().mockResolvedValue(undefined),
+    invalidateRealmCache: jest.fn().mockResolvedValue(undefined),
+    getCachedRealmByName: jest.fn().mockResolvedValue(null),
+    cacheRealmByName: jest.fn().mockResolvedValue(undefined),
+    getCachedJWKS: jest.fn().mockResolvedValue(null),
+    cacheJWKS: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockThemeService() {
+  return {
+    getAvailableThemes: jest.fn().mockReturnValue([]),
+    getTheme: jest.fn().mockReturnValue(null),
+  };
+}
+
 describe('RealmsService', () => {
   let service: RealmsService;
   let prisma: MockPrismaService;
   let jwkService: { generateRsaKeyPair: jest.Mock };
+  let cacheService: ReturnType<typeof createMockCacheService>;
+  let themeService: ReturnType<typeof createMockThemeService>;
 
   const mockRealm = {
     id: 'realm-1',
@@ -41,12 +65,20 @@ describe('RealmsService', () => {
     jwkService = {
       generateRsaKeyPair: jest.fn(),
     };
+    cacheService = createMockCacheService();
+    themeService = createMockThemeService();
     const scopeSeedService = {
       seedDefaultScopes: jest.fn().mockResolvedValue(undefined),
       getDefaultScopeNames: jest.fn().mockReturnValue(['openid', 'profile', 'email', 'roles']),
       getOptionalScopeNames: jest.fn().mockReturnValue(['web-origins', 'offline_access']),
     };
-    service = new RealmsService(prisma as any, jwkService as any, scopeSeedService as any);
+    service = new RealmsService(
+      prisma as any,
+      jwkService as any,
+      scopeSeedService as any,
+      themeService as any,
+      cacheService as any,
+    );
   });
 
   describe('create', () => {

--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -1,5 +1,6 @@
 jest.mock('../crypto/jwk.service.js', () => ({ JwkService: jest.fn() }));
 
+import { UnauthorizedException } from '@nestjs/common';
 import { TokensController } from './tokens.controller.js';
 import type { Realm } from '@prisma/client';
 
@@ -98,27 +99,17 @@ describe('TokensController', () => {
       expect(result).toEqual(expected);
     });
 
-    it('should return an error object when Authorization header is missing', () => {
+    it('should throw UnauthorizedException when Authorization header is missing', () => {
       const req = { headers: {} };
 
-      const result = controller.userinfo(realm, req as any);
-
-      expect(result).toEqual({
-        error: 'invalid_token',
-        error_description: 'Missing Bearer token',
-      });
+      expect(() => controller.userinfo(realm, req as any)).toThrow(UnauthorizedException);
       expect(mockTokensService.userinfo).not.toHaveBeenCalled();
     });
 
-    it('should return an error object when Authorization header does not start with Bearer', () => {
+    it('should throw UnauthorizedException when Authorization header does not start with Bearer', () => {
       const req = { headers: { authorization: 'Basic dXNlcjpwYXNz' } };
 
-      const result = controller.userinfo(realm, req as any);
-
-      expect(result).toEqual({
-        error: 'invalid_token',
-        error_description: 'Missing Bearer token',
-      });
+      expect(() => controller.userinfo(realm, req as any)).toThrow(UnauthorizedException);
       expect(mockTokensService.userinfo).not.toHaveBeenCalled();
     });
   });

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -327,7 +327,7 @@ describe('TokensService', () => {
       prisma.refreshToken.updateMany.mockResolvedValue({ count: 2 });
       prisma.session.delete.mockResolvedValue({});
 
-      await service.logout(mockRealm, 'refresh-token-value');
+      await service.logout(mockRealm, '127.0.0.1', 'refresh-token-value');
 
       expect(cryptoService.sha256).toHaveBeenCalledWith('refresh-token-value');
       expect(prisma.refreshToken.findUnique).toHaveBeenCalledWith({
@@ -348,7 +348,7 @@ describe('TokensService', () => {
       prisma.refreshToken.findUnique.mockResolvedValue(null);
 
       await expect(
-        service.logout(mockRealm, 'invalid-refresh'),
+        service.logout(mockRealm, '127.0.0.1', 'invalid-refresh'),
       ).rejects.toThrow(UnauthorizedException);
     });
   });

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -70,6 +70,9 @@ describe('UsersService', () => {
       getSubject: jest.fn().mockReturnValue('Verify Your Email — AuthMe'),
       renderEmail: jest.fn().mockReturnValue('<html>verify</html>'),
     };
+    const bruteForceService = {
+      resetFailures: jest.fn().mockResolvedValue(undefined),
+    };
     service = new UsersService(
       prisma as any,
       cryptoService as any,
@@ -78,6 +81,7 @@ describe('UsersService', () => {
       configService as any,
       passwordPolicyService as any,
       themeEmailService as any,
+      bruteForceService as any,
     );
   });
 

--- a/src/well-known/well-known.controller.spec.ts
+++ b/src/well-known/well-known.controller.spec.ts
@@ -7,10 +7,26 @@ import {
 } from '../prisma/prisma.mock.js';
 import type { Realm } from '@prisma/client';
 
+function createMockCacheService() {
+  return {
+    getCachedClientConfig: jest.fn().mockResolvedValue(null),
+    cacheClientConfig: jest.fn().mockResolvedValue(undefined),
+    invalidateClientCache: jest.fn().mockResolvedValue(undefined),
+    getCachedRealmConfig: jest.fn().mockResolvedValue(null),
+    cacheRealmConfig: jest.fn().mockResolvedValue(undefined),
+    invalidateRealmCache: jest.fn().mockResolvedValue(undefined),
+    getCachedRealmByName: jest.fn().mockResolvedValue(null),
+    cacheRealmByName: jest.fn().mockResolvedValue(undefined),
+    getCachedJWKS: jest.fn().mockResolvedValue(null),
+    cacheJWKS: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe('WellKnownController', () => {
   let controller: WellKnownController;
   let prisma: MockPrismaService;
   let mockJwkService: { publicKeyToJwk: jest.Mock };
+  let mockCacheService: ReturnType<typeof createMockCacheService>;
 
   const realm = {
     id: 'realm-1',
@@ -23,8 +39,9 @@ describe('WellKnownController', () => {
     mockJwkService = {
       publicKeyToJwk: jest.fn(),
     };
+    mockCacheService = createMockCacheService();
 
-    controller = new WellKnownController(prisma as any, mockJwkService as any);
+    controller = new WellKnownController(prisma as any, mockJwkService as any, mockCacheService as any);
     process.env['BASE_URL'] = 'https://auth.example.com';
   });
 


### PR DESCRIPTION
## Summary
- Add CacheService mock to clients, realms, well-known, health test suites
- Add BruteForceService mock to users test suite
- Update tokens specs for updated method signatures
- Fixes all 23 previously failing unit tests

## Test plan
- [x] All 7 previously failing test suites now pass

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)