### PR TITLE
fix(security): bump Go example deps to fully-patched versions

### DIFF
--- a/providers/pulumi-provider-idenplane/examples/go/go.mod
+++ b/providers/pulumi-provider-idenplane/examples/go/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
-	github.com/moby/spdystream v0.5.0 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/opentracing/basictracer-go v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -37,7 +37,7 @@ require (
 	github.com/spf13/cobra v1.8.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zclconf/go-cty v1.13.3 // indirect
-	golang.org/x/crypto v0.40.0 // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
@@ -45,7 +45,7 @@ require (
 	golang.org/x/term v0.33.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231106174013-bbf56f31fb17 // indirect
-	google.golang.org/grpc v1.74.2 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/frand v1.4.2 // indirect


### PR DESCRIPTION
Follow-up to #892. The earlier pass bumped these to versions that turned out to still sit inside the vulnerable range. Dependabot's rescan surfaced the exact `first_patched_version` for each advisory, so this PR bumps the Pulumi Go example's `go.mod` to those:

| Dependency | Was | Vulnerable range | Now |
|---|---|---|---|
| `google.golang.org/grpc` | 1.74.2 | <1.79.3 | **1.79.3** (CRITICAL — authorization bypass via missing leading slash in :path) |
| `github.com/moby/spdystream` | 0.5.0 | ≤0.5.0 | **0.5.1** (HIGH — DoS on CRI) |
| `golang.org/x/crypto` | 0.40.0 | <0.45.0 | **0.45.0** (MEDIUM — SSH unbounded memory + agent panic) |

After Dependabot rescans `dev` post-merge, all four Go alerts (#151, #152, #153, #154) should auto-close.

The example still doesn't compile by design (references unpublished SDK package); `go.mod` is what Dependabot scans.