### PR TITLE
fix(security): batch — MFA cross-realm, SAML digest, Docker defaults, IP spoofing

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,6 +46,35 @@ if [ -z "$ADMIN_API_KEY" ]; then
   echo ""
 fi
 
+if [ "$ADMIN_API_KEY" = "changeme" ]; then
+  echo ""
+  echo "============================================"
+  echo "  WARNING: ADMIN_API_KEY is set to the"
+  echo "  insecure default value 'changeme'"
+  echo "============================================"
+  echo ""
+  echo "  Change ADMIN_API_KEY to a strong, randomly"
+  echo "  generated secret before exposing this"
+  echo "  instance to a network."
+  echo ""
+  echo "============================================"
+  echo ""
+fi
+
+if [ "$ADMIN_PASSWORD" = "admin" ]; then
+  echo ""
+  echo "============================================"
+  echo "  WARNING: ADMIN_PASSWORD is set to the"
+  echo "  weak default value 'admin'"
+  echo "============================================"
+  echo ""
+  echo "  Change ADMIN_PASSWORD to a strong password"
+  echo "  before exposing this instance to a network."
+  echo ""
+  echo "============================================"
+  echo ""
+fi
+
 echo "Running Prisma migrations..."
 npx prisma migrate deploy
 

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -16,6 +16,8 @@ describe('AuthController', () => {
   const req = {
     ip: '127.0.0.1',
     headers: { 'user-agent': 'test-agent' },
+    socket: { remoteAddress: '127.0.0.1' },
+    connection: { remoteAddress: '127.0.0.1' },
   };
 
   const res = {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
 import { RateLimitGuard, RateLimitByClient } from '../rate-limit/rate-limit.guard.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiTags('Authentication')
 @Controller('realms/:realmName/protocol/openid-connect')
@@ -59,7 +60,7 @@ export class AuthController {
     return this.authService.handleTokenRequest(
       realm,
       body,
-      req.ip,
+      resolveClientIp(req),
       req.headers['user-agent'],
     );
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -187,6 +187,14 @@ export class AuthService {
       throw new UnauthorizedException('Invalid or expired MFA token, or too many failed attempts');
     }
 
+    // Ensure the challenge was issued for this realm (prevents cross-realm token reuse)
+    if (challenge.realmId !== realm.id) {
+      this.logger.warn(
+        `MFA cross-realm token use attempt: challenge realm ${challenge.realmId} used against realm ${realm.id}`,
+      );
+      throw new UnauthorizedException('Invalid or expired MFA token, or too many failed attempts');
+    }
+
     const verified = await this.mfaService.verifyTotp(challenge.userId, otp);
     if (!verified) {
       // Try as recovery code

--- a/src/device/device.controller.ts
+++ b/src/device/device.controller.ts
@@ -21,6 +21,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { BruteForceService } from '../brute-force/brute-force.service.js';
 import { ThemeRenderService } from '../theme/theme-render.service.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiTags('Device Authorization')
 @Controller('realms/:realmName')
@@ -108,7 +109,7 @@ export class DeviceController {
 
       const valid = await this.crypto.verifyPassword(user.passwordHash, body.password);
       if (!valid) {
-        await this.bruteForce.recordFailure(realm, user.id, req.ip);
+        await this.bruteForce.recordFailure(realm, user.id, resolveClientIp(req));
         return this.themeRender.render(res, realm, 'login', 'device', {
           pageTitle: 'Device Authorization',
           userCode: body.user_code,

--- a/src/impersonation/impersonation.controller.ts
+++ b/src/impersonation/impersonation.controller.ts
@@ -16,6 +16,7 @@ import { ImpersonationService } from './impersonation.service.js';
 import { EndImpersonationBodyDto } from './dto/end-impersonation.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 function getAdminUserId(req: Request): string {
   const adminUser = (req as Request & { adminUser?: { userId?: string } })['adminUser'];
@@ -51,7 +52,7 @@ export class ImpersonationController {
     @Req() req: Request,
   ) {
     const adminUserId = getAdminUserId(req);
-    const ip = req.ip;
+    const ip = resolveClientIp(req);
     return this.impersonationService.startImpersonation(
       realm,
       adminUserId,
@@ -77,7 +78,7 @@ export class ImpersonationController {
     @Req() req: Request,
   ) {
     const adminUserId = getAdminUserId(req);
-    const ip = req.ip;
+    const ip = resolveClientIp(req);
     await this.impersonationService.endImpersonation(
       realm,
       dto.impersonationSessionId,

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Logger,
   Post,
   UseGuards,
   Query,
@@ -36,6 +37,7 @@ import { LoginEventType } from '../events/event-types.js';
 import { CustomAttributesService } from '../custom-attributes/custom-attributes.service.js';
 import { RiskAssessmentService } from '../risk-assessment/risk-assessment.service.js';
 import { CsrfService } from '../common/csrf/csrf.service.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 const SCOPE_DESCRIPTIONS: Record<string, string> = {
   openid: 'Verify your identity',
@@ -49,6 +51,8 @@ const SCOPE_DESCRIPTIONS: Record<string, string> = {
 @UseGuards(RealmGuard)
 @Public()
 export class LoginController {
+  private readonly logger = new Logger(LoginController.name);
+
   constructor(
     private readonly loginService: LoginService,
     private readonly oauthService: OAuthService,
@@ -134,7 +138,7 @@ export class LoginController {
         realm,
         body['username'],
         body['password'],
-        req.ip,
+        resolveClientIp(req),
       );
 
       // ── Adaptive authentication / risk assessment ──────────────────────────
@@ -143,7 +147,7 @@ export class LoginController {
           userId: user.id,
           realmId: realm.id,
           realmName: realm.name,
-          ipAddress: req.ip,
+          ipAddress: resolveClientIp(req),
           userAgent: req.headers['user-agent'] ?? null,
           deviceFingerprint: body['device_fingerprint'] ?? null,
           timestamp: new Date(),
@@ -167,7 +171,7 @@ export class LoginController {
             type: LoginEventType.LOGIN_ERROR,
             userId: user.id,
             clientId: body['client_id'],
-            ipAddress: req.ip,
+            ipAddress: resolveClientIp(req),
             error: `Login blocked by risk assessment (score=${assessment.riskScore})`,
           });
 
@@ -275,7 +279,7 @@ export class LoginController {
         // Realm requires MFA but user hasn't set it up yet
         // Create session first so they can set up TOTP
         const sessionToken = await this.loginService.createLoginSession(
-          realm, user, req.ip, req.headers['user-agent'],
+          realm, user, resolveClientIp(req), req.headers['user-agent'],
           req.cookies?.['AUTHME_SESSION'] as string | undefined,
         );
 
@@ -297,7 +301,7 @@ export class LoginController {
         realmId: realm.id,
         type: LoginEventType.LOGIN_ERROR,
         clientId: body['client_id'],
-        ipAddress: req.ip,
+        ipAddress: resolveClientIp(req),
         error: errMessage,
       });
 
@@ -325,7 +329,7 @@ export class LoginController {
     }
 
     const sessionToken = await this.loginService.createLoginSession(
-      realm, user, req.ip, req.headers['user-agent'],
+      realm, user, resolveClientIp(req), req.headers['user-agent'],
       req.cookies?.['AUTHME_SESSION'] as string | undefined,
     );
 
@@ -342,7 +346,7 @@ export class LoginController {
       type: LoginEventType.LOGIN,
       userId: user.id,
       clientId: oauthParams['client_id'],
-      ipAddress: req.ip,
+      ipAddress: resolveClientIp(req),
     });
 
     if (!client) {
@@ -407,6 +411,15 @@ export class LoginController {
       return res.redirect(`/realms/${realm.name}/login?error=${encodeURIComponent('MFA session expired or too many failed attempts. Please login again.')}`);
     }
 
+    // Ensure the challenge was issued for this realm (prevents cross-realm token reuse)
+    if (challenge.realmId !== realm.id) {
+      this.logger.warn(
+        `MFA cross-realm token use attempt: challenge realm ${challenge.realmId} used against realm ${realm.id}`,
+      );
+      res.clearCookie('AUTHME_MFA_CHALLENGE', { path: `/realms/${realm.name}` });
+      return res.redirect(`/realms/${realm.name}/login?error=${encodeURIComponent('MFA session expired. Please login again.')}`);
+    }
+
     const code = body['code'];
     const recoveryCode = body['recoveryCode'];
 
@@ -422,7 +435,7 @@ export class LoginController {
         realmId: realm.id,
         type: LoginEventType.MFA_VERIFY_ERROR,
         userId: challenge.userId,
-        ipAddress: req.ip,
+        ipAddress: resolveClientIp(req),
         error: 'Invalid MFA code',
       });
       // Same challenge token is reused — attempt counter was already incremented

--- a/src/saml/saml-idp.service.ts
+++ b/src/saml/saml-idp.service.ts
@@ -344,17 +344,28 @@ ${attrXml}
     publicKeyPem: string,
     insertAfterTag: string,
   ): string {
-    // 1) Apply exclusive C14N canonicalization (exc-c14n) to the XML before
-    //    digesting. This prevents XML Signature Wrapping (XSW) attacks by
-    //    ensuring the digest is over a canonical, attribute-order-stable form
-    //    rather than raw serialised XML which an attacker could reorder.
-    const canonicalXml = this.exclusiveC14N(xml);
-
-    // 2) Compute digest of the element (SHA-256)
     const { createHash } = require('crypto') as typeof import('crypto');
-    const digest = createHash('sha256').update(canonicalXml, 'utf-8').digest('base64');
 
-    // 3) Build SignedInfo
+    // 1) Extract the referenced element (identified by ID) from the document so
+    //    the SHA-256 digest covers only that element, not the entire document.
+    //    Per the XML-DSig spec the digest MUST be computed over the dereferenced
+    //    content of the URI, which for an ID reference is the single element.
+    const refElementRegex = new RegExp(
+      `<(?:[\\w-]+:)?(?:Assertion|Response)[^>]*\\sID="${refId}"[^>]*>[\\s\\S]*?</(?:[\\w-]+:)?(?:Assertion|Response)>`,
+    );
+    const refElementMatch = xml.match(refElementRegex);
+    const refElement = refElementMatch ? refElementMatch[0] : xml;
+
+    // 2) Apply exclusive C14N canonicalization (exc-c14n) to the referenced
+    //    element before digesting. This prevents XML Signature Wrapping (XSW)
+    //    attacks by ensuring the digest is over a canonical, attribute-order-
+    //    stable form rather than raw serialised XML an attacker could reorder.
+    const canonicalRefElement = this.exclusiveC14N(refElement);
+
+    // 3) Compute digest of only the referenced element (SHA-256).
+    const digest = createHash('sha256').update(canonicalRefElement, 'utf-8').digest('base64');
+
+    // 4) Build SignedInfo
     const signedInfo = `<ds:SignedInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
   <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
@@ -368,19 +379,26 @@ ${attrXml}
   </ds:Reference>
 </ds:SignedInfo>`;
 
-    // 4) Sign the SignedInfo block
+    // 5) Canonicalize SignedInfo before signing — the XML-DSig spec (§6.5.1)
+    //    requires that the signer apply the CanonicalizationMethod algorithm
+    //    listed in SignedInfo to the SignedInfo element itself before computing
+    //    the cryptographic signature.  Signing the raw string would produce a
+    //    different value than what a verifier (who canonicalises first) expects.
+    const canonicalSignedInfo = this.exclusiveC14N(signedInfo);
+
+    // 6) Sign the canonicalized SignedInfo block
     const signer = createSign('RSA-SHA256');
-    signer.update(signedInfo);
+    signer.update(canonicalSignedInfo);
     const key = createPrivateKey(privateKeyPem);
     const signatureValue = signer.sign(key, 'base64');
 
-    // 5) Extract certificate body
+    // 7) Extract certificate body
     const certBody = publicKeyPem
       .replace(/-----BEGIN [A-Z ]+-----/g, '')
       .replace(/-----END [A-Z ]+-----/g, '')
       .replace(/\s+/g, '');
 
-    // 6) Build the full <ds:Signature> block
+    // 8) Build the full <ds:Signature> block
     const signatureBlock = `<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
   ${signedInfo}
   <ds:SignatureValue>${signatureValue}</ds:SignatureValue>
@@ -391,7 +409,7 @@ ${attrXml}
   </ds:KeyInfo>
 </ds:Signature>`;
 
-    // 7) Insert signature after the specified tag
+    // 9) Insert signature after the specified tag
     const closingTag = `</${insertAfterTag}>`;
     const insertPos = xml.indexOf(closingTag);
     if (insertPos === -1) {

--- a/src/step-up/step-up.controller.ts
+++ b/src/step-up/step-up.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Logger,
   Post,
   Query,
   Body,
@@ -21,12 +22,15 @@ import { WebAuthnService } from '../webauthn/webauthn.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiTags('Step-Up Authentication')
 @Controller('realms/:realmName/step-up')
 @UseGuards(RealmGuard)
 @Public()
 export class StepUpController {
+  private readonly logger = new Logger(StepUpController.name);
+
   constructor(
     private readonly stepUpService: StepUpService,
     private readonly prisma: PrismaService,
@@ -206,6 +210,14 @@ export class StepUpController {
         throw new UnauthorizedException('MFA token does not match session user');
       }
 
+      // Ensure the challenge was issued for this realm (prevents cross-realm token reuse)
+      if (challenge.realmId !== realm.id) {
+        this.logger.warn(
+          `MFA cross-realm token use attempt: challenge realm ${challenge.realmId} used against realm ${realm.id}`,
+        );
+        throw new UnauthorizedException('Invalid or expired MFA token');
+      }
+
       const verified = await this.mfaService.verifyTotp(challenge.userId, otp);
       if (!verified) {
         const recoveryVerified = await this.mfaService.verifyRecoveryCode(challenge.userId, otp);
@@ -233,7 +245,7 @@ export class StepUpController {
         throw new BadRequestException('password is required for password step-up');
       }
 
-      const ip = req.ip;
+      const ip = resolveClientIp(req);
       try {
         await this.loginService.validateCredentials(realm, user.username, password, ip);
       } catch {

--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -67,7 +67,7 @@ describe('TokensController', () => {
   });
 
   const mockReq = (overrides: Record<string, unknown> = {}) =>
-    ({ ip: '127.0.0.1', headers: {}, ...overrides } as any);
+    ({ ip: '127.0.0.1', headers: {}, socket: { remoteAddress: '127.0.0.1' }, connection: { remoteAddress: '127.0.0.1' }, ...overrides } as any);
 
   describe('introspect', () => {
     it('should authenticate client and call tokensService.introspect', async () => {

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -21,6 +21,7 @@ import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiTags('Tokens')
 @Controller('realms/:realmName/protocol/openid-connect')
@@ -142,7 +143,7 @@ export class TokensController {
     @Body() body: { refresh_token?: string },
     @Req() req: Request,
   ) {
-    return this.tokensService.logout(realm, req.ip, body.refresh_token);
+    return this.tokensService.logout(realm, resolveClientIp(req), body.refresh_token);
   }
 
   @Get('logout')
@@ -169,7 +170,7 @@ export class TokensController {
       );
     }
 
-    await this.tokensService.logoutByIdToken(realm, req.ip, idTokenHint);
+    await this.tokensService.logoutByIdToken(realm, resolveClientIp(req), idTokenHint);
 
     if (postLogoutRedirectUri) {
       const redirectUrl = new URL(postLogoutRedirectUri);

--- a/src/webauthn/webauthn.controller.ts
+++ b/src/webauthn/webauthn.controller.ts
@@ -33,6 +33,7 @@ import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
 } from '@simplewebauthn/server';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiExcludeController()
 @Controller('realms/:realmName')
@@ -150,7 +151,7 @@ export class WebAuthnController {
     const sessionToken = await this.loginService.createLoginSession(
       realm,
       user,
-      req.ip,
+      resolveClientIp(req),
       req.headers['user-agent'],
       req.cookies?.['AUTHME_SESSION'] as string | undefined,
     );


### PR DESCRIPTION
## Summary
5 security fixes.

| Issue | Fix |
|-------|-----|
| #430 | Plugin integrity — verified already working |
| #431 | MFA cross-realm bypass — add realmId check in 3 call sites |
| #432 | SAML digest scope + SignedInfo canonicalization |
| #433 | Warn on default ADMIN_API_KEY/ADMIN_PASSWORD |
| #434 | resolveClientIp() in 7 controllers (was req.ip) |

## Test plan
- [x] 100 suites, 1579 tests pass

Closes #430, #431, #432, #433, #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)