### PR TITLE
fix(backend,admin-ui): cache CORS origins and add 404 page

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -32,6 +32,7 @@ import LoginEventsPage from './pages/events/LoginEventsPage';
 import AdminEventsPage from './pages/events/AdminEventsPage';
 import AuthFlowListPage from './pages/auth-flows/AuthFlowListPage';
 import AuthFlowEditorPage from './pages/auth-flows/AuthFlowEditorPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 function ProtectedRoute() {
   const apiKey = sessionStorage.getItem('adminApiKey');
@@ -81,11 +82,13 @@ export default function App() {
           <Route path="/console/realms/:name/saml-providers/:id" element={<SamlSpDetailPage />} />
           <Route path="/console/realms/:name/auth-flows" element={<AuthFlowListPage />} />
           <Route path="/console/realms/:name/auth-flows/:flowId" element={<AuthFlowEditorPage />} />
+          {/* Catch-all for unknown /console/... paths — rendered inside the Layout shell */}
+          <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Route>
 
-      {/* Catch-all: redirect to console */}
-      <Route path="*" element={<Navigate to="/console/" replace />} />
+      {/* Catch-all for every other URL (e.g. bare / or unknown top-level paths) */}
+      <Route path="*" element={<NotFoundPage />} />
     </Routes>
   );
 }

--- a/admin-ui/src/pages/NotFoundPage.tsx
+++ b/admin-ui/src/pages/NotFoundPage.tsx
@@ -1,0 +1,39 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+
+export default function NotFoundPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-10 text-center shadow-sm">
+        {/* 404 numeric display */}
+        <p className="text-8xl font-extrabold tracking-tight text-indigo-600">404</p>
+
+        <h1 className="mt-4 text-2xl font-bold text-gray-900">Page Not Found</h1>
+        <p className="mt-2 text-sm text-gray-500">
+          The page{' '}
+          <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-700">
+            {location.pathname}
+          </code>{' '}
+          does not exist.
+        </p>
+
+        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:justify-center">
+          <button
+            onClick={() => navigate(-1)}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            Go Back
+          </button>
+          <button
+            onClick={() => navigate('/console', { replace: true })}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+          >
+            Go to Dashboard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -55,6 +55,7 @@ import { StepUpModule } from './step-up/step-up.module.js';
 import { OrganizationsModule } from './organizations/organizations.module.js';
 import { RiskAssessmentModule } from './risk-assessment/risk-assessment.module.js';
 import { MigrationModule } from './migration/migration.module.js';
+import { CorsModule } from './cors/cors.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -120,6 +121,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     OrganizationsModule,
     RiskAssessmentModule,
     MigrationModule,
+    CorsModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/cache/cache.service.spec.ts
+++ b/src/cache/cache.service.spec.ts
@@ -160,6 +160,55 @@ describe('CacheService', () => {
     });
   });
 
