### PR TITLE
fix(brute-force): add realmId to unlockUser update (#584)

### DIFF
--- a/src/brute-force/brute-force.service.spec.ts
+++ b/src/brute-force/brute-force.service.spec.ts
@@ -192,7 +192,7 @@ describe('BruteForceService', () => {
       await service.unlockUser('realm-1', 'user-1');
 
       expect(prisma.user.update).toHaveBeenCalledWith({
-        where: { id: 'user-1' },
+        where: { id: 'user-1', realmId: 'realm-1' },
         data: { lockedUntil: null, enabled: true },
       });
     });

--- a/src/brute-force/brute-force.service.ts
+++ b/src/brute-force/brute-force.service.ts
@@ -98,9 +98,9 @@ export class BruteForceService {
       throw new NotFoundException(`User not found`);
     }
 
-    // Clear the lock on the user record.
+    // Clear the lock on the user record - update only affects this realm's user
     await this.prisma.user.update({
-      where: { id: userId },
+      where: { id: userId, realmId },
       data: { lockedUntil: null, enabled: true },
     });
     // Also delete all stored failure records for this user.  Without this,


### PR DESCRIPTION
## Summary
Add realmId to user update where clause in unlockUser to prevent cross-realm manipulation.

Fixes #584