### PR TITLE
fix(realms): add admin role verification for critical realm operations (#577)

### DIFF
--- a/src/admin-auth/admin-auth.module.ts
+++ b/src/admin-auth/admin-auth.module.ts
@@ -2,11 +2,12 @@ import { Global, Module } from '@nestjs/common';
 import { AdminAuthService } from './admin-auth.service.js';
 import { AdminAuthController } from './admin-auth.controller.js';
 import { AdminSeedService } from './admin-seed.service.js';
+import { AdminRolesGuard } from '../common/guards/admin-roles.guard.js';
 
 @Global()
 @Module({
   controllers: [AdminAuthController],
-  providers: [AdminAuthService, AdminSeedService],
-  exports: [AdminAuthService],
+  providers: [AdminAuthService, AdminSeedService, AdminRolesGuard],
+  exports: [AdminAuthService, AdminRolesGuard],
 })
 export class AdminAuthModule {}

--- a/src/common/decorators/require-admin-roles.decorator.ts
+++ b/src/common/decorators/require-admin-roles.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const REQUIRED_ADMIN_ROLES_KEY = 'requiredAdminRoles';
+
+export interface AdminRolesOptions {
+  roles: string[];
+  requireAll?: boolean;
+}
+
+export const RequireAdminRoles = (roles: string[], requireAll = false) =>
+  SetMetadata(REQUIRED_ADMIN_ROLES_KEY, { roles, requireAll } as AdminRolesOptions);

--- a/src/common/guards/admin-roles.guard.ts
+++ b/src/common/guards/admin-roles.guard.ts
@@ -1,0 +1,56 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Request } from 'express';
+import { REQUIRED_ADMIN_ROLES_KEY, AdminRolesOptions } from '../decorators/require-admin-roles.decorator.js';
+import { AdminAuthService } from '../../admin-auth/admin-auth.service.js';
+
+@Injectable()
+export class AdminRolesGuard implements CanActivate {
+  constructor(
+    private readonly reflector: Reflector,
+    private readonly adminAuthService: AdminAuthService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const options = this.reflector.get<AdminRolesOptions>(
+      REQUIRED_ADMIN_ROLES_KEY,
+      context.getHandler(),
+    );
+
+    if (!options || options.roles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const adminUser = (request as any).adminUser;
+
+    if (!adminUser?.roles) {
+      throw new ForbiddenException('No admin roles found');
+    }
+
+    const { roles, requireAll } = options;
+
+    if (requireAll) {
+      const hasAllRoles = roles.every((role) => this.adminAuthService.hasRole(adminUser.roles, role));
+      if (!hasAllRoles) {
+        throw new ForbiddenException(
+          `Insufficient permissions. Required roles: ${roles.join(', ')}`,
+        );
+      }
+    } else {
+      const hasAnyRole = roles.some((role) => this.adminAuthService.hasRole(adminUser.roles, role));
+      if (!hasAnyRole) {
+        throw new ForbiddenException(
+          `Insufficient permissions. Required at least one of: ${roles.join(', ')}`,
+        );
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/realms/realms.controller.ts
+++ b/src/realms/realms.controller.ts
@@ -23,11 +23,13 @@ import { ThemeEmailService } from '../theme/theme-email.service.js';
 import { CreateRealmDto } from './dto/create-realm.dto.js';
 import { UpdateRealmDto } from './dto/update-realm.dto.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
+import { AdminRolesGuard } from '../common/guards/admin-roles.guard.js';
+import { RequireAdminRoles } from '../common/decorators/require-admin-roles.decorator.js';
 
 @ApiTags('Realms')
 @Controller('admin/realms')
 @ApiSecurity('admin-api-key')
-@UseGuards(AdminApiKeyGuard)
+@UseGuards(AdminApiKeyGuard, AdminRolesGuard)
 export class RealmsController {
   constructor(
     private readonly realmsService: RealmsService,
@@ -39,10 +41,12 @@ export class RealmsController {
   ) {}
 
   @Post()
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Create a new realm' })
   @ApiResponse({ status: 201, description: 'Realm created successfully' })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires super-admin role' })
   create(@Body() dto: CreateRealmDto) {
     return this.realmsService.create(dto);
   }
@@ -73,10 +77,12 @@ export class RealmsController {
   }
 
   @Put(':realmName')
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Update a realm' })
   @ApiResponse({ status: 200, description: 'Realm updated successfully' })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires super-admin role' })
   @ApiResponse({ status: 404, description: 'Realm not found' })
   update(
     @Param('realmName') realmName: string,
@@ -86,10 +92,12 @@ export class RealmsController {
   }
 
   @Patch(':realmName')
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Partially update a realm' })
   @ApiResponse({ status: 200, description: 'Realm updated successfully' })
   @ApiResponse({ status: 400, description: 'Invalid request body' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires super-admin role' })
   @ApiResponse({ status: 404, description: 'Realm not found' })
   partialUpdate(
     @Param('realmName') realmName: string,
@@ -100,9 +108,11 @@ export class RealmsController {
 
   @Delete(':realmName')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Delete a realm' })
   @ApiResponse({ status: 204, description: 'Realm deleted successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires super-admin role' })
   @ApiResponse({ status: 404, description: 'Realm not found' })
   remove(@Param('realmName') realmName: string) {
     return this.realmsService.remove(realmName);
@@ -125,10 +135,12 @@ export class RealmsController {
   }
 
   @Post('import')
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Import a realm from JSON' })
   @ApiResponse({ status: 201, description: 'Realm imported successfully' })
   @ApiResponse({ status: 400, description: 'Invalid import data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - requires super-admin role' })
   importRealm(
     @Body() body: Record<string, unknown>,
     @Query('overwrite') overwrite?: string,


### PR DESCRIPTION
## Summary
Adds role-based access control for critical realm operations. Critical operations (create, update, delete, import) now require  role.

## Changes
- **src/common/decorators/require-admin-roles.decorator.ts**: New decorator to specify required admin roles
- **src/common/guards/admin-roles.guard.ts**: New guard that checks admin roles before allowing access
- **src/realms/realms.controller.ts**: Apply  to create, update, delete, and import endpoints
- **src/admin-auth/admin-auth.module.ts**: Export  so other modules can reuse it

## Security
-  bypass is correctly handled by existing  method
-  and  users can no longer perform critical operations
- Clear 403 Forbidden responses when role requirements aren't met

Fixes #577