### PR TITLE
fix(build): regenerate Prisma client on install via postinstall hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "authme",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "UNLICENSED",
       "dependencies": {
         "@apollo/server": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "postinstall": "prisma generate",
     "prisma:generate": "npx prisma generate",
     "prisma:migrate": "npx prisma migrate dev",
     "prisma:seed": "npx ts-node prisma/seed.ts",

--- a/packages/authme-angular/package-lock.json
+++ b/packages/authme-angular/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@authme/angular",
+  "name": "authme-angular",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@authme/angular",
+      "name": "authme-angular",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/packages/authme-nextjs/package-lock.json
+++ b/packages/authme-nextjs/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@authme/nextjs",
+  "name": "authme-nextjs",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@authme/nextjs",
+      "name": "authme-nextjs",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/packages/authme-vue/package-lock.json
+++ b/packages/authme-vue/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@authme/vue",
+  "name": "authme-vue",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@authme/vue",
+      "name": "authme-vue",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Adds `"postinstall": "prisma generate"` to root `package.json` so the Prisma client is rebuilt after every `npm install`. This unblocks the opencode CI workflow's build-verify step, which was failing on PRs unrelated to the backend (e.g. #687) because the cached Prisma client didn't include the `UsedTotpCode` and `RateLimitEntry` models added by recently-merged PRs #680 / #671.
- Resyncs SDK `package-lock.json` files (`packages/authme-{angular,nextjs,vue}`) to use the unscoped names already in their `package.json` (`@authme/* → authme-*`).

## Why this fixes opencode auto-merge
The workflow runs `npm install --silent && npm run build` (which is `nest build`). Without `prisma generate`, the cached client lacks the new models, `nest build` fails with `Property 'usedTotpCode' does not exist on type 'PrismaService'`, opencode's retry can't fix it (the code is correct — the client is stale), and the workflow posts "Auto-fix retry attempted but build is still failing. Manual review needed."

## Test plan
- [x] Wipe `node_modules/.prisma` and `node_modules/@prisma/client`
- [x] Run `npm install` — confirm Prisma client is regenerated automatically
- [x] Run `npm run build` — confirm `nest build` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)