### PR TITLE
chore(rebrand): replace residual Authme references after repo transfer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # ─── Database ──────────────────────────────────────────────────────────────────
 #
-# Authme supports three database providers.  Set DATABASE_URL to the connection
+# Idenplane supports three database providers.  Set DATABASE_URL to the connection
 # string that matches your environment.
 #
 # PostgreSQL (recommended for production):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,10 +1,10 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 Discussions
-    url: https://github.com/Islamawad132/Authme/discussions
+    url: https://github.com/idenplane/idenplane/discussions
     about: Ask questions, share ideas, and chat with the community.
   - name: 🔒 Report a security vulnerability
-    url: https://github.com/Islamawad132/Authme/security/policy
+    url: https://github.com/idenplane/idenplane/security/policy
     about: Please report security issues privately — do not open a public issue.
   - name: 📖 Documentation
     url: https://idenplane.dev

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Thank you for your interest in contributing to Idenplane!
 
 1. **Clone the repository**
 ```bash
-git clone https://github.com/Islamawad132/Authme.git
-cd Authme
+git clone https://github.com/idenplane/idenplane.git
+cd Idenplane
 ```
 
 2. **Install dependencies**
@@ -236,7 +236,7 @@ Email: security@idenplane.dev (or follow your organization's responsible disclos
 
 ## Questions?
 
-- GitHub Discussions: https://github.com/Islamawad132/Authme/discussions
+- GitHub Discussions: https://github.com/idenplane/idenplane/discussions
 - Discord: https://discord.gg/idenplane
 - Documentation: https://idenplane.dev/docs
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Islamawad132/Authme/actions"><img src="https://github.com/Islamawad132/Authme/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/idenplane/idenplane/actions"><img src="https://github.com/idenplane/idenplane/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://www.npmjs.com/package/idenplane-sdk"><img src="https://img.shields.io/npm/v/idenplane-sdk?label=idenplane-sdk" alt="npm idenplane-sdk" /></a>
   <a href="https://www.npmjs.com/package/idenplane-cli"><img src="https://img.shields.io/npm/v/idenplane-cli?label=idenplane-cli" alt="npm idenplane-cli" /></a>
   <a href="https://hub.docker.com/r/islamawad/idenplane"><img src="https://img.shields.io/docker/v/islamawad/idenplane?label=Docker%20Hub" alt="Docker Hub" /></a>
-  <a href="https://github.com/Islamawad132/Authme/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License" /></a>
+  <a href="https://github.com/idenplane/idenplane/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License" /></a>
   <a href="https://idenplane.dev"><img src="https://img.shields.io/badge/docs-idenplane.dev-blue" alt="Docs" /></a>
 </p>
 
@@ -122,7 +122,7 @@ Most identity solutions are either too complex to self-host (Keycloak — 1GB+ R
 ### Docker Hub (Recommended)
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/Islamawad132/Authme/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/idenplane/idenplane/main/docker-compose.yml
 docker compose up -d
 ```
 
@@ -150,8 +150,8 @@ That's it. Idenplane is now running:
 **Prerequisites:** Node.js 22+, PostgreSQL 16+
 
 ```bash
-git clone https://github.com/Islamawad132/Authme.git
-cd Authme
+git clone https://github.com/idenplane/idenplane.git
+cd Idenplane
 
 # Install dependencies
 npm install
@@ -193,9 +193,9 @@ Idenplane provides official SDKs for every major platform:
 ### Quick Example (5 Lines to Authenticate)
 
 ```typescript
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 
-const idenplane = new AuthmeClient({
+const idenplane = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -211,21 +211,21 @@ if (!idenplane.isAuthenticated()) {
 ### React
 
 ```tsx
-import { AuthmeClient } from 'idenplane-sdk';
-import { AuthmeProvider, useAuthme, useUser } from 'idenplane-sdk/react';
+import { IdenplaneClient } from 'idenplane-sdk';
+import { IdenplaneProvider, useIdenplane, useUser } from 'idenplane-sdk/react';
 
-const idenplane = new AuthmeClient({ /* config */ });
+const idenplane = new IdenplaneClient({ /* config */ });
 
 function App() {
   return (
-    <AuthmeProvider client={idenplane}>
+    <IdenplaneProvider client={idenplane}>
       <Dashboard />
-    </AuthmeProvider>
+    </IdenplaneProvider>
   );
 }
 
 function Dashboard() {
-  const { isAuthenticated, login, logout } = useAuthme();
+  const { isAuthenticated, login, logout } = useIdenplane();
   const user = useUser();
 
   if (!isAuthenticated) return <button onClick={() => login()}>Sign In</button>;
@@ -287,9 +287,9 @@ export class AppModule {}
 
 ```typescript
 // main.ts
-import { createAuthmePlugin } from 'idenplane-vue';
+import { createIdenplanePlugin } from 'idenplane-vue';
 
-app.use(createAuthmePlugin({
+app.use(createIdenplanePlugin({
   serverUrl: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -527,7 +527,7 @@ GET  /admin/metrics    # Requires x-admin-api-key header
 ## Project Structure
 
 ```
-Authme/
+Idenplane/
 ├── src/                           # NestJS backend (71 modules)
 │   ├── auth/                      # Core OAuth 2.0 authentication
 │   ├── oauth/                     # OAuth 2.0 protocol logic

--- a/admin-ui/index.html
+++ b/admin-ui/index.html
@@ -8,7 +8,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/console/" />
-    <title>Authme Admin Console</title>
+    <title>Idenplane Admin Console</title>
   </head>
   <body>
     <div id="root"></div>

--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -371,7 +371,7 @@ export default function DashboardPage() {
       <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="mt-1 text-sm text-gray-500">Overview of your Authme identity server</p>
+          <p className="mt-1 text-sm text-gray-500">Overview of your Idenplane identity server</p>
         </div>
 
         {/* System health */}

--- a/admin-ui/src/pages/LoginPage.tsx
+++ b/admin-ui/src/pages/LoginPage.tsx
@@ -63,7 +63,7 @@ export default function LoginPage() {
                 />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-gray-900">Authme Admin</h1>
+            <h1 className="text-2xl font-bold text-gray-900">Idenplane Admin</h1>
             <p className="mt-1 text-sm text-gray-500">
               {mode === 'credentials'
                 ? 'Sign in with your admin credentials'

--- a/admin-ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/LoginPage.test.tsx
@@ -13,7 +13,7 @@ import LoginPage from '../LoginPage';
 describe('LoginPage – credentials mode', () => {
   it('renders the login form with username and password fields', () => {
     render(<LoginPage />);
-    expect(screen.getByText('Authme Admin')).toBeInTheDocument();
+    expect(screen.getByText('Idenplane Admin')).toBeInTheDocument();
     expect(screen.getByLabelText(/^username$/i)).toBeInTheDocument();
     // Use getByPlaceholderText to avoid ambiguity with "Show password" button
     expect(screen.getByPlaceholderText(/enter your password/i)).toBeInTheDocument();

--- a/benchmarks/.env.example
+++ b/benchmarks/.env.example
@@ -1,6 +1,6 @@
 # ─── Benchmark Configuration ──────────────────────────────────────────────────
 #
-# Target Authme instance to benchmark
+# Target Idenplane instance to benchmark
 TARGET_URL=http://localhost:3000
 
 # Admin API key for authenticated requests

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,16 +1,16 @@
-# Authme Benchmark Suite
+# Idenplane Benchmark Suite
 
-Performance testing infrastructure for the Authme authentication server using k6.
+Performance testing infrastructure for the Idenplane authentication server using k6.
 
 ## Overview
 
-This directory contains load testing scripts and configuration for benchmarking Authme's API endpoints under various load conditions. It also supports comparison benchmarking against other authentication solutions: Keycloak, Authentik, and Zitadel.
+This directory contains load testing scripts and configuration for benchmarking Idenplane's API endpoints under various load conditions. It also supports comparison benchmarking against other authentication solutions: Keycloak, Authentik, and Zitadel.
 
 ## Prerequisites
 
 - [k6](https://grafana.com/docs/k6/latest/) - Load testing tool
 - Docker & Docker Compose (for containerized benchmarks)
-- Authme server running with benchmark target endpoint
+- Idenplane server running with benchmark target endpoint
 
 ## Structure
 
@@ -43,7 +43,7 @@ benchmarks/
 # Copy environment template
 cp benchmarks/.env.example benchmarks/.env
 
-# Edit benchmarks/.env with your Authme instance details
+# Edit benchmarks/.env with your Idenplane instance details
 ```
 
 ### 2. Run Benchmarks
@@ -64,7 +64,7 @@ Results are saved to `benchmarks/results/` in JSON format for analysis.
 
 See `.env.example` for required environment variables:
 
-- `TARGET_URL` - Authme server URL (default: http://localhost:3000)
+- `TARGET_URL` - Idenplane server URL (default: http://localhost:3000)
 - `ADMIN_API_KEY` - API key for authentication
 - `VUS` - Virtual users for load test
 - `DURATION` - Test duration

--- a/benchmarks/docker-compose.benchmarks.yml
+++ b/benchmarks/docker-compose.benchmarks.yml
@@ -22,7 +22,7 @@ services:
     networks:
       - benchmarks
 
-  # Authme application instance for benchmarking
+  # Idenplane application instance for benchmarking
   app:
     image: islamawad/idenplane:latest
     container_name: idenplane-benchmark-target

--- a/benchmarks/k6/idenplane-discovery.js
+++ b/benchmarks/k6/idenplane-discovery.js
@@ -1,5 +1,5 @@
 /**
- * Authme OpenID Discovery Load Test
+ * Idenplane OpenID Discovery Load Test
  *
  * Tests the OpenID Connect Discovery endpoint which provides metadata
  * about the OAuth/OIDC provider configuration. This script simulates
@@ -10,7 +10,7 @@
  *   k6 run benchmarks/k6/idenplane-discovery.js -e TARGET_URL=http://localhost:3000 -e REALM_NAME=my-realm
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/idenplane-jwks.js
+++ b/benchmarks/k6/idenplane-jwks.js
@@ -1,5 +1,5 @@
 /**
- * Authme JWKS Endpoint Load Test
+ * Idenplane JWKS Endpoint Load Test
  *
  * Tests the OAuth2 JWKS (JSON Web Key Set) endpoint which provides public keys
  * for JWT signature verification. This script simulates clients fetching and
@@ -10,7 +10,7 @@
  *   k6 run benchmarks/k6/idenplane-jwks.js -e TARGET_URL=http://localhost:3000 -e REALM_NAME=my-realm
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/idenplane-login.js
+++ b/benchmarks/k6/idenplane-login.js
@@ -1,5 +1,5 @@
 /**
- * Authme Login Load Test
+ * Idenplane Login Load Test
  *
  * Tests the OAuth2 password grant flow which represents the user login operation.
  * This script simulates users authenticating with username/password credentials
@@ -10,7 +10,7 @@
  *   k6 run benchmarks/k6/idenplane-login.js -e TARGET_URL=http://localhost:3000 -e REALM_NAME=my-realm
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/idenplane-token-introspection.js
+++ b/benchmarks/k6/idenplane-token-introspection.js
@@ -1,5 +1,5 @@
 /**
- * Authme Token Introspection Load Test
+ * Idenplane Token Introspection Load Test
  *
  * Tests the OAuth2 token introspection endpoint which allows resource servers
  * to validate tokens and retrieve claims.
@@ -15,7 +15,7 @@
  *   k6 run benchmarks/k6/idenplane-token-introspection.js -e VUS=100 -e DURATION=120s
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/idenplane-token-issuance.js
+++ b/benchmarks/k6/idenplane-token-issuance.js
@@ -1,5 +1,5 @@
 /**
- * Authme Token Issuance Load Test
+ * Idenplane Token Issuance Load Test
  *
  * Tests OAuth2 token issuance across multiple grant types:
  * - Client Credentials Grant (machine-to-machine)
@@ -14,7 +14,7 @@
  *   k6 run benchmarks/k6/idenplane-token-issuance.js -e VUS=100 -e DURATION=120s
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/idenplane-token-revocation.js
+++ b/benchmarks/k6/idenplane-token-revocation.js
@@ -1,5 +1,5 @@
 /**
- * Authme Token Revocation Load Test
+ * Idenplane Token Revocation Load Test
  *
  * Tests the OAuth2 token revocation endpoint which allows clients to revoke
  * access tokens and refresh tokens. This script simulates users logging out
@@ -10,7 +10,7 @@
  *   k6 run benchmarks/k6/idenplane-token-revocation.js -e TARGET_URL=http://localhost:3000 -e REALM_NAME=my-realm
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/idenplane-userinfo.js
+++ b/benchmarks/k6/idenplane-userinfo.js
@@ -1,5 +1,5 @@
 /**
- * Authme Userinfo Endpoint Load Test
+ * Idenplane Userinfo Endpoint Load Test
  *
  * Tests the OAuth2/OIDC UserInfo endpoint which returns claims about the
  * authenticated user. This endpoint is typically called after token validation
@@ -16,7 +16,7 @@
  *   k6 run benchmarks/k6/idenplane-userinfo.js -e VUS=100 -e DURATION=120s
  *
  * Environment Variables:
- *   TARGET_URL         - Base URL of Authme server (default: http://localhost:3000)
+ *   TARGET_URL         - Base URL of Idenplane server (default: http://localhost:3000)
  *   REALM_NAME         - Realm name to test against (default: test-realm)
  *   VUS                - Number of virtual users (default: 50)
  *   DURATION           - Test duration (default: 60s)

--- a/benchmarks/k6/shared-scenarios.js
+++ b/benchmarks/k6/shared-scenarios.js
@@ -1,5 +1,5 @@
 /**
- * Shared scenarios and utilities for Authme OAuth k6 load tests.
+ * Shared scenarios and utilities for Idenplane OAuth k6 load tests.
  *
  * This module provides common functionality shared across all OAuth flow test scripts:
  * - Custom metrics (error rates, trends)
@@ -68,7 +68,7 @@ export const TEST_PASSWORD = __ENV.TEST_PASSWORD || 'TestPassword123!';
 /**
  * Build OAuth endpoint URLs for a given realm.
  * @param {string} realmName - The realm name
- * @param {string} baseUrl - The base URL of the Authme server
+ * @param {string} baseUrl - The base URL of the Idenplane server
  * @returns {Object} Object containing all OAuth endpoint URLs
  */
 export function buildOAuthUrls(realmName = DEFAULT_REALM, baseUrl = DEFAULT_TARGET_URL) {

--- a/docs/docs/configuration/environment-variables.md
+++ b/docs/docs/configuration/environment-variables.md
@@ -336,6 +336,6 @@ Deploy to production with Docker
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -892,6 +892,6 @@ Deploy with Docker Compose
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/deployment/bare-metal.mdx
+++ b/docs/docs/deployment/bare-metal.mdx
@@ -31,11 +31,11 @@ Idenplane runs in approximately 150 MB RAM, making it suitable for small VPS ins
 
 ```bash
 # Clone the repository
-git clone https://github.com/Islamawad132/Authme.git
-cd Authme
+git clone https://github.com/idenplane/idenplane.git
+cd Idenplane
 
 # Run the setup script (installs dependencies, builds, sets up database)
-curl -sSL https://raw.githubusercontent.com/Islamawad132/Authme/main/scripts/setup-bare-metal.sh | bash
+curl -sSL https://raw.githubusercontent.com/idenplane/idenplane/main/scripts/setup-bare-metal.sh | bash
 ```
 
 ---
@@ -99,8 +99,8 @@ sudo systemctl enable redis-server
 ### 1. Clone and Install Dependencies
 
 ```bash
-git clone https://github.com/Islamawad132/Authme.git
-cd Authme
+git clone https://github.com/idenplane/idenplane.git
+cd Idenplane
 
 # Install backend dependencies
 npm install
@@ -697,6 +697,6 @@ Deploy on Kubernetes
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> ·
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> ·
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> ·
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/deployment/docker.mdx
+++ b/docs/docs/deployment/docker.mdx
@@ -17,10 +17,10 @@ The fastest way to deploy Idenplane with Docker Compose:
 
 ```bash
 # Download the production compose file
-curl -o docker-compose.yml https://raw.githubusercontent.com/Islamawad132/Authme/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/idenplane/idenplane/main/docker-compose.yml
 
 # Download the environment template
-curl -o .env https://raw.githubusercontent.com/Islamawad132/Authme/main/.env.example
+curl -o .env https://raw.githubusercontent.com/idenplane/idenplane/main/.env.example
 
 # Edit .env and set your secrets
 nano .env
@@ -434,6 +434,6 @@ Detailed configuration guide
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/deployment/kubernetes.mdx
+++ b/docs/docs/deployment/kubernetes.mdx
@@ -547,6 +547,6 @@ Deploy using Docker Compose
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> ·
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> ·
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> ·
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -266,6 +266,6 @@ Integrate Idenplane with your application
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -38,7 +38,7 @@ The fastest way to get started is using our pre-built Docker image from Docker H
 docker pull islamawad/idenplane:latest
 
 # Start with Docker Compose
-curl -o docker-compose.yml https://raw.githubusercontent.com/Islamawad132/Authme/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/idenplane/idenplane/main/docker-compose.yml
 docker compose up -d
 ```
 
@@ -154,8 +154,8 @@ For development or custom deployments, build from source.
 1. **Clone the repository:**
 
    ```bash
-   git clone https://github.com/Islamawad132/Authme.git
-   cd Authme
+   git clone https://github.com/idenplane/idenplane.git
+   cd Idenplane
    ```
 
 2. **Install dependencies:**
@@ -290,6 +290,6 @@ Configure realms, users, and clients
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/authentication.mdx
+++ b/docs/docs/guides/authentication.mdx
@@ -234,13 +234,13 @@ curl -X POST "http://localhost:3000/realms/my-realm/protocol/openid-connect/toke
 ### Complete Authorization Code Example
 
 ```typescript
-import { AuthmeClient, TokenResponse } from 'idenplane-sdk';
+import { IdenplaneClient, TokenResponse } from 'idenplane-sdk';
 
 class AuthService {
-  private client: AuthmeClient;
+  private client: IdenplaneClient;
 
   constructor() {
-    this.client = new AuthmeClient({
+    this.client = new IdenplaneClient({
       url: 'http://localhost:3000',
       realm: 'my-realm',
       clientId: 'my-app',
@@ -534,7 +534,7 @@ Idenplane uses refresh token rotation by default. Each refresh token can only be
 ```typescript
 class TokenManager {
   private refreshToken: string | null = null;
-  private client: AuthmeClient;
+  private client: IdenplaneClient;
 
   async refreshAccessToken(): Promise<void> {
     if (!this.refreshToken) {
@@ -913,6 +913,6 @@ Integrate Idenplane into your React application
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/authorization.mdx
+++ b/docs/docs/guides/authorization.mdx
@@ -585,9 +585,9 @@ import TabItem from '@theme/TabItem';
 <TabItem value="typescript" label="TypeScript">
 
 ```typescript
-import { AuthmeClient, PolicyEvaluationResult } from 'idenplane-sdk';
+import { IdenplaneClient, PolicyEvaluationResult } from 'idenplane-sdk';
 
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -635,9 +635,9 @@ async function testPolicy(): Promise<void> {
 <TabItem value="python" label="Python">
 
 ```python
-from idenplane import AuthmeClient
+from idenplane import IdenplaneClient
 
-client = AuthmeClient(
+client = IdenplaneClient(
     url='http://localhost:3000',
     realm='my-realm',
     client_id='my-app',
@@ -669,10 +669,10 @@ async def check_access():
 <TabItem value="kotlin" label="Kotlin">
 
 ```kotlin
-import com.idenplane.sdk.AuthmeClient
+import com.idenplane.sdk.IdenplaneClient
 import com.idenplane.sdk.authorization.*
 
-val client = AuthmeClient(
+val client = IdenplaneClient(
     url = "http://localhost:3000",
     realm = "my-realm",
     clientId = "my-app"
@@ -812,6 +812,6 @@ Integrate Idenplane into your React application
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/mfa.mdx
+++ b/docs/docs/guides/mfa.mdx
@@ -593,6 +593,6 @@ Integrate Idenplane into your React application
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -37,7 +37,7 @@ Add the dependency to your app or library module `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.Islamawad132:Authme:1.0.0")
+    implementation("com.github.Islamawad132:Idenplane:1.0.0")
 }
 ```
 
@@ -398,6 +398,6 @@ Core SDK for non-React applications
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/sdks/angular.mdx
+++ b/docs/docs/guides/sdks/angular.mdx
@@ -6,7 +6,7 @@ description: Integrate Idenplane authentication into your Angular application us
 
 # Angular SDK
 
-The Idenplane Angular SDK provides Angular-specific bindings for the idenplane-sdk, including an injectable `AuthService`, a route guard (`AuthGuard`), an HTTP interceptor (`AuthInterceptor` / `authInterceptor`), and an `NgModule` entry point (`AuthmeModule`).
+The Idenplane Angular SDK provides Angular-specific bindings for the idenplane-sdk, including an injectable `AuthService`, a route guard (`AuthGuard`), an HTTP interceptor (`AuthInterceptor` / `authInterceptor`), and an `NgModule` entry point (`IdenplaneModule`).
 
 ## Installation
 
@@ -18,18 +18,18 @@ npm install @idenplane/angular idenplane-sdk rxjs
 
 ## Quick Start
 
-### 1. Import `AuthmeModule.forRoot()`
+### 1. Import `IdenplaneModule.forRoot()`
 
 ```typescript
 // app.module.ts
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { AuthmeModule } from '@idenplane/angular';
+import { IdenplaneModule } from '@idenplane/angular';
 
 @NgModule({
   imports: [
     HttpClientModule,
-    AuthmeModule.forRoot({
+    IdenplaneModule.forRoot({
       url: 'http://localhost:3000',
       realm: 'my-realm',
       clientId: 'my-app',
@@ -94,7 +94,7 @@ export const routes: Routes = [
 
 ### 4. Automatically Attach Bearer Tokens (HTTP Interceptor)
 
-The HTTP interceptor is registered automatically when you use `AuthmeModule.forRoot()`.
+The HTTP interceptor is registered automatically when you use `IdenplaneModule.forRoot()`.
 
 For standalone / functional interceptor style (Angular 15+):
 
@@ -113,9 +113,9 @@ export const appConfig: ApplicationConfig = {
 
 ---
 
-## AuthmeModule
+## IdenplaneModule
 
-The `AuthmeModule.forRoot()` method registers all providers including `AuthService`, `AuthGuard`, and `AuthInterceptor`.
+The `IdenplaneModule.forRoot()` method registers all providers including `AuthService`, `AuthGuard`, and `AuthInterceptor`.
 
 ### Configuration
 
@@ -135,11 +135,11 @@ The `AuthmeModule.forRoot()` method registers all providers including `AuthServi
 ```typescript
 // app.module.ts
 import { NgModule } from '@angular/core';
-import { AuthmeModule } from '@idenplane/angular';
+import { IdenplaneModule } from '@idenplane/angular';
 
 @NgModule({
   imports: [
-    AuthmeModule.forRoot({
+    IdenplaneModule.forRoot({
       url: 'http://localhost:3000',
       realm: 'my-realm',
       clientId: 'my-app',
@@ -344,20 +344,20 @@ The HTTP interceptor automatically attaches `Authorization: Bearer <token>` head
 
 ### Class-based Interceptor (NgModule style)
 
-The interceptor is registered automatically with `AuthmeModule.forRoot()`.
+The interceptor is registered automatically with `IdenplaneModule.forRoot()`.
 
 For manual registration:
 
 ```typescript
 // app.module.ts
 import { NgModule } from '@angular/core';
-import { AuthmeModule, AuthInterceptor } from '@idenplane/angular';
+import { IdenplaneModule, AuthInterceptor } from '@idenplane/angular';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
 @NgModule({
   imports: [
     HttpClientModule,
-    AuthmeModule.forRoot({
+    IdenplaneModule.forRoot({
       url: 'http://localhost:3000',
       realm: 'my-realm',
       clientId: 'my-app',
@@ -488,8 +488,8 @@ export class UserCardComponent {
 The SDK is written in TypeScript and provides full type definitions:
 
 ```typescript
-import { AuthService, AuthmeModule, AuthGuard, authInterceptor } from '@idenplane/angular';
-import type { AuthmeConfig, UserInfo, TokenResponse } from 'idenplane-sdk';
+import { AuthService, IdenplaneModule, AuthGuard, authInterceptor } from '@idenplane/angular';
+import type { IdenplaneConfig, UserInfo, TokenResponse } from 'idenplane-sdk';
 
 // AuthService is fully typed
 constructor(public auth: AuthService) {
@@ -525,6 +525,6 @@ Core SDK for non-framework applications
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/sdks/ios.mdx
+++ b/docs/docs/guides/sdks/ios.mdx
@@ -28,7 +28,7 @@ Add the package to your `Package.swift` dependencies:
 ```swift
 dependencies: [
     .package(
-        url: "https://github.com/Islamawad132/Authme",
+        url: "https://github.com/idenplane/idenplane",
         from: "1.0.0"
     )
 ]
@@ -42,7 +42,7 @@ Add `Idenplane` to your target:
 .target(
     name: "MyApp",
     dependencies: [
-        .product(name: "Idenplane", package: "Authme")
+        .product(name: "Idenplane", package: "Idenplane")
     ]
 )
 ```
@@ -337,6 +337,6 @@ Idenplane SDK for Android with Kotlin
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/sdks/nextjs.mdx
+++ b/docs/docs/guides/sdks/nextjs.mdx
@@ -123,7 +123,7 @@ The `AuthProvider` wraps your Next.js application and provides authentication st
 | `realm` | `string` | Yes* | Realm name |
 | `clientId` | `string` | Yes* | OAuth2 client ID |
 | `redirectUri` | `string` | Yes* | Redirect URI after login |
-| `client` | `AuthmeClient` | Yes* | Pre-built client instance |
+| `client` | `IdenplaneClient` | Yes* | Pre-built client instance |
 | `scope` | `string[]` | No | OAuth2 scopes (default: `['openid', 'profile', 'email']`) |
 | `autoHandleCallback` | `boolean` | No | Auto-handle callback when URL has `?code=` (default: `true`) |
 | `onReady` | `(authenticated: boolean) => void` | No | Called when initialization completes |
@@ -171,10 +171,10 @@ For more control over the client configuration:
 ```tsx
 // app/providers.tsx
 'use client';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 import { AuthProvider } from '@idenplane/nextjs';
 
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -217,7 +217,7 @@ The `useAuth` hook provides access to authentication state and actions in client
 
 ```tsx
 const {
-  client,           // The AuthmeClient instance
+  client,           // The IdenplaneClient instance
   isAuthenticated,  // boolean - whether user is authenticated
   isLoading,        // boolean - whether auth state is loading
   user,             // UserInfo | null - current user info
@@ -626,12 +626,12 @@ Re-exports from `idenplane-sdk/react`:
 
 | Export | Description |
 |--------|-------------|
-| `AuthProvider` / `AuthmeProvider` | Context provider for client components |
+| `AuthProvider` / `IdenplaneProvider` | Context provider for client components |
 | `useAuth()` | Authentication state and actions hook |
 | `useUser()` | Current user info hook |
 | `usePermissions()` | Role and permission helpers hook |
 | `ProtectedRoute` | Render-gate component for route protection |
-| `AuthmeClient` | Raw client class |
+| `IdenplaneClient` | Raw client class |
 
 ### `@idenplane/nextjs/middleware`
 
@@ -675,8 +675,8 @@ All exports are fully typed:
 
 ```tsx
 import type {
-  AuthmeClient,
-  AuthmeConfig,
+  IdenplaneClient,
+  IdenplaneConfig,
   TokenResponse,
   UserInfo,
   AuthSession,
@@ -721,6 +721,6 @@ Complete REST API documentation
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/sdks/react.mdx
+++ b/docs/docs/guides/sdks/react.mdx
@@ -92,7 +92,7 @@ The `AuthProvider` is the root component that initializes authentication and pro
 | `realm` | `string` | Yes* | Realm name |
 | `clientId` | `string` | Yes* | OAuth2 client ID |
 | `redirectUri` | `string` | Yes* | Redirect URI after login |
-| `client` | `AuthmeClient` | Yes* | Pre-built client instance |
+| `client` | `IdenplaneClient` | Yes* | Pre-built client instance |
 | `scope` | `string[]` | No | OAuth2 scopes (default: `['openid', 'profile', 'email']`) |
 | `autoHandleCallback` | `boolean` | No | Auto-handle callback when URL has `?code=` (default: `true`) |
 | `onReady` | `(authenticated: boolean) => void` | No | Called when initialization completes |
@@ -126,10 +126,10 @@ The `AuthProvider` is the root component that initializes authentication and pro
 For more control over the client configuration:
 
 ```tsx
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 import { AuthProvider } from 'idenplane-sdk/react';
 
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -157,7 +157,7 @@ The `useAuth` hook provides access to authentication state and actions:
 
 ```tsx
 const {
-  client,        // The AuthmeClient instance
+  client,        // The IdenplaneClient instance
   isAuthenticated, // boolean - whether user is authenticated
   isLoading,     // boolean - whether auth state is loading
   user,          // UserInfo | null - current user info
@@ -440,10 +440,10 @@ Configure how the SDK refreshes tokens via the `refreshStrategy` option:
 ### Example: Eager Refresh
 
 ```tsx
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 import { AuthProvider } from 'idenplane-sdk/react';
 
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -567,12 +567,12 @@ The SDK is written in TypeScript and provides full type definitions:
 
 ```tsx
 import type {
-  AuthmeClient,
-  AuthmeConfig,
+  IdenplaneClient,
+  IdenplaneConfig,
   TokenResponse,
   UserInfo,
   TokenClaims,
-  AuthmeEventMap,
+  IdenplaneEventMap,
 } from 'idenplane-sdk';
 
 // All hooks are fully typed
@@ -607,6 +607,6 @@ Core SDK for non-React applications
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/guides/sdks/vue.mdx
+++ b/docs/docs/guides/sdks/vue.mdx
@@ -6,7 +6,7 @@ description: Integrate Idenplane authentication into your Vue 3 application usin
 
 # Vue SDK
 
-The Idenplane Vue SDK provides Vue 3-specific bindings for the idenplane-sdk, including an `AuthmePlugin`, composables (`useAuth`, `useUser`, `usePermissions`), a Vue Router navigation guard (`createAuthGuard`), and an `AuthProvider` component for scoped authentication context.
+The Idenplane Vue SDK provides Vue 3-specific bindings for the idenplane-sdk, including an `IdenplanePlugin`, composables (`useAuth`, `useUser`, `usePermissions`), a Vue Router navigation guard (`createAuthGuard`), and an `AuthProvider` component for scoped authentication context.
 
 ## Installation
 
@@ -23,12 +23,12 @@ npm install @idenplane/vue idenplane-sdk vue
 ```typescript
 // main.ts
 import { createApp } from 'vue';
-import { AuthmePlugin } from '@idenplane/vue';
+import { IdenplanePlugin } from '@idenplane/vue';
 import App from './App.vue';
 
 const app = createApp(App);
 
-app.use(AuthmePlugin, {
+app.use(IdenplanePlugin, {
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -65,9 +65,9 @@ const { isAuthenticated, user, login, logout, isLoading } = useAuth();
 // router/index.ts
 import { createRouter, createWebHistory } from 'vue-router';
 import { createAuthGuard } from '@idenplane/vue';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 
-const authClient = new AuthmeClient({
+const authClient = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -98,9 +98,9 @@ export default router;
 
 ---
 
-## AuthmePlugin
+## IdenplanePlugin
 
-The `AuthmePlugin` is a Vue 3 plugin that initializes authentication and provides auth state globally via composables.
+The `IdenplanePlugin` is a Vue 3 plugin that initializes authentication and provides auth state globally via composables.
 
 ### Plugin Options
 
@@ -123,12 +123,12 @@ The `AuthmePlugin` is a Vue 3 plugin that initializes authentication and provide
 ```typescript
 // main.ts
 import { createApp } from 'vue';
-import { AuthmePlugin } from '@idenplane/vue';
+import { IdenplanePlugin } from '@idenplane/vue';
 import App from './App.vue';
 
 const app = createApp(App);
 
-app.use(AuthmePlugin, {
+app.use(IdenplanePlugin, {
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -155,11 +155,11 @@ For more control over the client configuration:
 ```typescript
 // main.ts
 import { createApp } from 'vue';
-import { AuthmePlugin } from '@idenplane/vue';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplanePlugin } from '@idenplane/vue';
+import { IdenplaneClient } from 'idenplane-sdk';
 import App from './App.vue';
 
-const authClient = new AuthmeClient({
+const authClient = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -171,7 +171,7 @@ const authClient = new AuthmeClient({
 
 const app = createApp(App);
 
-app.use(AuthmePlugin, authClient);
+app.use(IdenplanePlugin, authClient);
 
 app.mount('#app');
 ```
@@ -184,7 +184,7 @@ The `useAuth` composable provides access to authentication state and actions:
 
 ```typescript
 const {
-  client,            // AuthmeClient - the SDK client instance
+  client,            // IdenplaneClient - the SDK client instance
   isAuthenticated,    // boolean - whether user is authenticated
   isLoading,          // boolean - whether auth state is loading
   user,               // UserInfo | null - current user info
@@ -477,9 +477,9 @@ export default router;
 // router/index.ts
 import { createRouter, createWebHistory } from 'vue-router';
 import { createAuthGuard } from '@idenplane/vue';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 
-const authClient = new AuthmeClient({
+const authClient = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -535,7 +535,7 @@ import { AuthProvider } from '@idenplane/vue';
 | `realm` | `string` | Yes | Realm name |
 | `clientId` | `string` | Yes | OAuth2 client ID |
 | `redirectUri` | `string` | Yes | Redirect URI after login |
-| `client` | `AuthmeClient` | Yes* | Pre-built client instance |
+| `client` | `IdenplaneClient` | Yes* | Pre-built client instance |
 | `scope` | `string[]` | No | OAuth2 scopes |
 | `auto-handle-callback` | `boolean` | No | Auto-handle callback (default: `true`) |
 
@@ -553,9 +553,9 @@ import { AuthProvider } from '@idenplane/vue';
 
 <script setup lang="ts">
 import { AuthProvider } from '@idenplane/vue';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 
-const authClient = new AuthmeClient({
+const authClient = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -572,7 +572,7 @@ const authClient = new AuthmeClient({
 
 | Export | Description |
 |--------|-------------|
-| `AuthmePlugin` | Vue 3 plugin, call `app.use(AuthmePlugin, AuthmeConfig)` |
+| `IdenplanePlugin` | Vue 3 plugin, call `app.use(IdenplanePlugin, IdenplaneConfig)` |
 
 ### Composables
 
@@ -597,7 +597,7 @@ const authClient = new AuthmeClient({
 ### Types
 
 ```typescript
-interface AuthmeConfig {
+interface IdenplaneConfig {
   url: string;
   realm: string;
   clientId: string;
@@ -640,8 +640,8 @@ The SDK is written in TypeScript and provides full type definitions:
 
 ```typescript
 import type {
-  AuthmeClient,
-  AuthmeConfig,
+  IdenplaneClient,
+  IdenplaneConfig,
   TokenResponse,
   UserInfo,
 } from 'idenplane-sdk';
@@ -686,6 +686,6 @@ React-specific hooks and components
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -188,6 +188,6 @@ Complete REST API documentation
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/migration/auth0.mdx
+++ b/docs/docs/migration/auth0.mdx
@@ -629,6 +629,6 @@ Integrate Idenplane into your React application
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/migration/keycloak.mdx
+++ b/docs/docs/migration/keycloak.mdx
@@ -513,6 +513,6 @@ Integrate Idenplane into your React application
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -15,7 +15,7 @@ Get Idenplane up and running in under 30 seconds.
 The fastest way to get started is with Docker Compose:
 
 ```bash
-curl -o docker-compose.yml https://raw.githubusercontent.com/Islamawad132/Authme/main/docker-compose.yml
+curl -o docker-compose.yml https://raw.githubusercontent.com/idenplane/idenplane/main/docker-compose.yml
 docker compose up -d
 ```
 
@@ -68,8 +68,8 @@ If you prefer to build from source, you'll need:
 **Prerequisites:** Node.js 22+, PostgreSQL 16+
 
 ```bash
-git clone https://github.com/Islamawad132/Authme.git
-cd Authme
+git clone https://github.com/idenplane/idenplane.git
+cd Idenplane
 
 # Install dependencies
 npm install
@@ -174,6 +174,6 @@ REDIS_URL=redis://your-redis:6379
 
 <p align="center">
   <a href="https://idenplane.dev">idenplane.dev</a> &middot;
-  <a href="https://github.com/Islamawad132/Authme">GitHub</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
   <a href="https://discord.gg/idenplane">Discord</a>
 </p>

--- a/helm/idenplane/Chart.yaml
+++ b/helm/idenplane/Chart.yaml
@@ -14,9 +14,9 @@ keywords:
   - saml
   - webauthn
 
-home: https://github.com/Islamawad132/Authme
+home: https://github.com/idenplane/idenplane
 sources:
-  - https://github.com/Islamawad132/Authme
+  - https://github.com/idenplane/idenplane
 
 maintainers:
   - name: Islamawad132

--- a/packages/idenplane-android/README.md
+++ b/packages/idenplane-android/README.md
@@ -1,6 +1,6 @@
 # Idenplane Android SDK
 
-Native Kotlin SDK for the [Idenplane](https://github.com/Islamawad132/Authme) Identity and Access Management server.
+Native Kotlin SDK for the [Idenplane](https://github.com/idenplane/idenplane) Identity and Access Management server.
 
 Implements the **OAuth 2.0 Authorization Code flow with PKCE** (RFC 7636) using Chrome Custom Tabs. Tokens are stored securely with `EncryptedSharedPreferences` (AES-256-GCM) and optional biometric gating via `BiometricPrompt` is built in.
 
@@ -33,7 +33,7 @@ Add the dependency to your app or library module `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.Islamawad132:Authme:1.0.0")
+    implementation("com.github.Islamawad132:Idenplane:1.0.0")
 }
 ```
 

--- a/packages/idenplane-android/build.gradle.kts
+++ b/packages/idenplane-android/build.gradle.kts
@@ -90,7 +90,7 @@ afterEvaluate {
                 pom {
                     name.set("Idenplane Android SDK")
                     description.set("Android SDK for the Idenplane Identity and Access Management Server")
-                    url.set("https://github.com/Islamawad132/Authme")
+                    url.set("https://github.com/idenplane/idenplane")
                     licenses {
                         license {
                             name.set("MIT License")

--- a/packages/idenplane-android/package.json
+++ b/packages/idenplane-android/package.json
@@ -6,7 +6,7 @@
   "main": "build.gradle.kts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-android"
   },
   "keywords": [

--- a/packages/idenplane-angular/README.md
+++ b/packages/idenplane-angular/README.md
@@ -1,6 +1,6 @@
 # idenplane-angular
 
-Angular SDK for [Idenplane](https://github.com/Islamawad132/Authme) — an injectable `AuthService`, a route guard, an HTTP interceptor, and an `NgModule` entry point.
+Angular SDK for [Idenplane](https://github.com/idenplane/idenplane) — an injectable `AuthService`, a route guard, an HTTP interceptor, and an `NgModule` entry point.
 
 ## Installation
 
@@ -10,18 +10,18 @@ npm install idenplane-angular idenplane-sdk rxjs
 
 ## Quick Start
 
-### 1. Import `AuthmeModule.forRoot()`
+### 1. Import `IdenplaneModule.forRoot()`
 
 ```typescript
 // app.module.ts
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-import { AuthmeModule } from 'idenplane-angular';
+import { IdenplaneModule } from 'idenplane-angular';
 
 @NgModule({
   imports: [
     HttpClientModule,
-    AuthmeModule.forRoot({
+    IdenplaneModule.forRoot({
       url: 'http://localhost:3000',
       realm: 'my-realm',
       clientId: 'my-app',
@@ -86,7 +86,7 @@ export const routes: Routes = [
 
 ### 4. Automatically attach Bearer tokens (HTTP interceptor)
 
-The HTTP interceptor is registered automatically when you use `AuthmeModule.forRoot()`.
+The HTTP interceptor is registered automatically when you use `IdenplaneModule.forRoot()`.
 
 For standalone / functional interceptor style (Angular 15+):
 
@@ -104,9 +104,9 @@ export const appConfig = {
 
 ## API Reference
 
-### `AuthmeModule`
+### `IdenplaneModule`
 
-- `AuthmeModule.forRoot(config: AuthmeConfig)` — registers all providers
+- `IdenplaneModule.forRoot(config: IdenplaneConfig)` — registers all providers
 
 ### `AuthService`
 

--- a/packages/idenplane-angular/package.json
+++ b/packages/idenplane-angular/package.json
@@ -52,7 +52,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-angular"
   },
   "publishConfig": {

--- a/packages/idenplane-angular/src/__tests__/auth.service.test.ts
+++ b/packages/idenplane-angular/src/__tests__/auth.service.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BehaviorSubject } from 'rxjs';
 
 // ── We test AuthService logic without Angular DI machinery ────────
-// We construct the service manually, injecting a fake AuthmeClient.
+// We construct the service manually, injecting a fake IdenplaneClient.
 
-// ── Fake AuthmeClient ─────────────────────────────────────────────
+// ── Fake IdenplaneClient ─────────────────────────────────────────────
 
 function buildFakeClient(opts: {
   authenticated?: boolean;

--- a/packages/idenplane-angular/src/auth.config.ts
+++ b/packages/idenplane-angular/src/auth.config.ts
@@ -3,13 +3,13 @@
  */
 
 import { InjectionToken } from '@angular/core';
-import type { AuthmeConfig } from 'idenplane-sdk';
+import type { IdenplaneConfig } from 'idenplane-sdk';
 
 /** Re-export so consumers only need to import from @idenplane/angular */
-export type { AuthmeConfig };
+export type { IdenplaneConfig };
 
 /**
  * Angular DI token for the Idenplane configuration object.
- * Provided via `AuthmeModule.forRoot(config)`.
+ * Provided via `IdenplaneModule.forRoot(config)`.
  */
-export const IDENPLANE_CONFIG = new InjectionToken<AuthmeConfig>('IDENPLANE_CONFIG');
+export const IDENPLANE_CONFIG = new InjectionToken<IdenplaneConfig>('IDENPLANE_CONFIG');

--- a/packages/idenplane-angular/src/auth.module.ts
+++ b/packages/idenplane-angular/src/auth.module.ts
@@ -1,5 +1,5 @@
 /**
- * AuthmeModule — NgModule entry point for the Angular SDK.
+ * IdenplaneModule — NgModule entry point for the Angular SDK.
  *
  * @example
  * ```typescript
@@ -7,13 +7,13 @@
  * import { NgModule } from '@angular/core';
  * import { BrowserModule } from '@angular/platform-browser';
  * import { HttpClientModule } from '@angular/common/http';
- * import { AuthmeModule } from '@idenplane/angular';
+ * import { IdenplaneModule } from '@idenplane/angular';
  *
  * @NgModule({
  *   imports: [
  *     BrowserModule,
  *     HttpClientModule,
- *     AuthmeModule.forRoot({
+ *     IdenplaneModule.forRoot({
  *       url: 'http://localhost:3000',
  *       realm: 'my-realm',
  *       clientId: 'my-app',
@@ -29,22 +29,22 @@
 import { NgModule } from '@angular/core';
 import type { ModuleWithProviders } from '@angular/core';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import type { AuthmeConfig } from 'idenplane-sdk';
+import type { IdenplaneConfig } from 'idenplane-sdk';
 import { IDENPLANE_CONFIG } from './auth.config.js';
 import { AuthService } from './auth.service.js';
 import { AuthGuard } from './auth.guard.js';
 import { AuthInterceptor } from './auth.interceptor.js';
 
 @NgModule({})
-export class AuthmeModule {
+export class IdenplaneModule {
   /**
    * Call `forRoot` in the root `AppModule` with your Idenplane configuration.
    * This registers `AuthService`, `AuthGuard`, and `AuthInterceptor` as
    * module-level providers.
    */
-  static forRoot(config: AuthmeConfig): ModuleWithProviders<AuthmeModule> {
+  static forRoot(config: IdenplaneConfig): ModuleWithProviders<IdenplaneModule> {
     return {
-      ngModule: AuthmeModule,
+      ngModule: IdenplaneModule,
       providers: [
         { provide: IDENPLANE_CONFIG, useValue: config },
         AuthService,

--- a/packages/idenplane-angular/src/auth.service.ts
+++ b/packages/idenplane-angular/src/auth.service.ts
@@ -1,8 +1,8 @@
 /**
- * AuthService — injectable Angular service that wraps `AuthmeClient`.
+ * AuthService — injectable Angular service that wraps `IdenplaneClient`.
  *
  * Provides reactive auth state as RxJS observables and exposes the full
- * `AuthmeClient` API.
+ * `IdenplaneClient` API.
  *
  * @example
  * ```typescript
@@ -21,14 +21,14 @@
 
 import { Injectable, Inject, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { AuthmeClient } from 'idenplane-sdk';
-import type { UserInfo, AuthmeConfig, TokenResponse } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
+import type { UserInfo, IdenplaneConfig, TokenResponse } from 'idenplane-sdk';
 import { IDENPLANE_CONFIG } from './auth.config.js';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService implements OnDestroy {
-  /** The underlying AuthmeClient instance. */
-  readonly client: AuthmeClient;
+  /** The underlying IdenplaneClient instance. */
+  readonly client: IdenplaneClient;
 
   // ── Reactive state ──────────────────────────────────────────────
 
@@ -36,7 +36,7 @@ export class AuthService implements OnDestroy {
   private readonly _isLoading$ = new BehaviorSubject<boolean>(true);
   private readonly _user$ = new BehaviorSubject<UserInfo | null>(null);
   // Bug #438-5 fix: errors thrown during initialization (and surfaced by the
-  // underlying AuthmeClient 'error' event) were silently swallowed — the catch
+  // underlying IdenplaneClient 'error' event) were silently swallowed — the catch
   // block only updated isAuthenticated$ with no way for consumers to react.
   // Fix: expose a dedicated authError$ observable backed by a BehaviorSubject
   // so components can subscribe and display/log errors as needed.
@@ -55,7 +55,7 @@ export class AuthService implements OnDestroy {
   /**
    * Observable of the last authentication error, or `null` when no error has
    * occurred.  Errors are emitted for both initialization failures and for any
-   * errors propagated by the underlying `AuthmeClient` 'error' event.
+   * errors propagated by the underlying `IdenplaneClient` 'error' event.
    *
    * @example
    * ```typescript
@@ -70,8 +70,8 @@ export class AuthService implements OnDestroy {
 
   private readonly _unsubscribers: Array<() => void> = [];
 
-  constructor(@Inject(IDENPLANE_CONFIG) config: AuthmeConfig) {
-    this.client = new AuthmeClient(config);
+  constructor(@Inject(IDENPLANE_CONFIG) config: IdenplaneConfig) {
+    this.client = new IdenplaneClient(config);
     this._wireEvents();
     this._initialize();
   }

--- a/packages/idenplane-angular/src/index.ts
+++ b/packages/idenplane-angular/src/index.ts
@@ -2,10 +2,10 @@
  * @idenplane/angular — Angular SDK for Idenplane
  */
 
-export { AuthmeModule } from './auth.module.js';
+export { IdenplaneModule } from './auth.module.js';
 export { AuthService } from './auth.service.js';
 export { AuthGuard } from './auth.guard.js';
 export type { AuthRouteData } from './auth.guard.js';
 export { AuthInterceptor, authInterceptor } from './auth.interceptor.js';
 export { IDENPLANE_CONFIG } from './auth.config.js';
-export type { AuthmeConfig } from './auth.config.js';
+export type { IdenplaneConfig } from './auth.config.js';

--- a/packages/idenplane-cli/package.json
+++ b/packages/idenplane-cli/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-cli"
   },
   "publishConfig": {

--- a/packages/idenplane-ios/README.md
+++ b/packages/idenplane-ios/README.md
@@ -1,6 +1,6 @@
 # Idenplane iOS SDK
 
-Native Swift SDK for the [Idenplane](https://github.com/Islamawad132/Authme) Identity and Access Management server.
+Native Swift SDK for the [Idenplane](https://github.com/idenplane/idenplane) Identity and Access Management server.
 
 Implements the **OAuth 2.0 Authorization Code flow with PKCE** (RFC 7636) using `ASWebAuthenticationSession`. Tokens are stored securely in the iOS Keychain and optional Face ID / Touch ID gating is built in.
 
@@ -22,7 +22,7 @@ Add the package to your `Package.swift` dependencies:
 ```swift
 dependencies: [
     .package(
-        url: "https://github.com/Islamawad132/Authme",
+        url: "https://github.com/idenplane/idenplane",
         from: "1.0.0"
     )
 ]
@@ -36,7 +36,7 @@ Add `Idenplane` to your target:
 .target(
     name: "MyApp",
     dependencies: [
-        .product(name: "Idenplane", package: "Authme")
+        .product(name: "Idenplane", package: "Idenplane")
     ]
 )
 ```

--- a/packages/idenplane-ios/package.json
+++ b/packages/idenplane-ios/package.json
@@ -6,7 +6,7 @@
   "main": "Package.swift",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-ios"
   },
   "keywords": [

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -11,7 +11,7 @@
 
     <name>Idenplane Java SDK</name>
     <description>Java SDK for the Idenplane Identity and Access Management Server</description>
-    <url>https://github.com/Islamawad132/Authme</url>
+    <url>https://github.com/idenplane/idenplane</url>
 
     <modules>
         <module>idenplane-java-core</module>

--- a/packages/idenplane-js/README.md
+++ b/packages/idenplane-js/README.md
@@ -31,9 +31,9 @@ npm install idenplane-sdk
 ### Vanilla JavaScript / TypeScript
 
 ```typescript
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 
-const idenplane = new AuthmeClient({
+const idenplane = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -52,7 +52,7 @@ if (!idenplane.isAuthenticated()) {
 On your callback page:
 
 ```typescript
-const idenplane = new AuthmeClient({ /* same config */ });
+const idenplane = new IdenplaneClient({ /* same config */ });
 const success = await idenplane.handleCallback();
 if (success) {
   const user = idenplane.getUserInfo();
@@ -108,10 +108,10 @@ function Main() {
 ### AuthProvider with pre-built client
 
 ```tsx
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 import { AuthProvider } from 'idenplane-sdk/react';
 
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -167,7 +167,7 @@ Configure how the SDK refreshes tokens via the `refreshStrategy` option:
 | `silent` | Uses a hidden iframe with `prompt=none` for silent re-auth |
 
 ```typescript
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -200,7 +200,7 @@ For the `silent` strategy, your app's redirect URI page must post a message back
 Subscribe to SDK events to react to authentication state changes:
 
 ```typescript
-const client = new AuthmeClient({ ... });
+const client = new IdenplaneClient({ ... });
 
 // Subscribe — returns an unsubscribe function
 const unsubscribe = client.on('login', (tokens) => {
@@ -232,7 +232,7 @@ client.off('login', myHandler);
 Alternatively, pass callbacks directly in the config:
 
 ```typescript
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -338,7 +338,7 @@ The SDK is fully SSR-safe. When `window` is undefined (e.g., in Node.js / Next.j
 
 ```typescript
 // This works safely in both browser and SSR environments
-const client = new AuthmeClient({
+const client = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -351,12 +351,12 @@ const client = new AuthmeClient({
 
 ## API Reference
 
-### `AuthmeClient`
+### `IdenplaneClient`
 
 #### Constructor
 
 ```typescript
-new AuthmeClient(config: AuthmeConfig)
+new IdenplaneClient(config: IdenplaneConfig)
 ```
 
 | Option | Type | Default | Description |
@@ -419,7 +419,7 @@ Import from `idenplane-sdk/react`.
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `client` | `AuthmeClient` | Pre-built client (mutually exclusive with inline config props) |
+| `client` | `IdenplaneClient` | Pre-built client (mutually exclusive with inline config props) |
 | `serverUrl` | `string` | Idenplane server URL (alternative to `client`) |
 | `realm` | `string` | Realm name (alternative to `client`) |
 | `clientId` | `string` | OAuth2 client ID (alternative to `client`) |
@@ -446,7 +446,7 @@ const { isAuthenticated, isLoading, login, logout, getToken, user, client } = us
 | `logout` | `() => Promise<void>` | Trigger logout |
 | `getToken` | `() => string \| null` | Get current access token |
 | `user` | `UserInfo \| null` | Current user profile |
-| `client` | `AuthmeClient` | Underlying SDK client instance |
+| `client` | `IdenplaneClient` | Underlying SDK client instance |
 
 #### `useUser()`
 
@@ -499,11 +499,11 @@ Helper for Next.js API routes and `getServerSideProps`.
 
 Factory for Next.js middleware with route protection.
 
-#### `createAuthmeMiddleware(config)`
+#### `createIdenplaneMiddleware(config)`
 
 Express middleware for token validation.
 
-#### `createAuthmeGuard(config)`
+#### `createIdenplaneGuard(config)`
 
 NestJS guard factory for token validation.
 
@@ -515,26 +515,26 @@ NestJS guard factory for token validation.
 
 ```typescript
 import express from 'express';
-import { createAuthmeMiddleware } from 'idenplane-sdk/server';
+import { createIdenplaneMiddleware } from 'idenplane-sdk/server';
 
 const app = express();
-const idenplane = createAuthmeMiddleware({
+const idenplane = createIdenplaneMiddleware({
   issuerUrl: 'http://localhost:3000',
   realm: 'my-realm',
   requiredRoles: ['user'],  // optional
 });
 
 app.get('/api/profile', idenplane, (req: any, res) => {
-  res.json(req.user); // AuthmeTokenPayload
+  res.json(req.user); // IdenplaneTokenPayload
 });
 ```
 
 ### NestJS
 
 ```typescript
-import { createAuthmeGuard } from 'idenplane-sdk/server';
+import { createIdenplaneGuard } from 'idenplane-sdk/server';
 
-const AuthmeGuard = createAuthmeGuard({
+const IdenplaneGuard = createIdenplaneGuard({
   issuerUrl: 'http://localhost:3000',
   realm: 'my-realm',
 });
@@ -542,7 +542,7 @@ const AuthmeGuard = createAuthmeGuard({
 @Controller('api')
 export class AppController {
   @Get('profile')
-  @UseGuards(AuthmeGuard)
+  @UseGuards(IdenplaneGuard)
   getProfile(@Req() req) {
     return req.user;
   }

--- a/packages/idenplane-js/package.json
+++ b/packages/idenplane-js/package.json
@@ -82,7 +82,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-js"
   },
   "publishConfig": {

--- a/packages/idenplane-js/src/__tests__/client.test.ts
+++ b/packages/idenplane-js/src/__tests__/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { AuthmeClient } from '../client.js';
-import type { AuthmeConfig, TokenResponse } from '../types.js';
+import { IdenplaneClient } from '../client.js';
+import type { IdenplaneConfig, TokenResponse } from '../types.js';
 
 // ── Helpers ──────────────────────────────────────────────────────
 
@@ -79,7 +79,7 @@ const oidcDiscovery = {
   claims_supported: ['sub', 'name', 'email'],
 };
 
-const BASE_CONFIG: AuthmeConfig = {
+const BASE_CONFIG: IdenplaneConfig = {
   url: 'http://localhost:3000',
   realm: 'test',
   clientId: 'test-client',
@@ -101,7 +101,7 @@ function mockFetchDiscovery() {
 
 // ── Tests ────────────────────────────────────────────────────────
 
-describe('AuthmeClient', () => {
+describe('IdenplaneClient', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
@@ -118,18 +118,18 @@ describe('AuthmeClient', () => {
 
   describe('constructor', () => {
     it('sets default values for optional config', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       expect(client).toBeDefined();
     });
 
     it('accepts refreshStrategy option', () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'eager' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'eager' });
       expect(client).toBeDefined();
     });
 
     it('wires up onLogin callback', () => {
       const onLogin = vi.fn();
-      const client = new AuthmeClient({ ...BASE_CONFIG, onLogin });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, onLogin });
       // Simulate event
       const tokens = makeTokenResponse();
       (client as any).events.emit('login', tokens);
@@ -138,14 +138,14 @@ describe('AuthmeClient', () => {
 
     it('wires up onLogout callback', () => {
       const onLogout = vi.fn();
-      const client = new AuthmeClient({ ...BASE_CONFIG, onLogout });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, onLogout });
       (client as any).events.emit('logout');
       expect(onLogout).toHaveBeenCalled();
     });
 
     it('wires up onError callback', () => {
       const onError = vi.fn();
-      const client = new AuthmeClient({ ...BASE_CONFIG, onError });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, onError });
       const err = new Error('test error');
       (client as any).events.emit('error', err);
       expect(onError).toHaveBeenCalledWith(err);
@@ -153,7 +153,7 @@ describe('AuthmeClient', () => {
 
     it('wires up onTokenRefresh callback', () => {
       const onTokenRefresh = vi.fn();
-      const client = new AuthmeClient({ ...BASE_CONFIG, onTokenRefresh });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, onTokenRefresh });
       const tokens = makeTokenResponse();
       (client as any).events.emit('tokenRefresh', tokens);
       expect(onTokenRefresh).toHaveBeenCalledWith(tokens);
@@ -164,13 +164,13 @@ describe('AuthmeClient', () => {
 
   describe('init()', () => {
     it('returns false when no tokens in storage', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const result = await client.init();
       expect(result).toBe(false);
     });
 
     it('returns true when valid access token is in storage', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       // Pre-populate storage
       (client as any).storage.set('access_token', makeValidAccessToken());
       const result = await client.init();
@@ -178,7 +178,7 @@ describe('AuthmeClient', () => {
     });
 
     it('attempts refresh when access token is expired but refresh token exists', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const tokens = makeTokenResponse();
 
       (client as any).storage.set('access_token', makeExpiredAccessToken());
@@ -199,7 +199,7 @@ describe('AuthmeClient', () => {
     });
 
     it('returns false and clears tokens when refresh fails', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
 
       (client as any).storage.set('access_token', makeExpiredAccessToken());
       (client as any).storage.set('refresh_token', 'expired-refresh-token');
@@ -223,7 +223,7 @@ describe('AuthmeClient', () => {
     });
 
     it('emits ready event with correct value', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const handler = vi.fn();
       client.on('ready', handler);
 
@@ -236,18 +236,18 @@ describe('AuthmeClient', () => {
 
   describe('isAuthenticated()', () => {
     it('returns false when no token', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       expect(client.isAuthenticated()).toBe(false);
     });
 
     it('returns true when valid token is present', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('access_token', makeValidAccessToken());
       expect(client.isAuthenticated()).toBe(true);
     });
 
     it('returns false when token is expired', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('access_token', makeExpiredAccessToken());
       expect(client.isAuthenticated()).toBe(false);
     });
@@ -257,19 +257,19 @@ describe('AuthmeClient', () => {
 
   describe('getAccessToken()', () => {
     it('returns null when no token stored', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       expect(client.getAccessToken()).toBeNull();
     });
 
     it('returns the token string when valid', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const token = makeValidAccessToken();
       (client as any).storage.set('access_token', token);
       expect(client.getAccessToken()).toBe(token);
     });
 
     it('returns null for expired token', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('access_token', makeExpiredAccessToken());
       expect(client.getAccessToken()).toBeNull();
     });
@@ -279,12 +279,12 @@ describe('AuthmeClient', () => {
 
   describe('getTokenClaims()', () => {
     it('returns null when no token', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       expect(client.getTokenClaims()).toBeNull();
     });
 
     it('returns parsed claims', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('access_token', makeValidAccessToken());
       const claims = client.getTokenClaims();
       expect(claims?.sub).toBe('user-123');
@@ -295,10 +295,10 @@ describe('AuthmeClient', () => {
   // ── Role helpers ──────────────────────────────────────────────
 
   describe('role helpers', () => {
-    let client: AuthmeClient;
+    let client: IdenplaneClient;
 
     beforeEach(() => {
-      client = new AuthmeClient(BASE_CONFIG);
+      client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('access_token', makeValidAccessToken());
     });
 
@@ -340,12 +340,12 @@ describe('AuthmeClient', () => {
 
   describe('getUserInfo()', () => {
     it('returns null when not authenticated', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       expect(client.getUserInfo()).toBeNull();
     });
 
     it('extracts user info from ID token', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const idToken = makeJwt({
         sub: 'user-123',
         iss: 'http://localhost:3000/realms/test',
@@ -371,13 +371,13 @@ describe('AuthmeClient', () => {
 
   describe('handleCallback()', () => {
     it('returns false when no code in URL', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const result = await client.handleCallback('http://localhost:5173/callback');
       expect(result).toBe(false);
     });
 
     it('returns false and emits error when error param is present', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const errorHandler = vi.fn();
       client.on('error', errorHandler);
 
@@ -390,7 +390,7 @@ describe('AuthmeClient', () => {
     });
 
     it('returns false and emits error when state does not match', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const errorHandler = vi.fn();
       client.on('error', errorHandler);
 
@@ -409,7 +409,7 @@ describe('AuthmeClient', () => {
     });
 
     it('exchanges code for tokens successfully', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const tokens = makeTokenResponse();
       const loginHandler = vi.fn();
       client.on('login', loginHandler);
@@ -441,7 +441,7 @@ describe('AuthmeClient', () => {
     });
 
     it('deduplicates concurrent callback calls', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const tokens = makeTokenResponse();
 
       (client as any).storage.set('auth_state', 'valid-state');
@@ -477,12 +477,12 @@ describe('AuthmeClient', () => {
 
   describe('refreshTokens()', () => {
     it('throws when no refresh token is available', async () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
       await expect(client.refreshTokens()).rejects.toThrow('No refresh token available');
     });
 
     it('refreshes tokens successfully with rotation strategy', async () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
       const newTokens = makeTokenResponse();
       const refreshHandler = vi.fn();
       client.on('tokenRefresh', refreshHandler);
@@ -505,7 +505,7 @@ describe('AuthmeClient', () => {
     });
 
     it('clears tokens when refresh fails', async () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
       (client as any).storage.set('access_token', makeValidAccessToken());
       (client as any).storage.set('refresh_token', 'expired-refresh');
 
@@ -528,7 +528,7 @@ describe('AuthmeClient', () => {
     });
 
     it('emits backward-compatible tokenRefreshed event', async () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'rotation' });
       const newTokens = makeTokenResponse();
       const legacyHandler = vi.fn();
       client.on('tokenRefreshed', legacyHandler);
@@ -554,7 +554,7 @@ describe('AuthmeClient', () => {
 
   describe('logout()', () => {
     it('clears tokens on logout', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('access_token', makeValidAccessToken());
       (client as any).storage.set('refresh_token', 'some-refresh');
 
@@ -573,7 +573,7 @@ describe('AuthmeClient', () => {
     });
 
     it('emits logout event', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const logoutHandler = vi.fn();
       client.on('logout', logoutHandler);
 
@@ -589,7 +589,7 @@ describe('AuthmeClient', () => {
     });
 
     it('completes even if server logout fails', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       (client as any).storage.set('refresh_token', 'some-refresh');
 
       fetchMock.mockImplementation((url: string) => {
@@ -608,7 +608,7 @@ describe('AuthmeClient', () => {
 
   describe('event system', () => {
     it('on() returns an unsubscribe function', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const handler = vi.fn();
       const unsubscribe = client.on('logout', handler);
 
@@ -621,7 +621,7 @@ describe('AuthmeClient', () => {
     });
 
     it('off() removes a specific handler', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const handler = vi.fn();
       client.on('logout', handler);
       client.off('logout', handler);
@@ -631,7 +631,7 @@ describe('AuthmeClient', () => {
     });
 
     it('supports login event (new API)', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const handler = vi.fn();
       client.on('login', handler);
       const tokens = makeTokenResponse();
@@ -640,7 +640,7 @@ describe('AuthmeClient', () => {
     });
 
     it('supports tokenRefresh event (new API)', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const handler = vi.fn();
       client.on('tokenRefresh', handler);
       const tokens = makeTokenResponse();
@@ -649,7 +649,7 @@ describe('AuthmeClient', () => {
     });
 
     it('backward-compatible authenticated event fires on login', async () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       const legacyHandler = vi.fn();
       client.on('authenticated', legacyHandler);
       const tokens = makeTokenResponse();
@@ -678,7 +678,7 @@ describe('AuthmeClient', () => {
     it('createStorage falls back to MemoryStorage when window is undefined', async () => {
       // The storage.ts module already handles this via createStorage()
       // By using storage: 'memory' in tests, we simulate SSR storage
-      const client = new AuthmeClient({ ...BASE_CONFIG, storage: 'memory' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, storage: 'memory' });
       expect(client).toBeDefined();
       // Should not throw when window is undefined
       expect(client.isAuthenticated()).toBe(false);
@@ -689,22 +689,22 @@ describe('AuthmeClient', () => {
 
   describe('refresh strategies', () => {
     it('uses rotation strategy by default', () => {
-      const client = new AuthmeClient(BASE_CONFIG);
+      const client = new IdenplaneClient(BASE_CONFIG);
       expect((client as any).config.refreshStrategy).toBe('rotation');
     });
 
     it('accepts silent strategy', () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'silent' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'silent' });
       expect((client as any).config.refreshStrategy).toBe('silent');
     });
 
     it('accepts eager strategy', () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'eager' });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'eager' });
       expect((client as any).config.refreshStrategy).toBe('eager');
     });
 
     it('eager strategy uses a larger refresh buffer', () => {
-      const client = new AuthmeClient({ ...BASE_CONFIG, refreshStrategy: 'eager', refreshBuffer: 30 });
+      const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'eager', refreshBuffer: 30 });
       // The eager multiplier doubles the buffer (30 * 2 = 60)
       const config = (client as any).config;
       expect(config.refreshStrategy).toBe('eager');

--- a/packages/idenplane-js/src/__tests__/server.test.ts
+++ b/packages/idenplane-js/src/__tests__/server.test.ts
@@ -6,8 +6,8 @@ import {
   getRolesFromToken,
   getServerSideAuth,
   createNextMiddleware,
-  type AuthmeTokenPayload,
-  type AuthmeServerConfig,
+  type IdenplaneTokenPayload,
+  type IdenplaneServerConfig,
 } from '../server.js';
 
 // ── Mocks ──────────────────────────────────────────────────────
@@ -19,12 +19,12 @@ vi.mock('jose', () => ({
 
 const { jwtVerify } = await import('jose');
 
-const SERVER_CONFIG: AuthmeServerConfig = {
+const SERVER_CONFIG: IdenplaneServerConfig = {
   issuerUrl: 'http://localhost:3000',
   realm: 'test',
 };
 
-function makePayload(overrides: Partial<AuthmeTokenPayload> = {}): AuthmeTokenPayload {
+function makePayload(overrides: Partial<IdenplaneTokenPayload> = {}): IdenplaneTokenPayload {
   return {
     sub: 'user-123',
     iss: 'http://localhost:3000/realms/test',

--- a/packages/idenplane-js/src/client.ts
+++ b/packages/idenplane-js/src/client.ts
@@ -1,6 +1,6 @@
 import type {
-  AuthmeConfig,
-  AuthmeEventMap,
+  IdenplaneConfig,
+  IdenplaneEventMap,
   OpenIDConfiguration,
   TokenClaims,
   TokenResponse,
@@ -60,9 +60,9 @@ export function handleSilentCallback(): void {
   );
 }
 
-export class AuthmeClient {
+export class IdenplaneClient {
   private config: Required<
-    Pick<AuthmeConfig, 'url' | 'realm' | 'clientId' | 'redirectUri'>
+    Pick<IdenplaneConfig, 'url' | 'realm' | 'clientId' | 'redirectUri'>
   > & {
     scopes: string[];
     autoRefresh: boolean;
@@ -77,7 +77,7 @@ export class AuthmeClient {
   };
 
   private storage: TokenStorage;
-  private events = new EventEmitter<AuthmeEventMap>();
+  private events = new EventEmitter<IdenplaneEventMap>();
   private oidcConfig: OpenIDConfiguration | null = null;
   // Bug #438-2 fix: the discovery document was cached forever.  If the IdP
   // returns an error (e.g. 5xx) and `oidcConfig` somehow already held a stale
@@ -97,7 +97,7 @@ export class AuthmeClient {
   private callbackPromise: Promise<boolean> | null = null;
   private silentRefreshIframe: HTMLIFrameElement | null = null;
 
-  constructor(config: AuthmeConfig) {
+  constructor(config: IdenplaneConfig) {
     this.config = {
       url: config.url.replace(/\/$/, ''),
       realm: config.realm,
@@ -717,18 +717,18 @@ export class AuthmeClient {
   // ── Events ──────────────────────────────────────────────────────
 
   /** Subscribe to an event. Returns an unsubscribe function. */
-  on<K extends keyof AuthmeEventMap>(
+  on<K extends keyof IdenplaneEventMap>(
     event: K,
-    handler: AuthmeEventMap[K] extends void ? () => void : (data: AuthmeEventMap[K]) => void,
+    handler: IdenplaneEventMap[K] extends void ? () => void : (data: IdenplaneEventMap[K]) => void,
   ): () => void {
     this.events.on(event, handler);
     return () => this.events.off(event, handler);
   }
 
   /** Unsubscribe from an event. */
-  off<K extends keyof AuthmeEventMap>(
+  off<K extends keyof IdenplaneEventMap>(
     event: K,
-    handler: AuthmeEventMap[K] extends void ? () => void : (data: AuthmeEventMap[K]) => void,
+    handler: IdenplaneEventMap[K] extends void ? () => void : (data: IdenplaneEventMap[K]) => void,
   ): void {
     this.events.off(event, handler);
   }
@@ -785,7 +785,7 @@ export class AuthmeClient {
     const now = Date.now();
     const isExpired =
       this.oidcConfigFetchedAt === null ||
-      now - this.oidcConfigFetchedAt > AuthmeClient.DISCOVERY_TTL_MS;
+      now - this.oidcConfigFetchedAt > IdenplaneClient.DISCOVERY_TTL_MS;
 
     if (!this.oidcConfig || isExpired) {
       await this.fetchDiscovery();

--- a/packages/idenplane-js/src/continuous-verification.ts
+++ b/packages/idenplane-js/src/continuous-verification.ts
@@ -6,10 +6,10 @@
  *
  * @example
  * ```typescript
- * import { AuthmeClient } from 'idenplane-sdk';
+ * import { IdenplaneClient } from 'idenplane-sdk';
  * import { ContinuousVerification } from 'idenplane-sdk/continuous-verification';
  *
- * const client = new AuthmeClient(config);
+ * const client = new IdenplaneClient(config);
  * const cv = new ContinuousVerification(client);
  *
  * // Report device posture
@@ -32,7 +32,7 @@
  * ```
  */
 
-import type { AuthmeClient } from './client.js';
+import type { IdenplaneClient } from './client.js';
 
 // ─── Device Posture Types ────────────────────────────────────────────────────
 
@@ -155,14 +155,14 @@ export interface NetworkContextInput {
  * Enables client applications to report device posture, behavioral biometrics,
  * and network context signals for continuous session risk assessment.
  *
- * The SDK requires an initialized AuthmeClient for accessing auth tokens.
+ * The SDK requires an initialized IdenplaneClient for accessing auth tokens.
  */
 export class ContinuousVerification {
-  private readonly client: AuthmeClient;
+  private readonly client: IdenplaneClient;
   private readonly baseUrl: string;
   private readonly realm: string;
 
-  constructor(client: AuthmeClient, baseUrl?: string) {
+  constructor(client: IdenplaneClient, baseUrl?: string) {
     this.client = client;
     // Derive base URL from the client's configured URL
     this.baseUrl = baseUrl ?? client.getConfig().url;

--- a/packages/idenplane-js/src/index.ts
+++ b/packages/idenplane-js/src/index.ts
@@ -1,7 +1,7 @@
-export { AuthmeClient, handleSilentCallback } from './client.js';
+export { IdenplaneClient, handleSilentCallback } from './client.js';
 export type {
-  AuthmeConfig,
-  AuthmeEventMap,
+  IdenplaneConfig,
+  IdenplaneEventMap,
   OpenIDConfiguration,
   TokenClaims,
   TokenResponse,

--- a/packages/idenplane-js/src/react.ts
+++ b/packages/idenplane-js/src/react.ts
@@ -9,15 +9,15 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { AuthmeClient as AuthmeClientClass } from './client.js';
-import type { AuthmeClient } from './client.js';
-import type { AuthmeConfig, TokenResponse, UserInfo } from './types.js';
+import { IdenplaneClient as IdenplaneClientClass } from './client.js';
+import type { IdenplaneClient } from './client.js';
+import type { IdenplaneConfig, TokenResponse, UserInfo } from './types.js';
 
 // Re-export core for convenience
-export { AuthmeClient } from './client.js';
+export { IdenplaneClient } from './client.js';
 export type {
-  AuthmeConfig,
-  AuthmeEventMap,
+  IdenplaneConfig,
+  IdenplaneEventMap,
   TokenClaims,
   TokenResponse,
   UserInfo,
@@ -26,7 +26,7 @@ export type {
 // ── Context ─────────────────────────────────────────────────────
 
 interface AuthContextValue {
-  client: AuthmeClient;
+  client: IdenplaneClient;
   isAuthenticated: boolean;
   isLoading: boolean;
   user: UserInfo | null;
@@ -41,10 +41,10 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export interface AuthProviderProps {
   /**
-   * An already-constructed AuthmeClient instance.
+   * An already-constructed IdenplaneClient instance.
    * Mutually exclusive with the individual config props.
    */
-  client?: AuthmeClient;
+  client?: IdenplaneClient;
 
   // Inline config props (alternative to passing a pre-built client)
   /** Idenplane server URL */
@@ -75,7 +75,7 @@ export interface AuthProviderProps {
 }
 
 /**
- * AuthProvider wraps your application, initializes an AuthmeClient,
+ * AuthProvider wraps your application, initializes an IdenplaneClient,
  * and provides auth state to all child components via context.
  *
  * ```tsx
@@ -100,7 +100,7 @@ export function AuthProvider({
   onTokenRefresh,
 }: AuthProviderProps) {
   // Build or use the client. We hold it in a ref so we build it at most once.
-  const clientRef = useRef<AuthmeClient | null>(null);
+  const clientRef = useRef<IdenplaneClient | null>(null);
   if (!clientRef.current) {
     if (clientProp) {
       clientRef.current = clientProp;
@@ -110,7 +110,7 @@ export function AuthProvider({
           'AuthProvider requires either a `client` prop or all of: serverUrl, realm, clientId, redirectUri',
         );
       }
-      const config: AuthmeConfig = {
+      const config: IdenplaneConfig = {
         url: serverUrl,
         realm,
         clientId,
@@ -121,7 +121,7 @@ export function AuthProvider({
         onError,
         onTokenRefresh,
       };
-      clientRef.current = new AuthmeClientClass(config);
+      clientRef.current = new IdenplaneClientClass(config);
     }
   }
 
@@ -233,23 +233,23 @@ export function AuthProvider({
   return createElement(AuthContext.Provider, { value }, children);
 }
 
-// ── Backward-compatible AuthmeProvider alias ─────────────────────
+// ── Backward-compatible IdenplaneProvider alias ─────────────────────
 
 /** @deprecated Use AuthProvider instead */
-export interface AuthmeProviderProps {
-  client: AuthmeClient;
+export interface IdenplaneProviderProps {
+  client: IdenplaneClient;
   children: ReactNode;
   autoHandleCallback?: boolean;
   onReady?: (authenticated: boolean) => void;
 }
 
 /** @deprecated Use AuthProvider instead. This alias will be removed in v2. */
-export function AuthmeProvider({
+export function IdenplaneProvider({
   client,
   children,
   autoHandleCallback = true,
   onReady,
-}: AuthmeProviderProps) {
+}: IdenplaneProviderProps) {
   return createElement(AuthProvider, { client, children, autoHandleCallback, onReady });
 }
 
@@ -281,7 +281,7 @@ export function useAuth() {
  * @deprecated Use useAuth() instead.
  * Hook for authentication state and actions.
  */
-export function useAuthme() {
+export function useIdenplane() {
   const { client, isAuthenticated, isLoading, login, logout, getToken } = useAuthContext();
   const token = isAuthenticated ? getToken() : null;
   return { isAuthenticated, isLoading, login, logout, token, client };

--- a/packages/idenplane-js/src/server.ts
+++ b/packages/idenplane-js/src/server.ts
@@ -3,16 +3,16 @@
  *
  * Provides:
  * - `verifyToken` — verify a JWT using JWKS
- * - `createAuthmeMiddleware` — Express middleware
- * - `createAuthmeGuard` — NestJS guard factory
+ * - `createIdenplaneMiddleware` — Express middleware
+ * - `createIdenplaneGuard` — NestJS guard factory
  * - `getServerSideAuth` — Next.js getServerSideProps helper
  * - `createNextMiddleware` — Next.js middleware helper
  *
  * @example
  * ```typescript
- * import { createAuthmeMiddleware } from 'idenplane-sdk/server';
+ * import { createIdenplaneMiddleware } from 'idenplane-sdk/server';
  *
- * app.use('/api', createAuthmeMiddleware({
+ * app.use('/api', createIdenplaneMiddleware({
  *   issuerUrl: 'http://localhost:3000',
  *   realm: 'my-realm',
  * }));
@@ -21,7 +21,7 @@
 
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
 
-export interface AuthmeServerConfig {
+export interface IdenplaneServerConfig {
   /** Idenplane server base URL (e.g., 'http://localhost:3000') */
   issuerUrl: string;
   /** Realm name */
@@ -32,7 +32,7 @@ export interface AuthmeServerConfig {
   rolesClaimPath?: string;
 }
 
-export interface AuthmeTokenPayload extends JWTPayload {
+export interface IdenplaneTokenPayload extends JWTPayload {
   preferred_username?: string;
   email?: string;
   name?: string;
@@ -58,13 +58,13 @@ function getJWKS(issuerUrl: string, realm: string) {
  */
 export async function verifyToken(
   token: string,
-  config: AuthmeServerConfig,
-): Promise<AuthmeTokenPayload> {
+  config: IdenplaneServerConfig,
+): Promise<IdenplaneTokenPayload> {
   const JWKS = getJWKS(config.issuerUrl, config.realm);
   const issuer = `${config.issuerUrl}/realms/${config.realm}`;
 
   const { payload } = await jwtVerify(token, JWKS, { issuer });
-  return payload as AuthmeTokenPayload;
+  return payload as IdenplaneTokenPayload;
 }
 
 /**
@@ -81,7 +81,7 @@ export function extractBearerToken(authHeader: string | string[] | undefined): s
  * Check if a token payload has the required realm roles.
  */
 export function hasRealmRoles(
-  payload: AuthmeTokenPayload,
+  payload: IdenplaneTokenPayload,
   requiredRoles: string[],
 ): boolean {
   const userRoles = payload.realm_access?.roles ?? [];
@@ -92,7 +92,7 @@ export function hasRealmRoles(
  * Check if a token payload has the required client roles.
  */
 export function hasClientRoles(
-  payload: AuthmeTokenPayload,
+  payload: IdenplaneTokenPayload,
   clientId: string,
   requiredRoles: string[],
 ): boolean {
@@ -102,8 +102,8 @@ export function hasClientRoles(
 
 // ─── Express Middleware ────────────────────────────────────
 
-export interface AuthmeRequest {
-  user?: AuthmeTokenPayload;
+export interface IdenplaneRequest {
+  user?: IdenplaneTokenPayload;
   headers: Record<string, string | string[] | undefined>;
 }
 
@@ -113,10 +113,10 @@ export interface AuthmeRequest {
  * @example
  * ```typescript
  * import express from 'express';
- * import { createAuthmeMiddleware } from 'idenplane-sdk/server';
+ * import { createIdenplaneMiddleware } from 'idenplane-sdk/server';
  *
  * const app = express();
- * const idenplane = createAuthmeMiddleware({
+ * const idenplane = createIdenplaneMiddleware({
  *   issuerUrl: 'http://localhost:3000',
  *   realm: 'my-realm',
  * });
@@ -126,9 +126,9 @@ export interface AuthmeRequest {
  * });
  * ```
  */
-export function createAuthmeMiddleware(config: AuthmeServerConfig) {
+export function createIdenplaneMiddleware(config: IdenplaneServerConfig) {
   return async (
-    req: AuthmeRequest,
+    req: IdenplaneRequest,
     res: { status: (code: number) => { json: (body: unknown) => void } },
     next: () => void,
   ) => {
@@ -182,9 +182,9 @@ class HttpError extends Error {
  *
  * @example
  * ```typescript
- * import { createAuthmeGuard } from 'idenplane-sdk/server';
+ * import { createIdenplaneGuard } from 'idenplane-sdk/server';
  *
- * const AuthmeGuard = createAuthmeGuard({
+ * const IdenplaneGuard = createIdenplaneGuard({
  *   issuerUrl: 'http://localhost:3000',
  *   realm: 'my-realm',
  * });
@@ -192,17 +192,17 @@ class HttpError extends Error {
  * @Controller('api')
  * export class AppController {
  *   @Get('profile')
- *   @UseGuards(AuthmeGuard)
+ *   @UseGuards(IdenplaneGuard)
  *   getProfile(@Req() req) {
  *     return req.user;
  *   }
  * }
  * ```
  */
-export function createAuthmeGuard(config: AuthmeServerConfig) {
-  return class AuthmeGuard {
+export function createIdenplaneGuard(config: IdenplaneServerConfig) {
+  return class IdenplaneGuard {
     async canActivate(context: {
-      switchToHttp: () => { getRequest: () => AuthmeRequest };
+      switchToHttp: () => { getRequest: () => IdenplaneRequest };
     }): Promise<boolean> {
       const request = context.switchToHttp().getRequest();
       const authHeader = request.headers['authorization'] ?? request.headers['Authorization'];
@@ -235,7 +235,7 @@ export function createAuthmeGuard(config: AuthmeServerConfig) {
  * Helper to extract roles from an Idenplane token payload.
  */
 export function getRolesFromToken(
-  payload: AuthmeTokenPayload,
+  payload: IdenplaneTokenPayload,
   clientId?: string,
 ): string[] {
   if (clientId) {
@@ -261,7 +261,7 @@ export interface NextRequest {
 
 export interface ServerSideAuthResult {
   /** The verified token payload, or null if not authenticated */
-  user: AuthmeTokenPayload | null;
+  user: IdenplaneTokenPayload | null;
   /** The raw access token string, or null if not present/invalid */
   accessToken: string | null;
   /** Whether the user is authenticated */
@@ -304,7 +304,7 @@ export interface ServerSideAuthResult {
  */
 export async function getServerSideAuth(
   req: { headers: Record<string, string | string[] | undefined> },
-  config: AuthmeServerConfig,
+  config: IdenplaneServerConfig,
 ): Promise<ServerSideAuthResult> {
   const authHeader = req.headers['authorization'] ?? req.headers['Authorization'];
   const token = extractBearerToken(authHeader);
@@ -348,7 +348,7 @@ export async function getServerSideAuth(
  * };
  * ```
  */
-export interface NextMiddlewareConfig extends AuthmeServerConfig {
+export interface NextMiddlewareConfig extends IdenplaneServerConfig {
   /** Path prefixes that require authentication */
   protectedPaths?: string[];
   /** Path to redirect unauthenticated users to */

--- a/packages/idenplane-js/src/types.ts
+++ b/packages/idenplane-js/src/types.ts
@@ -1,5 +1,5 @@
-/** Configuration for creating an AuthmeClient instance. */
-export interface AuthmeConfig {
+/** Configuration for creating an IdenplaneClient instance. */
+export interface IdenplaneConfig {
   /** Base URL of the Idenplane server (e.g. "http://localhost:3000") */
   url: string;
   /** Realm name to authenticate against */
@@ -142,8 +142,8 @@ export interface OpenIDConfiguration {
   code_challenge_methods_supported?: string[];
 }
 
-/** Events emitted by AuthmeClient. */
-export type AuthmeEventMap = {
+/** Events emitted by IdenplaneClient. */
+export type IdenplaneEventMap = {
   /** Fired after successful login or callback */
   login: TokenResponse;
   /** Fired after logout completes */

--- a/packages/idenplane-nextjs/README.md
+++ b/packages/idenplane-nextjs/README.md
@@ -1,6 +1,6 @@
 # idenplane-nextjs
 
-Next.js SDK for [Idenplane](https://github.com/Islamawad132/Authme) — integrates Idenplane OIDC authentication into Next.js applications with support for the App Router, Pages Router, middleware, and Server Components.
+Next.js SDK for [Idenplane](https://github.com/idenplane/idenplane) — integrates Idenplane OIDC authentication into Next.js applications with support for the App Router, Pages Router, middleware, and Server Components.
 
 ## Installation
 
@@ -133,12 +133,12 @@ export const GET = withAuthHandler(
 
 Re-exports from `idenplane-sdk/react`:
 
-- `AuthProvider` / `AuthmeProvider` — context provider
+- `AuthProvider` / `IdenplaneProvider` — context provider
 - `useAuth()` — authentication state and actions
 - `useUser()` — current user info
 - `usePermissions()` — role and permission helpers
 - `ProtectedRoute` — render-gate component
-- `AuthmeClient` — raw client class
+- `IdenplaneClient` — raw client class
 
 ### `idenplane-nextjs/middleware`
 

--- a/packages/idenplane-nextjs/package.json
+++ b/packages/idenplane-nextjs/package.json
@@ -92,7 +92,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-nextjs"
   },
   "publishConfig": {

--- a/packages/idenplane-nextjs/src/index.ts
+++ b/packages/idenplane-nextjs/src/index.ts
@@ -11,21 +11,21 @@
  */
 export {
   AuthProvider,
-  AuthmeProvider,
+  IdenplaneProvider,
   useAuth,
-  useAuthme,
+  useIdenplane,
   useUser,
   usePermissions,
   useRoles,
   ProtectedRoute,
-  AuthmeClient,
+  IdenplaneClient,
 } from 'idenplane-sdk/react';
 
 export type {
   AuthProviderProps,
-  AuthmeProviderProps,
+  IdenplaneProviderProps,
   ProtectedRouteProps,
-  AuthmeConfig,
+  IdenplaneConfig,
   TokenResponse,
   TokenClaims,
   UserInfo,

--- a/packages/idenplane-python/run_mypy.sh
+++ b/packages/idenplane-python/run_mypy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-cd /home/islam/projects/Authme/Authme/packages/idenplane-python
+cd /home/islam/projects/Idenplane/Idenplane/packages/idenplane-python
 python3 -m mypy idenplane/ --strict 2>&1 | head -100

--- a/packages/idenplane-vue/README.md
+++ b/packages/idenplane-vue/README.md
@@ -1,6 +1,6 @@
 # idenplane-vue
 
-Vue 3 SDK for [Idenplane](https://github.com/Islamawad132/Authme) — composables, a Vue plugin, Vue Router guard, and an `AuthProvider` component.
+Vue 3 SDK for [Idenplane](https://github.com/idenplane/idenplane) — composables, a Vue plugin, Vue Router guard, and an `AuthProvider` component.
 
 ## Installation
 
@@ -15,12 +15,12 @@ npm install idenplane-vue idenplane-sdk vue
 ```typescript
 // main.ts
 import { createApp } from 'vue';
-import { AuthmePlugin } from 'idenplane-vue';
+import { IdenplanePlugin } from 'idenplane-vue';
 import App from './App.vue';
 
 const app = createApp(App);
 
-app.use(AuthmePlugin, {
+app.use(IdenplanePlugin, {
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -57,9 +57,9 @@ const { isAuthenticated, user, login, logout, isLoading } = useAuth();
 // router/index.ts
 import { createRouter, createWebHistory } from 'vue-router';
 import { createAuthGuard } from 'idenplane-vue';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 
-const authClient = new AuthmeClient({
+const authClient = new IdenplaneClient({
   url: 'http://localhost:3000',
   realm: 'my-realm',
   clientId: 'my-app',
@@ -126,7 +126,7 @@ const { hasRole, hasPermission, roles } = usePermissions();
 
 ### Plugin
 
-- `AuthmePlugin` — Vue plugin, call `app.use(AuthmePlugin, AuthmeConfig)`
+- `IdenplanePlugin` — Vue plugin, call `app.use(IdenplanePlugin, IdenplaneConfig)`
 
 ### Composables
 

--- a/packages/idenplane-vue/package.json
+++ b/packages/idenplane-vue/package.json
@@ -61,7 +61,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Islamawad132/Authme.git",
+    "url": "https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-vue"
   },
   "publishConfig": {

--- a/packages/idenplane-vue/src/__tests__/composables.test.ts
+++ b/packages/idenplane-vue/src/__tests__/composables.test.ts
@@ -4,7 +4,7 @@ import { mount } from '@vue/test-utils';
 import { IDENPLANE_KEY } from '../plugin.js';
 import { useAuth, useUser, usePermissions } from '../composables.js';
 
-// ── Fake AuthmeClient ─────────────────────────────────────────────
+// ── Fake IdenplaneClient ─────────────────────────────────────────────
 
 function buildClient(o: {
   authenticated?: boolean;
@@ -76,7 +76,7 @@ describe('useAuth', () => {
   it('throws when used outside AuthProvider', () => {
     const Bad = defineComponent({
       setup() {
-        expect(() => useAuth()).toThrow(/No AuthmeClient found/);
+        expect(() => useAuth()).toThrow(/No IdenplaneClient found/);
         return () => h('div');
       },
     });

--- a/packages/idenplane-vue/src/components.ts
+++ b/packages/idenplane-vue/src/components.ts
@@ -1,7 +1,7 @@
 /**
  * AuthProvider Vue component.
  *
- * An alternative to installing `AuthmePlugin` globally — useful when you want
+ * An alternative to installing `IdenplanePlugin` globally — useful when you want
  * to scope the auth context to a subtree of your component tree, or when you
  * prefer to instantiate the client inline in a template.
  *
@@ -31,8 +31,8 @@ import {
   h,
   onUnmounted,
 } from 'vue';
-import { AuthmeClient } from 'idenplane-sdk';
-import type { AuthmeConfig } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
+import type { IdenplaneConfig } from 'idenplane-sdk';
 import { IDENPLANE_KEY } from './plugin.js';
 
 export const AuthProvider = defineComponent({
@@ -52,7 +52,7 @@ export const AuthProvider = defineComponent({
   },
 
   setup(props, { slots }) {
-    const config: AuthmeConfig = {
+    const config: IdenplaneConfig = {
       url: props.url,
       realm: props.realm,
       clientId: props.clientId,
@@ -62,7 +62,7 @@ export const AuthProvider = defineComponent({
       autoRefresh: props.autoRefresh,
     };
 
-    const client = new AuthmeClient(config);
+    const client = new IdenplaneClient(config);
     provide(IDENPLANE_KEY, client);
 
     onUnmounted(() => {

--- a/packages/idenplane-vue/src/composables.ts
+++ b/packages/idenplane-vue/src/composables.ts
@@ -1,25 +1,25 @@
 /**
  * Vue composables for Idenplane.
  *
- * All composables rely on an `AuthmeClient` injected by `AuthmePlugin` or
+ * All composables rely on an `IdenplaneClient` injected by `IdenplanePlugin` or
  * provided manually via `AuthProvider.vue`.
  */
 
 import { inject, ref, readonly, onMounted, onUnmounted, computed } from 'vue';
 import type { Ref, ComputedRef } from 'vue';
-import { AuthmeClient } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
 import type { UserInfo } from 'idenplane-sdk';
 import { IDENPLANE_KEY } from './plugin.js';
 
 // ── Init singleton ────────────────────────────────────────────────
 // Bug #438-4 fix: every component that calls useAuth() was triggering its own
-// client.init() call.  Although AuthmeClient.init() is re-entrant-safe and
+// client.init() call.  Although IdenplaneClient.init() is re-entrant-safe and
 // coalesces concurrent calls onto a single Promise, each component still went
 // through the full async path and set its own isLoading = false only after
 // awaiting.  The visible symptom is a loading flicker in every component that
 // mounts after the first one.
 //
-// Fix: keep a module-level WeakMap that maps each AuthmeClient instance to the
+// Fix: keep a module-level WeakMap that maps each IdenplaneClient instance to the
 // single init Promise (and its settled result).  Subsequent useAuth() calls on
 // the same client skip the init() await entirely when the Promise has already
 // resolved, and share the same in-flight Promise when init is still running.
@@ -28,9 +28,9 @@ interface InitRecord {
   settled: boolean;
   result: boolean;
 }
-const initRecords = new WeakMap<AuthmeClient, InitRecord>();
+const initRecords = new WeakMap<IdenplaneClient, InitRecord>();
 
-function getOrStartInit(client: AuthmeClient): Promise<boolean> {
+function getOrStartInit(client: IdenplaneClient): Promise<boolean> {
   const existing = initRecords.get(client);
   if (existing) return existing.promise;
 
@@ -52,11 +52,11 @@ function getOrStartInit(client: AuthmeClient): Promise<boolean> {
 
 // ── Internal helper ──────────────────────────────────────────────
 
-function useClient(): AuthmeClient {
-  const client = inject<AuthmeClient>(IDENPLANE_KEY);
+function useClient(): IdenplaneClient {
+  const client = inject<IdenplaneClient>(IDENPLANE_KEY);
   if (!client) {
     throw new Error(
-      '[idenplane-vue] No AuthmeClient found. Make sure you installed AuthmePlugin or wrapped your component with <AuthProvider>.',
+      '[idenplane-vue] No IdenplaneClient found. Make sure you installed IdenplanePlugin or wrapped your component with <AuthProvider>.',
     );
   }
   return client;
@@ -77,8 +77,8 @@ export interface UseAuthReturn {
   logout: () => Promise<void>;
   /** Get the current access token string */
   getToken: () => string | null;
-  /** Direct access to the underlying AuthmeClient */
-  client: AuthmeClient;
+  /** Direct access to the underlying IdenplaneClient */
+  client: IdenplaneClient;
 }
 
 /**

--- a/packages/idenplane-vue/src/guard.ts
+++ b/packages/idenplane-vue/src/guard.ts
@@ -31,7 +31,7 @@
 
 import type { NavigationGuard, RouteLocationNormalized } from 'vue-router';
 import { inject } from 'vue';
-import type { AuthmeClient } from 'idenplane-sdk';
+import type { IdenplaneClient } from 'idenplane-sdk';
 import { IDENPLANE_KEY } from './plugin.js';
 
 export interface AuthGuardOptions {
@@ -59,23 +59,23 @@ export interface AuthRouteMeta {
  * Create a Vue Router `NavigationGuard` that enforces authentication and
  * optional role requirements.
  *
- * The guard reads the `AuthmeClient` from the Vue provide/inject system, so
- * it must be used inside a component tree that has had `AuthmePlugin` installed.
+ * The guard reads the `IdenplaneClient` from the Vue provide/inject system, so
+ * it must be used inside a component tree that has had `IdenplanePlugin` installed.
  *
  * For use outside a component (e.g. in router/index.ts before `app.use`),
  * pass a pre-built `client` directly:
  *
  * ```typescript
  * import { createAuthGuard } from '@idenplane/vue';
- * import { AuthmeClient } from 'idenplane-sdk';
+ * import { IdenplaneClient } from 'idenplane-sdk';
  *
- * const client = new AuthmeClient({ ... });
+ * const client = new IdenplaneClient({ ... });
  * router.beforeEach(createAuthGuard({ loginRoute: '/login' }, client));
  * ```
  */
 export function createAuthGuard(
   options: AuthGuardOptions = {},
-  clientOverride?: AuthmeClient,
+  clientOverride?: IdenplaneClient,
 ): NavigationGuard {
   const { loginRoute = '/login', roles: globalRoles = [] } = options;
 
@@ -84,10 +84,10 @@ export function createAuthGuard(
   // because the active component instance is no longer set once the first
   // await resumes.  Capture the reference here, synchronously, so the async
   // guard below can close over it safely.
-  let injectedClient: AuthmeClient | undefined;
+  let injectedClient: IdenplaneClient | undefined;
   if (!clientOverride) {
     try {
-      injectedClient = inject<AuthmeClient>(IDENPLANE_KEY);
+      injectedClient = inject<IdenplaneClient>(IDENPLANE_KEY);
     } catch {
       // Outside component context — client must be passed explicitly.
     }
@@ -99,12 +99,12 @@ export function createAuthGuard(
   ) => {
     // Resolve the client — prefer the explicit override, then the reference
     // captured synchronously above.
-    const client: AuthmeClient | undefined = clientOverride ?? injectedClient;
+    const client: IdenplaneClient | undefined = clientOverride ?? injectedClient;
 
     if (!client) {
       console.warn(
-        '[idenplane-vue] createAuthGuard: no AuthmeClient available. ' +
-          'Pass the client as the second argument or install AuthmePlugin.',
+        '[idenplane-vue] createAuthGuard: no IdenplaneClient available. ' +
+          'Pass the client as the second argument or install IdenplanePlugin.',
       );
       // Fail closed: no client means we cannot verify identity, so block
       // navigation and redirect to the login route.

--- a/packages/idenplane-vue/src/index.ts
+++ b/packages/idenplane-vue/src/index.ts
@@ -3,8 +3,8 @@
  */
 
 // Plugin
-export { AuthmePlugin, IDENPLANE_KEY } from './plugin.js';
-export type { AuthmePluginOptions } from './plugin.js';
+export { IdenplanePlugin, IDENPLANE_KEY } from './plugin.js';
+export type { IdenplanePluginOptions } from './plugin.js';
 
 // Composables
 export { useAuth, useUser, usePermissions } from './composables.js';
@@ -18,9 +18,9 @@ export type { AuthGuardOptions, AuthRouteMeta } from './guard.js';
 export { AuthProvider } from './components.js';
 
 // Re-export core types from idenplane-sdk for convenience
-export { AuthmeClient } from 'idenplane-sdk';
+export { IdenplaneClient } from 'idenplane-sdk';
 export type {
-  AuthmeConfig,
+  IdenplaneConfig,
   TokenResponse,
   TokenClaims,
   UserInfo,

--- a/packages/idenplane-vue/src/plugin.ts
+++ b/packages/idenplane-vue/src/plugin.ts
@@ -1,19 +1,19 @@
 /**
  * Vue plugin for Idenplane.
  *
- * Install via `app.use(AuthmePlugin, options)`.  The plugin creates a shared
- * `AuthmeClient` instance and makes it available to every component through
+ * Install via `app.use(IdenplanePlugin, options)`.  The plugin creates a shared
+ * `IdenplaneClient` instance and makes it available to every component through
  * Vue's provide/inject mechanism.
  *
  * @example
  * ```typescript
  * // main.ts
  * import { createApp } from 'vue';
- * import { AuthmePlugin } from '@idenplane/vue';
+ * import { IdenplanePlugin } from '@idenplane/vue';
  * import App from './App.vue';
  *
  * const app = createApp(App);
- * app.use(AuthmePlugin, {
+ * app.use(IdenplanePlugin, {
  *   url: 'http://localhost:3000',
  *   realm: 'my-realm',
  *   clientId: 'my-app',
@@ -24,18 +24,18 @@
  */
 
 import type { App } from 'vue';
-import { AuthmeClient } from 'idenplane-sdk';
-import type { AuthmeConfig } from 'idenplane-sdk';
+import { IdenplaneClient } from 'idenplane-sdk';
+import type { IdenplaneConfig } from 'idenplane-sdk';
 
 /** The provide/inject key used internally. */
 export const IDENPLANE_KEY = Symbol('idenplane');
 
-/** Options accepted by the Vue plugin — same as `AuthmeConfig`. */
-export type AuthmePluginOptions = AuthmeConfig;
+/** Options accepted by the Vue plugin — same as `IdenplaneConfig`. */
+export type IdenplanePluginOptions = IdenplaneConfig;
 
-export const AuthmePlugin = {
-  install(app: App, options: AuthmePluginOptions): void {
-    const client = new AuthmeClient(options);
+export const IdenplanePlugin = {
+  install(app: App, options: IdenplanePluginOptions): void {
+    const client = new IdenplaneClient(options);
     app.provide(IDENPLANE_KEY, client);
     // Kick off OIDC discovery and session restoration immediately so that
     // guards and composables see the correct auth state on first render.

--- a/prisma/schema.mysql.prisma
+++ b/prisma/schema.mysql.prisma
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// MySQL / MariaDB variant of the Authme Prisma schema.
+// MySQL / MariaDB variant of the Idenplane Prisma schema.
 //
 // Intended for deployments that require MySQL 8.0+ or MariaDB 10.5+.
 // For new projects, PostgreSQL is still the recommended provider.

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// Authme — primary Prisma schema (PostgreSQL)
+// Idenplane — primary Prisma schema (PostgreSQL)
 //
 // This is the canonical schema used in production.  Two additional provider
 // variants live alongside it for alternative deployments:

--- a/prisma/schema.sqlite.prisma
+++ b/prisma/schema.sqlite.prisma
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// SQLite variant of the Authme Prisma schema.
+// SQLite variant of the Idenplane Prisma schema.
 //
 // Intended for local development and CI testing only — not for production use.
 //

--- a/providers/pulumi-provider-idenplane/examples/csharp/realm/Idenplane.csproj
+++ b/providers/pulumi-provider-idenplane/examples/csharp/realm/Idenplane.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>Authme</RootNamespace>
+    <RootNamespace>Idenplane</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/providers/pulumi-provider-idenplane/examples/csharp/realm/Program.cs
+++ b/providers/pulumi-provider-idenplane/examples/csharp/realm/Program.cs
@@ -11,7 +11,7 @@
 using System;
 using System.Collections.Generic;
 using Pulumi;
-using Authme.PulumiAuthme;
+using Idenplane.PulumiIdenplane;
 
 return await Deployment.RunAsync(() =>
 {

--- a/src/broker/broker.service.ts
+++ b/src/broker/broker.service.ts
@@ -65,7 +65,7 @@ export class BrokerService {
       throw new BadRequestException(`Identity provider '${alias}' is disabled`);
     }
 
-    // Validate the Authme client
+    // Validate the Idenplane client
     const client = await this.prisma.client.findUnique({
       where: {
         realmId_clientId: { realmId: realm.id, clientId: params.client_id },
@@ -114,7 +114,7 @@ export class BrokerService {
 
   /**
    * Handle the callback from the external provider.
-   * Exchange code, fetch user info, link/create user, issue Authme auth code.
+   * Exchange code, fetch user info, link/create user, issue Idenplane auth code.
    */
   async handleCallback(
     realm: Realm,
@@ -156,7 +156,7 @@ export class BrokerService {
     // Link or create local user
     const user = await this.linkOrCreateUser(realm, idp, externalUser);
 
-    // Issue Authme authorization code
+    // Issue Idenplane authorization code
     const client = await this.prisma.client.findUnique({
       where: {
         realmId_clientId: { realmId: realm.id, clientId: brokerState.clientId },

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -48,8 +48,8 @@ export class EmailService {
       await transporter.sendMail({
         from: realm.smtpFrom ?? `noreply@${realm.smtpHost}`,
         to: realm.smtpFrom ?? `test@${realm.smtpHost}`,
-        subject: 'Authme SMTP Test',
-        html: '<p>This is a test email from Authme setup wizard.</p>',
+        subject: 'Idenplane SMTP Test',
+        html: '<p>This is a test email from Idenplane setup wizard.</p>',
       });
 
       this.logger.log(`Test email sent successfully for realm "${realmName}"`);

--- a/src/events/audit-streams.service.ts
+++ b/src/events/audit-streams.service.ts
@@ -151,7 +151,7 @@ export class AuditStreamsService {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'User-Agent': 'Authme-AuditStream/1.0',
+          'User-Agent': 'Idenplane-AuditStream/1.0',
           ...extraHeaders,
         },
         body,

--- a/src/webhooks/webhook-scheduler.service.ts
+++ b/src/webhooks/webhook-scheduler.service.ts
@@ -281,7 +281,7 @@ export class WebhookSchedulerService {
           'Content-Type': 'application/json',
           'X-Webhook-Signature': signature,
           'X-Webhook-Timestamp': new Date().toISOString(),
-          'User-Agent': 'Authme-Webhook/1.0',
+          'User-Agent': 'Idenplane-Webhook/1.0',
         },
         body,
         signal: controller.signal,

--- a/src/webhooks/webhooks.service.ts
+++ b/src/webhooks/webhooks.service.ts
@@ -350,7 +350,7 @@ export class WebhooksService {
           'Content-Type': 'application/json',
           'X-Webhook-Signature': signature,
           'X-Webhook-Timestamp': new Date().toISOString(),
-          'User-Agent': 'Authme-Webhook/1.0',
+          'User-Agent': 'Idenplane-Webhook/1.0',
         },
         body,
         signal: controller.signal,

--- a/terraform-provider-idenplane/provider/config.go
+++ b/terraform-provider-idenplane/provider/config.go
@@ -18,11 +18,11 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces
 var (
-	_ provider.Provider = &AuthmeProvider{}
+	_ provider.Provider = &IdenplaneProvider{}
 )
 
-// AuthmeProvider satisfies the terraform-plugin-framework provider interface
-type AuthmeProvider struct {
+// IdenplaneProvider satisfies the terraform-plugin-framework provider interface
+type IdenplaneProvider struct {
 	// version is set during build via ldflags
 	version string
 
@@ -39,19 +39,19 @@ type ProviderConfigModel struct {
 
 // New creates a new provider instance
 func New() provider.Provider {
-	return &AuthmeProvider{
+	return &IdenplaneProvider{
 		version: os.Getenv("IDENPLANE_PROVIDER_VERSION"),
 	}
 }
 
 // Metadata returns the provider metadata (name and version)
-func (p *AuthmeProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+func (p *IdenplaneProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "idenplane"
 	resp.Version = p.version
 }
 
 // Schema returns the provider schema (configuration options)
-func (p *AuthmeProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+func (p *IdenplaneProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Terraform provider for Idenplane Identity and Access Management. " +
 			"Manages realms, clients, roles, groups, users, identity providers, authentication flows, and organizations.",
@@ -71,7 +71,7 @@ func (p *AuthmeProvider) Schema(ctx context.Context, req provider.SchemaRequest,
 }
 
 // Configure is called by Terraform to configure the provider
-func (p *AuthmeProvider) Configure(ctx context.Context, req provider.ConfigureRequest) (interface{}, any) {
+func (p *IdenplaneProvider) Configure(ctx context.Context, req provider.ConfigureRequest) (interface{}, any) {
 	tflog.Debug(ctx, "Configuring Idenplane provider")
 
 	// Retrieve provider config from terraform configuration
@@ -95,7 +95,7 @@ func (p *AuthmeProvider) Configure(ctx context.Context, req provider.ConfigureRe
 }
 
 // Resources returns a slice of resource implementations
-func (p *AuthmeProvider) Resources(ctx context.Context) []resource.Resource {
+func (p *IdenplaneProvider) Resources(ctx context.Context) []resource.Resource {
 	return []resource.Resource{
 		NewRealmResource(),
 		NewClientResource(),
@@ -108,7 +108,7 @@ func (p *AuthmeProvider) Resources(ctx context.Context) []resource.Resource {
 }
 
 // DataSources returns a slice of data source implementations
-func (p *AuthmeProvider) DataSources(ctx context.Context) []datasource.DataSource {
+func (p *IdenplaneProvider) DataSources(ctx context.Context) []datasource.DataSource {
 	return []datasource.DataSource{
 		NewRealmDataSource(),
 		NewClientDataSource(),
@@ -122,7 +122,7 @@ func (p *AuthmeProvider) DataSources(ctx context.Context) []datasource.DataSourc
 }
 
 // Functions returns a slice of function implementations
-func (p *AuthmeProvider) Functions(ctx context.Context) []function.Function {
+func (p *IdenplaneProvider) Functions(ctx context.Context) []function.Function {
 	return []function.Function{
 		// Functions will be added in future phases
 	}

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,5 +1,5 @@
 /**
- * Shared E2E test setup for Authme.
+ * Shared E2E test setup for Idenplane.
  *
  * REQUIREMENTS:
  * - A running PostgreSQL database is required.


### PR DESCRIPTION
Follow-up to #889 and the repo transfer to `idenplane/idenplane`.

The original rename pass replaced `AUTHME`, `AuthMe`, and `authme` but missed mixed-case `Authme` (capital A, lowercase rest). Most of those occurrences were in repository URLs — GitHub clone URLs in CONTRIBUTING.md and READMEs, the `repository.url` field across the SDK package.json files, and SDK README headers.

Also fixes the speculative `idenplane/server` path used in the original rename — the actual repo lives at `idenplane/idenplane`.

After this PR: `git grep -i authme` returns only the 8 deliberate backward-compat references in `src/main.ts` (legacy cookie alias) and `packages/idenplane-cli/src/config.ts` (legacy env vars + `~/.authme/` config path).

## Testing
- `npm run lint` passes.
- `npm run build` succeeds.
- No code logic changed — pure string replacements.