### PR TITLE
fix(roles): add user existence check before role removal (#576)

### DIFF
--- a/src/roles/roles.service.spec.ts
+++ b/src/roles/roles.service.spec.ts
@@ -278,7 +278,10 @@ describe('RolesService', () => {
   });
 
   describe('removeUserRealmRoles', () => {
+    const mockUser = { id: 'user-1', realmId: 'realm-1' };
+
     it('should remove roles from a user', async () => {
+      prisma.user.findFirst.mockResolvedValue(mockUser);
       prisma.role.findMany.mockResolvedValue([
         { id: 'role-1', name: 'admin' },
       ]);
@@ -297,7 +300,16 @@ describe('RolesService', () => {
       });
     });
 
+    it('should throw NotFoundException when user does not exist', async () => {
+      prisma.user.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.removeUserRealmRoles(mockRealm, 'nonexistent', ['admin']),
+      ).rejects.toThrow(NotFoundException);
+    });
+
     it('should handle removal of non-existent roles gracefully', async () => {
+      prisma.user.findFirst.mockResolvedValue(mockUser);
       prisma.role.findMany.mockResolvedValue([]);
       prisma.userRole.deleteMany.mockResolvedValue({ count: 0 });
 
@@ -383,8 +395,11 @@ describe('RolesService', () => {
   });
 
   describe('removeUserClientRoles', () => {
+    const mockUser = { id: 'user-1', realmId: 'realm-1' };
+
     it('should remove client roles from a user', async () => {
       prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.user.findFirst.mockResolvedValue(mockUser);
       prisma.role.findMany.mockResolvedValue([
         { id: 'crole-1', name: 'editor' },
       ]);
@@ -416,8 +431,20 @@ describe('RolesService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
+    it('should throw NotFoundException when user does not exist', async () => {
+      prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.user.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.removeUserClientRoles(mockRealm, 'nonexistent-user', 'my-app', [
+          'editor',
+        ]),
+      ).rejects.toThrow(NotFoundException);
+    });
+
     it('should handle removal of non-existent roles gracefully', async () => {
       prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.user.findFirst.mockResolvedValue(mockUser);
       prisma.role.findMany.mockResolvedValue([]);
       prisma.userRole.deleteMany.mockResolvedValue({ count: 0 });
 

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -160,6 +160,13 @@ export class RolesService {
     userId: string,
     roleNames: string[],
   ) {
+    const user = await this.prisma.user.findFirst({
+      where: { id: userId, realmId: realm.id },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
     const roles = await this.prisma.role.findMany({
       where: { realmId: realm.id, clientId: null, name: { in: roleNames } },
     });
@@ -216,6 +223,13 @@ export class RolesService {
     });
     if (!client) {
       throw new NotFoundException(`Client '${clientId}' not found`);
+    }
+
+    const user = await this.prisma.user.findFirst({
+      where: { id: userId, realmId: realm.id },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
     }
 
     const roles = await this.prisma.role.findMany({


### PR DESCRIPTION
## Summary
Add user existence validation to  and  methods to prevent IDOR vulnerability.

## Changes
- **src/roles/roles.service.ts**: Added user existence check before role removal in both  and 
- **src/roles/roles.service.spec.ts**: Updated tests to mock 

## Security
Previously, these methods would silently succeed (returning ) even when the user didn't exist in the realm. Now they throw  consistent with the assign methods.

Fixes #576