### PR TITLE
fix(security): remove unused vulnerable xmldom direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,8 +53,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "twilio": "^6.0.2",
-        "xml-crypto": "^6.1.2",
-        "xmldom": "^0.6.0"
+        "xml-crypto": "^6.1.2"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
@@ -13924,15 +13923,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/xpath": {

--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "twilio": "^6.0.2",
-    "xml-crypto": "^6.1.2",
-    "xmldom": "^0.6.0"
+    "xml-crypto": "^6.1.2"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",


### PR DESCRIPTION
Removes the legacy `xmldom@0.6.0` direct dependency. The package is **deprecated upstream** and is the source of **7 Dependabot security alerts** on this repo, including XML injection, uncontrolled recursion (DoS), and multi-root-node misinterpretation issues. None of them have a patched version, so the only fix is removal.

## Why this is safe

`xmldom` is declared in our `package.json` but **never imported by any source file**. SAML/XML processing in [src/saml/](src/saml/) uses `@xmldom/xmldom` (the maintained scoped fork) via the `@node-saml/node-saml` and `xml-crypto` transitive dependencies, both of which already pull in `@xmldom/xmldom@0.8.13`.

```
$ npm ls @xmldom/xmldom
idenplane@0.0.1
├─┬ @node-saml/node-saml@5.1.0
│ ├── @xmldom/xmldom@0.8.13
│ └─┬ xml-encryption@3.1.0
│   └── @xmldom/xmldom@0.8.13 deduped
└─┬ xml-crypto@6.1.2
  └── @xmldom/xmldom@0.8.13 deduped
```

After removal: `grep -rn xmldom src/` returns zero matches outside of `@xmldom/xmldom`.

## Closes (Dependabot alerts)

- xmldom: Uncontrolled recursion in XML serialization leads to DoS
- xmldom: XML injection through unvalidated DocumentType serialization
- xmldom: XML node injection through unvalidated processing instruction serialization
- xmldom: XML node injection through unvalidated comment serialization
- xmldom: XML injection via unsafe CDATA serialization allows attacker-controlled markup insertion
- xmldom: Misinterpretation of malicious XML input
- xmldom: allows multiple root nodes in a DOM

## Testing

- `npm run build` — succeeds.
- `npx jest src/saml` — 40/40 SAML unit tests pass.
- `npm audit` — reports **0 vulnerabilities** in the npm tree after removal.