### PR TITLE
fix: MFA status code, rate limit spoofing, device flow polling, error filter, iOS SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,17 @@ BASE_URL=http://localhost:3000
 
 # Session store backend: "database" (default) or "redis"
 # SESSION_STORE=database
+
+# ─── Reverse proxy / trusted proxies ──────────────────────────────────────────
+# Controls whether X-Forwarded-For is trusted for client-IP resolution used by
+# rate limiting.  Leave unset (the default) to always use the raw socket address,
+# which prevents header spoofing when the app is exposed directly.
+#
+# Set to a comma-separated list of trusted proxy IPs or CIDR blocks when the app
+# sits behind a known reverse proxy:
+#   TRUSTED_PROXIES=10.0.0.1,172.16.0.0/12
+#
+# Set to * to trust all proxies unconditionally (only safe when the network layer
+# prevents direct public access to the app process, e.g. a managed cloud LB):
+#   TRUSTED_PROXIES=*
+# TRUSTED_PROXIES=

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -62,7 +62,6 @@ export default function App() {
           <Route path="/console/realms/:name/users/:id" element={<UserDetailPage />} />
           <Route path="/console/realms/:name/clients" element={<ClientListPage />} />
           <Route path="/console/realms/:name/clients/new" element={<ClientCreatePage />} />
-          <Route path="/console/realms/:name/clients/create" element={<ClientCreatePage />} />
           <Route path="/console/realms/:name/clients/:id" element={<ClientDetailPage />} />
           <Route path="/console/realms/:name/roles" element={<RoleListPage />} />
           <Route path="/console/realms/:name/groups" element={<GroupListPage />} />

--- a/admin-ui/src/pages/clients/ClientListPage.tsx
+++ b/admin-ui/src/pages/clients/ClientListPage.tsx
@@ -38,7 +38,7 @@ export default function ClientListPage() {
           </p>
         </div>
         <button
-          onClick={() => navigate(`/console/realms/${name}/clients/create`)}
+          onClick={() => navigate(`/console/realms/${name}/clients/new`)}
           className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
         >
           Create Client

--- a/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
+++ b/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
@@ -8,8 +8,8 @@ import ClientCreatePage from '../ClientCreatePage';
 
 function renderPage(realm = 'test-realm') {
   return render(<ClientCreatePage />, {
-    initialUrl: `/console/realms/${realm}/clients/create`,
-    routePattern: '/console/realms/:name/clients/create',
+    initialUrl: `/console/realms/${realm}/clients/new`,
+    routePattern: '/console/realms/:name/clients/new',
   });
 }
 

--- a/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
+++ b/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
@@ -31,6 +31,11 @@ public final class AuthMeClient: NSObject {
     private var oidcConfig: OIDCConfiguration?
     private var refreshTask: Task<Void, Never>?
 
+    /// Retained for the duration of an active login flow.
+    /// `ASWebAuthenticationSession` must be held by a strong reference or iOS will
+    /// silently cancel the session before the callback fires (see issue #368).
+    private var authSession: ASWebAuthenticationSession?
+
     // MARK: - Init
 
     /// Create a new AuthMeClient with the given configuration.
@@ -113,7 +118,9 @@ public final class AuthMeClient: NSObject {
             let session = ASWebAuthenticationSession(
                 url: authURL,
                 callbackURLScheme: callbackScheme
-            ) { url, error in
+            ) { [weak self] url, error in
+                // Release the strong reference now that the callback has fired.
+                self?.authSession = nil
                 if let error {
                     continuation.resume(throwing: AuthMeError.networkError(error))
                 } else if let url {
@@ -131,6 +138,9 @@ public final class AuthMeClient: NSObject {
                 session.presentationContextProvider = DefaultPresentationContextProvider()
             }
 
+            // Retain the session on self so ARC does not deallocate it before
+            // the callback fires (issue #368: silent cancellation on iOS).
+            authSession = session
             session.start()
         }
 

--- a/src/admin-auth/admin-auth.controller.spec.ts
+++ b/src/admin-auth/admin-auth.controller.spec.ts
@@ -1,5 +1,6 @@
 import { UnauthorizedException, HttpException, HttpStatus } from '@nestjs/common';
 import { AdminAuthController } from './admin-auth.controller.js';
+import { resetTrustedProxyConfig } from '../common/utils/proxy-ip.util.js';
 
 /** Build a minimal Express-like mock for req / res used by the login handler. */
 function makeReqRes(overrides: Partial<{ ip: string; forwardedFor: string }> = {}) {
@@ -23,11 +24,19 @@ describe('AdminAuthController', () => {
   };
 
   beforeEach(() => {
+    // Ensure no leftover TRUSTED_PROXIES env from other tests
+    delete process.env['TRUSTED_PROXIES'];
+    resetTrustedProxyConfig();
     adminAuthService = {
       login: jest.fn(),
       revokeToken: jest.fn(),
     };
     controller = new AdminAuthController(adminAuthService as any);
+  });
+
+  afterEach(() => {
+    delete process.env['TRUSTED_PROXIES'];
+    resetTrustedProxyConfig();
   });
 
   describe('login', () => {
@@ -58,18 +67,38 @@ describe('AdminAuthController', () => {
       expect(res._headers['X-RateLimit-Remaining']).toBe('4');
     });
 
-    it('should prefer x-forwarded-for header over socket address', async () => {
+    it('should ignore X-Forwarded-For and use socket address when TRUSTED_PROXIES is not set', async () => {
+      // Default behaviour: no trusted proxies configured.
+      // X-Forwarded-For must be ignored to prevent IP spoofing.
       adminAuthService.login.mockResolvedValue({
         access_token: 'tok',
         token_type: 'Bearer',
         expires_in: 3600,
         rateLimitHeaders: {},
       });
-      const { req, res } = makeReqRes({ forwardedFor: '203.0.113.5, 10.0.0.1' });
+      const { req, res } = makeReqRes({ ip: '10.0.0.1', forwardedFor: '203.0.113.5, 10.0.0.1' });
 
       await controller.login({ username: 'admin', password: 'pass' }, req, res);
 
-      // Should use first value from x-forwarded-for
+      // Must use the socket address, not the spoofable header value
+      expect(adminAuthService.login).toHaveBeenCalledWith('admin', 'pass', '10.0.0.1');
+    });
+
+    it('should use X-Forwarded-For when the peer is a TRUSTED_PROXIES entry', async () => {
+      process.env['TRUSTED_PROXIES'] = '10.0.0.1';
+      resetTrustedProxyConfig();
+
+      adminAuthService.login.mockResolvedValue({
+        access_token: 'tok',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        rateLimitHeaders: {},
+      });
+      const { req, res } = makeReqRes({ ip: '10.0.0.1', forwardedFor: '203.0.113.5, 10.0.0.1' });
+
+      await controller.login({ username: 'admin', password: 'pass' }, req, res);
+
+      // Peer is trusted — use first value from X-Forwarded-For
       expect(adminAuthService.login).toHaveBeenCalledWith('admin', 'pass', '203.0.113.5');
     });
 

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { Public } from '../common/decorators/public.decorator.js';
 import { AdminAuthService } from './admin-auth.service.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiTags('Admin Auth')
 @Controller('admin/auth')
@@ -18,10 +19,7 @@ export class AdminAuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
-    const ip =
-      (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
-      req.socket?.remoteAddress ??
-      'unknown';
+    const ip = resolveClientIp(req);
 
     const { rateLimitHeaders, ...tokenResponse } = await this.adminAuthService.login(
       body.username,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1014,6 +1014,211 @@ describe('AuthService', () => {
   });
 
   // -----------------------------------------------------------------------
+  // Device code grant — polling interval enforcement (RFC 8628 §3.5)
+  // -----------------------------------------------------------------------
+
+  describe('handleTokenRequest - device_code grant', () => {
+    const deviceClientId = 'device-client';
+    const deviceClientSecret = 'device-secret';
+
+    const deviceClient = {
+      ...dbClient,
+      clientId: deviceClientId,
+      clientSecret: '$argon2id$hashed-device-secret',
+      grantTypes: ['urn:ietf:params:oauth:grant-type:device_code'],
+    };
+
+    function makeDeviceCode(overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'dc-1',
+        deviceCode: 'test-device-code',
+        userCode: 'ABCD-EFGH',
+        clientId: deviceClient.id,
+        realmId: realm.id,
+        scope: 'openid',
+        userId: dbUser.id,
+        approved: true,
+        denied: false,
+        interval: 5,
+        lastPolledAt: null as Date | null,
+        expiresAt: new Date(Date.now() + 600_000),
+        createdAt: new Date(),
+        ...overrides,
+      };
+    }
+
+    function setupDeviceClient() {
+      prisma.client.findUnique.mockResolvedValue(deviceClient as any);
+      crypto.verifyPassword.mockResolvedValue(true);
+    }
+
+    it('should throw BadRequestException with slow_down when polled before the interval elapses', async () => {
+      setupDeviceClient();
+      prisma.deviceCode.findUnique.mockResolvedValue(
+        makeDeviceCode({
+          // lastPolledAt is only 2 seconds ago — interval is 5 s, so too soon
+          lastPolledAt: new Date(Date.now() - 2_000),
+        }) as any,
+      );
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+
+      await expect(
+        service.handleTokenRequest(realm, {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: 'test-device-code',
+          client_id: deviceClientId,
+          client_secret: deviceClientSecret,
+        }),
+      ).rejects.toThrow('slow_down');
+    });
+
+    it('should increase the polling interval by 5 seconds when returning slow_down', async () => {
+      setupDeviceClient();
+      const dc = makeDeviceCode({
+        lastPolledAt: new Date(Date.now() - 2_000),
+        interval: 5,
+      });
+      prisma.deviceCode.findUnique.mockResolvedValue(dc as any);
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+
+      await expect(
+        service.handleTokenRequest(realm, {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: 'test-device-code',
+          client_id: deviceClientId,
+          client_secret: deviceClientSecret,
+        }),
+      ).rejects.toThrow('slow_down');
+
+      // The update must bump the interval by 5
+      expect(prisma.deviceCode.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ interval: 10, lastPolledAt: expect.any(Date) }),
+        }),
+      );
+    });
+
+    it('should not throw slow_down when polled after the full interval has elapsed', async () => {
+      setupForTokenIssuance(deviceClient as any);
+      const dc = makeDeviceCode({
+        // 6 seconds ago — safely past the 5 s interval
+        lastPolledAt: new Date(Date.now() - 6_000),
+      });
+      prisma.deviceCode.findUnique.mockResolvedValue(dc as any);
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+      prisma.user.findUnique.mockResolvedValue(dbUser as any);
+
+      const result = await service.handleTokenRequest(realm, {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'test-device-code',
+        client_id: deviceClientId,
+        client_secret: deviceClientSecret,
+      });
+
+      expect(result.access_token).toBeDefined();
+    });
+
+    it('should not throw slow_down on the very first poll (no lastPolledAt)', async () => {
+      setupForTokenIssuance(deviceClient as any);
+      const dc = makeDeviceCode({ lastPolledAt: null });
+      prisma.deviceCode.findUnique.mockResolvedValue(dc as any);
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+      prisma.user.findUnique.mockResolvedValue(dbUser as any);
+
+      const result = await service.handleTokenRequest(realm, {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'test-device-code',
+        client_id: deviceClientId,
+        client_secret: deviceClientSecret,
+      });
+
+      expect(result.access_token).toBeDefined();
+    });
+
+    it('should record the poll timestamp on a normal (non-slow) poll', async () => {
+      setupForTokenIssuance(deviceClient as any);
+      const dc = makeDeviceCode({ lastPolledAt: null });
+      prisma.deviceCode.findUnique.mockResolvedValue(dc as any);
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+      prisma.user.findUnique.mockResolvedValue(dbUser as any);
+
+      await service.handleTokenRequest(realm, {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'test-device-code',
+        client_id: deviceClientId,
+        client_secret: deviceClientSecret,
+      });
+
+      // The first update call must set lastPolledAt without changing interval
+      expect(prisma.deviceCode.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ lastPolledAt: expect.any(Date) }),
+        }),
+      );
+    });
+
+    it('should throw BadRequestException with authorization_pending when not yet approved', async () => {
+      setupDeviceClient();
+      prisma.deviceCode.findUnique.mockResolvedValue(
+        makeDeviceCode({ approved: false, userId: null }) as any,
+      );
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+
+      await expect(
+        service.handleTokenRequest(realm, {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: 'test-device-code',
+          client_id: deviceClientId,
+          client_secret: deviceClientSecret,
+        }),
+      ).rejects.toThrow('authorization_pending');
+    });
+
+    it('should throw BadRequestException with access_denied when device is denied', async () => {
+      setupDeviceClient();
+      prisma.deviceCode.findUnique.mockResolvedValue(
+        makeDeviceCode({ denied: true }) as any,
+      );
+      prisma.deviceCode.update.mockResolvedValue({} as any);
+
+      await expect(
+        service.handleTokenRequest(realm, {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: 'test-device-code',
+          client_id: deviceClientId,
+          client_secret: deviceClientSecret,
+        }),
+      ).rejects.toThrow('access_denied');
+    });
+
+    it('should throw BadRequestException with expired_token when device code is expired', async () => {
+      setupDeviceClient();
+      prisma.deviceCode.findUnique.mockResolvedValue(
+        makeDeviceCode({ expiresAt: new Date(Date.now() - 1_000) }) as any,
+      );
+
+      await expect(
+        service.handleTokenRequest(realm, {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          device_code: 'test-device-code',
+          client_id: deviceClientId,
+          client_secret: deviceClientSecret,
+        }),
+      ).rejects.toThrow('expired_token');
+    });
+
+    it('should throw BadRequestException when device_code parameter is missing', async () => {
+      await expect(
+        service.handleTokenRequest(realm, {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          client_id: deviceClientId,
+          client_secret: deviceClientSecret,
+        }),
+      ).rejects.toThrow('device_code is required');
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // issueTokens - ID token generation and scope filtering
   // -----------------------------------------------------------------------
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,6 +3,8 @@ import {
   Optional,
   UnauthorizedException,
   BadRequestException,
+  HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
@@ -29,8 +31,6 @@ export interface TokenResponse {
   refresh_token?: string;
   scope?: string;
   id_token?: string;
-  error?: string;
-  mfa_token?: string;
 }
 
 @Injectable()
@@ -126,10 +126,14 @@ export class AuthService {
 
     if (mfaEnabled) {
       const mfaToken = await this.mfaService.createMfaChallenge(user.id, realm.id);
-      return {
-        error: 'mfa_required',
-        mfa_token: mfaToken,
-      } as TokenResponse;
+      throw new HttpException(
+        {
+          error: 'mfa_required',
+          error_description: 'MFA verification is required to complete authentication',
+          mfa_token: mfaToken,
+        },
+        HttpStatus.UNAUTHORIZED,
+      );
     }
 
     if (mfaRequired && !mfaEnabled) {
@@ -469,20 +473,24 @@ export class AuthService {
       throw new BadRequestException('access_denied');
     }
 
-    // Check for slow polling
+    // RFC 8628 §3.5 — enforce minimum polling interval.
+    // If the client polls before the required interval has elapsed, increase the
+    // interval by 5 seconds and return `slow_down` so the client backs off.
     if (deviceCode.lastPolledAt) {
       const elapsed = Date.now() - deviceCode.lastPolledAt.getTime();
       if (elapsed < deviceCode.interval * 1000) {
-        // Update poll timestamp anyway
         await this.prisma.deviceCode.update({
           where: { id: deviceCode.id },
-          data: { lastPolledAt: new Date() },
+          data: {
+            lastPolledAt: new Date(),
+            interval: deviceCode.interval + 5,
+          },
         });
         throw new BadRequestException('slow_down');
       }
     }
 
-    // Update poll timestamp
+    // Polling is within the allowed window — record the timestamp.
     await this.prisma.deviceCode.update({
       where: { id: deviceCode.id },
       data: { lastPolledAt: new Date() },

--- a/src/common/filters/http-exception.filter.spec.ts
+++ b/src/common/filters/http-exception.filter.spec.ts
@@ -19,67 +19,163 @@ describe('GlobalExceptionFilter', () => {
     };
   });
 
-  it('should handle HttpException with string message', () => {
-    const exception = new HttpException('Forbidden', HttpStatus.FORBIDDEN);
-
-    filter.catch(exception, mockHost);
-
-    expect(mockResponse.status).toHaveBeenCalledWith(403);
-    expect(mockResponse.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        statusCode: 403,
-        timestamp: expect.any(String),
-      }),
-    );
-  });
-
-  it('should handle HttpException with object response', () => {
-    const exception = new BadRequestException({
-      message: ['field is required'],
-      error: 'Bad Request',
+  describe('non-production environment', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'development';
     });
 
-    filter.catch(exception, mockHost);
+    it('should handle HttpException with string message', () => {
+      const exception = new HttpException('Forbidden', HttpStatus.FORBIDDEN);
 
-    expect(mockResponse.status).toHaveBeenCalledWith(400);
-    const jsonArg = mockResponse.json.mock.calls[0][0];
-    expect(jsonArg.statusCode).toBe(400);
-    expect(jsonArg.timestamp).toBeDefined();
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(403);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 403,
+          timestamp: expect.any(String),
+        }),
+      );
+    });
+
+    it('should handle HttpException with object response', () => {
+      const exception = new BadRequestException({
+        message: ['field is required'],
+        error: 'Bad Request',
+      });
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      expect(jsonArg.statusCode).toBe(400);
+      expect(jsonArg.timestamp).toBeDefined();
+    });
+
+    it('should handle non-HttpException as 500', () => {
+      const exception = new Error('Something broke');
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          message: 'Internal server error',
+        }),
+      );
+    });
+
+    it('should handle non-Error exceptions as 500', () => {
+      filter.catch('string-error', mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 500,
+          message: 'Internal server error',
+        }),
+      );
+    });
+
+    it('should include ISO timestamp in response', () => {
+      const exception = new HttpException('Test', 400);
+
+      filter.catch(exception, mockHost);
+
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      // Verify it's a valid ISO string
+      expect(new Date(jsonArg.timestamp).toISOString()).toBe(jsonArg.timestamp);
+    });
+
+    it('should expose HttpException message for 5xx in non-production', () => {
+      const exception = new HttpException('Service unavailable detail', HttpStatus.SERVICE_UNAVAILABLE);
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(503);
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          statusCode: 503,
+          message: 'Service unavailable detail',
+        }),
+      );
+    });
   });
 
