### PR TITLE
fix(security): add AdminApiKeyGuard to all admin controllers

### DIFF
--- a/src/brute-force/brute-force.controller.ts
+++ b/src/brute-force/brute-force.controller.ts
@@ -19,6 +19,7 @@ import type { Request } from 'express';
 import type { Realm } from '@prisma/client';
 import { BruteForceService } from './brute-force.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { StepUpService, ACR_MFA } from '../step-up/step-up.service.js';
 import { LoginService } from '../login/login.service.js';
@@ -27,7 +28,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 
 @ApiTags('Brute Force Protection')
 @Controller('admin/realms/:realmName/brute-force')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class BruteForceController {
   constructor(

--- a/src/clients/clients.controller.ts
+++ b/src/clients/clients.controller.ts
@@ -22,11 +22,12 @@ import { ClientsService } from './clients.service.js';
 import { CreateClientDto } from './dto/create-client.dto.js';
 import { UpdateClientDto } from './dto/update-client.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Clients')
 @Controller('admin/realms/:realmName/clients')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class ClientsController {
   constructor(private readonly clientsService: ClientsService) {}

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -21,11 +21,12 @@ import { GroupsService } from './groups.service.js';
 import { CreateGroupDto } from './dto/create-group.dto.js';
 import { UpdateGroupDto } from './dto/update-group.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Groups')
 @Controller('admin/realms/:realmName')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class GroupsController {
   constructor(private readonly groupsService: GroupsService) {}

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -23,11 +23,12 @@ import { CreateRoleDto } from './dto/create-role.dto.js';
 import { UpdateRoleDto } from './dto/update-role.dto.js';
 import { AssignRolesDto } from './dto/assign-role.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Roles')
 @Controller('admin/realms/:realmName')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class RolesController {
   constructor(private readonly rolesService: RolesService) {}

--- a/src/saml/saml-sp-admin.controller.ts
+++ b/src/saml/saml-sp-admin.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import type { Realm } from '@prisma/client';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { SamlIdpService } from './saml-idp.service.js';
 import { CreateSamlSpDto } from './dto/create-saml-sp.dto.js';
@@ -26,7 +27,7 @@ import { UpdateSamlSpDto } from './dto/update-saml-sp.dto.js';
 
 @ApiTags('SAML Service Providers')
 @Controller('admin/realms/:realmName/saml-service-providers')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class SamlSpAdminController {
   constructor(private readonly samlIdpService: SamlIdpService) {}

--- a/src/scim/scim-provisioning.controller.ts
+++ b/src/scim/scim-provisioning.controller.ts
@@ -27,11 +27,12 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { ScimTokensService } from './scim-tokens.service.js';
 import type { CreateScimTokenDto } from './dto/scim.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('SCIM Provisioning (Admin)')
 @Controller('admin/realms/:realmName/scim')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class ScimProvisioningController {
   private readonly logger = new Logger(ScimProvisioningController.name);

--- a/src/service-accounts/service-accounts.controller.ts
+++ b/src/service-accounts/service-accounts.controller.ts
@@ -22,11 +22,12 @@ import { CreateServiceAccountDto } from './dto/create-service-account.dto.js';
 import { UpdateServiceAccountDto } from './dto/update-service-account.dto.js';
 import { CreateApiKeyDto } from './dto/create-api-key.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Service Accounts')
 @Controller('admin/realms/:realmName/service-accounts')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class ServiceAccountsController {
   constructor(

--- a/src/sessions/sessions.controller.ts
+++ b/src/sessions/sessions.controller.ts
@@ -17,11 +17,12 @@ import {
 import type { Realm } from '@prisma/client';
 import { SessionsService } from './sessions.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Sessions')
 @Controller('admin/realms/:realmName')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class SessionsController {
   constructor(private readonly sessionsService: SessionsService) {}

--- a/src/stats/stats.controller.ts
+++ b/src/stats/stats.controller.ts
@@ -9,11 +9,12 @@ import type { Realm } from '@prisma/client';
 import { StatsService } from './stats.service.js';
 import { ConsentStatisticsService } from '../consent/consent-stats.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Stats')
 @Controller('admin/realms/:realmName')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class StatsController {
   constructor(

--- a/src/user-federation/user-federation.controller.ts
+++ b/src/user-federation/user-federation.controller.ts
@@ -6,6 +6,7 @@ import {
   Delete,
   Body,
   Param,
+  UseGuards,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -16,9 +17,12 @@ import {
 import { UserFederationService } from './user-federation.service.js';
 import { CreateUserFederationDto } from './dto/create-user-federation.dto.js';
 import { UpdateUserFederationDto } from './dto/update-user-federation.dto.js';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 
 @ApiTags('User Federation')
 @Controller('admin/realms/:realmName/user-federation')
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class UserFederationController {
   constructor(private readonly service: UserFederationService) {}

--- a/src/webhooks/webhooks.controller.ts
+++ b/src/webhooks/webhooks.controller.ts
@@ -21,11 +21,12 @@ import type { Realm } from '@prisma/client';
 import { WebhooksService } from './webhooks.service.js';
 import { CreateWebhookDto, UpdateWebhookDto } from './webhooks.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 
 @ApiTags('Webhooks')
 @Controller('admin/realms/:realmName/webhooks')
-@UseGuards(RealmGuard)
+@UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class WebhooksController {
   constructor(private readonly webhooksService: WebhooksService) {}


### PR DESCRIPTION
## Summary

Added `AdminApiKeyGuard` to all admin controllers that were missing it.

### Changes Made

Added `AdminApiKeyGuard` to the following controllers:
- `roles.controller.ts`
- `clients.controller.ts`
- `groups.controller.ts`
- `brute-force.controller.ts`
- `webhooks.controller.ts`
- `stats.controller.ts`
- `sessions.controller.ts`
- `service-accounts.controller.ts`
- `saml-sp-admin.controller.ts`
- `scim-provisioning.controller.ts`
- `user-federation.controller.ts`

### Security Fix

These controllers had `@UseGuards(RealmGuard)` but were missing `AdminApiKeyGuard`. The `RealmGuard` only validates that the realm exists, not that the request is authenticated with an admin API key.

### Related Issues

Fixes #777

### Note

Issue #786 (webhook encryption keys) was already fixed in a previous update - the `onModuleInit()` in `crypto.service.ts` now properly calls `process.exit(1)` in production if default values are used.