### PR TITLE
fix: HSTS, auth code race, backchannel logout, migration fixes

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -343,22 +343,34 @@ export class AuthService {
       'authorization_code',
     );
 
-    const authCode = await this.prisma.authorizationCode.findUnique({
-      where: { code },
-    });
-
-    if (
-      !authCode ||
-      authCode.clientId !== client.id ||
-      authCode.used ||
-      authCode.expiresAt < new Date()
-    ) {
-      if (authCode && !authCode.used) {
-        await this.prisma.authorizationCode.update({
-          where: { id: authCode.id },
-          data: { used: true },
-        });
+    // Atomically mark the code as used in a single conditional UPDATE so that
+    // concurrent requests racing to exchange the same code cannot both succeed.
+    // Prisma throws P2025 when no row matches the where clause, which happens
+    // when: (a) the code does not exist, (b) it was already used by a
+    // concurrent request, or (c) it has already expired.  All three cases are
+    // treated identically — the caller receives an "invalid or expired" error.
+    let authCode: Awaited<ReturnType<typeof this.prisma.authorizationCode.update>>;
+    try {
+      authCode = await this.prisma.authorizationCode.update({
+        where: {
+          code,
+          used: false,
+          expiresAt: { gt: new Date() },
+        },
+        data: { used: true },
+      });
+    } catch (err: unknown) {
+      const isPrismaNotFound =
+        typeof err === 'object' &&
+        err !== null &&
+        (err as { code?: string }).code === 'P2025';
+      if (isPrismaNotFound) {
+        throw new UnauthorizedException('Invalid or expired authorization code');
       }
+      throw err;
+    }
+
+    if (authCode.clientId !== client.id) {
       throw new UnauthorizedException('Invalid or expired authorization code');
     }
 
@@ -388,12 +400,6 @@ export class AuthService {
         throw new UnauthorizedException('Invalid code_verifier');
       }
     }
-
-    // Mark code as used
-    await this.prisma.authorizationCode.update({
-      where: { id: authCode.id },
-      data: { used: true },
-    });
 
     const user = await this.prisma.user.findUnique({
       where: { id: authCode.userId },

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,11 @@ async function bootstrap() {
           upgradeInsecureRequests: null,
         },
       },
-      hsts: false,
+      hsts: {
+        maxAge: 31536000, // 1 year in seconds
+        includeSubDomains: true,
+        preload: true,
+      },
       crossOriginOpenerPolicy: false,
       crossOriginResourcePolicy: false,
     }),

