### PR TITLE
fix(impersonation): normalize API key adminUserId format (#573)

### DIFF
--- a/src/impersonation/impersonation.service.ts
+++ b/src/impersonation/impersonation.service.ts
@@ -54,9 +54,9 @@ export class ImpersonationService {
     }
 
     // Validate admin user exists.
-    // When authenticated via static API key, adminUserId is 'api-key' (not a real user).
+    // When authenticated via static API key, adminUserId is 'api-key:...' (with fingerprint).
     // API key auth is already verified by AdminApiKeyGuard, so skip the DB lookup.
-    if (adminUserId !== 'api-key') {
+    if (!adminUserId.startsWith('api-key:')) {
       const adminUser = await this.prisma.user.findUnique({
         where: { id: adminUserId },
       });


### PR DESCRIPTION
## Summary
Fix privilege escalation where any API key admin could terminate any impersonation session.

## Root Cause
The  checked for exact  string, but  was already setting  format. This mismatch meant the ownership check at  was bypassed.

## Fix
Changed  to check for  instead of exact match, ensuring consistency with how guard sets the value.

Fixes #573