### PR TITLE
test: add missing status to refresh failure mock

### DIFF
--- a/packages/authme-js/src/__tests__/client.test.ts
+++ b/packages/authme-js/src/__tests__/client.test.ts
@@ -516,6 +516,7 @@ describe('AuthmeClient', () => {
         if (url.includes('/token')) {
           return Promise.resolve({
             ok: false,
+            status: 400,
             json: () => Promise.resolve({ error: 'invalid_grant' }),
           });
         }


### PR DESCRIPTION
## Summary
- Add missing `status: 400` property to the mocked failed token response in the "clears tokens when refresh fails" test
- Without the status property, the client code condition `response.status >= 400 && response.status < 500` evaluates to false (undefined >= 400), preventing the intended token-clearing branch from executing

Fixes #747

## Verification
```bash
cd packages/authme-js
npm test
```

Result: 6 test files passed, 104 tests passed (including the previously failing "clears tokens when refresh fails" test).