### PR TITLE
fix(webauthn): add realm boundary check to removeCredential (#587)

### DIFF
--- a/src/webauthn/webauthn.controller.ts
+++ b/src/webauthn/webauthn.controller.ts
@@ -240,6 +240,6 @@ export class WebAuthnController {
       throw new BadRequestException('You must be signed in to remove a passkey');
     }
 
-    await this.webAuthnService.removeCredential(user.id, credentialId);
+    await this.webAuthnService.removeCredential(user.id, realm.id, credentialId);
   }
 }

--- a/src/webauthn/webauthn.service.spec.ts
+++ b/src/webauthn/webauthn.service.spec.ts
@@ -490,24 +490,30 @@ describe('WebAuthnService', () => {
     it('should throw NotFoundException when credential does not exist', async () => {
       prisma.webAuthnCredential.findFirst.mockResolvedValue(null);
 
-      await expect(service.removeCredential('user-1', 'cred-db-1'))
+      await expect(service.removeCredential('user-1', 'realm-1', 'cred-db-1'))
         .rejects.toThrow(NotFoundException);
     });
 
     it('should throw NotFoundException when credential belongs to different user', async () => {
-      // findFirst returns null when userId does not match
       prisma.webAuthnCredential.findFirst.mockResolvedValue(null);
 
-      await expect(service.removeCredential('user-1', 'cred-db-1'))
+      await expect(service.removeCredential('user-1', 'realm-1', 'cred-db-1'))
         .rejects.toThrow(NotFoundException);
     });
 
-    it('should delete the credential when it belongs to the user', async () => {
+    it('should throw NotFoundException when credential belongs to different realm', async () => {
+      prisma.webAuthnCredential.findFirst.mockResolvedValue(null);
+
+      await expect(service.removeCredential('user-1', 'wrong-realm', 'cred-db-1'))
+        .rejects.toThrow(NotFoundException);
+    });
+
+    it('should delete the credential when it belongs to the user and realm', async () => {
       const cred = makeCredential();
       prisma.webAuthnCredential.findFirst.mockResolvedValue(cred as any);
       prisma.webAuthnCredential.delete.mockResolvedValue(cred as any);
 
-      await service.removeCredential('user-1', 'cred-db-1');
+      await service.removeCredential('user-1', 'realm-1', 'cred-db-1');
 
       expect(prisma.webAuthnCredential.delete).toHaveBeenCalledWith({
         where: { id: 'cred-db-1' },

--- a/src/webauthn/webauthn.service.ts
+++ b/src/webauthn/webauthn.service.ts
@@ -293,9 +293,9 @@ export class WebAuthnService {
     });
   }
 
-  async removeCredential(userId: string, credentialId: string): Promise<void> {
+  async removeCredential(userId: string, realmId: string, credentialId: string): Promise<void> {
     const credential = await this.prisma.webAuthnCredential.findFirst({
-      where: { id: credentialId, userId },
+      where: { id: credentialId, userId, realmId },
     });
 
     if (!credential) {


### PR DESCRIPTION
## Summary
Add realm boundary check to  to prevent cross-realm credential deletion.

## Changes
- Added  parameter to  method
- Added realmId to findFirst where clause
- Updated controller to pass realm.id
- Added test for cross-realm attack prevention

Fixes #587