### PR TITLE
fix(security): prevent enumeration via error messages (#582, #583)

### DIFF
--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -294,9 +294,7 @@ export class TokensService {
     }
 
     if (!clientId) {
-      throw new BadRequestException(
-        'Unable to determine client from id_token_hint',
-      );
+      throw new BadRequestException('Invalid logout request');
     }
 
     const client = await this.prisma.client.findUnique({
@@ -305,14 +303,12 @@ export class TokensService {
     });
 
     if (!client) {
-      throw new BadRequestException(
-        `Client '${clientId}' not found in this realm`,
-      );
+      throw new BadRequestException('Invalid logout request');
     }
 
     if (!matchesRedirectUri(postLogoutRedirectUri, client.redirectUris)) {
       throw new BadRequestException(
-        'post_logout_redirect_uri does not match any registered redirect URI for this client',
+        'post_logout_redirect_uri is not valid for this client',
       );
     }
   }

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -131,7 +131,7 @@ describe('UsersController', () => {
       expect(result).toEqual({ message: 'Verification email sent' });
     });
 
-    it('should return message when user has no email', async () => {
+    it('should return success message even when user has no email (does not send)', async () => {
       const user = { id: 'u1', email: null };
       usersService.findById.mockResolvedValue(user);
 
@@ -139,17 +139,17 @@ describe('UsersController', () => {
 
       expect(usersService.findById).toHaveBeenCalledWith(realm, 'u1');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
-      expect(result).toEqual({ message: 'User has no email address' });
+      expect(result).toEqual({ message: 'Verification email sent' });
     });
 
-    it('should return message when user email is empty string', async () => {
+    it('should return success message even when user email is empty string', async () => {
       const user = { id: 'u1', email: '' };
       usersService.findById.mockResolvedValue(user);
 
       const result = await controller.sendVerificationEmail(realm, 'u1');
 
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
-      expect(result).toEqual({ message: 'User has no email address' });
+      expect(result).toEqual({ message: 'Verification email sent' });
     });
   });
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -173,10 +173,9 @@ export class UsersController {
     @Param('userId') userId: string,
   ) {
     const user = await this.usersService.findById(realm, userId);
-    if (!user.email) {
-      return { message: 'User has no email address' };
+    if (user.email) {
+      await this.usersService.sendVerificationEmail(realm, user.id, user.email);
     }
-    await this.usersService.sendVerificationEmail(realm, user.id, user.email);
     return { message: 'Verification email sent' };
   }
 


### PR DESCRIPTION
## Summary
Prevent user and client enumeration attacks via error message differences:

1. **#582** - sendVerificationEmail returns same success message even when user has no email (doesn't reveal email status)
2. **#583** - validatePostLogoutRedirectUri returns generic 'Invalid logout request' instead of revealing client existence

Fixes #582, #583