--- a/src/migration/auth0-importer.service.spec.ts
+++ b/src/migration/auth0-importer.service.spec.ts
@@ -38,6 +38,12 @@ describe('Auth0ImporterService', () => {
         client_secret: 'super-secret',
         grant_types: ['client_credentials'],
       },
+      {
+        client_id: 'device-app',
+        name: 'Device App',
+        grant_types: ['urn:ietf:params:oauth:grant-type:device_code'],
+        token_endpoint_auth_method: 'none',
+      },
     ],
     roles: [
       { name: 'admin', description: 'Admin role' },
@@ -100,7 +106,7 @@ describe('Auth0ImporterService', () => {
 
   it('should import clients with correct types', async () => {
     const report = await service.importData(mockAuth0Export, { dryRun: false, targetRealm: 'test' });
-    expect(report.summary.clients.created).toBe(2);
+    expect(report.summary.clients.created).toBe(3);
     // SPA is public
     expect(prisma.client.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ clientId: 'spa-app', clientType: 'PUBLIC' }),
@@ -109,6 +115,25 @@ describe('Auth0ImporterService', () => {
     expect(prisma.client.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ clientId: 'api-service', clientType: 'CONFIDENTIAL' }),
     }));
+    // Device app has the full URN grant type so auth service validation passes
+    expect(prisma.client.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        clientId: 'device-app',
+        grantTypes: ['urn:ietf:params:oauth:grant-type:device_code'],
+      }),
+    }));
+  });
+
+  it('should map device_code grant type to the full URN used internally', async () => {
+    await service.importData(mockAuth0Export, { dryRun: false, targetRealm: 'test' });
+    const deviceAppCall = prisma.client.create.mock.calls.find(
+      (call: any[]) => call[0].data.clientId === 'device-app',
+    );
+    expect(deviceAppCall).toBeDefined();
+    expect(deviceAppCall[0].data.grantTypes).toContain(
+      'urn:ietf:params:oauth:grant-type:device_code',
+    );
+    expect(deviceAppCall[0].data.grantTypes).not.toContain('device_code');
   });
 
   it('should import roles', async () => {

--- a/src/migration/auth0-importer.service.ts
+++ b/src/migration/auth0-importer.service.ts
@@ -249,7 +249,7 @@ export class Auth0ImporterService {
       'client_credentials': 'client_credentials',
       'password': 'password',
       'refresh_token': 'refresh_token',
-      'urn:ietf:params:oauth:grant-type:device_code': 'device_code',
+      'urn:ietf:params:oauth:grant-type:device_code': 'urn:ietf:params:oauth:grant-type:device_code',
     };
     return grantTypes.map(g => map[g] ?? g).filter(Boolean);
   }

--- a/src/migration/keycloak-importer.service.ts
+++ b/src/migration/keycloak-importer.service.ts
@@ -3,6 +3,9 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import type { KeycloakRealmExport, KeycloakUser, KeycloakClient, KeycloakGroup } from './keycloak-types.js';
 import { createEmptyReport, type MigrationReport } from './migration-report.js';
+import type { Prisma } from '@prisma/client';
+
+type PrismaTx = Prisma.TransactionClient;
 
 export interface KeycloakImportOptions {
   dryRun: boolean;
@@ -25,30 +28,46 @@ export class KeycloakImporterService {
     const report = createEmptyReport('keycloak', options.dryRun);
     const realmName = options.targetRealm ?? data.realm;
 
-    // 1. Create or find realm
-    const realmId = await this.importRealmEntity(data, realmName, report, options.dryRun);
-    if (!realmId) {
-      report.completedAt = new Date();
-      return report;
+    if (options.dryRun) {
+      // Dry-run: simulate without writing — no transaction needed.
+      const realmId = await this.importRealmEntity(data, realmName, report, true);
+      if (!realmId) {
+        report.completedAt = new Date();
+        return report;
+      }
+      await this.importRoles(data, realmId, report, true);
+      await this.importGroups(data.groups ?? [], realmId, null, report, true);
+      await this.importClientScopes(data, realmId, report, true);
+      await this.importClients(data, realmId, report, true);
+      await this.importUsers(data, realmId, report, true);
+      await this.importIdentityProviders(data, realmId, report, true);
+    } else {
+      // Real import: wrap every write in a single transaction so that any
+      // failure causes a full rollback, preventing partial/corrupt data.
+      try {
+        await this.prisma.$transaction(async (tx) => {
+          const realmId = await this.importRealmEntity(data, realmName, report, false, tx);
+          if (!realmId) {
+            // A fatal realm-level error was already recorded; abort the transaction.
+            throw new Error(`Failed to create realm '${realmName}' — rolling back`);
+          }
+
+          await this.importRoles(data, realmId, report, false, tx);
+          await this.importGroups(data.groups ?? [], realmId, null, report, false, tx);
+          await this.importClientScopes(data, realmId, report, false, tx);
+          await this.importClients(data, realmId, report, false, tx);
+          await this.importUsers(data, realmId, report, false, tx);
+          await this.importIdentityProviders(data, realmId, report, false, tx);
+        });
+      } catch (error: any) {
+        // If the error was injected by us to trigger a rollback it is already
+        // recorded in report.errors.  For any other unexpected error, add it.
+        const alreadyRecorded = report.errors.some(e => e.error === error.message);
+        if (!alreadyRecorded) {
+          report.errors.push({ entity: 'realm', name: realmName, error: error.message });
+        }
+      }
     }
-
-    // 2. Import roles
-    await this.importRoles(data, realmId, report, options.dryRun);
-
-    // 3. Import groups
-    await this.importGroups(data.groups ?? [], realmId, null, report, options.dryRun);
-
-    // 4. Import client scopes
-    await this.importClientScopes(data, realmId, report, options.dryRun);
-
-    // 5. Import clients
-    await this.importClients(data, realmId, report, options.dryRun);
-
-    // 6. Import users
-    await this.importUsers(data, realmId, report, options.dryRun);
-
-    // 7. Import identity providers
-    await this.importIdentityProviders(data, realmId, report, options.dryRun);
 
     report.completedAt = new Date();
     return report;
@@ -59,9 +78,11 @@ export class KeycloakImporterService {
     realmName: string,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<string | null> {
+    const db = tx ?? this.prisma;
     try {
-      const existing = await this.prisma.realm.findUnique({ where: { name: realmName } });
+      const existing = await db.realm.findUnique({ where: { name: realmName } });
       if (existing) {
         report.summary.realms.skipped++;
         report.warnings.push({ entity: 'realm', message: `Realm '${realmName}' already exists, using existing` });
@@ -73,7 +94,7 @@ export class KeycloakImporterService {
         return 'dry-run-realm-id';
       }
 
-      const realm = await this.prisma.realm.create({
+      const realm = await db.realm.create({
         data: {
           name: realmName,
           displayName: data.displayName,
@@ -90,7 +111,7 @@ export class KeycloakImporterService {
             smtpSsl: data.smtpServer.ssl === 'true',
           }),
           ...(data.bruteForceProtected && {
-            bruteForceProtected: true,
+            bruteForceEnabled: true,
             maxLoginFailures: data.failureFactor ?? 5,
           }),
         },
@@ -110,13 +131,15 @@ export class KeycloakImporterService {
     realmId: string,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<void> {
+    const db = tx ?? this.prisma;
     for (const role of data.roles?.realm ?? []) {
       if (['offline_access', 'uma_authorization', 'default-roles-' + data.realm].includes(role.name)) {
         continue; // Skip Keycloak built-in roles
       }
       try {
-        const existing = await this.prisma.role.findFirst({
+        const existing = await db.role.findFirst({
           where: { realmId, name: role.name, clientId: null },
         });
         if (existing) {
@@ -124,7 +147,7 @@ export class KeycloakImporterService {
           continue;
         }
         if (!dryRun) {
-          await this.prisma.role.create({
+          await db.role.create({
             data: { realmId, name: role.name, description: role.description },
           });
         }
@@ -142,29 +165,31 @@ export class KeycloakImporterService {
     parentId: string | null,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<void> {
+    const db = tx ?? this.prisma;
     for (const group of groups) {
       try {
-        const existing = await this.prisma.group.findFirst({
+        const existing = await db.group.findFirst({
           where: { realmId, name: group.name, parentId },
         });
         if (existing) {
           report.summary.groups.skipped++;
           if (group.subGroups?.length) {
-            await this.importGroups(group.subGroups, realmId, existing.id, report, dryRun);
+            await this.importGroups(group.subGroups, realmId, existing.id, report, dryRun, tx);
           }
           continue;
         }
         let groupId = 'dry-run-group-id';
         if (!dryRun) {
-          const created = await this.prisma.group.create({
+          const created = await db.group.create({
             data: { realmId, name: group.name, parentId },
           });
           groupId = created.id;
         }
         report.summary.groups.created++;
         if (group.subGroups?.length) {
-          await this.importGroups(group.subGroups, realmId, dryRun ? null : groupId, report, dryRun);
+          await this.importGroups(group.subGroups, realmId, dryRun ? null : groupId, report, dryRun, tx);
         }
       } catch (error: any) {
         report.summary.groups.failed++;
@@ -178,10 +203,12 @@ export class KeycloakImporterService {
     realmId: string,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<void> {
+    const db = tx ?? this.prisma;
     for (const scope of data.clientScopes ?? []) {
       try {
-        const existing = await this.prisma.clientScope.findFirst({
+        const existing = await db.clientScope.findFirst({
           where: { realmId, name: scope.name },
         });
         if (existing) {
@@ -189,7 +216,7 @@ export class KeycloakImporterService {
           continue;
         }
         if (!dryRun) {
-          await this.prisma.clientScope.create({
+          await db.clientScope.create({
             data: {
               realmId,
               name: scope.name,
@@ -211,11 +238,13 @@ export class KeycloakImporterService {
     realmId: string,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<void> {
+    const db = tx ?? this.prisma;
     for (const client of data.clients ?? []) {
       if (this.isKeycloakBuiltinClient(client.clientId)) continue;
       try {
-        const existing = await this.prisma.client.findFirst({
+        const existing = await db.client.findFirst({
           where: { realmId, clientId: client.clientId },
         });
         if (existing) {
@@ -225,7 +254,7 @@ export class KeycloakImporterService {
         if (!dryRun) {
           const grantTypes = this.mapKeycloakGrantTypes(client);
           const secretHash = client.secret ? await this.crypto.hashPassword(client.secret) : null;
-          await this.prisma.client.create({
+          await db.client.create({
             data: {
               realmId,
               clientId: client.clientId,
@@ -254,10 +283,12 @@ export class KeycloakImporterService {
     realmId: string,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<void> {
+    const db = tx ?? this.prisma;
     for (const user of data.users ?? []) {
       try {
-        const existing = await this.prisma.user.findFirst({
+        const existing = await db.user.findFirst({
           where: { realmId, username: user.username },
         });
         if (existing) {
@@ -269,7 +300,7 @@ export class KeycloakImporterService {
         const hash = (needsHashing && rawHash) ? await this.crypto.hashPassword(rawHash) : rawHash;
 
         if (!dryRun) {
-          const created = await this.prisma.user.create({
+          const created = await db.user.create({
             data: {
               realmId,
               username: user.username,
@@ -286,11 +317,11 @@ export class KeycloakImporterService {
           // Assign realm roles
           if (user.realmRoles?.length) {
             for (const roleName of user.realmRoles) {
-              const role = await this.prisma.role.findFirst({
+              const role = await db.role.findFirst({
                 where: { realmId, name: roleName, clientId: null },
               });
               if (role) {
-                await this.prisma.userRole.create({
+                await db.userRole.create({
                   data: { userId: created.id, roleId: role.id },
                 }).catch(() => {}); // Ignore duplicate
               }
@@ -329,10 +360,12 @@ export class KeycloakImporterService {
     realmId: string,
     report: MigrationReport,
     dryRun: boolean,
+    tx?: PrismaTx,
   ): Promise<void> {
+    const db = tx ?? this.prisma;
     for (const idp of data.identityProviders ?? []) {
       try {
-        const existing = await this.prisma.identityProvider.findFirst({
+        const existing = await db.identityProvider.findFirst({
           where: { realmId, alias: idp.alias },
         });
         if (existing) {
@@ -341,7 +374,7 @@ export class KeycloakImporterService {
         }
         if (!dryRun) {
           const providerType = this.mapKeycloakProviderType(idp.providerId);
-          await this.prisma.identityProvider.create({
+          await db.identityProvider.create({
             data: {
               realmId,
               alias: idp.alias,

--- a/src/tokens/backchannel-logout.service.spec.ts
+++ b/src/tokens/backchannel-logout.service.spec.ts
@@ -10,6 +10,9 @@ import {
 } from '../prisma/prisma.mock.js';
 import type { Realm } from '@prisma/client';
 
+/** Drain the microtask / promise queue so fire-and-forget work completes. */
+const flushPromises = () => new Promise<void>((resolve) => setImmediate(resolve));
+
 describe('BackchannelLogoutService', () => {
   let service: BackchannelLogoutService;
   let prisma: MockPrismaService;
@@ -50,7 +53,8 @@ describe('BackchannelLogoutService', () => {
     it('should return early when no clients have a backchannelLogoutUri', async () => {
       prisma.client.findMany.mockResolvedValue([]);
 
-      await service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      await flushPromises();
 
       expect(prisma.client.findMany).toHaveBeenCalledWith({
         where: {
@@ -73,7 +77,8 @@ describe('BackchannelLogoutService', () => {
       ]);
       prisma.realmSigningKey.findFirst.mockResolvedValue(null);
 
-      await service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      await flushPromises();
 
       expect(prisma.realmSigningKey.findFirst).toHaveBeenCalledWith({
         where: { realmId: 'realm-1', active: true },
@@ -103,7 +108,8 @@ describe('BackchannelLogoutService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
 
-      await service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      await flushPromises();
 
       expect(mockJwkService.signJwt).toHaveBeenCalledTimes(2);
       expect(global.fetch).toHaveBeenCalledTimes(2);
@@ -143,7 +149,8 @@ describe('BackchannelLogoutService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
 
-      await service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      await flushPromises();
 
       expect(mockJwkService.signJwt).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -173,7 +180,8 @@ describe('BackchannelLogoutService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
       (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
 
-      await service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      service.sendLogoutTokens(mockRealm, 'user-1', 'session-1');
+      await flushPromises();
 
       const signCall = mockJwkService.signJwt.mock.calls[0][0];
       expect(signCall).not.toHaveProperty('sid');
@@ -201,10 +209,9 @@ describe('BackchannelLogoutService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
       (global.fetch as jest.Mock).mockRejectedValue(new Error('Network error'));
 
-      // Should not throw even though fetch fails
-      await expect(
-        service.sendLogoutTokens(mockRealm, 'user-1', 'session-1'),
-      ).resolves.toBeUndefined();
+      // sendLogoutTokens is fire-and-forget (void); errors must not propagate
+      expect(() => service.sendLogoutTokens(mockRealm, 'user-1', 'session-1')).not.toThrow();
+      await flushPromises(); // confirm the background work also swallows the error
     });
 
     it('should handle non-ok response gracefully without throwing', async () => {
@@ -221,10 +228,9 @@ describe('BackchannelLogoutService', () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
       (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
 
-      // Should not throw even though the response is not ok
-      await expect(
-        service.sendLogoutTokens(mockRealm, 'user-1', 'session-1'),
-      ).resolves.toBeUndefined();
+      // sendLogoutTokens is fire-and-forget (void); non-ok responses must not propagate
+      expect(() => service.sendLogoutTokens(mockRealm, 'user-1', 'session-1')).not.toThrow();
+      await flushPromises(); // confirm the background work also swallows the warning
     });
   });
 });

--- a/src/tokens/backchannel-logout.service.ts
+++ b/src/tokens/backchannel-logout.service.ts
@@ -12,7 +12,19 @@ export class BackchannelLogoutService {
     private readonly jwkService: JwkService,
   ) {}
 
-  async sendLogoutTokens(
+  sendLogoutTokens(
+    realm: Realm,
+    userId: string,
+    sessionId: string,
+  ): void {
+    // Intentionally fire-and-forget: building and sending logout tokens to all
+    // registered relying parties must not block the caller's token operation.
+    // Each per-client promise already handles its own errors, so the
+    // Promise.allSettled chain can never produce an unhandled rejection.
+    void this.dispatchLogoutTokens(realm, userId, sessionId);
+  }
+
+  private async dispatchLogoutTokens(
     realm: Realm,
     userId: string,
     sessionId: string,

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -68,7 +68,7 @@ describe('TokensService', () => {
       blacklistToken: jest.fn(),
     };
     const backchannelLogoutService = {
-      sendLogoutTokens: jest.fn().mockResolvedValue(undefined),
+      sendLogoutTokens: jest.fn(),
     };
     const eventsService = {
       recordLoginEvent: jest.fn().mockResolvedValue(undefined),

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -238,9 +238,9 @@ export class TokensService {
       data: { revoked: true },
     });
 
-    // Send backchannel logout notifications
+    // Send backchannel logout notifications (fire-and-forget — must not block)
     if (userId) {
-      await this.backchannelLogout.sendLogoutTokens(realm, userId, sessionId);
+      this.backchannelLogout.sendLogoutTokens(realm, userId, sessionId);
     }
 
     // Record logout event before deleting session


### PR DESCRIPTION
## Summary
- **#357**: Enable HSTS with 1-year max-age, includeSubDomains, preload
- **#361**: Fix Keycloak importer field name bruteForceProtected → bruteForceEnabled
- **#364**: Fix Auth0 device_code grant type mapping to full URN
- **#360**: Fix auth code exchange TOCTOU race with atomic conditional update
- **#351**: Make backchannel logout fire-and-forget (non-blocking)
- **#337**: Wrap Keycloak import in Prisma transaction for rollback

## Test plan
- [x] TypeScript compilation passes
- [x] Updated unit tests pass
- [ ] Manual: HSTS header present in responses
- [ ] Manual: concurrent auth code exchange only succeeds once

Closes #357, #361, #364, #360, #351, #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)