### PR TITLE
fix(sessions): fix race condition in revokeAllUserSessions (#574)

### DIFF
--- a/src/sessions/sessions.service.spec.ts
+++ b/src/sessions/sessions.service.spec.ts
@@ -189,40 +189,33 @@ describe('SessionsService', () => {
   // ─── revokeAllUserSessions ──────────────────────────────────
 
   describe('revokeAllUserSessions', () => {
-    it('should find all oauth sessions, revoke their tokens, and delete all sessions', async () => {
+    it('should revoke all user sessions in batch operations', async () => {
       prisma.session.findMany.mockResolvedValue([
         { id: 'session-1' },
         { id: 'session-2' },
       ]);
-      prisma.refreshToken.updateMany.mockResolvedValue({ count: 1 });
+      prisma.refreshToken.updateMany.mockResolvedValue({ count: 2 });
       prisma.session.deleteMany.mockResolvedValue({ count: 2 });
       (prisma.loginSession.deleteMany as jest.Mock).mockResolvedValue({ count: 1 });
 
       await service.revokeAllUserSessions(mockRealm, 'user-1');
 
-      // Should find all oauth sessions
       expect(prisma.session.findMany).toHaveBeenCalledWith({
         where: { userId: 'user-1', user: { realmId: 'realm-1' } },
         select: { id: true },
       });
 
-      // Should revoke refresh tokens for each session
-      expect(prisma.refreshToken.updateMany).toHaveBeenCalledTimes(2);
+      expect(prisma.refreshToken.updateMany).toHaveBeenCalledTimes(1);
       expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith({
-        where: { sessionId: 'session-1' },
-        data: { revoked: true },
-      });
-      expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith({
-        where: { sessionId: 'session-2' },
+        where: { sessionId: { in: ['session-1', 'session-2'] } },
         data: { revoked: true },
       });
 
-      // Should delete all oauth sessions
+      expect(prisma.session.deleteMany).toHaveBeenCalledTimes(1);
       expect(prisma.session.deleteMany).toHaveBeenCalledWith({
-        where: { userId: 'user-1', user: { realmId: 'realm-1' } },
+        where: { id: { in: ['session-1', 'session-2'] } },
       });
 
-      // Should delete all sso sessions
       expect(prisma.loginSession.deleteMany).toHaveBeenCalledWith({
         where: { userId: 'user-1', realmId: 'realm-1' },
       });
@@ -230,13 +223,12 @@ describe('SessionsService', () => {
 
     it('should handle case with no existing sessions', async () => {
       prisma.session.findMany.mockResolvedValue([]);
-      prisma.session.deleteMany.mockResolvedValue({ count: 0 });
       (prisma.loginSession.deleteMany as jest.Mock).mockResolvedValue({ count: 0 });
 
       await service.revokeAllUserSessions(mockRealm, 'user-1');
 
       expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
-      expect(prisma.session.deleteMany).toHaveBeenCalled();
+      expect(prisma.session.deleteMany).not.toHaveBeenCalled();
       expect(prisma.loginSession.deleteMany).toHaveBeenCalled();
     });
   });

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -121,22 +121,25 @@ export class SessionsService {
   }
 
   async revokeAllUserSessions(realm: Realm, userId: string): Promise<void> {
-    // Revoke all OAuth sessions
+    // Get all session IDs for this user in this realm
     const sessions = await this.prisma.session.findMany({
       where: { userId, user: { realmId: realm.id } },
       select: { id: true },
     });
+    const sessionIds = sessions.map((s) => s.id);
 
-    for (const session of sessions) {
+    if (sessionIds.length > 0) {
+      // Revoke all refresh tokens for these sessions in a single operation
       await this.prisma.refreshToken.updateMany({
-        where: { sessionId: session.id },
+        where: { sessionId: { in: sessionIds } },
         data: { revoked: true },
       });
-    }
 
-    await this.prisma.session.deleteMany({
-      where: { userId, user: { realmId: realm.id } },
-    });
+      // Delete all sessions
+      await this.prisma.session.deleteMany({
+        where: { id: { in: sessionIds } },
+      });
+    }
 
     // Revoke all SSO sessions
     await this.prisma.loginSession.deleteMany({


### PR DESCRIPTION
## Summary
Fix TOCTOU race condition in  that could leave orphaned refresh tokens.

## Root Cause
Sequential per-session operations allowed new sessions to be created between finding and deleting, orphaning their refresh tokens.

## Fix
- Collect all session IDs upfront
- Use batch operations with  for both refresh token revocation and session deletion
- Skip batch operations when no sessions exist

Fixes #574