### PR TITLE
fix: session 12 — admin login 500, broker crash, realm create, userinfo, DTO compat

### DIFF
--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Get, Body, Req, Res, UnauthorizedException, HttpCode, HttpStatus } from '@nestjs/common';
+import { Controller, Post, Get, Body, Req, Res, UnauthorizedException, BadRequestException, HttpCode, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { Public } from '../common/decorators/public.decorator.js';
@@ -23,6 +23,13 @@ export class AdminAuthController {
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
   ) {
+    if (!body.username || typeof body.username !== 'string') {
+      throw new BadRequestException('username is required');
+    }
+    if (!body.password || typeof body.password !== 'string') {
+      throw new BadRequestException('password is required');
+    }
+
     const ip = resolveClientIp(req);
 
     const { rateLimitHeaders, ...tokenResponse } = await this.adminAuthService.login(

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -359,8 +359,16 @@ export class AuthService {
     }
 
     // #532 — Enforce that the refresh token was issued to the requesting client
-    if (storedToken.clientId && storedToken.clientId !== client_id) {
-      throw new UnauthorizedException('Refresh token was not issued to this client');
+    if (storedToken.clientId) {
+      if (storedToken.clientId !== client_id) {
+        throw new UnauthorizedException('Refresh token was not issued to this client');
+      }
+    } else {
+      // Legacy token without clientId — backfill it for future checks
+      await this.prisma.refreshToken.update({
+        where: { id: storedToken.id },
+        data: { clientId: client_id },
+      });
     }
 
     // Rotate: revoke old token

--- a/src/broker/broker.service.ts
+++ b/src/broker/broker.service.ts
@@ -47,6 +47,13 @@ export class BrokerService {
     alias: string,
     params: { client_id: string; redirect_uri: string; scope?: string; state?: string; nonce?: string },
   ): Promise<string> {
+    if (!params.client_id) {
+      throw new BadRequestException('client_id is required');
+    }
+    if (!params.redirect_uri) {
+      throw new BadRequestException('redirect_uri is required');
+    }
+
     const idp = await this.idpService.findByAlias(realm, alias);
     if (!idp.enabled) {
       throw new BadRequestException(`Identity provider '${alias}' is disabled`);

--- a/src/client-scopes/client-scopes.controller.ts
+++ b/src/client-scopes/client-scopes.controller.ts
@@ -97,7 +97,7 @@ export class ClientScopesController {
   addMapper(
     @CurrentRealm() realm: Realm,
     @Param('scopeId') scopeId: string,
-    @Body() body: { name: string; mapperType: string; protocol?: string; config?: Record<string, unknown> },
+    @Body() body: { name: string; mapperType?: string; protocolMapper?: string; protocol?: string; config?: Record<string, unknown> },
   ) {
     return this.service.addMapper(realm, scopeId, body);
   }

--- a/src/client-scopes/client-scopes.service.ts
+++ b/src/client-scopes/client-scopes.service.ts
@@ -83,16 +83,21 @@ export class ClientScopesService {
 
   async addMapper(realm: Realm, scopeId: string, data: {
     name: string;
-    mapperType: string;
+    mapperType?: string;
+    protocolMapper?: string;
     protocol?: string;
     config?: Record<string, unknown>;
   }) {
+    const resolvedMapperType = data.mapperType ?? data.protocolMapper;
+    if (!resolvedMapperType) {
+      throw new Error('mapperType (or protocolMapper) is required');
+    }
     await this.findById(realm, scopeId);
     return this.prisma.protocolMapper.create({
       data: {
         clientScopeId: scopeId,
         name: data.name,
-        mapperType: data.mapperType,
+        mapperType: resolvedMapperType,
         protocol: data.protocol ?? 'openid-connect',
         config: (data.config ?? {}) as unknown as Prisma.InputJsonValue,
       },

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -138,12 +138,25 @@ export class ClientsService {
     const cached = await this.cache.getCachedClientConfig<typeof CLIENT_SELECT>(cacheKey);
     if (cached) return cached as unknown as Prisma.ClientGetPayload<{ select: typeof CLIENT_SELECT }>;
 
-    const client = await this.prisma.client.findUnique({
+    let client = await this.prisma.client.findUnique({
       where: {
         realmId_clientId: { realmId: realm.id, clientId },
       },
       select: CLIENT_SELECT,
     });
+
+    // Fallback: if the identifier looks like a UUID, try the primary key (id column)
+    if (!client && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(clientId)) {
+      client = await this.prisma.client.findUnique({
+        where: { id: clientId },
+        select: CLIENT_SELECT,
+      }) ?? null;
+      // Ensure the found client belongs to this realm
+      if (client && client.realmId !== realm.id) {
+        client = null;
+      }
+    }
+
     if (!client) {
       throw new NotFoundException(`Client '${clientId}' not found`);
     }

--- a/src/custom-attributes/registration-flow.spec.ts
+++ b/src/custom-attributes/registration-flow.spec.ts
@@ -56,13 +56,12 @@ describe('resolveUserClaims with custom attribute OIDC claims', () => {
     expect(claims['email']).toBe('john@example.com');
   });
 
-  it('should include sub regardless of allowed claims', () => {
-    // sub is always set at the service level, not via resolveUserClaims
-    // verify that it does not appear in filtered when not in allowedClaims
+  it('should always include sub per OIDC Core §5.3', () => {
+    // sub is mandatory in every userinfo response regardless of requested scopes
     const allowed = new Set<string>();
     const claims = resolveUserClaims(baseUser, allowed);
 
-    expect(claims['sub']).toBeUndefined();
+    expect(claims['sub']).toBe('user-1');
     expect(claims['preferred_username']).toBeUndefined();
   });
 });

--- a/src/groups/dto/create-group.dto.ts
+++ b/src/groups/dto/create-group.dto.ts
@@ -16,4 +16,9 @@ export class CreateGroupDto {
   @IsOptional()
   @IsUUID()
   parentId?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  path?: string;
 }

--- a/src/realms/realms.service.ts
+++ b/src/realms/realms.service.ts
@@ -66,16 +66,46 @@ export class RealmsService {
         failureResetTime: dto.failureResetTime,
         permanentLockoutAfter: dto.permanentLockoutAfter,
         registrationAllowed: dto.registrationAllowed,
+        requireEmailVerification: dto.requireEmailVerification,
         mfaRequired: dto.mfaRequired,
         offlineTokenLifespan: dto.offlineTokenLifespan,
         eventsEnabled: dto.eventsEnabled,
         eventsExpiration: dto.eventsExpiration,
         adminEventsEnabled: dto.adminEventsEnabled,
+        // Rate limiting
+        rateLimitEnabled: dto.rateLimitEnabled,
+        clientRateLimitPerMinute: dto.clientRateLimitPerMinute,
+        clientRateLimitPerHour: dto.clientRateLimitPerHour,
+        userRateLimitPerMinute: dto.userRateLimitPerMinute,
+        userRateLimitPerHour: dto.userRateLimitPerHour,
+        ipRateLimitPerMinute: dto.ipRateLimitPerMinute,
+        ipRateLimitPerHour: dto.ipRateLimitPerHour,
+        // Session management
+        maxSessionsPerUser: dto.maxSessionsPerUser,
+        // Theming
         themeName: dto.themeName,
         theme: dto.theme !== undefined ? dto.theme as unknown as Prisma.InputJsonValue : undefined,
         loginTheme: dto.loginTheme,
         accountTheme: dto.accountTheme,
         emailTheme: dto.emailTheme,
+        // Impersonation
+        impersonationEnabled: dto.impersonationEnabled,
+        impersonationMaxDuration: dto.impersonationMaxDuration,
+        // WebAuthn / passkeys
+        webAuthnEnabled: dto.webAuthnEnabled,
+        webAuthnRpName: dto.webAuthnRpName,
+        webAuthnRpId: dto.webAuthnRpId,
+        // Adaptive authentication
+        adaptiveAuthEnabled: dto.adaptiveAuthEnabled,
+        riskThresholdStepUp: dto.riskThresholdStepUp,
+        riskThresholdBlock: dto.riskThresholdBlock,
+        // Localisation
+        defaultLocale: dto.defaultLocale,
+        supportedLocales: dto.supportedLocales,
+        // Legal / registration controls
+        termsOfServiceUrl: dto.termsOfServiceUrl,
+        registrationApprovalRequired: dto.registrationApprovalRequired,
+        allowedEmailDomains: dto.allowedEmailDomains,
         signingKeys: {
           create: {
             kid: keyPair.kid,

--- a/src/scopes/claims.resolver.ts
+++ b/src/scopes/claims.resolver.ts
@@ -32,8 +32,10 @@ export function resolveUserClaims(
     email_verified: user.emailVerified,
   };
 
-  const filtered: Record<string, unknown> = {};
+  // `sub` is mandatory in every OIDC response — always include it.
+  const filtered: Record<string, unknown> = { sub: user.id };
   for (const [key, value] of Object.entries(allClaims)) {
+    if (key === 'sub') continue; // already set above
     if (allowedClaims.has(key) && value !== undefined) {
       filtered[key] = value;
     }

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -170,10 +170,10 @@ export class TokensController {
   @ApiResponse({ status: 400, description: 'invalid_grant — refresh token not found or already revoked' })
   logout(
     @CurrentRealm() realm: Realm,
-    @Body() body: { refresh_token?: string },
+    @Body() body: { refresh_token?: string } = {},
     @Req() req: Request,
   ) {
-    return this.tokensService.logout(realm, resolveClientIp(req), body.refresh_token);
+    return this.tokensService.logout(realm, resolveClientIp(req), body?.refresh_token);
   }
 
   @Get('logout')

--- a/src/users/dto/set-password.dto.ts
+++ b/src/users/dto/set-password.dto.ts
@@ -1,9 +1,14 @@
-import { IsString, MinLength } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsOptional, IsString, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SetPasswordDto {
   @ApiProperty({ minLength: 8 })
   @IsString()
   @MinLength(8)
   password!: string;
+
+  @ApiPropertyOptional({ description: 'If true, the user must change the password on next login' })
+  @IsOptional()
+  @IsBoolean()
+  temporary?: boolean;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -90,7 +90,7 @@ export class UsersController {
     @CurrentRealm() realm: Realm,
     @Query() query: ListUsersQueryDto,
   ) {
-    return this.usersService.findAll(realm, query.skip ?? 0, query.limit ?? 50, {
+    return this.usersService.findAll(realm, query.skip ?? 0, query.limit ?? 20, {
       search: query.search,
       username: query.username,
       email: query.email,


### PR DESCRIPTION
## Summary
8 issues resolved — 4 critical 500s fixed, security hardening, OIDC compliance.

| Issue | Fix |
|-------|-----|
| #537 | Admin login: validate before CryptoService |
| #538 | Broker: validate client_id/redirect_uri |
| #539 | Protocol mapper: accept both field names |
| #540 | Realm create: all 22 fields persisted |
| #541 | Refresh token: backfill legacy clientId |
| #542 | Logout empty body + userinfo sub always present |
| #543 | Client UUID lookup, group path, reset-password temporary |
| #544 | User limit default 20, consistent |

## Test plan
- [x] `npm run build` — zero errors
- [x] 100 suites, 1580 tests pass

Closes #537-#544

🤖 Generated with [Claude Code](https://claude.com/claude-code)