### PR TITLE
fix(security): prevent user enumeration and fix introspection (#580, #591)

### DIFF
--- a/src/roles/roles.service.spec.ts
+++ b/src/roles/roles.service.spec.ts
@@ -353,6 +353,7 @@ describe('RolesService', () => {
   describe('getUserClientRoles', () => {
     it('should return the user client roles', async () => {
       prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.user.findFirst.mockResolvedValue({ id: 'user-1', realmId: 'realm-1' });
       const roles = [{ id: 'crole-1', name: 'editor' }];
       prisma.role.findMany.mockResolvedValue(roles);
 

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -244,6 +244,13 @@ export class RolesService {
       throw new NotFoundException(`Client '${clientId}' not found`);
     }
 
+    const user = await this.prisma.user.findFirst({
+      where: { id: userId, realmId: realm.id },
+    });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
     return this.prisma.role.findMany({
       where: {
         realmId: realm.id,

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -93,6 +93,7 @@ describe('TokensService', () => {
   describe('introspect', () => {
     it('should return active=true with claims for a valid token', async () => {
       prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      prisma.user.findUnique.mockResolvedValue({ id: 'user-1', username: 'testuser', enabled: true });
       jwkService.verifyJwt.mockResolvedValue({
         sub: 'user-1',
         iss: 'https://authme/realm-1',

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -66,16 +66,25 @@ export class TokensService {
       // on it being present even when the claim is not embedded in the JWT.
       const sub = payload.sub as string | undefined;
       let username: string | undefined;
+      let active = true;
       if (sub) {
         const user = await this.prisma.user.findUnique({
           where: { id: sub },
-          select: { username: true },
+          select: { username: true, enabled: true },
         });
-        username = user?.username;
+        if (!user) {
+          // User was deleted after token was issued
+          return { active: false };
+        }
+        if (!user.enabled) {
+          // User is disabled
+          active = false;
+        }
+        username = user.username;
       }
 
       return {
-        active: true,
+        active,
         sub: payload.sub,
         iss: payload.iss,
         aud: payload.aud,


### PR DESCRIPTION
## Summary
Two fixes:

1. **#580** - getUserClientRoles now checks if user exists before returning roles, preventing user enumeration via empty array response

2. **#591** - Token introspection now returns active:false when user was deleted or disabled after token was issued

Fixes #580, #591