### PR TITLE
fix(security): require client auth on introspect and revoke endpoints

### DIFF
--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -12,12 +12,34 @@ describe('TokensController', () => {
     logout: jest.Mock;
     userinfo: jest.Mock;
   };
+  let mockPrisma: {
+    client: { findUnique: jest.Mock };
+  };
+  let mockCrypto: {
+    verifyPassword: jest.Mock;
+  };
 
   const realm = {
     id: 'realm-1',
     name: 'test-realm',
     enabled: true,
   } as Realm;
+
+  const publicClient = {
+    id: 'c1',
+    clientId: 'public-app',
+    clientType: 'PUBLIC',
+    clientSecret: null,
+    enabled: true,
+  };
+
+  const confidentialClient = {
+    id: 'c2',
+    clientId: 'confidential-app',
+    clientType: 'CONFIDENTIAL',
+    clientSecret: 'hashed-secret',
+    enabled: true,
+  };
 
   beforeEach(() => {
     mockTokensService = {
@@ -27,31 +49,69 @@ describe('TokensController', () => {
       userinfo: jest.fn(),
     };
 
-    controller = new TokensController(mockTokensService as any);
+    mockPrisma = {
+      client: {
+        findUnique: jest.fn().mockResolvedValue(publicClient),
+      },
+    };
+
+    mockCrypto = {
+      verifyPassword: jest.fn().mockResolvedValue(true),
+    };
+
+    controller = new TokensController(
+      mockTokensService as any,
+      mockPrisma as any,
+      mockCrypto as any,
+    );
   });
 
-  describe('introspect', () => {
-    it('should call tokensService.introspect with realm and body.token', () => {
-      const body = { token: 'some-token' };
-      controller.introspect(realm, body);
+  const mockReq = (overrides: Record<string, unknown> = {}) =>
+    ({ ip: '127.0.0.1', headers: {}, ...overrides } as any);
 
+  describe('introspect', () => {
+    it('should authenticate client and call tokensService.introspect', async () => {
+      const body = { token: 'some-token', client_id: 'public-app' };
+      mockTokensService.introspect.mockResolvedValue({ active: true, sub: 'user-1' });
+
+      const result = await controller.introspect(realm, body, mockReq());
+
+      expect(mockPrisma.client.findUnique).toHaveBeenCalled();
       expect(mockTokensService.introspect).toHaveBeenCalledWith(realm, 'some-token');
+      expect(result).toEqual({ active: true, sub: 'user-1' });
     });
 
-    it('should return the result from tokensService.introspect', async () => {
-      const expected = { active: true, sub: 'user-1' };
-      mockTokensService.introspect.mockResolvedValue(expected);
+    it('should reject requests without client_id', async () => {
+      await expect(
+        controller.introspect(realm, { token: 'tok' }, mockReq()),
+      ).rejects.toThrow(UnauthorizedException);
+    });
 
-      const result = await controller.introspect(realm, { token: 'tok' });
+    it('should authenticate confidential client with secret', async () => {
+      mockPrisma.client.findUnique.mockResolvedValue(confidentialClient);
+      const body = { token: 'tok', client_id: 'confidential-app', client_secret: 'raw-secret' };
 
-      expect(result).toEqual(expected);
+      await controller.introspect(realm, body, mockReq());
+
+      expect(mockCrypto.verifyPassword).toHaveBeenCalledWith('hashed-secret', 'raw-secret');
+      expect(mockTokensService.introspect).toHaveBeenCalled();
+    });
+
+    it('should support HTTP Basic authentication', async () => {
+      const basicAuth = Buffer.from('public-app:').toString('base64');
+      const req = mockReq({ headers: { authorization: `Basic ${basicAuth}` } });
+
+      await controller.introspect(realm, { token: 'tok' }, req);
+
+      expect(mockTokensService.introspect).toHaveBeenCalled();
     });
   });
 
   describe('revoke', () => {
-    it('should call tokensService.revoke with realm, token, and token_type_hint', () => {
-      const body = { token: 'some-token', token_type_hint: 'refresh_token' };
-      controller.revoke(realm, body);
+    it('should authenticate client and call tokensService.revoke', async () => {
+      const body = { token: 'some-token', token_type_hint: 'refresh_token' as const, client_id: 'public-app' };
+
+      await controller.revoke(realm, body, mockReq());
 
       expect(mockTokensService.revoke).toHaveBeenCalledWith(
         realm,
@@ -60,24 +120,19 @@ describe('TokensController', () => {
       );
     });
 
-    it('should pass undefined for token_type_hint when not provided', () => {
-      const body = { token: 'some-token' };
-      controller.revoke(realm, body);
-
-      expect(mockTokensService.revoke).toHaveBeenCalledWith(
-        realm,
-        'some-token',
-        undefined,
-      );
+    it('should reject revoke without client authentication', async () => {
+      await expect(
+        controller.revoke(realm, { token: 'some-token' }, mockReq()),
+      ).rejects.toThrow(UnauthorizedException);
     });
   });
 
   describe('logout', () => {
     it('should call tokensService.logout with realm, ip, and refresh_token', () => {
       const body = { refresh_token: 'rt-123' };
-      const req = { ip: '127.0.0.1', headers: {} };
+      const req = mockReq();
 
-      controller.logout(realm, body, req as any);
+      controller.logout(realm, body, req);
 
       expect(mockTokensService.logout).toHaveBeenCalledWith(
         realm,
@@ -89,27 +144,27 @@ describe('TokensController', () => {
 
   describe('userinfo', () => {
     it('should extract Bearer token and call tokensService.userinfo', async () => {
-      const req = { headers: { authorization: 'Bearer abc-123' } };
+      const req = mockReq({ headers: { authorization: 'Bearer abc-123' } });
       const expected = { sub: 'user-1', email: 'user@test.com' };
       mockTokensService.userinfo.mockResolvedValue(expected);
 
-      const result = await controller.userinfo(realm, req as any);
+      const result = await controller.userinfo(realm, req);
 
       expect(mockTokensService.userinfo).toHaveBeenCalledWith(realm, 'abc-123');
       expect(result).toEqual(expected);
     });
 
     it('should throw UnauthorizedException when Authorization header is missing', () => {
-      const req = { headers: {} };
+      const req = mockReq();
 
-      expect(() => controller.userinfo(realm, req as any)).toThrow(UnauthorizedException);
+      expect(() => controller.userinfo(realm, req)).toThrow(UnauthorizedException);
       expect(mockTokensService.userinfo).not.toHaveBeenCalled();
     });
 
     it('should throw UnauthorizedException when Authorization header does not start with Bearer', () => {
-      const req = { headers: { authorization: 'Basic dXNlcjpwYXNz' } };
+      const req = mockReq({ headers: { authorization: 'Basic dXNlcjpwYXNz' } });
 
-      expect(() => controller.userinfo(realm, req as any)).toThrow(UnauthorizedException);
+      expect(() => controller.userinfo(realm, req)).toThrow(UnauthorizedException);
       expect(mockTokensService.userinfo).not.toHaveBeenCalled();
     });
   });

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -19,32 +19,111 @@ import { TokensService } from './tokens.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
 
 @ApiTags('Tokens')
 @Controller('realms/:realmName/protocol/openid-connect')
 @UseGuards(RealmGuard)
 @Public()
 export class TokensController {
-  constructor(private readonly tokensService: TokensService) {}
+  constructor(
+    private readonly tokensService: TokensService,
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
 
   @Post('token/introspect')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Token introspection (RFC 7662)' })
-  introspect(
+  async introspect(
     @CurrentRealm() realm: Realm,
-    @Body() body: { token: string },
+    @Body() body: { token: string; client_id?: string; client_secret?: string },
+    @Req() req: Request,
   ) {
+    await this.authenticateClient(realm, body.client_id, body.client_secret, req);
     return this.tokensService.introspect(realm, body.token);
   }
 
   @Post('revoke')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Token revocation (RFC 7009)' })
-  revoke(
+  async revoke(
     @CurrentRealm() realm: Realm,
-    @Body() body: { token: string; token_type_hint?: string },
+    @Body() body: { token: string; token_type_hint?: string; client_id?: string; client_secret?: string },
+    @Req() req: Request,
   ) {
+    await this.authenticateClient(realm, body.client_id, body.client_secret, req);
     return this.tokensService.revoke(realm, body.token, body.token_type_hint);
+  }
+
+  /**
+   * Authenticate the calling client via client_id/client_secret in the body
+   * or via HTTP Basic Authentication (RFC 6749 §2.3.1).
+   * Public clients are allowed with only client_id (no secret required).
+   */
+  private async authenticateClient(
+    realm: Realm,
+    clientId?: string,
+    clientSecret?: string,
+    req?: Request,
+  ): Promise<void> {
+    let cId = clientId;
+    let cSecret = clientSecret;
+
+    // Fall back to HTTP Basic Authentication
+    if (!cId && req) {
+      const authHeader = req.headers['authorization'];
+      if (authHeader?.startsWith('Basic ')) {
+        const decoded = Buffer.from(authHeader.slice(6), 'base64').toString();
+        const colonIdx = decoded.indexOf(':');
+        if (colonIdx > 0) {
+          cId = decodeURIComponent(decoded.slice(0, colonIdx));
+          cSecret = decodeURIComponent(decoded.slice(colonIdx + 1));
+        }
+      }
+    }
+
+    if (!cId) {
+      throw new UnauthorizedException({
+        error: 'invalid_client',
+        error_description: 'Client authentication is required. Provide client_id/client_secret or use HTTP Basic.',
+      });
+    }
+
+    const client = await this.prisma.client.findUnique({
+      where: { realmId_clientId: { realmId: realm.id, clientId: cId } },
+    });
+
+    if (!client || !client.enabled) {
+      throw new UnauthorizedException({
+        error: 'invalid_client',
+        error_description: 'Invalid client_id or client is disabled.',
+      });
+    }
+
+    // Confidential clients must provide a valid secret
+    if (client.clientType === 'CONFIDENTIAL') {
+      if (!cSecret) {
+        throw new UnauthorizedException({
+          error: 'invalid_client',
+          error_description: 'client_secret is required for confidential clients.',
+        });
+      }
+      if (!client.clientSecret) {
+        throw new UnauthorizedException({
+          error: 'invalid_client',
+          error_description: 'Client has no secret configured.',
+        });
+      }
+      const valid = await this.crypto.verifyPassword(client.clientSecret, cSecret);
+      if (!valid) {
+        throw new UnauthorizedException({
+          error: 'invalid_client',
+          error_description: 'Invalid client credentials.',
+        });
+      }
+    }
   }
 
   @Post('logout')


### PR DESCRIPTION
## Summary
Token introspection and revocation endpoints were `@Public()` with no client authentication — any unauthenticated caller could introspect tokens (information disclosure) or revoke them (DoS).

## Changes
- Added `authenticateClient()` method supporting body params and HTTP Basic auth
- Introspect and revoke now require `client_id` (+ `client_secret` for confidential clients)
- Updated tests: 10 tests covering auth scenarios

## Test plan
- [x] 100 suites, 1578 tests pass
- [x] Unauthenticated introspect → 401
- [x] Unauthenticated revoke → 401
- [x] Public client with client_id → allowed
- [x] Confidential client with valid secret → allowed
- [x] HTTP Basic auth → allowed

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)