### PR TITLE
fix(sdk): fix 15 critical bugs across all 7 SDK packages

### DIFF
--- a/packages/authme-android/src/main/kotlin/com/authme/sdk/AuthMeClient.kt
+++ b/packages/authme-android/src/main/kotlin/com/authme/sdk/AuthMeClient.kt
@@ -151,7 +151,12 @@ class AuthMeClient(
      */
     suspend fun handleRedirectIntent(intent: Intent?): Boolean {
         val uri = intent?.data ?: return false
-        if (!uri.toString().startsWith(config.redirectUri)) return false
+        // Use exact URI comparison (scheme + host + path) to prevent a crafted
+        // URI such as "com.example.myapp://callback.evil.com" from being accepted
+        // by a prefix match against "com.example.myapp://callback".
+        val incomingBase = uri.buildUpon().clearQuery().fragment(null).build()
+        val expectedBase = Uri.parse(config.redirectUri).buildUpon().clearQuery().fragment(null).build()
+        if (incomingBase != expectedBase) return false
 
         val oidc = fetchDiscovery()
 
@@ -405,8 +410,11 @@ class AuthMeClient(
 
         try {
             connection.connect()
-            val code = connection.responseCode
-            val body = connection.inputStream.bufferedReader().readText()
+            val code   = connection.responseCode
+            // For error responses the JVM throws if inputStream is read; use
+            // errorStream instead so we can surface a meaningful message.
+            val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+            val body   = stream?.bufferedReader()?.readText() ?: ""
 
             if (code !in 200..299) {
                 throw AuthMeException.ServerError("HTTP $code: $body")

--- a/packages/authme-angular/src/auth.service.ts
+++ b/packages/authme-angular/src/auth.service.ts
@@ -140,7 +140,7 @@ export class AuthService implements OnDestroy {
       // Handle OIDC callback if URL has `code` param
       if (typeof window !== 'undefined') {
         const params = new URL(window.location.href).searchParams;
-        if (params.has('code')) {
+        if (params.has('code') && params.has('state')) {
           const success = await this.client.handleCallback();
           this._isAuthenticated$.next(success);
           if (success) this._user$.next(this.client.getUserInfo());

--- a/packages/authme-cli/src/commands/realm.ts
+++ b/packages/authme-cli/src/commands/realm.ts
@@ -107,7 +107,14 @@ export function registerRealmCommands(program: Command): void {
     .option('--json', 'Output as JSON')
     .action(async (file: string, opts) => {
       const raw = readFileSync(file, 'utf-8');
-      const body = JSON.parse(raw);
+      let body: unknown;
+      try {
+        body = JSON.parse(raw);
+      } catch {
+        console.error(`Error: "${file}" does not contain valid JSON.`);
+        process.exitCode = 1;
+        return;
+      }
       const client = new HttpClient();
       const query: Record<string, string> = {};
       if (opts.overwrite) query.overwrite = 'true';

--- a/packages/authme-cli/src/commands/upgrade.ts
+++ b/packages/authme-cli/src/commands/upgrade.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import chalk from 'chalk';
 import { HttpClient } from '../http.js';
 import { success, warn } from '../output.js';
@@ -175,8 +175,9 @@ async function handleRollback(opts: {
 
   console.log(chalk.dim(`\n  Running: prisma migrate resolve --rolled-back ${lastMigration}\n`));
   try {
-    const out = execSync(
-      `npx prisma migrate resolve --rolled-back ${lastMigration}`,
+    const out = execFileSync(
+      'npx',
+      ['prisma', 'migrate', 'resolve', '--rolled-back', lastMigration],
       { encoding: 'utf-8', stdio: ['inherit', 'pipe', 'pipe'] },
     );
     console.log(out);

--- a/packages/authme-cli/src/config.ts
+++ b/packages/authme-cli/src/config.ts
@@ -9,7 +9,14 @@ const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
 export function loadConfig(): CliConfig | null {
   if (!existsSync(CONFIG_FILE)) return null;
   const raw = readFileSync(CONFIG_FILE, 'utf-8');
-  return JSON.parse(raw) as CliConfig;
+  try {
+    return JSON.parse(raw) as CliConfig;
+  } catch {
+    throw new Error(
+      `Config file at ${CONFIG_FILE} contains invalid JSON. ` +
+        'Fix or remove it and run `authme login` again.',
+    );
+  }
 }
 
 export function saveConfig(config: CliConfig): void {

--- a/packages/authme-cli/src/http.ts
+++ b/packages/authme-cli/src/http.ts
@@ -91,10 +91,7 @@ export function createHttpClient(config: CliConfig): HttpClient {
 }
 
 export function handleApiError(error: unknown): never {
-  if (error instanceof Error) {
-    console.error(chalk.red(error.message));
-  } else {
-    console.error(chalk.red('An unexpected error occurred'));
-  }
-  process.exit(1);
+  const message =
+    error instanceof Error ? error.message : 'An unexpected error occurred';
+  throw new Error(chalk.red(message));
 }

--- a/packages/authme-cli/src/prompt.ts
+++ b/packages/authme-cli/src/prompt.ts
@@ -12,7 +12,7 @@ export function ask(question: string): Promise<string> {
 
 export async function askPassword(question: string): Promise<string> {
   process.stdout.write(question);
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let password = '';
     const stdin = process.stdin;
     if (stdin.setRawMode) stdin.setRawMode(true);
@@ -31,12 +31,12 @@ export async function askPassword(question: string): Promise<string> {
           process.stdout.write('\b \b');
         }
       } else if (ch === '\u0003') {
-        // Ctrl+C
+        // Ctrl+C — reject the promise so the caller can handle it cleanly
         if (stdin.setRawMode) stdin.setRawMode(false);
         stdin.pause();
         stdin.removeListener('data', onData);
         console.log();
-        throw new Error('Interrupted');
+        reject(new Error('Interrupted'));
       } else {
         password += ch;
         process.stdout.write('*');

--- a/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
+++ b/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
@@ -202,9 +202,10 @@ public final class AuthMeClient: NSObject {
     public func logout() async {
         if let refreshToken = storage.refreshToken,
            let oidc = try? await fetchDiscovery(),
-           let endSessionEndpoint = oidc.endSessionEndpoint
+           let endSessionEndpoint = oidc.endSessionEndpoint,
+           let endSessionURL = URL(string: endSessionEndpoint)
         {
-            var request = URLRequest(url: URL(string: endSessionEndpoint)!)
+            var request = URLRequest(url: endSessionURL)
             request.httpMethod = "POST"
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = try? JSONEncoder().encode(["refresh_token": refreshToken])
@@ -245,7 +246,10 @@ public final class AuthMeClient: NSObject {
             throw AuthMeError.noRefreshToken
         }
 
-        var request = URLRequest(url: URL(string: oidc.tokenEndpoint)!)
+        guard let tokenURL = URL(string: oidc.tokenEndpoint) else {
+            throw AuthMeError.serverError("Invalid token endpoint URL: \(oidc.tokenEndpoint)")
+        }
+        var request = URLRequest(url: tokenURL)
         request.httpMethod = "POST"
         request.setValue(
             "application/x-www-form-urlencoded",
@@ -280,7 +284,10 @@ public final class AuthMeClient: NSObject {
 
         let oidc = try await fetchDiscovery()
 
-        var request = URLRequest(url: URL(string: oidc.userinfoEndpoint)!)
+        guard let userinfoURL = URL(string: oidc.userinfoEndpoint) else {
+            throw AuthMeError.serverError("Invalid userinfo endpoint URL: \(oidc.userinfoEndpoint)")
+        }
+        var request = URLRequest(url: userinfoURL)
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
 
         let (data, response) = try await urlSession.data(for: request)
@@ -315,7 +322,10 @@ public final class AuthMeClient: NSObject {
         verifier: String,
         tokenEndpoint: String
     ) async throws -> TokenResponse {
-        var request = URLRequest(url: URL(string: tokenEndpoint)!)
+        guard let tokenURL = URL(string: tokenEndpoint) else {
+            throw AuthMeError.serverError("Invalid token endpoint URL: \(tokenEndpoint)")
+        }
+        var request = URLRequest(url: tokenURL)
         request.httpMethod = "POST"
         request.setValue(
             "application/x-www-form-urlencoded",

--- a/packages/authme-js/src/client.ts
+++ b/packages/authme-js/src/client.ts
@@ -37,6 +37,10 @@ export class AuthmeClient {
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   private cachedUserInfo: UserInfo | null = null;
   private initialized = false;
+  // Bug #4 fix: guard against concurrent calls to init() (e.g. React StrictMode
+  // double-mount, multiple components calling init simultaneously).
+  private _initializing = false;
+  private _initPromise: Promise<boolean> | null = null;
   private callbackPromise: Promise<boolean> | null = null;
   private silentRefreshIframe: HTMLIFrameElement | null = null;
 
@@ -83,6 +87,19 @@ export class AuthmeClient {
    * existing session from storage. Must be called before other methods.
    */
   async init(): Promise<boolean> {
+    // Bug #4 fix: if init() is already in flight, return the same promise so
+    // concurrent callers coalesce onto a single initialization run.
+    if (this._initializing && this._initPromise) return this._initPromise;
+    if (this.initialized) return this.isAuthenticated();
+
+    this._initializing = true;
+    this._initPromise = this._init().finally(() => {
+      this._initializing = false;
+    });
+    return this._initPromise;
+  }
+
+  private async _init(): Promise<boolean> {
     await this.fetchDiscovery();
 
     const accessToken = this.storage.get('access_token');
@@ -265,10 +282,17 @@ export class AuthmeClient {
       try {
         const config = await this.getOidcConfig();
         if (config.end_session_endpoint) {
+          // Bug #3 fix: OIDC end_session_endpoint expects form-urlencoded, not JSON.
+          // Sending JSON causes the server to ignore the refresh_token parameter,
+          // leaving the server-side session alive.
+          const body = new URLSearchParams({
+            client_id: this.config.clientId,
+            refresh_token: refreshToken,
+          });
           await fetch(config.end_session_endpoint, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ refresh_token: refreshToken }),
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
           });
         }
       } catch {
@@ -449,8 +473,14 @@ export class AuthmeClient {
     });
 
     if (!response.ok) {
-      this.clearTokens();
       const err = await response.json().catch(() => ({ error: 'refresh_failed' }));
+      // Bug #2 fix: only discard stored tokens when the server definitively rejects
+      // the refresh token (4xx — e.g. invalid_grant, token revoked).  On 5xx
+      // (server errors, network hiccups) the tokens may still be valid; clearing
+      // them would silently log the user out due to a transient server problem.
+      if (response.status >= 400 && response.status < 500) {
+        this.clearTokens();
+      }
       throw new Error(err.error_description ?? err.error);
     }
 

--- a/packages/authme-nextjs/src/middleware.ts
+++ b/packages/authme-nextjs/src/middleware.ts
@@ -66,14 +66,31 @@ interface NextResponseStatic {
 }
 
 /**
- * Decode a JWT payload without verification (verification happens server-side
- * via JWKS when using `getServerAuth`).  Here we just need the `exp` claim to
- * decide whether to redirect without an extra round-trip.
+ * Decode a JWT payload without cryptographic signature verification.
+ *
+ * SECURITY NOTE (#10): This function only checks the token's expiry claim
+ * (`exp`) and validates that the token is structurally well-formed (three
+ * dot-separated parts, valid base64url encoding).  It does NOT verify the
+ * signature.  A tampered or forged token with a future `exp` will pass this
+ * check.
+ *
+ * This is intentional for Edge Middleware: signature verification requires the
+ * JWKS public key and an async network fetch, which adds latency on every
+ * request.  The authoritative verification MUST be performed server-side via
+ * `verifyToken` (JWKS) before acting on any token claims for authorization
+ * decisions.  Middleware should only be used as a first-pass redirect guard,
+ * not as a security boundary by itself.
  */
 function isTokenExpiredLocally(token: string): boolean {
   try {
-    const [, payloadB64] = token.split('.');
-    if (!payloadB64) return true;
+    const parts = token.split('.');
+    // Structural validation: a well-formed JWT has exactly three parts.
+    if (parts.length !== 3) return true;
+
+    const [, payloadB64] = parts;
+    // Validate the payload segment contains only valid base64url characters.
+    if (!/^[A-Za-z0-9_-]+$/.test(payloadB64)) return true;
+
     const json = atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/'));
     const payload = JSON.parse(json) as { exp?: number };
     if (!payload.exp) return false;

--- a/packages/authme-nextjs/src/server.ts
+++ b/packages/authme-nextjs/src/server.ts
@@ -78,9 +78,21 @@ export interface ReadonlyRequestCookies {
 // ── JWT decode (no verification — use verifyToken from authme-sdk/server for full JWKS validation) ──
 
 /**
- * Decode a JWT payload.  For server components, this avoids an extra network
- * call when the token was already verified upstream (e.g. in middleware).
- * For full cryptographic verification use `verifyToken` from `authme-sdk/server`.
+ * Decode a JWT payload WITHOUT cryptographic signature verification.
+ *
+ * SECURITY NOTE: This function decodes the payload segment of a JWT by
+ * base64url-decoding it.  It does NOT validate the signature, issuer (`iss`),
+ * audience (`aud`), or any other security-relevant claims beyond expiry.
+ * The decoded claims must NOT be trusted for authorization decisions.
+ *
+ * Intended use — convenience reading in Server Components where the token has
+ * already been cryptographically verified by a trusted upstream layer (e.g.
+ * your API gateway, the AuthMe Edge middleware backed by JWKS verification, or
+ * a call to `verifyToken` from `authme-sdk/server`).
+ *
+ * If you are making access-control decisions based on the returned claims,
+ * you MUST verify the token first with `verifyToken` from `authme-sdk/server`
+ * (which performs full JWKS signature verification).
  */
 function decodeJwtPayload(token: string): TokenPayload | null {
   try {
@@ -104,6 +116,16 @@ function isExpired(payload: TokenPayload): boolean {
 
 /**
  * Read and decode the auth session from request cookies (Next.js Server Components).
+ *
+ * WARNING (#11): This function decodes the JWT locally WITHOUT verifying its
+ * cryptographic signature.  It is provided for convenience when reading user
+ * identity in Server Components where an upstream layer has already verified
+ * the token (e.g. middleware + JWKS).
+ *
+ * DO NOT use the returned `payload` for authorization decisions (role checks,
+ * permission gates, data access) without first verifying the token with
+ * `verifyToken` from `authme-sdk/server`.  An attacker who can set an
+ * arbitrary cookie value could otherwise forge any claims returned here.
  *
  * Returns `AuthSession | null`.  The token is decoded locally (no JWKS call).
  * Call `verifyToken` from `authme-sdk/server` if you need cryptographic validation.

--- a/packages/authme-vue/src/guard.ts
+++ b/packages/authme-vue/src/guard.ts
@@ -99,7 +99,9 @@ export function createAuthGuard(
         '[authme-vue] createAuthGuard: no AuthmeClient available. ' +
           'Pass the client as the second argument or install AuthmePlugin.',
       );
-      return true; // fail-open so navigation is not permanently blocked
+      // Fail closed: no client means we cannot verify identity, so block
+      // navigation and redirect to the login route.
+      return { path: loginRoute, query: { next: to.fullPath } };
     }
 
     const meta = to.meta as AuthRouteMeta | undefined;


### PR DESCRIPTION
## Summary
Fix 15 critical/high bugs across all 7 SDK packages (of 56 reported).

| Package | Bugs Fixed | Key Fixes |
|---------|-----------|-----------|
| authme-js | 3 | form-urlencoded logout, init re-entrancy, 5xx token preservation |
| authme-nextjs | 2 | JWT structure validation, security warnings |
| authme-cli | 5 | Shell injection, JSON error handling, process.exit removal |
| authme-vue | 1 | Guard fails closed |
| authme-angular | 1 | Require code+state for OAuth callback |
| authme-ios | 1 | Force-unwrap removal (4 instances) |
| authme-android | 2 | Exact redirect URI match, errorStream handling |

## Test plan
- [x] 100 suites, 1579 tests pass
- [x] 12 files across 7 packages modified

Note: 41 remaining lower-severity SDK bugs tracked for follow-up.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)