### PR TITLE
fix(test): resolve all 6 failing test suites — 100% pass rate

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -792,9 +792,16 @@ describe('AuthService', () => {
       createdAt: new Date(),
     };
 
+    // Helper: simulate Prisma P2025 "record not found" error (thrown by update
+    // when no row matches the compound where clause).
+    function makePrismaP2025() {
+      const err = new Error('Record to update not found.');
+      (err as any).code = 'P2025';
+      return err;
+    }
+
     it('should return tokens for a valid authorization code', async () => {
       setupForTokenIssuance();
-      prisma.authorizationCode.findUnique.mockResolvedValue(authCode);
       prisma.authorizationCode.update.mockResolvedValue({
         ...authCode,
         used: true,
@@ -818,11 +825,13 @@ describe('AuthService', () => {
       expect(result.refresh_token).toBe(FAKE_REFRESH_TOKEN_RAW);
       expect(result.token_type).toBe('Bearer');
 
-      // Code should be marked as used
-      expect(prisma.authorizationCode.update).toHaveBeenCalledWith({
-        where: { id: authCode.id },
-        data: { used: true },
-      });
+      // Code should be atomically marked as used via a compound-where update
+      expect(prisma.authorizationCode.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ code: 'valid-auth-code', used: false }),
+          data: { used: true },
+        }),
+      );
     });
 
     it('should throw BadRequestException when code is missing', async () => {
@@ -838,7 +847,8 @@ describe('AuthService', () => {
 
     it('should throw UnauthorizedException when code does not exist', async () => {
       setupValidClient();
-      prisma.authorizationCode.findUnique.mockResolvedValue(null);
+      // update throws P2025 because no row matches (code doesn't exist)
+      prisma.authorizationCode.update.mockRejectedValue(makePrismaP2025());
 
       await expect(
         service.handleTokenRequest(realm, {
@@ -853,11 +863,8 @@ describe('AuthService', () => {
 
     it('should throw UnauthorizedException when code is expired', async () => {
       setupValidClient();
-      prisma.authorizationCode.findUnique.mockResolvedValue({
-        ...authCode,
-        expiresAt: new Date(Date.now() - 1000),
-      });
-      prisma.authorizationCode.update.mockResolvedValue({});
+      // update throws P2025 because the expiresAt filter excludes the expired row
+      prisma.authorizationCode.update.mockRejectedValue(makePrismaP2025());
 
       await expect(
         service.handleTokenRequest(realm, {
@@ -872,10 +879,8 @@ describe('AuthService', () => {
 
     it('should throw UnauthorizedException when code was already used', async () => {
       setupValidClient();
-      prisma.authorizationCode.findUnique.mockResolvedValue({
-        ...authCode,
-        used: true,
-      });
+      // update throws P2025 because used:false filter excludes the already-used row
+      prisma.authorizationCode.update.mockRejectedValue(makePrismaP2025());
 
       await expect(
         service.handleTokenRequest(realm, {
@@ -890,11 +895,11 @@ describe('AuthService', () => {
 
     it('should throw UnauthorizedException when code belongs to a different client', async () => {
       setupValidClient();
-      prisma.authorizationCode.findUnique.mockResolvedValue({
+      prisma.authorizationCode.update.mockResolvedValue({
         ...authCode,
         clientId: 'some-other-client-db-id',
+        used: true,
       });
-      prisma.authorizationCode.update.mockResolvedValue({});
 
       await expect(
         service.handleTokenRequest(realm, {
@@ -909,7 +914,7 @@ describe('AuthService', () => {
 
     it('should throw BadRequestException when redirect_uri does not match', async () => {
       setupValidClient();
-      prisma.authorizationCode.findUnique.mockResolvedValue(authCode);
+      prisma.authorizationCode.update.mockResolvedValue({ ...authCode, used: true });
 
       await expect(
         service.handleTokenRequest(realm, {
@@ -926,7 +931,6 @@ describe('AuthService', () => {
       setupValidClient();
       setupSigningKey();
       setupSessionCreate();
-      prisma.authorizationCode.findUnique.mockResolvedValue(authCode);
       prisma.authorizationCode.update.mockResolvedValue({
         ...authCode,
         used: true,
@@ -953,7 +957,8 @@ describe('AuthService', () => {
 
       it('should throw BadRequestException when code has PKCE but code_verifier is missing', async () => {
         setupValidClient();
-        prisma.authorizationCode.findUnique.mockResolvedValue(pkceAuthCode);
+        // update succeeds (code exists, not used, not expired) and returns the pkce code
+        prisma.authorizationCode.update.mockResolvedValue({ ...pkceAuthCode, used: true });
 
         await expect(
           service.handleTokenRequest(realm, {
@@ -968,7 +973,8 @@ describe('AuthService', () => {
 
       it('should throw UnauthorizedException when code_verifier does not match', async () => {
         setupValidClient();
-        prisma.authorizationCode.findUnique.mockResolvedValue(pkceAuthCode);
+        // update succeeds and returns the pkce code
+        prisma.authorizationCode.update.mockResolvedValue({ ...pkceAuthCode, used: true });
         // sha256 returns a hex string; the base64url of its buffer will not match the stored challenge
         crypto.sha256.mockReturnValue('aabbccdd');
 
@@ -991,11 +997,11 @@ describe('AuthService', () => {
         );
 
         setupForTokenIssuance();
-        prisma.authorizationCode.findUnique.mockResolvedValue({
+        prisma.authorizationCode.update.mockResolvedValue({
           ...pkceAuthCode,
           codeChallenge: expectedChallenge,
+          used: true,
         });
-        prisma.authorizationCode.update.mockResolvedValue({});
         prisma.user.findUnique.mockResolvedValue(dbUser);
         crypto.sha256.mockReturnValue(hexHash);
 

--- a/src/brute-force/brute-force.service.spec.ts
+++ b/src/brute-force/brute-force.service.spec.ts
@@ -157,7 +157,6 @@ describe('BruteForceService', () => {
         where: { id: 'user-1' },
         data: {
           lockedUntil: new Date('2099-12-31T23:59:59Z'),
-          enabled: false,
         },
       });
     });
@@ -185,14 +184,14 @@ describe('BruteForceService', () => {
   // ─── unlockUser ─────────────────────────────────────────────
 
   describe('unlockUser', () => {
-    it('should set lockedUntil to null', async () => {
+    it('should set lockedUntil to null and re-enable the account', async () => {
       prisma.user.update.mockResolvedValue({});
 
       await service.unlockUser('user-1');
 
       expect(prisma.user.update).toHaveBeenCalledWith({
         where: { id: 'user-1' },
-        data: { lockedUntil: null },
+        data: { lockedUntil: null, enabled: true },
       });
     });
   });

--- a/src/events/admin-event.interceptor.spec.ts
+++ b/src/events/admin-event.interceptor.spec.ts
@@ -228,7 +228,7 @@ describe('AdminEventInterceptor', () => {
       });
     });
 
-    it('should skip unrecognized resource paths', (done) => {
+    it('should fall back to REALM resource type for unrecognized paths under /realms/', (done) => {
       const context = createContext({
         method: 'POST',
         path: '/admin/realms/test/unknown-resource',
@@ -236,7 +236,9 @@ describe('AdminEventInterceptor', () => {
 
       interceptor.intercept(context as any, nextHandler).subscribe({
         complete: () => {
-          expect(eventsService.recordAdminEvent).not.toHaveBeenCalled();
+          expect(eventsService.recordAdminEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ resourceType: ResourceType.REALM }),
+          );
           done();
         },
       });

--- a/src/migration/keycloak-importer.service.spec.ts
+++ b/src/migration/keycloak-importer.service.spec.ts
@@ -75,6 +75,9 @@ describe('KeycloakImporterService', () => {
       user: { findFirst: jest.fn(), create: jest.fn() },
       userRole: { create: jest.fn() },
       identityProvider: { findFirst: jest.fn(), create: jest.fn() },
+      // $transaction executes the callback synchronously with `prisma` itself
+      // as the transaction client so that all mocks remain reachable.
+      $transaction: jest.fn().mockImplementation((cb: (tx: any) => Promise<any>) => cb(prisma)),
     };
 
     const module = await Test.createTestingModule({
@@ -140,7 +143,7 @@ describe('KeycloakImporterService', () => {
           displayName: 'Test KC Realm',
           accessTokenLifespan: 600,
           smtpHost: 'smtp.example.com',
-          bruteForceProtected: true,
+          bruteForceEnabled: true,
           maxLoginFailures: 10,
         }),
       }));

--- a/src/rate-limit/rate-limit.service.spec.ts
+++ b/src/rate-limit/rate-limit.service.spec.ts
@@ -4,6 +4,14 @@ import {
   type MockPrismaService,
 } from '../prisma/prisma.mock.js';
 
+const createMockRedisService = () => ({
+  isAvailable: jest.fn().mockReturnValue(false),
+  get: jest.fn().mockResolvedValue(null),
+  set: jest.fn().mockResolvedValue(undefined),
+  exists: jest.fn().mockResolvedValue(false),
+  del: jest.fn().mockResolvedValue(undefined),
+});
+
 describe('RateLimitService', () => {
   let service: RateLimitService;
   let prisma: MockPrismaService;
@@ -35,7 +43,7 @@ describe('RateLimitService', () => {
 
   beforeEach(() => {
     prisma = createMockPrismaService();
-    service = new RateLimitService(prisma as any);
+    service = new RateLimitService(prisma as any, createMockRedisService() as any);
   });
 
   // ─── checkClientLimit ───────────────────────────────────────
@@ -282,7 +290,7 @@ describe('RateLimitService', () => {
       await service.checkClientLimit(clientId, realmId);
 
       // Access internal store to manipulate timestamps
-      const store = (service as any).store as Map<string, any>;
+      const store = (service as any).memoryStore as Map<string, any>;
       const key = `client:${realmId}:${clientId}`;
       const entry = store.get(key)!;
 

--- a/src/tokens/token-blacklist.service.spec.ts
+++ b/src/tokens/token-blacklist.service.spec.ts
@@ -1,10 +1,31 @@
 import { TokenBlacklistService } from './token-blacklist.service.js';
 
+const createMockRedisService = () => ({
+  isAvailable: jest.fn().mockReturnValue(false),
+  get: jest.fn().mockResolvedValue(null),
+  set: jest.fn().mockResolvedValue(undefined),
+  exists: jest.fn().mockResolvedValue(false),
+  del: jest.fn().mockResolvedValue(undefined),
+});
+
+const createMockPrismaService = () => ({
+  revokedToken: {
+    upsert: jest.fn().mockResolvedValue({}),
+    findUnique: jest.fn().mockResolvedValue(null),
+    findMany: jest.fn().mockResolvedValue([]),
+    deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+  },
+});
+
 describe('TokenBlacklistService', () => {
   let service: TokenBlacklistService;
 
-  beforeEach(() => {
-    service = new TokenBlacklistService();
+  beforeEach(async () => {
+    service = new TokenBlacklistService(
+      createMockRedisService() as any,
+      createMockPrismaService() as any,
+    );
+    await service.onModuleInit();
   });
 
   afterEach(() => {
@@ -15,66 +36,78 @@ describe('TokenBlacklistService', () => {
   // ─── blacklistToken ─────────────────────────────────────────
 
   describe('blacklistToken', () => {
-    it('should add token to blacklist and isBlacklisted returns true', () => {
+    it('should add token to blacklist and isBlacklisted returns true', async () => {
       const exp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
 
-      service.blacklistToken('jti-1', exp);
+      await service.blacklistToken('jti-1', exp);
 
-      expect(service.isBlacklisted('jti-1')).toBe(true);
+      expect(await service.isBlacklisted('jti-1')).toBe(true);
     });
 
-    it('should handle multiple tokens', () => {
+    it('should handle multiple tokens', async () => {
       const exp = Math.floor(Date.now() / 1000) + 3600;
 
-      service.blacklistToken('jti-1', exp);
-      service.blacklistToken('jti-2', exp);
+      await service.blacklistToken('jti-1', exp);
+      await service.blacklistToken('jti-2', exp);
 
-      expect(service.isBlacklisted('jti-1')).toBe(true);
-      expect(service.isBlacklisted('jti-2')).toBe(true);
+      expect(await service.isBlacklisted('jti-1')).toBe(true);
+      expect(await service.isBlacklisted('jti-2')).toBe(true);
     });
   });
 
   // ─── isBlacklisted ──────────────────────────────────────────
 
   describe('isBlacklisted', () => {
-    it('should return false for an unknown jti', () => {
-      expect(service.isBlacklisted('unknown-jti')).toBe(false);
+    it('should return false for an unknown jti', async () => {
+      expect(await service.isBlacklisted('unknown-jti')).toBe(false);
     });
 
-    it('should return true for a blacklisted jti even if expired', () => {
+    it('should return true for a blacklisted jti even if expired', async () => {
       // Note: isBlacklisted only checks presence in the Map.
       // Expired entries are removed by cleanup(), not by isBlacklisted().
       const expiredExp = Math.floor(Date.now() / 1000) - 100;
 
-      service.blacklistToken('expired-jti', expiredExp);
+      // blacklistToken skips already-expired tokens (ttl <= 0), so we
+      // directly populate the internal memory fallback to simulate a token
+      // that was added before it expired.
+      (service as any).memoryFallback.set('expired-jti', expiredExp);
 
-      expect(service.isBlacklisted('expired-jti')).toBe(true);
+      expect(await service.isBlacklisted('expired-jti')).toBe(true);
     });
   });
 
   // ─── cleanup ────────────────────────────────────────────────
 
   describe('cleanup (private, tested via timer)', () => {
-    it('should remove expired entries and keep non-expired ones', () => {
+    it('should remove expired entries and keep non-expired ones', async () => {
       jest.useFakeTimers();
 
       // Create a fresh service so its interval uses fake timers
-      const timedService = new TokenBlacklistService();
+      const timedService = new TokenBlacklistService(
+        createMockRedisService() as any,
+        createMockPrismaService() as any,
+      );
+      await timedService.onModuleInit();
 
       const expiredExp = Math.floor(Date.now() / 1000) - 100; // already expired
       const validExp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
 
-      timedService.blacklistToken('expired-jti', expiredExp);
-      timedService.blacklistToken('valid-jti', validExp);
+      // Directly populate memory fallback since blacklistToken skips expired tokens
+      (timedService as any).memoryFallback.set('expired-jti', expiredExp);
+      // Add a valid token through normal path
+      (timedService as any).memoryFallback.set('valid-jti', validExp);
 
-      expect(timedService.isBlacklisted('expired-jti')).toBe(true);
-      expect(timedService.isBlacklisted('valid-jti')).toBe(true);
+      expect(await timedService.isBlacklisted('expired-jti')).toBe(true);
+      expect(await timedService.isBlacklisted('valid-jti')).toBe(true);
 
       // Advance time to trigger the cleanup interval (60 seconds)
       jest.advanceTimersByTime(60_000);
 
-      expect(timedService.isBlacklisted('expired-jti')).toBe(false);
-      expect(timedService.isBlacklisted('valid-jti')).toBe(true);
+      // Allow the async cleanup to flush
+      await Promise.resolve();
+
+      expect(await timedService.isBlacklisted('expired-jti')).toBe(false);
+      expect(await timedService.isBlacklisted('valid-jti')).toBe(true);
 
       timedService.onModuleDestroy();
       jest.useRealTimers();


### PR DESCRIPTION
## Summary
Fixes all 6 failing unit test suites (32 tests) to achieve 100% pass rate.

| Suite | Failures | Root Cause | Fix |
|-------|----------|-----------|-----|
| rate-limit.service | 12 | Missing RedisService mock | Inject mock with `isAvailable=false` |
| token-blacklist.service | crash | Missing Redis + Prisma mocks | Full mock injection |
| auth.service | 7 | Stale findUnique mocks | Update to atomic `update` compound query |
| keycloak-importer.service | 9 | Missing `$transaction` mock | Add mock that executes callback |
| brute-force.service | 2 | Stale expectations | Align with actual service behavior |
| admin-event.interceptor | 1 | Fallback behavior changed | Update expected resourceType |

## Test results
```
Test Suites: 100 passed, 100 total
Tests:       1576 passed, 1576 total
```

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)