+  // ─── CORS allowed origins ─────────────────────────────────────────────
+
+  describe('CORS allowed origins', () => {
+    it('cacheCorsOrigins stores JSON with default 300 s TTL', async () => {
+      const origins = ['https://app.example.com', '*'];
+      await service.cacheCorsOrigins(origins);
+      expect(redis.set).toHaveBeenCalledWith(
+        'cors:allowed-origins',
+        JSON.stringify(origins),
+        300,
+      );
+    });
+
+    it('cacheCorsOrigins respects a custom TTL', async () => {
+      await service.cacheCorsOrigins(['https://a.com'], 60);
+      expect(redis.set).toHaveBeenCalledWith(
+        'cors:allowed-origins',
+        JSON.stringify(['https://a.com']),
+        60,
+      );
+    });
+
+    it('getCachedCorsOrigins returns null on cache miss', async () => {
+      redis.get.mockResolvedValue(null);
+      const result = await service.getCachedCorsOrigins();
+      expect(result).toBeNull();
+      expect(metrics.cacheOperationsTotal.inc).toHaveBeenCalledWith({
+        operation: 'miss',
+        cache: 'cors_origins',
+      });
+    });
+
+    it('getCachedCorsOrigins returns the parsed array on cache hit', async () => {
+      const origins = ['https://app.example.com'];
+      redis.get.mockResolvedValue(JSON.stringify(origins));
+      const result = await service.getCachedCorsOrigins();
+      expect(result).toEqual(origins);
+      expect(metrics.cacheOperationsTotal.inc).toHaveBeenCalledWith({
+        operation: 'hit',
+        cache: 'cors_origins',
+      });
+    });
+
+    it('invalidateCorsOrigins deletes the cors:allowed-origins key', async () => {
+      await service.invalidateCorsOrigins();
+      expect(redis.del).toHaveBeenCalledWith('cors:allowed-origins');
+    });
+  });
+
   // ─── No-op when Redis unavailable ────────────────────────────────────
 
   describe('when Redis is unavailable', () => {

--- a/src/cache/cache.service.ts
+++ b/src/cache/cache.service.ts
@@ -7,6 +7,7 @@ const KEY = {
   realmByName: (name: string) => `realm:name:${name}`,
   client: (clientId: string) => `client:config:${clientId}`,
   jwks: (realmId: string) => `realm:jwks:${realmId}`,
+  corsOrigins: 'cors:allowed-origins',
 } as const;
 
 @Injectable()
@@ -74,6 +75,33 @@ export class CacheService {
 
   async getCachedJWKS<T = unknown>(realmId: string): Promise<T | null> {
     return this.getJson<T>(KEY.jwks(realmId), 'jwks');
+  }
+
+  // ─── CORS allowed origins ────────────────────────────────────────────────
+
+  /**
+   * Persist the full set of allowed CORS origins to Redis.
+   * @param origins - flat array of origin strings (e.g. ["https://app.example.com", "*"])
+   * @param ttl     - seconds until expiry (default 300 s)
+   */
+  async cacheCorsOrigins(origins: string[], ttl = 300): Promise<void> {
+    if (!this.redis.isAvailable()) return;
+    await this.redis.set(KEY.corsOrigins, JSON.stringify(origins), ttl);
+  }
+
+  /**
+   * Retrieve the cached set of allowed CORS origins.
+   * Returns null when there is no entry (cache miss or Redis unavailable).
+   */
+  async getCachedCorsOrigins(): Promise<string[] | null> {
+    return this.getJson<string[]>(KEY.corsOrigins, 'cors_origins');
+  }
+
+  /** Remove the CORS origins cache entry so the next request re-fetches from the DB. */
+  async invalidateCorsOrigins(): Promise<void> {
+    if (!this.redis.isAvailable()) return;
+    await this.redis.del(KEY.corsOrigins);
+    this.logger.debug('Invalidated CORS allowed-origins cache');
   }
 
   // ─── Internal helpers ────────────────────────────────────────────────────

--- a/src/clients/clients.module.ts
+++ b/src/clients/clients.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ClientsController } from './clients.controller.js';
 import { ClientsService } from './clients.service.js';
 import { CacheModule } from '../cache/cache.module.js';
+import { CorsModule } from '../cors/cors.module.js';
 
 @Module({
-  imports: [CacheModule],
+  imports: [CacheModule, CorsModule],
   controllers: [ClientsController],
   providers: [ClientsService],
   exports: [ClientsService],

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -8,6 +8,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { ScopeSeedService } from '../scopes/scope-seed.service.js';
 import { CacheService } from '../cache/cache.service.js';
+import { CorsOriginService } from '../cors/cors-origin.service.js';
 import { CreateClientDto } from './dto/create-client.dto.js';
 import { UpdateClientDto } from './dto/update-client.dto.js';
 
@@ -37,6 +38,7 @@ export class ClientsService {
     private readonly crypto: CryptoService,
     private readonly scopeSeedService: ScopeSeedService,
     private readonly cache: CacheService,
+    private readonly corsOriginService: CorsOriginService,
   ) {}
 
   async create(realm: Realm, dto: CreateClientDto) {
@@ -99,6 +101,10 @@ export class ClientsService {
     // Assign default and optional scopes to the new client
     await this.assignBuiltInScopes(realm.id, client.id);
 
+    // A new client may introduce additional allowed origins — bust the CORS cache.
+    await this.cache.invalidateCorsOrigins();
+    this.corsOriginService.invalidateLocalCache();
+
     return {
       ...client,
       ...(rawSecret
@@ -159,6 +165,11 @@ export class ClientsService {
 
     await this.cache.invalidateClientCache(`${realm.id}:${clientId}`);
 
+    // webOrigins may have changed — bust the CORS cache so new origins take effect
+    // and revoked ones are no longer accepted.
+    await this.cache.invalidateCorsOrigins();
+    this.corsOriginService.invalidateLocalCache();
+
     return updated;
   }
 
@@ -179,6 +190,10 @@ export class ClientsService {
     });
 
     await this.cache.invalidateClientCache(`${realm.id}:${clientId}`);
+
+    // Deleted client's origins should no longer be accepted — bust the CORS cache.
+    await this.cache.invalidateCorsOrigins();
+    this.corsOriginService.invalidateLocalCache();
   }
 
   async getServiceAccount(realm: Realm, clientId: string) {

--- a/src/cors/cors-origin.service.spec.ts
+++ b/src/cors/cors-origin.service.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CorsOriginService } from './cors-origin.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CacheService } from '../cache/cache.service.js';
+
+const makeMockPrisma = (webOriginsList: string[][] = []) => ({
+  client: {
+    findMany: jest.fn().mockResolvedValue(
+      webOriginsList.map((webOrigins) => ({ webOrigins })),
+    ),
+  },
+});
+
+const makeMockCache = (cachedOrigins: string[] | null = null) => ({
+  getCachedCorsOrigins: jest.fn().mockResolvedValue(cachedOrigins),
+  cacheCorsOrigins: jest.fn().mockResolvedValue(undefined),
+  invalidateCorsOrigins: jest.fn().mockResolvedValue(undefined),
+});
+
+describe('CorsOriginService', () => {
+  let service: CorsOriginService;
+  let prisma: ReturnType<typeof makeMockPrisma>;
+  let cache: ReturnType<typeof makeMockCache>;
+
+  async function build(
+    webOriginsList: string[][] = [],
+    cachedOrigins: string[] | null = null,
+  ) {
+    prisma = makeMockPrisma(webOriginsList);
+    cache = makeMockCache(cachedOrigins);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CorsOriginService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CacheService, useValue: cache },
+      ],
+    }).compile();
+
+    service = module.get<CorsOriginService>(CorsOriginService);
+  }
+
+  // ─── Cache miss → DB load ─────────────────────────────────────────────
+
+  describe('when Redis has no cached value', () => {
+    beforeEach(() => build([['https://app.example.com', 'https://admin.example.com']]));
+
+    it('loads origins from the database on first call', async () => {
+      expect(await service.isOriginAllowed('https://app.example.com')).toBe(true);
+      expect(prisma.client.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('denies an origin not in any client webOrigins', async () => {
+      expect(await service.isOriginAllowed('https://evil.com')).toBe(false);
+    });
+
+    it('persists the loaded origins to Redis', async () => {
+      await service.isOriginAllowed('https://app.example.com');
+      expect(cache.cacheCorsOrigins).toHaveBeenCalledWith(
+        expect.arrayContaining(['https://app.example.com', 'https://admin.example.com']),
+      );
+    });
+  });
+
+  // ─── Redis cache hit ──────────────────────────────────────────────────
+
+  describe('when Redis has a cached value', () => {
+    beforeEach(() => build([], ['https://cached.example.com']));
+
+    it('uses the cached value without hitting the database', async () => {
+      expect(await service.isOriginAllowed('https://cached.example.com')).toBe(true);
+      expect(prisma.client.findMany).not.toHaveBeenCalled();
+    });
+
+    it('denies origins not in the Redis cache', async () => {
+      expect(await service.isOriginAllowed('https://other.com')).toBe(false);
+    });
+  });
+
+  // ─── In-process cache (second call) ──────────────────────────────────
+
+  describe('in-process caching', () => {
+    beforeEach(() => build([['https://app.example.com']]));
+
+    it('does not hit Redis or the DB on a second call within TTL', async () => {
+      await service.isOriginAllowed('https://app.example.com');
+      await service.isOriginAllowed('https://app.example.com');
+
+      // Redis + DB each called only once despite two isOriginAllowed calls
+      expect(cache.getCachedCorsOrigins).toHaveBeenCalledTimes(1);
+      expect(prisma.client.findMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── Wildcard support ─────────────────────────────────────────────────
+
+  describe('wildcard origin', () => {
+    beforeEach(() => build([['*']]));
+
+    it('allows any origin when a client has webOrigin "*"', async () => {
+      expect(await service.isOriginAllowed('https://anything.example.com')).toBe(true);
+    });
+  });
+
+  // ─── invalidateLocalCache ─────────────────────────────────────────────
+
+  describe('invalidateLocalCache', () => {
+    beforeEach(() => build([['https://app.example.com']]));
+
+    it('forces a DB reload on the next call after invalidation', async () => {
+      // Populate in-process cache
+      await service.isOriginAllowed('https://app.example.com');
+      expect(prisma.client.findMany).toHaveBeenCalledTimes(1);
+
+      service.invalidateLocalCache();
+
+      // After invalidation the cache is gone — Redis returns null again
+      cache.getCachedCorsOrigins.mockResolvedValue(null);
+
+      await service.isOriginAllowed('https://app.example.com');
+      expect(prisma.client.findMany).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ─── DB error handling ────────────────────────────────────────────────
+
+  describe('when the database throws', () => {
+    beforeEach(async () => {
+      await build();
+      prisma.client.findMany.mockRejectedValue(new Error('connection lost'));
+    });
+
+    it('returns false for any origin (deny-safe) without throwing', async () => {
+      expect(await service.isOriginAllowed('https://app.example.com')).toBe(false);
+    });
+  });
+});

--- a/src/cors/cors-origin.service.ts
+++ b/src/cors/cors-origin.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CacheService } from '../cache/cache.service.js';
+
+/**
+ * CorsOriginService
+ *
+ * Centralises the "is this Origin allowed?" check that the CORS middleware runs
+ * on every cross-origin request.  Without caching each request triggered a DB
+ * query (findFirst on the client table), making CORS a performance bottleneck.
+ *
+ * Strategy (two-level cache, fast → slow):
+ *
+ *  1. In-process Set<string>  — zero-latency; rebuilt from level 2 on miss.
+ *  2. Redis (via CacheService) — survives process restarts; TTL 300 s.
+ *  3. Prisma (database)       — authoritative; only consulted on Redis miss.
+ *
+ * Invalidation:
+ *   Call invalidate() whenever a client's webOrigins or enabled flag changes.
+ *   ClientsService already calls cache.invalidateCorsOrigins(); that in turn
+ *   clears Redis and sets localCacheExpiry = 0 so the next request reloads.
+ */
+@Injectable()
+export class CorsOriginService {
+  private readonly logger = new Logger(CorsOriginService.name);
+
+  /** In-process cache: set of allowed origins (includes '*' sentinel when present). */
+  private localOrigins: Set<string> | null = null;
+  /** Epoch ms at which the in-process cache expires. */
+  private localCacheExpiry = 0;
+  /** Local TTL in ms (5 minutes — mirrors the Redis TTL). */
+  private readonly LOCAL_TTL_MS = 5 * 60 * 1000;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: CacheService,
+  ) {}
+
+  /**
+   * Returns true if the given origin is permitted by at least one enabled client.
+   * The empty / undefined origin (same-origin, server-to-server) must be handled
+   * by the caller — this method always expects a non-empty string.
+   */
+  async isOriginAllowed(origin: string): Promise<boolean> {
+    const origins = await this.getAllowedOrigins();
+
+    // Wildcard: any origin is permitted
+    if (origins.has('*')) return true;
+
+    return origins.has(origin);
+  }
+
+  /**
+   * Drop both caches so the next call reloads from the database.
+   * Called automatically by CacheService.invalidateCorsOrigins() via ClientsService.
+   */
+  invalidateLocalCache(): void {
+    this.localOrigins = null;
+    this.localCacheExpiry = 0;
+    this.logger.debug('In-process CORS origin cache invalidated');
+  }
+
+  // ─── Private helpers ──────────────────────────────────────────────────────
+
+  private async getAllowedOrigins(): Promise<Set<string>> {
+    const now = Date.now();
+
+    // 1. In-process cache hit
+    if (this.localOrigins !== null && now < this.localCacheExpiry) {
+      return this.localOrigins;
+    }
+
+    // 2. Redis cache hit
+    const redisOrigins = await this.cache.getCachedCorsOrigins();
+    if (redisOrigins !== null) {
+      this.localOrigins = new Set(redisOrigins);
+      this.localCacheExpiry = now + this.LOCAL_TTL_MS;
+      return this.localOrigins;
+    }
+
+    // 3. Database (cache miss)
+    return this.loadFromDatabase();
+  }
+
+  private async loadFromDatabase(): Promise<Set<string>> {
+    this.logger.debug('CORS origin cache miss — loading from database');
+
+    try {
+      const clients = await this.prisma.client.findMany({
+        where: { enabled: true },
+        select: { webOrigins: true },
+      });
+
+      const origins = new Set<string>();
+      for (const client of clients) {
+        for (const o of client.webOrigins) {
+          origins.add(o);
+        }
+      }
+
+      const originArray = Array.from(origins);
+
+      // Populate both cache levels
+      await this.cache.cacheCorsOrigins(originArray);
+
+      this.localOrigins = origins;
+      this.localCacheExpiry = Date.now() + this.LOCAL_TTL_MS;
+
+      return origins;
+    } catch (err) {
+      this.logger.error(
+        `Failed to load CORS origins from database: ${(err as Error).message}`,
+      );
+      // Return an empty set on error — the CORS callback will deny the request.
+      return new Set<string>();
+    }
+  }
+}

--- a/src/cors/cors.module.ts
+++ b/src/cors/cors.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CorsOriginService } from './cors-origin.service.js';
+import { CacheModule } from '../cache/cache.module.js';
+
+@Module({
+  imports: [CacheModule],
+  providers: [CorsOriginService],
+  exports: [CorsOriginService],
+})
+export class CorsModule {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { join } from 'path';
 import { AppModule } from './app.module.js';
 import { GlobalExceptionFilter } from './common/filters/http-exception.filter.js';
 import { registerHandlebarsHelpers } from './theme/handlebars-helpers.js';
-import { PrismaService } from './prisma/prisma.service.js';
+import { CorsOriginService } from './cors/cors-origin.service.js';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
@@ -42,9 +42,12 @@ async function bootstrap() {
       crossOriginResourcePolicy: false,
     }),
   );
-  // Dynamic CORS: validate Origin against client webOrigins stored in the database.
-  // This replaces the previous `app.enableCors()` which allowed all origins (*).
-  const prisma = app.get(PrismaService);
+  // Dynamic CORS: validate Origin against the cached set of client webOrigins.
+  // Origins are loaded from the database once and cached in Redis (TTL 300 s) plus
+  // an in-process Set.  This avoids a DB round-trip on every cross-origin request.
+  // The cache is invalidated automatically whenever a client is created, updated,
+  // or deleted (see ClientsService).
+  const corsOriginService = app.get(CorsOriginService);
   app.enableCors({
     origin: async (
       origin: string | undefined,
@@ -57,19 +60,8 @@ async function bootstrap() {
       }
 
       try {
-        // Check if any enabled client has '*' (allow all) or the specific origin in webOrigins
-        const matchingClient = await prisma.client.findFirst({
-          where: {
-            enabled: true,
-            OR: [
-              { webOrigins: { has: origin } },
-              { webOrigins: { has: '*' } },
-            ],
-          },
-          select: { id: true },
-        });
-
-        callback(null, !!matchingClient);
+        const allowed = await corsOriginService.isOriginAllowed(origin);
+        callback(null, allowed);
       } catch {
         callback(null, false);
       }


### PR DESCRIPTION
## Summary
- **#346**: CORS check now uses in-memory + Redis cached origins instead of DB query per request
- **#341**: Admin console shows proper 404 page with "Go Back" and "Dashboard" actions

## Test plan
- [x] Unit tests for CorsOriginService pass
- [x] TypeScript compilation passes
- [ ] Manual: CORS still works correctly
- [ ] Manual: navigating to invalid URL shows 404 page

Closes #346, #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)