### PR TITLE
fix(admin-api-key): simplify admin path matching (#588)

### DIFF
--- a/src/common/guards/admin-api-key.guard.ts
+++ b/src/common/guards/admin-api-key.guard.ts
@@ -28,8 +28,10 @@ export class AdminApiKeyGuard implements CanActivate {
 
     const request = context.switchToHttp().getRequest<Request>();
 
-    // Only enforce auth on admin routes
-    if (!request.path.startsWith('/admin/') && !request.path.startsWith('/admin')) {
+    // Only enforce auth on admin routes: /admin exactly, or /admin/...
+    const isAdminRoute =
+      request.path === '/admin' || request.path.startsWith('/admin/');
+    if (!isAdminRoute) {
       return true;
     }
 


### PR DESCRIPTION
## Summary
Clarify admin route path matching logic.

## Change
-  exactly OR  prefix = admin route
- Old confusing double-negation logic removed

Fixes #588