### PR TITLE
fix: show dashboard stats load errors

### DIFF
--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -99,7 +99,7 @@ function EventTypeBadge({ type }: { type: string }) {
 function RealmStatsSection({ realmName }: { realmName: string }) {
   const navigate = useNavigate();
 
-  const { data: stats, isLoading: statsLoading } = useQuery<RealmStats>({
+  const { data: stats, isLoading: statsLoading, error: statsError } = useQuery<RealmStats>({
     queryKey: ['realmStats', realmName],
     queryFn: () => getRealmStats(realmName),
     staleTime: 60_000,
@@ -166,6 +166,10 @@ function RealmStatsSection({ realmName }: { realmName: string }) {
             {Array.from({ length: 6 }).map((_, i) => (
               <div key={i} className="h-24 animate-pulse rounded-lg border border-gray-200 bg-gray-100" />
             ))}
+          </div>
+        ) : statsError ? (
+          <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+            Failed to load stats. Please try again.
           </div>
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/admin-ui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/DashboardPage.test.tsx
@@ -70,6 +70,19 @@ describe('DashboardPage', () => {
     expect(await screen.findByText('17')).toBeInTheDocument();
   });
 
+  it('shows an error message when stats fail to load', async () => {
+    server.use(
+      http.get('/admin/realms/:name/stats', () =>
+        HttpResponse.json({ message: 'stats unavailable' }, { status: 500 }),
+      ),
+    );
+
+    renderDashboard();
+
+    expect(await screen.findByText(/failed to load stats\. please try again\./i)).toBeInTheDocument();
+    expect(screen.queryByText('Active Users (24h)')).not.toBeInTheDocument();
+  });
+
   it('displays system health status', async () => {
     renderDashboard();
     expect(await screen.findByText('System')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Track stats query errors in `RealmStatsSection`
- Show `Failed to load stats. Please try again.` instead of silently rendering zero values when the stats request fails
- Add a regression test covering the stats API failure case

Fixes #743

## Verification
```bash
cd admin-ui
npm test -- DashboardPage.test.tsx --run
```

Result: 1 test file passed, 13 tests passed.