### PR TITLE
fix: final batch — status codes, service accounts, DTO compat, invitation hashing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,10 @@ dist
 .env.local
 .env.production
 .env.*.local
+.env.development
+.env.test
+.env.staging
+.env.production.local
 .git
 .claude
 coverage

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, Req, Res, UnauthorizedException } from '@nestjs/common';
+import { Controller, Post, Get, Body, Req, Res, UnauthorizedException, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { Public } from '../common/decorators/public.decorator.js';
@@ -13,8 +13,9 @@ export class AdminAuthController {
 
   @Post('login')
   @Public()
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Admin login' })
-  @ApiResponse({ status: 201, description: 'Login successful, returns token' })
+  @ApiResponse({ status: 200, description: 'Login successful, returns token' })
   @ApiResponse({ status: 400, description: 'Invalid input' })
   @ApiResponse({ status: 401, description: 'Invalid credentials' })
   async login(
@@ -38,8 +39,9 @@ export class AdminAuthController {
   }
 
   @Post('logout')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Admin logout – revoke current token' })
-  @ApiResponse({ status: 201, description: 'Logged out successfully' })
+  @ApiResponse({ status: 200, description: 'Logged out successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async logout(@Req() req: Request) {
     const authHeader = req.headers['authorization'];

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -56,6 +56,7 @@ import { OrganizationsModule } from './organizations/organizations.module.js';
 import { RiskAssessmentModule } from './risk-assessment/risk-assessment.module.js';
 import { MigrationModule } from './migration/migration.module.js';
 import { CorsModule } from './cors/cors.module.js';
+import { ServiceAccountsModule } from './service-accounts/service-accounts.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -122,6 +123,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     RiskAssessmentModule,
     MigrationModule,
     CorsModule,
+    ServiceAccountsModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/brute-force/brute-force.controller.ts
+++ b/src/brute-force/brute-force.controller.ts
@@ -29,12 +29,13 @@ export class BruteForceController {
   }
 
   @Post('users/:userId/unlock')
-  @HttpCode(HttpStatus.NO_CONTENT)
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Unlock a locked user' })
-  @ApiResponse({ status: 204, description: 'User unlocked' })
+  @ApiResponse({ status: 200, description: 'User unlocked' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async unlockUser(@Param('userId') userId: string) {
     await this.bruteForceService.unlockUser(userId);
+    return { message: 'User unlocked' };
   }
 }

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -56,7 +56,11 @@ export class ClientsService {
       );
     }
 
-    const clientType = (dto.clientType ?? 'CONFIDENTIAL') as ClientType;
+    // Resolve clientType: explicit field takes precedence, then the publicClient
+    // convenience alias, then the default of CONFIDENTIAL.
+    const clientType = (
+      dto.clientType ?? (dto.publicClient === true ? 'PUBLIC' : 'CONFIDENTIAL')
+    ) as ClientType;
     let rawSecret: string | undefined;
     let secretHash: string | undefined;
 

--- a/src/clients/dto/create-client.dto.ts
+++ b/src/clients/dto/create-client.dto.ts
@@ -60,6 +60,19 @@ export class CreateClientDto {
   @IsEnum({ CONFIDENTIAL: 'CONFIDENTIAL', PUBLIC: 'PUBLIC' })
   clientType?: 'CONFIDENTIAL' | 'PUBLIC';
 
+  /**
+   * Convenience alias for `clientType: 'PUBLIC'`.
+   * When `true` it is equivalent to sending `clientType: 'PUBLIC'`.
+   * Ignored when `clientType` is also provided.
+   */
+  @ApiPropertyOptional({
+    description: "Shorthand for clientType: 'PUBLIC'. Ignored when clientType is set.",
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  publicClient?: boolean;
+
   @ApiPropertyOptional({ default: true })
   @IsOptional()
   @IsBoolean()

--- a/src/organizations/organizations.service.spec.ts
+++ b/src/organizations/organizations.service.spec.ts
@@ -360,7 +360,9 @@ describe('OrganizationsService', () => {
         role: 'member',
       });
 
-      expect(result).toEqual(mockInvitation);
+      expect(result).toHaveProperty('token');
+      expect(result).toHaveProperty('expiresAt');
+      expect(typeof result.token).toBe('string');
       expect(prisma.organizationInvitation.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           organizationId: 'org-1',

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -183,25 +183,31 @@ export class OrganizationsService {
   async createInvitation(realm: Realm, slug: string, dto: CreateInvitationDto) {
     const org = await this.findOne(realm, slug);
 
-    const token = randomBytes(32).toString('hex');
+    const rawToken = randomBytes(32).toString('hex');
+    const tokenHash = createHash('sha256').update(rawToken).digest('hex');
     const expiresAt = new Date(Date.now() + INVITATION_TTL_MS);
 
-    return this.prisma.organizationInvitation.create({
+    await this.prisma.organizationInvitation.create({
       data: {
         organizationId: org.id,
         email: dto.email.toLowerCase(),
         role: dto.role ?? 'member',
-        token,
+        token: tokenHash,
         expiresAt,
       },
     });
+
+    // Return the raw token so callers can embed it in the invitation email link.
+    // The hash stored in the database is never exposed.
+    return { token: rawToken, expiresAt };
   }
 
   async acceptInvitation(realm: Realm, slug: string, token: string, userId: string) {
     const org = await this.findOne(realm, slug);
 
+    const tokenHash = createHash('sha256').update(token).digest('hex');
     const invitation = await this.prisma.organizationInvitation.findUnique({
-      where: { token },
+      where: { token: tokenHash },
     });
 
     if (!invitation || invitation.organizationId !== org.id) {

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -95,8 +95,9 @@ export class RolesController {
   // ─── User Realm Role Assignment ─────────────────────────
 
   @Post('users/:userId/role-mappings/realm')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Assign realm roles to a user' })
-  @ApiResponse({ status: 201, description: 'Realm roles assigned' })
+  @ApiResponse({ status: 200, description: 'Realm roles assigned' })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User or role not found' })
@@ -141,8 +142,9 @@ export class RolesController {
   // ─── User Client Role Assignment ────────────────────────
 
   @Post('users/:userId/role-mappings/clients/:clientId')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Assign client roles to a user' })
-  @ApiResponse({ status: 201, description: 'Client roles assigned' })
+  @ApiResponse({ status: 200, description: 'Client roles assigned' })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User, client, or role not found' })

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -94,8 +94,9 @@ export class UsersController {
   }
 
   @Post(':userId/send-verification-email')
+  @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Send or resend verification email to a user' })
-  @ApiResponse({ status: 201, description: 'Verification email sent' })
+  @ApiResponse({ status: 200, description: 'Verification email sent' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User not found' })
   async sendVerificationEmail(

--- a/src/webhooks/webhooks.dto.ts
+++ b/src/webhooks/webhooks.dto.ts
@@ -28,6 +28,19 @@ export class CreateWebhookDto {
   @IsString({ each: true })
   eventTypes!: string[];
 
+  /**
+   * Alias for `eventTypes` for API compatibility with clients that send `events`.
+   * When `eventTypes` is not provided, `events` is used as a fallback.
+   */
+  @ApiPropertyOptional({
+    example: ['user.login', 'user.created'],
+    description: "Alias for eventTypes. Used when eventTypes is not provided.",
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  events?: string[];
+
   @ApiPropertyOptional({ example: 'My webhook for user events' })
   @IsOptional()
   @IsString()

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -62,13 +62,16 @@ export class WebhooksService {
   async create(realm: Realm, dto: CreateWebhookDto) {
     const encryptedSecret = this.crypto.encrypt(dto.secret);
 
+    // Accept `events` as an alias for `eventTypes` for API compatibility.
+    const resolvedEventTypes = dto.eventTypes ?? dto.events ?? [];
+
     const webhook = await this.prisma.webhook.create({
       data: {
         realmId: realm.id,
         url: dto.url,
         secret: encryptedSecret,
         enabled: dto.enabled ?? true,
-        eventTypes: dto.eventTypes,
+        eventTypes: resolvedEventTypes,
         description: dto.description,
       },
       select: WEBHOOK_SELECT,


### PR DESCRIPTION
## Summary
8 issues resolved in one batch.

| Issue | Fix |
|-------|-----|
| #435 | Register ServiceAccountsModule in AppModule |
| #436 | Fix 5 wrong HTTP status codes (201→200, 204→200) |
| #437 | publicClient + events DTO aliases for Keycloak compat |
| #440 | Verified seed.ts is correct — no change needed |
| #441 | SHA-256 hash invitation tokens before storing |
| #442 | Add missing .env variants to .dockerignore |

## Test plan
- [x] 100 suites, 1579 tests pass

Closes #435, #436, #437, #440, #441, #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)