### PR TITLE
fix(security): use atomic Redis INCR for rate limiting — fix TOCTOU race

### DIFF
--- a/src/rate-limit/rate-limit.service.ts
+++ b/src/rate-limit/rate-limit.service.ts
@@ -184,14 +184,11 @@ export class RateLimitService {
   }
 
   /**
-   * Increment a Redis key and set TTL if it's a new key.
+   * Atomically increment a Redis key using native INCR (no TOCTOU race).
    */
   private async redisIncr(key: string, ttl: number): Promise<string> {
-    // Use set + get pattern since RedisService doesn't expose INCR directly
-    const current = await this.redis.get(key);
-    const newCount = (current ? parseInt(current, 10) : 0) + 1;
-    await this.redis.set(key, String(newCount), ttl);
-    return String(newCount);
+    const count = await this.redis.incr(key, ttl);
+    return String(count);
   }
 
   /**

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -111,6 +111,21 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     return count > 0;
   }
 
+  /**
+   * Atomically increment a key by 1 and set TTL if the key is new.
+   * Uses native Redis INCR (atomic, no race condition).
+   * Returns the new count after increment.
+   */
+  async incr(key: string, ttlSeconds: number): Promise<number> {
+    if (!this.isAvailable()) return 0;
+    const count = await this.client!.incr(key);
+    // Set TTL only on the first increment (when count becomes 1)
+    if (count === 1) {
+      await this.client!.expire(key, ttlSeconds);
+    }
+    return count;
+  }
+
   /** Delete all keys matching a glob pattern (uses SCAN to avoid blocking). */
   async delPattern(pattern: string): Promise<void> {
     if (!this.isAvailable()) return;


### PR DESCRIPTION
## Summary
Replaces non-atomic GET/SET pattern with native Redis INCR to prevent rate limit bypass under concurrent requests.

## Before (vulnerable)
```typescript
const current = await this.redis.get(key);     // Two requests both read 0
const newCount = (current ? parseInt(current, 10) : 0) + 1;  // Both compute 1
await this.redis.set(key, String(newCount), ttl);  // Both write 1 — one increment lost
```

## After (atomic)
```typescript
const count = await this.redis.incr(key, ttl);  // Native INCR — atomic, no race
```

## Test plan
- [x] 100 suites, 1578 tests pass

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)