### PR TITLE
fix: session 9 — CORS, seed crash, device flow, brute-force unlock, Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ COPY --from=build /app/themes ./themes
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/package-lock.json ./package-lock.json
 
-# Prisma config needed for migrate deploy
-COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+# prisma.config.ts is TypeScript and cannot be executed directly by Node in the
+# production image (no compiler present).  migrate deploy only needs the schema
+# file, which is already present under ./prisma/schema.prisma — the --schema flag
+# is passed explicitly in docker-entrypoint.sh instead.
 
 # Remove dev dependencies in production stage (not build stage)
 RUN npm prune --omit=dev

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -76,7 +76,11 @@ if [ "$ADMIN_PASSWORD" = "admin" ]; then
 fi
 
 echo "Running Prisma migrations..."
-npx prisma migrate deploy
+# Pass --schema explicitly so Prisma does not attempt to load prisma.config.ts
+# (a TypeScript file that cannot be executed without a compiler in the production
+# image).  The schema file is always present at prisma/schema.prisma because the
+# Dockerfile copies the entire ./prisma directory from the build stage.
+npx prisma migrate deploy --schema prisma/schema.prisma
 
 echo "Starting AuthMe..."
 exec node dist/main.js

--- a/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
+++ b/packages/authme-ios/Sources/AuthMe/AuthMeClient.swift
@@ -473,20 +473,52 @@ private extension Dictionary where Key == String, Value == String {
 // MARK: - Default presentation context
 
 /// A minimal `ASWebAuthenticationPresentationContextProviding` implementation that
-/// returns the app's key window.
+/// returns the app's key window using scene-based APIs.
+///
+/// The lookup strategy is:
+///   1. Prefer the foreground-active `UIWindowScene`'s key window (iOS 15+) or
+///      first key window (iOS < 15).
+///   2. Fall back to *any* connected `UIWindowScene` when no foreground-active
+///      scene is found (e.g. the app is mid-transition between states).
+///
+/// A bare `UIWindow()` is **never** returned; that creates a detached window that
+/// is not part of the scene hierarchy, causing `ASWebAuthenticationSession` to
+/// silently fail to present its browser sheet.  If no suitable window can be
+/// found at all the method traps with a clear message rather than returning a
+/// useless anchor.
 private final class DefaultPresentationContextProvider: NSObject,
     ASWebAuthenticationPresentationContextProviding
 {
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         #if os(iOS)
-        let scene = UIApplication.shared.connectedScenes
+        let windowScenes = UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .first { $0.activationState == .foregroundActive }
+
+        // 1. Prefer a foreground-active scene.
+        let activeScene = windowScenes.first { $0.activationState == .foregroundActive }
+            ?? windowScenes.first // 2. Any connected scene as fallback.
+
         if #available(iOS 15, *) {
-            return scene?.keyWindow ?? UIWindow()
-        } else {
-            return scene?.windows.first(where: \.isKeyWindow) ?? UIWindow()
+            if let window = activeScene?.keyWindow {
+                return window
+            }
         }
+        // Pre-iOS-15 path, or iOS 15+ when keyWindow is nil (uncommon but possible
+        // during transitions).
+        if let window = activeScene?.windows.first(where: \.isKeyWindow)
+            ?? activeScene?.windows.first
+        {
+            return window
+        }
+
+        // No window is available — this should never happen in a correctly
+        // configured app, but trap loudly so the root cause is obvious rather
+        // than producing a cryptic, silent failure.
+        preconditionFailure(
+            "[AuthMe] DefaultPresentationContextProvider: no UIWindow found in any " +
+            "connected UIWindowScene. Ensure the app has an active window before " +
+            "calling login(), or supply a custom presentationContextProvider."
+        )
         #else
         return ASPresentationAnchor()
         #endif

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -42,7 +42,9 @@ async function main() {
   });
   const publicKeyPem = await exportKeyToPem(publicKey, 'public');
   const privateKeyPem = await exportKeyToPem(privateKey, 'private');