-  it('should handle non-HttpException as 500', () => {
-    const exception = new Error('Something broke');
+  describe('production environment', () => {
+    const originalEnv = process.env.NODE_ENV;
 
-    filter.catch(exception, mockHost);
+    beforeEach(() => {
+      process.env.NODE_ENV = 'production';
+    });
 
-    expect(mockResponse.status).toHaveBeenCalledWith(500);
-    expect(mockResponse.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        statusCode: 500,
-        message: 'Internal server error',
-      }),
-    );
-  });
+    afterEach(() => {
+      process.env.NODE_ENV = originalEnv;
+    });
 
-  it('should handle non-Error exceptions as 500', () => {
-    filter.catch('string-error', mockHost);
+    it('should return generic message for unhandled 500 errors', () => {
+      const exception = new Error('DB password is hunter2');
 
-    expect(mockResponse.status).toHaveBeenCalledWith(500);
-    expect(mockResponse.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        statusCode: 500,
-        message: 'Internal server error',
-      }),
-    );
-  });
+      filter.catch(exception, mockHost);
 
-  it('should include ISO timestamp in response', () => {
-    const exception = new HttpException('Test', 400);
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      expect(jsonArg.statusCode).toBe(500);
+      expect(jsonArg.message).toBe('Internal server error');
+      // Must NOT leak any internal detail
+      expect(JSON.stringify(jsonArg)).not.toContain('hunter2');
+    });
 
