### PR TITLE
fix(test): add clear error messages when E2E database is unavailable

### DIFF
--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -1,0 +1,68 @@
+/**
+ * Jest global setup for E2E tests.
+ * Verifies database connectivity before running any test suite.
+ */
+
+import { execSync } from 'child_process';
+
+export default async function globalSetup(): Promise<void> {
+  const dbUrl = process.env['TEST_DATABASE_URL'] || process.env['DATABASE_URL'];
+
+  if (!dbUrl) {
+    // Try to load from .env file
+    try {
+      const fs = await import('fs');
+      const envContent = fs.readFileSync('.env', 'utf-8');
+      const match = envContent.match(/^DATABASE_URL=(.+)$/m);
+      if (match) {
+        process.env['DATABASE_URL'] = match[1];
+      }
+    } catch {
+      // .env doesn't exist
+    }
+  }
+
+  const finalUrl = process.env['TEST_DATABASE_URL'] || process.env['DATABASE_URL'];
+
+  if (!finalUrl) {
+    console.error(
+      '\n' +
+        '╔══════════════════════════════════════════════════════════════╗\n' +
+        '║  E2E TESTS REQUIRE A DATABASE                              ║\n' +
+        '║                                                            ║\n' +
+        '║  Set DATABASE_URL in .env or export TEST_DATABASE_URL.     ║\n' +
+        '║                                                            ║\n' +
+        '║  Quick start:                                              ║\n' +
+        '║    docker compose -f docker-compose.dev.yml up -d postgres ║\n' +
+        '║    npx prisma migrate deploy                               ║\n' +
+        '║    npm run test:e2e                                        ║\n' +
+        '╚══════════════════════════════════════════════════════════════╝\n',
+    );
+    throw new Error('DATABASE_URL is not set. E2E tests cannot run without a database.');
+  }
+
+  // Quick connectivity check for PostgreSQL
+  if (finalUrl.startsWith('postgresql://') || finalUrl.startsWith('postgres://')) {
+    try {
+      execSync('npx prisma db execute --stdin <<< "SELECT 1"', {
+        stdio: 'pipe',
+        timeout: 10_000,
+        env: { ...process.env, DATABASE_URL: finalUrl },
+      });
+    } catch {
+      console.error(
+        '\n' +
+          '╔══════════════════════════════════════════════════════════════╗\n' +
+          '║  DATABASE CONNECTION FAILED                                ║\n' +
+          '║                                                            ║\n' +
+          `║  URL: ${finalUrl.replace(/\/\/.*@/, '//***@').slice(0, 52).padEnd(52)} ║\n` +
+          '║                                                            ║\n' +
+          '║  Make sure the database is running:                        ║\n' +
+          '║    docker compose -f docker-compose.dev.yml up -d postgres ║\n' +
+          '║    npx prisma migrate deploy                               ║\n' +
+          '╚══════════════════════════════════════════════════════════════╝\n',
+      );
+      throw new Error('Cannot connect to database. Is PostgreSQL running?');
+    }
+  }
+}

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -12,5 +12,6 @@
   },
   "transformIgnorePatterns": [
     "node_modules/(?!jose)"
-  ]
+  ],
+  "globalSetup": "./global-setup.ts"
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -64,9 +64,30 @@ export async function createTestApp(): Promise<TestContext> {
     process.env['DATABASE_URL'] = process.env['TEST_DATABASE_URL'];
   }
 
-  const moduleFixture: TestingModule = await Test.createTestingModule({
-    imports: [AppModule],
-  }).compile();
+  const dbUrl = process.env['DATABASE_URL'];
+  if (!dbUrl) {
+    throw new Error(
+      'E2E tests require a database.\n' +
+        'Set DATABASE_URL in your .env file or export TEST_DATABASE_URL.\n' +
+        'Quick start: docker compose -f docker-compose.dev.yml up -d postgres\n' +
+        'Then run: npx prisma migrate deploy',
+    );
+  }
+
+  let moduleFixture: TestingModule;
+  try {
+    moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to compile test application — is the database running?\n` +
+        `DATABASE_URL: ${dbUrl.replace(/\/\/.*@/, '//***@')}\n` +
+        `Original error: ${message}\n\n` +
+        `Quick start: docker compose -f docker-compose.dev.yml up -d postgres && npx prisma migrate deploy`,
+    );
+  }
 
   const app = moduleFixture.createNestApplication();
 


### PR DESCRIPTION
## Summary
- Add Jest `globalSetup` that verifies database connectivity before running any E2E test
- Improve `createTestApp()` with actionable error messages including masked DB URL
- Users now see a clear diagnostic box instead of 190 cryptic `TypeError: Cannot read properties of undefined`

## Before
```
TypeError: Cannot read properties of undefined (reading 'getHttpServer')
  × 190 tests fail with no explanation
```

## After
```
╔══════════════════════════════════════════════════════════════╗
║  DATABASE CONNECTION FAILED                                ║
║                                                            ║
║  URL: postgresql://***@localhost:5432/authme               ║
║                                                            ║
║  Make sure the database is running:                        ║
║    docker compose -f docker-compose.dev.yml up -d postgres ║
║    npx prisma migrate deploy                               ║
╚══════════════════════════════════════════════════════════════╝
```

## Test plan
- [x] Invalid DB URL → clear "DATABASE CONNECTION FAILED" message
- [x] Missing DATABASE_URL → clear "E2E TESTS REQUIRE A DATABASE" message
- [x] Unit tests unaffected (1538 pass, same pre-existing failures)

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)