### PR TITLE
docs(readme): use the social-preview banner as the README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <p align="center">
-  <img src="branding/logos/idenplane-logo.svg" alt="Idenplane" width="420" />
-</p>
-
-<p align="center">
-  <strong>The identity control plane you own.</strong>
+  <a href="https://idenplane.com">
+    <img src="branding/logos/png/social-preview.png" alt="Idenplane — The identity control plane you own." width="100%" />
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
The README opened with a 420px wordmark-only image and a separate text tagline. Replaces both with the full 1280×640 branding banner already generated for the GitHub social preview (`branding/logos/png/social-preview.png`).

Now the brand reads consistently in every place a visitor sees the project:
- The README page itself
- The repo card on the GitHub homepage
- Open Graph / Twitter / Slack / Discord shares
- The OG image referenced from `idenplane.com`

The image is wrapped in a link to `https://idenplane.com` so the banner doubles as a call-to-action.