### PR TITLE
fix: ErrorBoundary, XSS sanitize, in-memory credentials, CORS wildcard, device code entropy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,10 @@ DATABASE_URL=postgresql://authme:authme@localhost:5432/authme
 
 PORT=3000
 NODE_ENV=development
-ADMIN_API_KEY=dev-admin-key-change-in-production
+# REQUIRED: Set a strong, randomly generated secret before running in production.
+# Generate one with: openssl rand -hex 32
+# NEVER use the placeholder value in production — startup will be blocked if you do.
+ADMIN_API_KEY=REPLACE_ME_WITH_A_STRONG_RANDOM_SECRET
 THROTTLE_TTL=60000
 THROTTLE_LIMIT=100
 BASE_URL=http://localhost:3000

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import ErrorBoundary from './components/ErrorBoundary';
 import Layout from './components/Layout';
 import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
@@ -33,11 +34,12 @@ import AdminEventsPage from './pages/events/AdminEventsPage';
 import AuthFlowListPage from './pages/auth-flows/AuthFlowListPage';
 import AuthFlowEditorPage from './pages/auth-flows/AuthFlowEditorPage';
 import NotFoundPage from './pages/NotFoundPage';
+import { hasCredentials } from './api/client';
 
 function ProtectedRoute() {
-  const apiKey = sessionStorage.getItem('adminApiKey');
-  const token = sessionStorage.getItem('adminToken');
-  if (!apiKey && !token) {
+  // hasCredentials() reads from the in-memory module-level store — no
+  // sessionStorage involved (see issue #330 fix).
+  if (!hasCredentials()) {
     return <Navigate to="/console/login" replace />;
   }
   return <Outlet />;
@@ -45,6 +47,7 @@ function ProtectedRoute() {
 
 export default function App() {
   return (
+    <ErrorBoundary>
     <Routes>
       <Route path="/console/login" element={<LoginPage />} />
 
@@ -90,5 +93,6 @@ export default function App() {
       {/* Catch-all for every other URL (e.g. bare / or unknown top-level paths) */}
       <Route path="*" element={<NotFoundPage />} />
     </Routes>
+    </ErrorBoundary>
   );
 }

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -1,17 +1,50 @@
+/**
+ * Axios client for the admin API.
+ *
+ * Credentials are stored in module-level variables (heap memory) rather than
+ * sessionStorage, preventing XSS scripts from reading them via the Storage API
+ * (issue #330).  The React AuthContext keeps these variables up to date through
+ * the exported helpers below.
+ */
+
 import axios from 'axios';
 
+// ---------------------------------------------------------------------------
+// In-memory credential store — module-level, never written to Web Storage.
+// ---------------------------------------------------------------------------
+let _apiKey: string | null = null;
+let _token: string | null = null;
+
+/** Called by AuthContext after a successful login. */
+export function setCredentials(opts: { apiKey?: string; token?: string }) {
+  _apiKey = opts.apiKey ?? null;
+  _token = opts.token ?? null;
+}
+
+/** Called on logout or a 401 response. */
+export function clearCredentials() {
+  _apiKey = null;
+  _token = null;
+}
+
+/** Returns true when any credential is present (used by ProtectedRoute). */
+export function hasCredentials(): boolean {
+  return _apiKey !== null || _token !== null;
+}
+
+// ---------------------------------------------------------------------------
+// Axios instance
+// ---------------------------------------------------------------------------
 const apiClient = axios.create({
   baseURL: '/admin',
 });
 
 apiClient.interceptors.request.use((config) => {
-  const token = sessionStorage.getItem('adminToken');
-  if (token) {
-    config.headers['Authorization'] = `Bearer ${token}`;
+  if (_token) {
+    config.headers['Authorization'] = `Bearer ${_token}`;
   }
-  const apiKey = sessionStorage.getItem('adminApiKey');
-  if (apiKey) {
-    config.headers['x-admin-api-key'] = apiKey;
+  if (_apiKey) {
+    config.headers['x-admin-api-key'] = _apiKey;
   }
   return config;
 });
@@ -21,8 +54,7 @@ apiClient.interceptors.response.use(
   (error) => {
     const isOnLoginPage = window.location.pathname === '/console/login';
     if (error.response?.status === 401 && !isOnLoginPage) {
-      sessionStorage.removeItem('adminApiKey');
-      sessionStorage.removeItem('adminToken');
+      clearCredentials();
       window.location.href = '/console/login';
     }
     return Promise.reject(error);

--- a/admin-ui/src/components/ErrorBoundary.tsx
+++ b/admin-ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,143 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error('[ErrorBoundary] Uncaught error:', error, info.componentStack);
+  }
+
+  handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '100vh',
+            padding: '2rem',
+            fontFamily: 'sans-serif',
+            backgroundColor: '#f9fafb',
+            color: '#111827',
+          }}
+        >
+          <div
+            style={{
+              maxWidth: '480px',
+              width: '100%',
+              background: '#ffffff',
+              border: '1px solid #e5e7eb',
+              borderRadius: '8px',
+              padding: '2rem',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+              textAlign: 'center',
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#ef4444"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              style={{ marginBottom: '1rem' }}
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+
+            <h1
+              style={{
+                fontSize: '1.25rem',
+                fontWeight: 600,
+                marginBottom: '0.5rem',
+              }}
+            >
+              Something went wrong
+            </h1>
+
+            <p
+              style={{
+                fontSize: '0.875rem',
+                color: '#6b7280',
+                marginBottom: '1.5rem',
+              }}
+            >
+              An unexpected error occurred in the admin console. You can try
+              reloading the page. If the problem persists, please contact your
+              administrator.
+            </p>
+
+            {this.state.error && (
+              <pre
+                style={{
+                  textAlign: 'left',
+                  background: '#f3f4f6',
+                  borderRadius: '4px',
+                  padding: '0.75rem',
+                  fontSize: '0.75rem',
+                  color: '#374151',
+                  overflowX: 'auto',
+                  marginBottom: '1.5rem',
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                }}
+              >
+                {this.state.error.message}
+              </pre>
+            )}
+
+            <button
+              onClick={this.handleReload}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '0.4rem',
+                padding: '0.5rem 1.25rem',
+                background: '#2563eb',
+                color: '#ffffff',
+                border: 'none',
+                borderRadius: '6px',
+                fontSize: '0.875rem',
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -1,0 +1,81 @@
+/**
+ * AuthContext — in-memory credential store.
+ *
+ * Credentials (API key and bearer token) are kept only in JavaScript heap
+ * memory, never written to sessionStorage/localStorage.  This eliminates the
+ * XSS-theft vector described in issue #330.
+ *
+ * Trade-off: credentials are lost on a full page reload (F5).  Users will be
+ * redirected to /console/login and must log in again, which is acceptable for
+ * an admin console.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+interface AuthState {
+  apiKey: string | null;
+  token: string | null;
+}
+
+interface AuthContextValue extends AuthState {
+  setApiKey: (key: string) => void;
+  setToken: (token: string) => void;
+  clearAuth: () => void;
+  /** Ref giving the api/client interceptor synchronous access to the latest credentials. */
+  credentialsRef: React.RefObject<AuthState>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [auth, setAuth] = useState<AuthState>({ apiKey: null, token: null });
+
+  // Keep a ref in sync so the axios interceptor (which runs outside React's
+  // render cycle) can read the latest value synchronously without a closure
+  // over a stale state snapshot.
+  const credentialsRef = useRef<AuthState>(auth);
+
+  const update = useCallback((next: AuthState) => {
+    credentialsRef.current = next;
+    setAuth(next);
+  }, []);
+
+  const setApiKey = useCallback(
+    (key: string) => update({ apiKey: key, token: null }),
+    [update],
+  );
+
+  const setToken = useCallback(
+    (tok: string) => update({ apiKey: null, token: tok }),
+    [update],
+  );
+
+  const clearAuth = useCallback(
+    () => update({ apiKey: null, token: null }),
+    [update],
+  );
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ ...auth, setApiKey, setToken, clearAuth, credentialsRef }),
+    [auth, setApiKey, setToken, clearAuth, credentialsRef],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+/** Returns the full AuthContext value — must be used inside <AuthProvider>. */
+export function useAuthContext(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuthContext must be used inside <AuthProvider>');
+  }
+  return ctx;
+}

--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -1,33 +1,36 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getAllRealms } from '../api/realms';
-import apiClient from '../api/client';
+import apiClient, { setCredentials, clearCredentials } from '../api/client';
+import { useAuthContext } from '../context/AuthContext';
 
 export function useAuth() {
   const navigate = useNavigate();
+  const { apiKey, token, setApiKey, setToken, clearAuth } = useAuthContext();
 
-  const isAuthenticated =
-    !!sessionStorage.getItem('adminApiKey') ||
-    !!sessionStorage.getItem('adminToken');
+  const isAuthenticated = apiKey !== null || token !== null;
 
   const clearAuthState = useCallback(() => {
-    sessionStorage.removeItem('adminApiKey');
-    sessionStorage.removeItem('adminToken');
-  }, []);
+    clearAuth();
+    clearCredentials();
+  }, [clearAuth]);
 
   const login = useCallback(
-    async (apiKey: string): Promise<boolean> => {
+    async (key: string): Promise<boolean> => {
       clearAuthState();
-      sessionStorage.setItem('adminApiKey', apiKey);
+      // Optimistically load credentials so the probe request is authenticated.
+      setCredentials({ apiKey: key });
       try {
         await getAllRealms();
+        // Probe succeeded — persist to React state.
+        setApiKey(key);
         return true;
       } catch {
-        sessionStorage.removeItem('adminApiKey');
+        clearCredentials();
         return false;
       }
     },
-    [clearAuthState],
+    [clearAuthState, setApiKey],
   );
 
   const loginWithCredentials = useCallback(
@@ -36,7 +39,8 @@ export function useAuth() {
       try {
         const { data } = await apiClient.post('/auth/login', { username, password });
         if (data.access_token) {
-          sessionStorage.setItem('adminToken', data.access_token);
+          setCredentials({ token: data.access_token });
+          setToken(data.access_token);
           return true;
         }
         return false;
@@ -44,14 +48,14 @@ export function useAuth() {
         return false;
       }
     },
-    [clearAuthState],
+    [clearAuthState, setToken],
   );
 
   const logout = useCallback(async () => {
     try {
       await apiClient.post('/auth/logout');
     } catch {
-      // Best-effort: clear locally even if server call fails
+      // Best-effort: clear locally even if server call fails.
     }
     clearAuthState();
     navigate('/console/login');

--- a/admin-ui/src/main.tsx
+++ b/admin-ui/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import './index.css';
 import App from './App';
+import { AuthProvider } from './context/AuthContext';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -19,7 +20,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <AuthProvider>
+          <App />
+        </AuthProvider>
       </QueryClientProvider>
     </BrowserRouter>
   </StrictMode>,

--- a/admin-ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/LoginPage.test.tsx
@@ -7,10 +7,8 @@ import { server } from '../../test/mocks/server';
 import LoginPage from '../LoginPage';
 
 // LoginPage uses useNavigate – the custom render helper provides MemoryRouter.
-// useAuth touches sessionStorage, so we clear that between tests.
-
-beforeEach(() => sessionStorage.clear());
-afterEach(() => sessionStorage.clear());
+// Credentials are stored in-memory (module-level variables in api/client.ts),
+// so no sessionStorage cleanup is needed between tests.
 
 describe('LoginPage – credentials mode', () => {
   it('renders the login form with username and password fields', () => {

--- a/admin-ui/src/test/utils.tsx
+++ b/admin-ui/src/test/utils.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '../context/AuthContext';
 
 interface WrapperOptions {
   /** Initial URL for the in-memory router, e.g. "/console/realms/test-realm/users" */
@@ -53,7 +54,9 @@ export function renderWithProviders(
 
     return (
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter initialEntries={[initialUrl]}>{content}</MemoryRouter>
+        <AuthProvider>
+          <MemoryRouter initialEntries={[initialUrl]}>{content}</MemoryRouter>
+        </AuthProvider>
       </QueryClientProvider>
     );
   }

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  BadRequestException,
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
@@ -42,6 +43,7 @@ export class ClientsService {
   ) {}
 
   async create(realm: Realm, dto: CreateClientDto) {
+    this.rejectWildcardOrigins(dto.webOrigins);
     const existing = await this.prisma.client.findUnique({
       where: {
         realmId_clientId: { realmId: realm.id, clientId: dto.clientId },
@@ -142,6 +144,7 @@ export class ClientsService {
   }
 
   async update(realm: Realm, clientId: string, dto: UpdateClientDto) {
+    this.rejectWildcardOrigins(dto.webOrigins);
     await this.findByClientId(realm, clientId);
 
     const updated = await this.prisma.client.update({
@@ -237,6 +240,24 @@ export class ClientsService {
       clientSecret: rawSecret,
       secretWarning: 'Store this secret securely. It will not be shown again.',
     };
+  }
+
+  /**
+   * Defense-in-depth guard: reject '*' as a webOrigin even if the DTO
+   * validation layer was somehow bypassed (e.g. direct service calls in tests,
+   * seeding scripts, or future programmatic callers that skip the HTTP stack).
+   *
+   * The primary rejection point is the @IsNoWildcardOrigin() decorator on
+   * CreateClientDto / UpdateClientDto, which catches this at request-validation
+   * time and returns a structured 400 before we ever reach the service layer.
+   */
+  private rejectWildcardOrigins(webOrigins: string[] | undefined): void {
+    if (webOrigins?.includes('*')) {
+      throw new BadRequestException(
+        'webOrigins must not contain the wildcard "*". ' +
+          'Specify explicit origins (e.g. "https://app.example.com") instead.',
+      );
+    }
   }
 
   private async assignBuiltInScopes(realmId: string, clientDbId: string) {

--- a/src/clients/dto/create-client.dto.ts
+++ b/src/clients/dto/create-client.dto.ts
@@ -5,8 +5,39 @@ import {
   IsEnum,
   IsArray,
   MinLength,
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Rejects arrays that contain the bare wildcard origin '*'.
+ *
+ * Allowing '*' in webOrigins would instruct the CORS middleware to echo back
+ * an Allow-Origin header for every request origin, effectively disabling CORS
+ * protection for the entire realm.  Concrete origins must always be specified.
+ */
+function IsNoWildcardOrigin(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'isNoWildcardOrigin',
+      target: (object as { constructor: Function }).constructor,
+      propertyName,
+      options: {
+        message:
+          'webOrigins must not contain the wildcard "*". Specify explicit origins instead.',
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: unknown, _args: ValidationArguments): boolean {
+          if (!Array.isArray(value)) return true; // let @IsArray handle that
+          return !(value as unknown[]).some((v) => v === '*');
+        },
+      },
+    });
+  };
+}
 
 export class CreateClientDto {
   @ApiProperty({ example: 'my-frontend' })
@@ -44,6 +75,7 @@ export class CreateClientDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
+  @IsNoWildcardOrigin()
   webOrigins?: string[];
 
   @ApiPropertyOptional({ example: ['authorization_code', 'client_credentials'] })

--- a/src/cors/cors-origin.service.spec.ts
+++ b/src/cors/cors-origin.service.spec.ts
@@ -92,13 +92,34 @@ describe('CorsOriginService', () => {
     });
   });
 
-  // ─── Wildcard support ─────────────────────────────────────────────────
+  // ─── Wildcard rejection (#320) ────────────────────────────────────────
+  //
+  // Even when a client record in the database contains '*' as a webOrigin
+  // (legacy data that pre-dates the creation-time validation), the service
+  // must NOT honour it.  The wildcard is filtered out at load time and a
+  // warning is emitted; all origin checks must return false in this case.
 
-  describe('wildcard origin', () => {
+  describe('wildcard origin in database (legacy data)', () => {
     beforeEach(() => build([['*']]));
 
-    it('allows any origin when a client has webOrigin "*"', async () => {
-      expect(await service.isOriginAllowed('https://anything.example.com')).toBe(true);
+    it('does NOT allow any origin when the only webOrigin stored is "*"', async () => {
+      expect(await service.isOriginAllowed('https://anything.example.com')).toBe(false);
+    });
+
+    it('does NOT allow the literal "*" origin string', async () => {
+      expect(await service.isOriginAllowed('*')).toBe(false);
+    });
+  });
+
+  describe('wildcard mixed with concrete origins (legacy data)', () => {
+    beforeEach(() => build([['*', 'https://app.example.com']]));
+
+    it('allows the concrete origin', async () => {
+      expect(await service.isOriginAllowed('https://app.example.com')).toBe(true);
+    });
+
+    it('does NOT allow an arbitrary origin just because "*" is present', async () => {
+      expect(await service.isOriginAllowed('https://evil.com')).toBe(false);
     });
   });
 

--- a/src/cors/cors-origin.service.ts
+++ b/src/cors/cors-origin.service.ts
@@ -24,7 +24,7 @@ import { CacheService } from '../cache/cache.service.js';
 export class CorsOriginService {
   private readonly logger = new Logger(CorsOriginService.name);
 
-  /** In-process cache: set of allowed origins (includes '*' sentinel when present). */
+  /** In-process cache: set of concrete allowed origins (wildcard '*' is never stored). */
   private localOrigins: Set<string> | null = null;
   /** Epoch ms at which the in-process cache expires. */
   private localCacheExpiry = 0;
@@ -40,13 +40,14 @@ export class CorsOriginService {
    * Returns true if the given origin is permitted by at least one enabled client.
    * The empty / undefined origin (same-origin, server-to-server) must be handled
    * by the caller — this method always expects a non-empty string.
+   *
+   * The bare wildcard '*' is never accepted as an allowed origin, even if a
+   * client record in the database still contains it (e.g. data that pre-dates
+   * the creation-time validation added in issue #320).  It is silently filtered
+   * out during {@link loadFromDatabase} and a warning is emitted instead.
    */
   async isOriginAllowed(origin: string): Promise<boolean> {
     const origins = await this.getAllowedOrigins();
-
-    // Wildcard: any origin is permitted
-    if (origins.has('*')) return true;
-
     return origins.has(origin);
   }
 
@@ -94,6 +95,18 @@ export class CorsOriginService {
       const origins = new Set<string>();
       for (const client of clients) {
         for (const o of client.webOrigins) {
+          if (o === '*') {
+            // A wildcard origin stored in the database means the client was
+            // created before the #320 validation was introduced.  Honouring it
+            // would bypass CORS protection for every request origin, so we
+            // skip it here and emit a warning so operators can remediate.
+            this.logger.warn(
+              'A client webOrigins entry contains the wildcard "*". ' +
+                'This origin is being ignored for CORS checks. ' +
+                'Update the client to use explicit origins to silence this warning.',
+            );
+            continue;
+          }
           origins.add(o);
         }
       }

--- a/src/device/device.service.ts
+++ b/src/device/device.service.ts
@@ -1,14 +1,18 @@
 import {
   Injectable,
   BadRequestException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { randomBytes } from 'crypto';
+import { randomBytes, randomInt } from 'crypto';
+import { Interval } from '@nestjs/schedule';
 import type { Realm } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 
 @Injectable()
 export class DeviceService {
+  private readonly logger = new Logger(DeviceService.name);
+
   constructor(private readonly prisma: PrismaService) {}
 
   async initiateDeviceAuth(
@@ -85,12 +89,26 @@ export class DeviceService {
     });
   }
 
+  @Interval(600_000) // every 10 minutes — matches the device-code TTL
+  async cleanupExpiredDeviceCodes(): Promise<void> {
+    const result = await this.prisma.deviceCode.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+
+    if (result.count > 0) {
+      this.logger.debug(
+        `Device-code cleanup removed ${result.count} expired device code(s)`,
+      );
+    }
+  }
+
   private generateUserCode(): string {
     const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
     let code = '';
-    const bytes = randomBytes(8);
     for (let i = 0; i < 8; i++) {
-      code += chars[bytes[i]! % chars.length];
+      // randomInt(max) is rejection-sampling based and therefore unbiased,
+      // unlike the bytes[i] % N pattern which has modulo bias when 256 % N != 0.
+      code += chars[randomInt(chars.length)];
       if (i === 3) code += '-';
     }
     return code;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,68 @@ import { GlobalExceptionFilter } from './common/filters/http-exception.filter.js
 import { registerHandlebarsHelpers } from './theme/handlebars-helpers.js';
 import { CorsOriginService } from './cors/cors-origin.service.js';
 
+/** Known-insecure / placeholder values that must never reach production. */
+const INSECURE_ADMIN_API_KEY_VALUES = new Set([
+  'REPLACE_ME_WITH_A_STRONG_RANDOM_SECRET',
+  'dev-admin-key-change-in-production',
+  'changeme',
+  'secret',
+  'admin',
+  'password',
+]);
+
+const MIN_ADMIN_API_KEY_LENGTH = 32;
+
+function validateAdminApiKey(): void {
+  const isProduction = process.env['NODE_ENV'] === 'production';
+  const key = process.env['ADMIN_API_KEY'];
+
+  // Absent key — guard falls back to JWT-only mode; warn in production.
+  if (!key) {
+    if (isProduction) {
+      console.warn(
+        '[SECURITY] ADMIN_API_KEY is not set. ' +
+          'The static API-key authentication path is disabled. ' +
+          'Ensure admin JWT authentication is properly configured.',
+      );
+    }
+    return;
+  }
+
+  const isInsecureValue = INSECURE_ADMIN_API_KEY_VALUES.has(key);
+  const isTooShort = key.length < MIN_ADMIN_API_KEY_LENGTH;
+
+  if (isProduction) {
+    if (isInsecureValue) {
+      console.error(
+        '[SECURITY] FATAL: ADMIN_API_KEY is set to a known placeholder or insecure value. ' +
+          'Set a strong, randomly generated secret (e.g. `openssl rand -hex 32`) ' +
+          'before running in production.',
+      );
+      process.exit(1);
+    }
+
+    if (isTooShort) {
+      console.error(
+        `[SECURITY] FATAL: ADMIN_API_KEY must be at least ${MIN_ADMIN_API_KEY_LENGTH} characters long in production. ` +
+          'Generate one with: openssl rand -hex 32',
+      );
+      process.exit(1);
+    }
+  } else {
+    // Development / test: warn but do not block startup.
+    if (isInsecureValue || isTooShort) {
+      console.warn(
+        '[SECURITY] WARNING: ADMIN_API_KEY is weak or a placeholder. ' +
+          'This is acceptable in development but MUST be replaced before deploying to production.',
+      );
+    }
+  }
+}
+
 async function bootstrap() {
+  validateAdminApiKey();
+
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     bufferLogs: true,
   });

--- a/src/migration/auth0-importer.service.ts
+++ b/src/migration/auth0-importer.service.ts
@@ -121,7 +121,17 @@ export class Auth0ImporterService {
               clientType: isPublic ? 'PUBLIC' : 'CONFIDENTIAL',
               clientSecret: secretHash,
               redirectUris: client.callbacks ?? [],
-              webOrigins: client.allowed_origins ?? [],
+              webOrigins: (client.allowed_origins ?? []).filter((o: string) => {
+                if (o === '*') {
+                  this.logger.warn(
+                    `Auth0 client '${client.client_id}' has a wildcard webOrigin "*" — ` +
+                      'it has been stripped during import. ' +
+                      'Update the client to use explicit origins.',
+                  );
+                  return false;
+                }
+                return true;
+              }),
               grantTypes,
             },
           });

--- a/src/migration/keycloak-importer.service.ts
+++ b/src/migration/keycloak-importer.service.ts
@@ -263,7 +263,17 @@ export class KeycloakImporterService {
               clientType: client.publicClient ? 'PUBLIC' : 'CONFIDENTIAL',
               clientSecret: secretHash,
               redirectUris: client.redirectUris ?? [],
-              webOrigins: client.webOrigins ?? [],
+              webOrigins: (client.webOrigins ?? []).filter((o: string) => {
+                if (o === '*') {
+                  this.logger.warn(
+                    `Keycloak client '${client.clientId}' has a wildcard webOrigin "*" — ` +
+                      'it has been stripped during import. ' +
+                      'Update the client to use explicit origins.',
+                  );
+                  return false;
+                }
+                return true;
+              }),
               grantTypes,
               consentRequired: client.consentRequired ?? false,
               serviceAccountEnabled: client.serviceAccountsEnabled ?? false,

--- a/src/realms/realm-import.service.ts
+++ b/src/realms/realm-import.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   BadRequestException,
   ConflictException,
+  Logger,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { JwkService } from '../crypto/jwk.service.js';
@@ -13,6 +14,8 @@ export interface ImportOptions {
 
 @Injectable()
 export class RealmImportService {
+  private readonly logger = new Logger(RealmImportService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwkService: JwkService,
@@ -140,7 +143,17 @@ export class RealmImportService {
           enabled: c.enabled ?? true,
           requireConsent: c.requireConsent ?? false,
           redirectUris: c.redirectUris ?? [],
-          webOrigins: c.webOrigins ?? [],
+          webOrigins: (c.webOrigins ?? []).filter((o: string) => {
+            if (o === '*') {
+              this.logger.warn(
+                `Imported client '${c.clientId}' has a wildcard webOrigin "*" — ` +
+                  'it has been stripped during import. ' +
+                  'Update the client to use explicit origins.',
+              );
+              return false;
+            }
+            return true;
+          }),
           grantTypes: c.grantTypes ?? ['authorization_code'],
           backchannelLogoutUri: c.backchannelLogoutUri ?? null,
           backchannelLogoutSessionRequired: c.backchannelLogoutSessionRequired ?? true,

--- a/src/theme/theme-render.service.spec.ts
+++ b/src/theme/theme-render.service.spec.ts
@@ -1,4 +1,4 @@
-import { ThemeRenderService } from './theme-render.service.js';
+import { ThemeRenderService, sanitizeCss } from './theme-render.service.js';
 
 describe('ThemeRenderService', () => {
   let service: ThemeRenderService;
@@ -182,6 +182,60 @@ describe('ThemeRenderService', () => {
       service.render(mockRes as any, realmWithLocale, 'login', 'login', {});
 
       expect(messageService.getMessages).toHaveBeenCalledWith('authme', 'login', 'es');
+    });
+
+    it('should sanitize customCss before passing it to res.render', () => {
+      themeService.resolveColors.mockReturnValue({
+        primaryColor: '#2563eb',
+        backgroundColor: '#f0f2f5',
+        customCss: 'body { color: red; } </style><script>alert(1)</script>',
+      });
+
+      service.render(mockRes as any, mockRealm, 'login', 'login', {}, mockReq as any);
+
+      const [, data] = mockRes.render.mock.calls[0];
+      expect(data.customCss).not.toContain('</style');
+      expect(data.customCss).not.toContain('<script');
+      expect(data.customCss).toContain('body { color: red; }');
+    });
+  });
+
+  describe('sanitizeCss', () => {
+    it('should pass through valid CSS unchanged', () => {
+      const css = 'body { color: red; } .foo > .bar { margin: 0; }';
+      expect(sanitizeCss(css)).toBe(css);
+    });
+
+    it('should strip </style> to prevent breaking out of the style block', () => {
+      // The closing > of </style> and the opening > of <script> are both left;
+      // what matters is that the dangerous sequences that break out of the <style>
+      // block are removed.
+      expect(sanitizeCss('</style>')).toBe('>');
+      const result = sanitizeCss('body{}</style><script>alert(1)</script>');
+      expect(result).not.toContain('</style');
+      expect(result).not.toContain('<script');
+      expect(result).toContain('body{}');
+      expect(result).toContain('alert(1)');
+    });
+
+    it('should strip </style case-insensitively', () => {
+      expect(sanitizeCss('</STYLE>')).toBe('>');
+      expect(sanitizeCss('</Style>')).toBe('>');
+    });
+
+    it('should strip <script case-insensitively', () => {
+      expect(sanitizeCss('<script>alert(1)</script>')).toBe('>alert(1)</script>');
+      expect(sanitizeCss('<SCRIPT>evil()</SCRIPT>')).toBe('>evil()</SCRIPT>');
+    });
+
+    it('should strip multiple occurrences', () => {
+      const input = '</style><style>a{}</style>';
+      // Both </style occurrences are removed
+      expect(sanitizeCss(input)).not.toContain('</style');
+    });
+
+    it('should return empty string unchanged', () => {
+      expect(sanitizeCss('')).toBe('');
     });
   });
 });

--- a/src/theme/theme-render.service.ts
+++ b/src/theme/theme-render.service.ts
@@ -8,6 +8,26 @@ import { ThemeMessageService } from './theme-message.service.js';
 import { I18nService, SUPPORTED_LOCALES } from './i18n.service.js';
 import type { ThemeType } from './theme.types.js';
 
+/**
+ * Sanitizes a CSS string so it cannot break out of a <style> block.
+ *
+ * Strips any occurrence of </style (case-insensitive) to prevent an attacker
+ * from closing the surrounding <style> element and injecting arbitrary HTML or
+ * script content.  A <script opening tag is also removed as defence-in-depth.
+ *
+ * Valid CSS selectors and property values that happen to contain angle brackets
+ * (extremely rare, and never required for `</style`) are unaffected in normal
+ * use; the restriction is intentionally narrow.
+ */
+export function sanitizeCss(css: string): string {
+  // Remove any </style...> sequence (the closing bracket is optional because a
+  // browser may still parse a partial tag).
+  // Also remove opening <script tags for defence-in-depth.
+  return css
+    .replace(/<\/style/gi, '')
+    .replace(/<script/gi, '');
+}
+
 @Injectable()
 export class ThemeRenderService {
   constructor(
@@ -63,10 +83,19 @@ export class ThemeRenderService {
       url: this.buildLangUrl(currentUrl, code),
     }));
 
+    // Sanitize customCss before it reaches the template.  The layout renders it
+    // with {{{customCss}}} (triple-brace / unescaped) so that valid CSS syntax
+    // such as `>`, `&`, and `{` is preserved.  We therefore must strip any
+    // HTML break-out sequences here, server-side.
+    const sanitizedColors = {
+      ...colors,
+      customCss: sanitizeCss(colors.customCss ?? ''),
+    };
+
     res.render(relativeTemplate, {
       layout: relativeLayout,
       ...data,
-      ...colors,
+      ...sanitizedColors,
       _messages: messages,
       themeCssFiles: cssFiles,
       realmName: data.realmName ?? realm.name,


### PR DESCRIPTION
## Summary
- **#331**: Admin UI Error Boundary catches unhandled React errors
- **#316**: customCss sanitized to prevent `</style><script>` XSS
- **#330**: Admin credentials moved from sessionStorage to in-memory
- **#317**: Insecure ADMIN_API_KEY blocked at startup in production
- **#320**: Wildcard `*` CORS origins rejected at DTO, service, and runtime
- **#318**: Device code user-code uses `crypto.randomInt` (no modulo bias)
- **#326**: Expired device codes cleaned up on 10-minute interval

## Test plan
- [x] TypeScript compilation passes
- [x] Updated unit tests pass

Closes #331, #316, #330, #317, #320, #318, #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)