-  const kid = randomUUID();
+  // Use a deterministic kid so re-seeding upserts the same row instead of
+  // accumulating stale keys on every run.
+  const kid = 'seed-default-signing-key';
 
   const realm = await prisma.realm.upsert({
     where: { name: 'test' },
@@ -63,8 +65,8 @@ async function main() {
 
   // Upsert the signing key separately so that re-seeding replaces it with a
   // fresh key pair rather than silently leaving the old one in place.
-  await prisma.signingKey.upsert({
-    where: { kid },
+  await prisma.realmSigningKey.upsert({
+    where: { realmId_kid: { realmId: realm.id, kid } },
     update: {
       algorithm: 'RS256',
       publicKey: publicKeyPem,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -600,10 +600,23 @@ export class AuthService {
       throw new UnauthorizedException('Invalid client');
     }
 
-    if (grantType && !client.grantTypes.includes(grantType)) {
-      throw new BadRequestException(
-        `Grant type '${grantType}' not allowed for this client`,
-      );
+    if (grantType) {
+      // For the device_code grant (RFC 8628) accept both the full URN and the
+      // shorthand alias so that clients stored with either value are permitted
+      // (issue #503).  All other grant types must match exactly.
+      const DEVICE_URN = 'urn:ietf:params:oauth:grant-type:device_code';
+      const isDeviceGrant =
+        grantType === DEVICE_URN || grantType === 'device_code';
+      const clientAllowsDevice =
+        client.grantTypes.includes(DEVICE_URN) ||
+        client.grantTypes.includes('device_code');
+
+      const allowed = isDeviceGrant ? clientAllowsDevice : client.grantTypes.includes(grantType);
+      if (!allowed) {
+        throw new BadRequestException(
+          `Grant type '${grantType}' not allowed for this client`,
+        );
+      }
     }
 
     if (client.clientType === 'CONFIDENTIAL') {

--- a/src/brute-force/brute-force.controller.ts
+++ b/src/brute-force/brute-force.controller.ts
@@ -28,9 +28,50 @@ export class BruteForceController {
     return this.bruteForceService.getLockedUsers(realm.id);
   }
 
+  /**
+   * POST /admin/realms/:realmName/brute-force/users/:userId/unlock
+   *
+   * Unlock a user that has been locked out by brute-force protection.
+   */
   @Post('users/:userId/unlock')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Unlock a locked user' })
+  @ApiResponse({ status: 200, description: 'User unlocked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  async unlockUser(@Param('userId') userId: string) {
+    await this.bruteForceService.unlockUser(userId);
+    return { message: 'User unlocked' };
+  }
+}
+
+/**
+ * Keycloak-compatible alias controller (issue #504).
+ *
+ * Keycloak exposes brute-force management under the "attack-detection" path
+ * segment.  Both of these paths must work:
+ *
+ *   POST /admin/realms/:realmName/attack-detection/brute-force/users/:userId  (Keycloak style)
+ *   POST /admin/realms/:realmName/brute-force/users/:userId/unlock             (AuthMe native, above)
+ *
+ * The Keycloak-style endpoint accepts the userId directly in the path with no
+ * trailing `/unlock` segment, matching the Keycloak Admin REST API contract.
+ */
+@ApiTags('Brute Force Protection')
+@Controller('admin/realms/:realmName/attack-detection/brute-force')
+@UseGuards(RealmGuard)
+@ApiSecurity('admin-api-key')
+export class BruteForceAttackDetectionController {
+  constructor(private readonly bruteForceService: BruteForceService) {}
+
+  /**
+   * POST /admin/realms/:realmName/attack-detection/brute-force/users/:userId
+   *
+   * Keycloak-compatible path for unlocking a brute-force-locked user.
+   */
+  @Post('users/:userId')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Unlock a locked user (Keycloak-compatible path)' })
   @ApiResponse({ status: 200, description: 'User unlocked' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })

--- a/src/brute-force/brute-force.module.ts
+++ b/src/brute-force/brute-force.module.ts
@@ -1,10 +1,10 @@
 import { Global, Module } from '@nestjs/common';
-import { BruteForceController } from './brute-force.controller.js';
+import { BruteForceController, BruteForceAttackDetectionController } from './brute-force.controller.js';
 import { BruteForceService } from './brute-force.service.js';
 
 @Global()
 @Module({
-  controllers: [BruteForceController],
+  controllers: [BruteForceController, BruteForceAttackDetectionController],
   providers: [BruteForceService],
   exports: [BruteForceService],
 })

--- a/src/device/device.service.ts
+++ b/src/device/device.service.ts
@@ -26,7 +26,12 @@ export class DeviceService {
     if (!client || !client.enabled) {
       throw new NotFoundException('Client not found');
     }
-    if (!client.grantTypes.includes('urn:ietf:params:oauth:grant-type:device_code')) {
+    // Accept both the full RFC 8628 URN and the shorthand alias so that clients
+    // stored with either value are permitted (issue #503).
+    const supportsDeviceFlow =
+      client.grantTypes.includes('urn:ietf:params:oauth:grant-type:device_code') ||
+      client.grantTypes.includes('device_code');
+    if (!supportsDeviceFlow) {
       throw new BadRequestException('Client does not support device authorization');
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -103,8 +103,20 @@ async function bootstrap() {
       }
 
       corsOriginService.isOriginAllowed(origin).then(
-        (allowed) => { callback(null, allowed ? origin : false); },
-        () => { callback(null, false); },
+        (allowed) => {
+          if (allowed) {
+            callback(null, origin);
+          } else {
+            // Returning an error causes the `cors` middleware to respond with
+            // 403 and no Access-Control-Allow-Origin header.  This is important
+            // for OPTIONS preflight requests: passing `false` instead would make
+            // `cors` call next() without ending the response, and since no route
+            // is registered for OPTIONS the request falls through to Express's
+            // default 404 handler — which is the bug described in issue #501.
+            callback(new Error('Not allowed by CORS'));
+          }
+        },
+        () => { callback(new Error('Not allowed by CORS')); },
       );
     },
     credentials: true,


### PR DESCRIPTION
## Summary
7 issues resolved.

| Issue | Fix |
|-------|-----|
| #501 | CORS: disallowed origins return 403 not 404 |
| #502 | seed.ts: correct Prisma model name + deterministic kid |
| #503 | Device flow: accept both shorthand and full URI grant type |
| #504 | Keycloak-compatible /attack-detection/brute-force/users/:id endpoint |
| #505 | Remove prisma.config.ts from production image, use --schema flag |
| #506 | Events export verified functional (no code change needed) |
| #507 | iOS: proper UIWindowScene keyWindow, no detached UIWindow() |

## Test plan
- [x] 100 suites, 1579 tests pass

Closes #501-#507

🤖 Generated with [Claude Code](https://claude.com/claude-code)