-    filter.catch(exception, mockHost);
+    it('should return generic message for HttpException with 5xx status in production', () => {
+      const exception = new HttpException(
+        'Database connection string: postgres://user:secret@host/db',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
 
-    const jsonArg = mockResponse.json.mock.calls[0][0];
-    // Verify it's a valid ISO string
-    expect(new Date(jsonArg.timestamp).toISOString()).toBe(jsonArg.timestamp);
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(500);
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      expect(jsonArg.message).toBe('Internal server error');
+      expect(JSON.stringify(jsonArg)).not.toContain('secret');
+    });
+
+    it('should return generic message for 503 HttpException in production', () => {
+      const exception = new HttpException(
+        { message: 'Internal service detail', internalCode: 'DB_FAIL' },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(503);
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      expect(jsonArg.message).toBe('Internal server error');
+      expect(JSON.stringify(jsonArg)).not.toContain('DB_FAIL');
+    });
+
+    it('should still expose specific messages for 4xx errors in production', () => {
+      const exception = new BadRequestException({
+        message: ['email must be an email'],
+        error: 'Bad Request',
+      });
+
+      filter.catch(exception, mockHost);
+
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      expect(jsonArg.statusCode).toBe(400);
+      expect(JSON.stringify(jsonArg)).toContain('email must be an email');
+    });
+
+    it('should include ISO timestamp in production response', () => {
+      const exception = new Error('boom');
+
+      filter.catch(exception, mockHost);
+
+      const jsonArg = mockResponse.json.mock.calls[0][0];
+      expect(new Date(jsonArg.timestamp).toISOString()).toBe(jsonArg.timestamp);
+    });
   });
 });

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -15,23 +15,40 @@ export class GlobalExceptionFilter implements ExceptionFilter {
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
+    const isProduction = process.env.NODE_ENV === 'production';
 
     const status =
       exception instanceof HttpException
         ? exception.getStatus()
         : HttpStatus.INTERNAL_SERVER_ERROR;
 
+    const isServerError = status >= 500;
+
+    // Always log 5xx errors with full details server-side.
+    if (isServerError) {
+      this.logger.error(
+        exception instanceof HttpException
+          ? `HttpException ${status}`
+          : 'Unhandled exception',
+        exception instanceof Error ? exception.stack : String(exception),
+      );
+    }
+
+    // In production, never leak internal details for 5xx responses.
+    if (isProduction && isServerError) {
+      response.status(status).json({
+        statusCode: status,
+        message: 'Internal server error',
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    // For 4xx (or any non-production environment), return the full HttpException payload.
     const message =
       exception instanceof HttpException
         ? exception.getResponse()
         : 'Internal server error';
-
-    if (!(exception instanceof HttpException)) {
-      this.logger.error(
-        'Unhandled exception',
-        exception instanceof Error ? exception.stack : String(exception),
-      );
-    }
 
     response.status(status).json({
       statusCode: status,

--- a/src/common/utils/proxy-ip.util.spec.ts
+++ b/src/common/utils/proxy-ip.util.spec.ts
@@ -1,0 +1,181 @@
+import { resolveClientIp, resetTrustedProxyConfig } from './proxy-ip.util.js';
+import type { Request } from 'express';
+
+/**
+ * Build a minimal Express-like Request mock.
+ */
+function makeRequest(
+  opts: {
+    socketIp?: string;
+    xForwardedFor?: string;
+  } = {},
+): Request {
+  return {
+    socket: { remoteAddress: opts.socketIp ?? '127.0.0.1' },
+    headers: opts.xForwardedFor
+      ? { 'x-forwarded-for': opts.xForwardedFor }
+      : {},
+  } as unknown as Request;
+}
+
+describe('resolveClientIp', () => {
+  beforeEach(() => {
+    resetTrustedProxyConfig();
+    delete process.env['TRUSTED_PROXIES'];
+  });
+
+  afterEach(() => {
+    resetTrustedProxyConfig();
+    delete process.env['TRUSTED_PROXIES'];
+  });
+
+  // ─── TRUSTED_PROXIES not set ────────────────────────────────────────────
+
+  describe('when TRUSTED_PROXIES is not set', () => {
+    it('returns the socket address when no X-Forwarded-For header is present', () => {
+      const req = makeRequest({ socketIp: '10.0.0.5' });
+      expect(resolveClientIp(req)).toBe('10.0.0.5');
+    });
+
+    it('ignores X-Forwarded-For and returns the socket address (prevents spoofing)', () => {
+      const req = makeRequest({
+        socketIp: '10.0.0.5',
+        xForwardedFor: '1.2.3.4',
+      });
+      expect(resolveClientIp(req)).toBe('10.0.0.5');
+    });
+
+    it('returns "unknown" when socket address is not available', () => {
+      const req = { socket: {}, headers: {} } as unknown as Request;
+      expect(resolveClientIp(req)).toBe('unknown');
+    });
+  });
+
+  // ─── TRUSTED_PROXIES=* ──────────────────────────────────────────────────
+
+  describe('when TRUSTED_PROXIES=* (trust all proxies)', () => {
+    beforeEach(() => {
+      process.env['TRUSTED_PROXIES'] = '*';
+      resetTrustedProxyConfig();
+    });
+
+    it('uses the first IP from X-Forwarded-For', () => {
+      const req = makeRequest({
+        socketIp: '10.0.0.1',
+        xForwardedFor: '203.0.113.5, 10.0.0.1',
+      });
+      expect(resolveClientIp(req)).toBe('203.0.113.5');
+    });
+
+    it('falls back to socket address when X-Forwarded-For is absent', () => {
+      const req = makeRequest({ socketIp: '10.0.0.1' });
+      expect(resolveClientIp(req)).toBe('10.0.0.1');
+    });
+  });
+
+  // ─── TRUSTED_PROXIES with specific IP list ───────────────────────────────
+
+  describe('when TRUSTED_PROXIES is a comma-separated list of IPs', () => {
+    beforeEach(() => {
+      process.env['TRUSTED_PROXIES'] = '10.0.0.1,10.0.0.2';
+      resetTrustedProxyConfig();
+    });
+
+    it('uses X-Forwarded-For when the peer is a trusted proxy', () => {
+      const req = makeRequest({
+        socketIp: '10.0.0.1',
+        xForwardedFor: '203.0.113.5',
+      });
+      expect(resolveClientIp(req)).toBe('203.0.113.5');
+    });
+
+    it('ignores X-Forwarded-For when the peer is NOT a trusted proxy', () => {
+      const req = makeRequest({
+        socketIp: '192.168.99.1',
+        xForwardedFor: '1.2.3.4',
+      });
+      expect(resolveClientIp(req)).toBe('192.168.99.1');
+    });
+
+    it('uses X-Forwarded-For for the second trusted proxy as well', () => {
+      const req = makeRequest({
+        socketIp: '10.0.0.2',
+        xForwardedFor: '203.0.113.99',
+      });
+      expect(resolveClientIp(req)).toBe('203.0.113.99');
+    });
+  });
+
+  // ─── TRUSTED_PROXIES with CIDR block ────────────────────────────────────
+
+  describe('when TRUSTED_PROXIES contains a CIDR block', () => {
+    beforeEach(() => {
+      process.env['TRUSTED_PROXIES'] = '10.0.0.0/24';
+      resetTrustedProxyConfig();
+    });
+
+    it('uses X-Forwarded-For when the peer is within the CIDR range', () => {
+      const req = makeRequest({
+        socketIp: '10.0.0.200',
+        xForwardedFor: '203.0.113.7',
+      });
+      expect(resolveClientIp(req)).toBe('203.0.113.7');
+    });
+
+    it('ignores X-Forwarded-For when the peer is outside the CIDR range', () => {
+      const req = makeRequest({
+        socketIp: '10.0.1.1',
+        xForwardedFor: '1.2.3.4',
+      });
+      expect(resolveClientIp(req)).toBe('10.0.1.1');
+    });
+  });
+
+  // ─── Edge cases ─────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('handles an empty TRUSTED_PROXIES string as "none" (no trust)', () => {
+      process.env['TRUSTED_PROXIES'] = '';
+      resetTrustedProxyConfig();
+
+      const req = makeRequest({
+        socketIp: '10.0.0.1',
+        xForwardedFor: '1.2.3.4',
+      });
+      expect(resolveClientIp(req)).toBe('10.0.0.1');
+    });
+
+    it('handles whitespace-only TRUSTED_PROXIES as "none"', () => {
+      process.env['TRUSTED_PROXIES'] = '   ';
+      resetTrustedProxyConfig();
+
+      const req = makeRequest({
+        socketIp: '10.0.0.1',
+        xForwardedFor: '1.2.3.4',
+      });
+      expect(resolveClientIp(req)).toBe('10.0.0.1');
+    });
+
+    it('uses only the first IP when X-Forwarded-For contains multiple entries', () => {
+      process.env['TRUSTED_PROXIES'] = '*';
+      resetTrustedProxyConfig();
+
+      const req = makeRequest({
+        socketIp: '10.0.0.1',
+        xForwardedFor: '5.5.5.5, 6.6.6.6, 7.7.7.7',
+      });
+      expect(resolveClientIp(req)).toBe('5.5.5.5');
+    });
+
+    it('trims spaces around IPs in TRUSTED_PROXIES', () => {
+      process.env['TRUSTED_PROXIES'] = ' 10.0.0.1 , 10.0.0.2 ';
+      resetTrustedProxyConfig();
+
+      const req = makeRequest({
+        socketIp: '10.0.0.1',
+        xForwardedFor: '203.0.113.5',
+      });
+      expect(resolveClientIp(req)).toBe('203.0.113.5');
+    });
+  });
+});

--- a/src/common/utils/proxy-ip.util.ts
+++ b/src/common/utils/proxy-ip.util.ts
@@ -1,0 +1,151 @@
+/**
+ * Utility for safe client-IP resolution behind a reverse proxy.
+ *
+ * Background
+ * ----------
+ * The `X-Forwarded-For` header is trivially spoofable by any client unless
+ * we know that the immediate TCP peer that set the header is a trusted proxy.
+ * Without that check an attacker can send:
+ *
+ *   X-Forwarded-For: 1.2.3.4
+ *
+ * and bypass per-IP rate limiting entirely.
+ *
+ * Resolution rules
+ * ----------------
+ * 1. If `TRUSTED_PROXIES` is not set (the default) we never consult
+ *    `X-Forwarded-For` — we use the raw socket address instead.
+ *
+ * 2. If `TRUSTED_PROXIES=*` we accept `X-Forwarded-For` unconditionally
+ *    (suitable for environments where the network layer already guarantees
+ *    the header is clean, e.g. a managed cloud load-balancer with no
+ *    direct public access to the app process).
+ *
+ * 3. If `TRUSTED_PROXIES` is a comma-separated list of IP addresses / CIDR
+ *    blocks (e.g. `10.0.0.1,172.16.0.0/12`) we only honour the header when
+ *    the immediate peer (socket address) is in that list.
+ *
+ * Usage
+ * -----
+ * Import `resolveClientIp` wherever a client IP is needed:
+ *
+ *   const ip = resolveClientIp(request);
+ */
+
+import type { Request } from 'express';
+
+// ─── CIDR helper (IPv4 only) ────────────────────────────────────────────────
+
+/**
+ * Parse an IPv4 CIDR block into its numeric base address and mask.
+ * Returns `null` when the input is not a valid IPv4 CIDR / address.
+ */
+function parseCidr(cidr: string): { base: number; mask: number } | null {
+  const [addr, prefix] = cidr.split('/');
+  const parts = addr?.split('.');
+  if (!parts || parts.length !== 4) return null;
+
+  let base = 0;
+  for (const part of parts) {
+    const octet = parseInt(part, 10);
+    if (isNaN(octet) || octet < 0 || octet > 255) return null;
+    base = (base << 8) | octet;
+  }
+  // Coerce to unsigned 32-bit integer
+  base = base >>> 0;
+
+  const prefixLen = prefix !== undefined ? parseInt(prefix, 10) : 32;
+  if (isNaN(prefixLen) || prefixLen < 0 || prefixLen > 32) return null;
+
+  const mask = prefixLen === 0 ? 0 : (~0 << (32 - prefixLen)) >>> 0;
+  return { base: base & mask, mask };
+}
+
+/**
+ * Return `true` when `ip` falls within the given CIDR block / host address.
+ */
+function ipInCidr(ip: string, cidr: string): boolean {
+  const range = parseCidr(cidr);
+  const host = parseCidr(ip);
+  if (!range || !host) return false;
+  return (host.base & range.mask) === range.base;
+}
+
+// ─── Trusted proxy list ─────────────────────────────────────────────────────
+
+/**
+ * Parsed representation of the `TRUSTED_PROXIES` environment variable.
+ *
+ * - `type: 'none'`  — variable unset; never trust X-Forwarded-For
+ * - `type: 'all'`   — `TRUSTED_PROXIES=*`; always trust X-Forwarded-For
+ * - `type: 'list'`  — comma-separated IPs/CIDRs; trust only when peer matches
+ */
+type TrustedProxyConfig =
+  | { type: 'none' }
+  | { type: 'all' }
+  | { type: 'list'; entries: string[] };
+
+function parseTrustedProxies(raw: string | undefined): TrustedProxyConfig {
+  if (!raw || raw.trim() === '') return { type: 'none' };
+  if (raw.trim() === '*') return { type: 'all' };
+  const entries = raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return { type: 'list', entries };
+}
+
+/** Lazily-initialised so tests can set env vars before the first import. */
+let _config: TrustedProxyConfig | null = null;
+
+function getTrustedProxyConfig(): TrustedProxyConfig {
+  if (_config === null) {
+    _config = parseTrustedProxies(process.env['TRUSTED_PROXIES']);
+  }
+  return _config;
+}
+
+/**
+ * Reset the cached config. Intended for use in tests only.
+ */
+export function resetTrustedProxyConfig(): void {
+  _config = null;
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the real client IP address from an Express request, taking the
+ * `TRUSTED_PROXIES` environment variable into account.
+ *
+ * @param request - The Express `Request` object.
+ * @returns The client IP string, or `'unknown'` if it cannot be determined.
+ */
+export function resolveClientIp(request: Request): string {
+  const socketIp = request.socket?.remoteAddress ?? 'unknown';
+  const config = getTrustedProxyConfig();
+
+  if (config.type === 'none') {
+    // No trusted proxy configured — always use the raw socket address to
+    // prevent X-Forwarded-For spoofing.
+    return socketIp;
+  }
+
+  const xff = request.headers['x-forwarded-for'] as string | undefined;
+  if (!xff) {
+    return socketIp;
+  }
+
+  const proxyTrusted =
+    config.type === 'all' ||
+    config.entries.some((cidr) => ipInCidr(socketIp, cidr));
+
+  if (!proxyTrusted) {
+    // The immediate peer is not a trusted proxy — ignore the header.
+    return socketIp;
+  }
+
+  // Use the leftmost (original client) IP from the header.
+  const clientIp = xff.split(',')[0]?.trim();
+  return clientIp || socketIp;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,6 +79,27 @@ async function bootstrap() {
 
   app.useLogger(app.get(Logger));
 
+  // ── Reverse-proxy trust configuration ──────────────────────────────────────
+  // Configure Express's built-in "trust proxy" setting to match the
+  // TRUSTED_PROXIES environment variable.  Express uses this to populate
+  // req.ip / req.ips from X-Forwarded-For, but our own resolveClientIp()
+  // utility performs the same check independently and is the authoritative
+  // source for all rate-limiting decisions.
+  //
+  // Setting trust proxy here ensures that other Express-level code (e.g.
+  // session middleware) that reads req.ip also behaves correctly.
+  const trustedProxiesEnv = process.env['TRUSTED_PROXIES'];
+  if (trustedProxiesEnv && trustedProxiesEnv.trim() !== '') {
+    if (trustedProxiesEnv.trim() === '*') {
+      app.set('trust proxy', true);
+    } else {
+      // Provide the list directly; Express accepts a comma-separated string.
+      app.set('trust proxy', trustedProxiesEnv);
+    }
+  }
+  // When TRUSTED_PROXIES is not set we leave "trust proxy" at its default
+  // (false), so Express never touches X-Forwarded-For.
+
   // Enable URI-based versioning: versioned routes are accessible at /api/v{N}/...
   // Unversioned routes continue to work (backward-compatible) but carry
   // Deprecation + Sunset headers injected by DeprecationInterceptor.

--- a/src/rate-limit/rate-limit.guard.ts
+++ b/src/rate-limit/rate-limit.guard.ts
@@ -10,6 +10,7 @@ import { Reflector } from '@nestjs/core';
 import type { Request, Response } from 'express';
 import { RateLimitService } from './rate-limit.service.js';
 import { MetricsService } from '../metrics/metrics.service.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 export const RATE_LIMIT_TYPE_KEY = 'rateLimitType';
 export const RATE_LIMIT_REALM_KEY = 'rateLimitRealm';
@@ -119,10 +120,6 @@ export class RateLimitGuard implements CanActivate {
   }
 
   private extractIp(request: Request): string {
-    return (
-      (request.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ??
-      request.socket?.remoteAddress ??
-      'unknown'
-    );
+    return resolveClientIp(request);
   }
 }


### PR DESCRIPTION
## Summary
- **#365**: MFA challenge returns HTTP 401 instead of error in 200 body
- **#314**: Rate limit uses TRUSTED_PROXIES to prevent X-Forwarded-For spoofing
- **#325**: Device flow enforces polling interval with +5s backoff per RFC 8628
- **#322**: GlobalExceptionFilter hides internal details for 5xx in production
- **#332**: Remove duplicate /clients/create route
- **#368**: iOS SDK retains ASWebAuthenticationSession

## Test plan
- [x] Unit tests pass for all changed files
- [x] TypeScript compilation passes

Closes #365, #314, #325, #322, #332, #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)