### PR TITLE
fix(security): prevent TOTP replay attacks and session fixation

### DIFF
--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -276,6 +276,7 @@ export class LoginController {
         // Create session first so they can set up TOTP
         const sessionToken = await this.loginService.createLoginSession(
           realm, user, req.ip, req.headers['user-agent'],
+          req.cookies?.['AUTHME_SESSION'] as string | undefined,
         );
 
         res.cookie('AUTHME_SESSION', sessionToken, {
@@ -325,6 +326,7 @@ export class LoginController {
 
     const sessionToken = await this.loginService.createLoginSession(
       realm, user, req.ip, req.headers['user-agent'],
+      req.cookies?.['AUTHME_SESSION'] as string | undefined,
     );
 
     res.cookie('AUTHME_SESSION', sessionToken, {

--- a/src/login/login.service.ts
+++ b/src/login/login.service.ts
@@ -103,7 +103,19 @@ export class LoginService {
     user: User,
     ip?: string,
     userAgent?: string,
+    existingSessionToken?: string,
   ): Promise<string> {
+    // Session-fixation prevention: invalidate the pre-existing session cookie
+    // before issuing a new one so an attacker cannot pre-plant a known token.
+    if (existingSessionToken) {
+      const oldTokenHash = this.crypto.sha256(existingSessionToken);
+      await this.prisma.loginSession
+        .delete({ where: { tokenHash: oldTokenHash } })
+        .catch(() => {
+          // Session may already be expired/absent — silently ignore.
+        });
+    }
+
     const maxSessions = realm.maxSessionsPerUser;
     if (maxSessions !== undefined && maxSessions > 0) {
       // Count active SSO (login) sessions for this user in this realm

--- a/src/mfa/mfa.service.ts
+++ b/src/mfa/mfa.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import * as OTPAuth from 'otpauth';
 import * as QRCode from 'qrcode';
 import { Interval } from '@nestjs/schedule';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
+import { RedisService } from '../redis/redis.service.js';
 import type { Realm } from '@prisma/client';
 
 /** The shape of the JSON object stored in PendingAction.data for MFA challenges. */
@@ -15,14 +16,49 @@ interface MfaChallengeData {
   attempts: number;
 }
 
+/** TTL in seconds for a used TOTP code entry — covers the full ±1-step window (3 periods × 30s). */
+const TOTP_USED_CODE_TTL_SECONDS = 90;
+
 @Injectable()
 export class MfaService {
   private readonly logger = new Logger(MfaService.name);
 
+  /**
+   * In-memory fallback store for used TOTP codes when Redis is unavailable.
+   * Key: `totp:used:{userId}:{code}`, Value: expiry timestamp (ms).
+   */
+  private readonly usedTotpCodes = new Map<string, number>();
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly crypto: CryptoService,
+    @Optional() private readonly redis?: RedisService,
   ) {}
+
+  /** Mark a TOTP code as used, preventing replay within the window. */
+  private async markTotpCodeUsed(userId: string, code: string): Promise<void> {
+    const key = `totp:used:${userId}:${code}`;
+    if (this.redis?.isAvailable()) {
+      await this.redis.set(key, '1', TOTP_USED_CODE_TTL_SECONDS);
+    } else {
+      this.usedTotpCodes.set(key, Date.now() + TOTP_USED_CODE_TTL_SECONDS * 1000);
+    }
+  }
+
+  /** Returns true if the TOTP code was already used within the replay window. */
+  private async isTotpCodeUsed(userId: string, code: string): Promise<boolean> {
+    const key = `totp:used:${userId}:${code}`;
+    if (this.redis?.isAvailable()) {
+      return this.redis.exists(key);
+    }
+    const expiry = this.usedTotpCodes.get(key);
+    if (expiry === undefined) return false;
+    if (Date.now() > expiry) {
+      this.usedTotpCodes.delete(key);
+      return false;
+    }
+    return true;
+  }
 
   async setupTotp(userId: string, realmName: string, username: string) {
     // Delete any existing unverified credential
@@ -96,6 +132,12 @@ export class MfaService {
 
     if (!credential || !credential.verified) return false;
 
+    // Replay-attack prevention: reject codes already used within the window.
+    if (await this.isTotpCodeUsed(userId, code)) {
+      this.logger.warn(`Replay attack detected: TOTP code reuse for user ${userId}`);
+      return false;
+    }
+
     const totp = new OTPAuth.TOTP({
       secret: OTPAuth.Secret.fromBase32(credential.secretKey),
       algorithm: credential.algorithm,
@@ -104,7 +146,11 @@ export class MfaService {
     });
 
     const delta = totp.validate({ token: code, window: 1 });
-    return delta !== null;
+    if (delta === null) return false;
+
+    // Mark the code as used so it cannot be replayed within the TOTP window.
+    await this.markTotpCodeUsed(userId, code);
+    return true;
   }
 
   async verifyRecoveryCode(userId: string, code: string): Promise<boolean> {

--- a/src/webauthn/webauthn.controller.ts
+++ b/src/webauthn/webauthn.controller.ts
@@ -137,12 +137,13 @@ export class WebAuthnController {
       if (typeof val === 'string' && val) oauthParams[key] = val;
     }
 
-    // Create session
+    // Create session (invalidating any pre-existing cookie to prevent session fixation)
     const sessionToken = await this.loginService.createLoginSession(
       realm,
       user,
       req.ip,
       req.headers['user-agent'],
+      req.cookies?.['AUTHME_SESSION'] as string | undefined,
     );
 
     res.cookie('AUTHME_SESSION', sessionToken, {


### PR DESCRIPTION
## Summary
Two security fixes:

### TOTP Replay Prevention (#398)
- Track used TOTP codes in Redis (90s TTL) or in-memory fallback
- Same code rejected within validation window per RFC 6238 §5.2

### Session Fixation Prevention (#399)
- Invalidate existing login session before creating new one
- Old AUTHME_SESSION cookie hash used to delete stale record

## Test plan
- [x] 100 suites, 1578 tests pass

Closes #398, Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)