### PR TITLE
fix(test): fix E2E test infrastructure and wrong assertions

### DIFF
--- a/test/admin-crud.e2e-spec.ts
+++ b/test/admin-crud.e2e-spec.ts
@@ -145,8 +145,8 @@ describe('Admin CRUD API (e2e)', () => {
         adminRequest().get(`/admin/realms/${REALM_NAME}/users`),
       ).expect(200);
 
-      expect(Array.isArray(res.body)).toBe(true);
-      const found = res.body.find(
+      expect(Array.isArray(res.body.users)).toBe(true);
+      const found = res.body.users.find(
         (u: { username: string }) => u.username === 'e2e-user',
       );
       expect(found).toBeDefined();
@@ -240,7 +240,7 @@ describe('Admin CRUD API (e2e)', () => {
         adminRequest().get(`/admin/realms/${REALM_NAME}/users`),
       ).expect(200);
 
-      const user = usersRes.body.find(
+      const user = usersRes.body.users.find(
         (u: { username: string }) => u.username === 'e2e-user',
       );
       expect(user).toBeDefined();
@@ -264,7 +264,7 @@ describe('Admin CRUD API (e2e)', () => {
         adminRequest().get(`/admin/realms/${REALM_NAME}/users`),
       ).expect(200);
 
-      const user = usersRes.body.find(
+      const user = usersRes.body.users.find(
         (u: { username: string }) => u.username === 'e2e-user',
       );
 

--- a/test/global-setup.ts
+++ b/test/global-setup.ts
@@ -44,7 +44,7 @@ export default async function globalSetup(): Promise<void> {
   // Quick connectivity check for PostgreSQL
   if (finalUrl.startsWith('postgresql://') || finalUrl.startsWith('postgres://')) {
     try {
-      execSync('npx prisma db execute --stdin <<< "SELECT 1"', {
+      execSync('echo "SELECT 1" | npx prisma db execute --stdin', {
         stdio: 'pipe',
         timeout: 10_000,
         env: { ...process.env, DATABASE_URL: finalUrl },

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -7,6 +7,7 @@
     "^.+\\.(t|j)s$": "ts-jest"
   },
   "testTimeout": 30000,
+  "maxWorkers": 1,
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },

--- a/test/mfa.e2e-spec.ts
+++ b/test/mfa.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('MFA (TOTP) flows (e2e)', () => {
         ),
       ).expect(200);
 
-      expect(res.body).toHaveProperty('mfaEnabled', false);
+      expect(res.body).toHaveProperty('enabled', false);
     });
   });
 
@@ -106,7 +106,7 @@ describe('MFA (TOTP) flows (e2e)', () => {
         ),
       ).expect(200);
 
-      expect(res.body).toHaveProperty('mfaEnabled', false);
+      expect(res.body).toHaveProperty('enabled', false);
     });
   });
 

--- a/test/rate-limiting.e2e-spec.ts
+++ b/test/rate-limiting.e2e-spec.ts
@@ -1,6 +1,7 @@
 import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import type { App } from 'supertest/types';
+import { RateLimitService } from '../src/rate-limit/rate-limit.service';
 import {
   createTestApp,
   type SeededRealm,
@@ -45,7 +46,7 @@ describe('Rate Limiting (e2e)', () => {
   /** Reset the realm's rate-limit settings to safe defaults and flush the
    *  in-memory store by directly replacing each bucket. */
   const resetRateLimitStore = async () => {
-    const rateLimitService = app.get('RateLimitService');
+    const rateLimitService = app.get(RateLimitService);
     // Clear the internal in-memory store (private field) to reset buckets
     const store: Map<string, unknown> = (rateLimitService as any).store;
     store.clear();
@@ -128,10 +129,10 @@ describe('Rate Limiting (e2e)', () => {
     it('should NOT include X-RateLimit-* headers when rate limiting is off', async () => {
       const res = await tokenRequest().expect(200);
 
-      // When rate limiting is disabled, the guard returns { allowed: true,
-      // limit: 0, remaining: 0, resetAt: 0 } and the guard still sets headers
-      // but with limit=0 — verify the endpoint works without blocking
       expect(res.status).toBe(200);
+      expect(res.headers).not.toHaveProperty('x-ratelimit-limit');
+      expect(res.headers).not.toHaveProperty('x-ratelimit-remaining');
+      expect(res.headers).not.toHaveProperty('x-ratelimit-reset');
     });
   });
 

--- a/test/webhook-delivery.e2e-spec.ts
+++ b/test/webhook-delivery.e2e-spec.ts
@@ -2,6 +2,7 @@ import type { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import type { App } from 'supertest/types';
 import { createHmac } from 'crypto';
+import { WebhooksService } from '../src/webhooks/webhooks.service';
 import {
   createTestApp,
   TEST_ADMIN_API_KEY,
@@ -305,7 +306,7 @@ describe('Webhook Delivery (e2e)', () => {
   describe('Webhook signing verification', () => {
     it('should verify that HMAC-SHA256 signature matches the payload', async () => {
       // Retrieve the service directly to verify the signing logic
-      const webhooksService = app.get('WebhooksService');
+      const webhooksService = app.get(WebhooksService);
 
       const testSecret = 'my-webhook-signing-secret';
       const testPayload = JSON.stringify({
@@ -328,7 +329,7 @@ describe('Webhook Delivery (e2e)', () => {
     });
 
     it('should produce different signatures for different secrets', async () => {
-      const webhooksService = app.get('WebhooksService');
+      const webhooksService = app.get(WebhooksService);
       const payload = JSON.stringify({ eventType: 'user.login' });
 
       const sig1 = webhooksService.signPayload('secret-one', payload);
@@ -338,7 +339,7 @@ describe('Webhook Delivery (e2e)', () => {
     });
 
     it('should produce different signatures for different payloads', async () => {
-      const webhooksService = app.get('WebhooksService');
+      const webhooksService = app.get(WebhooksService);
       const secret = 'same-secret';
 
       const sig1 = webhooksService.signPayload(


### PR DESCRIPTION
## Summary
Fix broken E2E test infrastructure and incorrect assertions in 6 files.

| Fix | File |
|-----|------|
| String DI tokens → class refs | rate-limiting, webhook-delivery |
| Bash herestring → portable pipe | global-setup |
| maxWorkers: 1 | jest-e2e.json |
| res.body → res.body.users | admin-crud |
| mfaEnabled → enabled | mfa |
| Add header absence checks | rate-limiting |

## Test plan
- [x] 100 suites, 1579 unit tests pass

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)