### PR TITLE
fix(security): add explicit @UseGuards to Realms and Migration controllers

### DIFF
--- a/src/migration/migration.controller.ts
+++ b/src/migration/migration.controller.ts
@@ -1,23 +1,39 @@
-import { Controller, Post, Body, HttpCode } from '@nestjs/common';
+import { Controller, Post, Body, HttpCode, UseGuards } from '@nestjs/common';
 import { ApiSecurity, ApiTags, ApiOperation } from '@nestjs/swagger';
+import { IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
 import { KeycloakImporterService } from './keycloak-importer.service.js';
 import { Auth0ImporterService } from './auth0-importer.service.js';
 import type { MigrationReport } from './migration-report.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 
 class KeycloakImportDto {
-  data: any;
+  @IsObject()
+  data!: Record<string, unknown>;
+
+  @IsOptional()
+  @IsBoolean()
   dryRun?: boolean;
+
+  @IsOptional()
+  @IsString()
   targetRealm?: string;
 }
 
 class Auth0ImportDto {
-  data: any;
+  @IsObject()
+  data!: Record<string, unknown>;
+
+  @IsOptional()
+  @IsBoolean()
   dryRun?: boolean;
-  targetRealm: string;
+
+  @IsString()
+  targetRealm!: string;
 }
 
 @ApiTags('Migration')
 @ApiSecurity('admin-api-key')
+@UseGuards(AdminApiKeyGuard)
 @Controller('admin/migration')
 export class MigrationController {
   constructor(

--- a/src/realms/realms.controller.ts
+++ b/src/realms/realms.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Query,
   BadRequestException,
+  UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiSecurity } from '@nestjs/swagger';
 import { RealmsService } from './realms.service.js';
@@ -18,10 +19,12 @@ import { ThemeService } from '../theme/theme.service.js';
 import { ThemeEmailService } from '../theme/theme-email.service.js';
 import { CreateRealmDto } from './dto/create-realm.dto.js';
 import { UpdateRealmDto } from './dto/update-realm.dto.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 
 @ApiTags('Realms')
 @Controller('admin/realms')
 @ApiSecurity('admin-api-key')
+@UseGuards(AdminApiKeyGuard)
 export class RealmsController {
   constructor(
     private readonly realmsService: RealmsService,


### PR DESCRIPTION
## Summary
- Add explicit `@UseGuards(AdminApiKeyGuard)` to Realms and Migration controllers for defense-in-depth
- Add `class-validator` decorators to migration DTOs (replacing `data: any`)

## Test plan
- [x] 100 suites, 1578 tests pass
- [x] TypeScript compilation clean

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)