### PR TITLE
fix(go-sdk): align pagination + timestamps with backend

### DIFF
--- a/packages/idenplane-go/idenplane.go
+++ b/packages/idenplane-go/idenplane.go
@@ -38,17 +38,22 @@ type TokenResponse struct {
 // User is the resolved shape of a user as exposed by the SDK. It covers both
 // admin API user records (ID, Username, FirstName, ...) and OIDC userinfo
 // claims for the same subject.
+//
+// CreatedAt and UpdatedAt are ISO 8601 strings (e.g. "2026-05-22T08:30:00.000Z")
+// because Prisma serializes DateTime columns as ISO strings on the wire — not
+// Unix-epoch integers.
 type User struct {
-	ID               string              `json:"id,omitempty"`
-	Username         string              `json:"username,omitempty"`
-	Enabled          bool                `json:"enabled,omitempty"`
-	EmailVerified    bool                `json:"emailVerified,omitempty"`
-	Email            string              `json:"email,omitempty"`
-	FirstName        string              `json:"firstName,omitempty"`
-	LastName         string              `json:"lastName,omitempty"`
-	Groups           []string            `json:"groups,omitempty"`
-	Attributes       map[string][]string `json:"attributes,omitempty"`
-	CreatedTimestamp *int64              `json:"createdTimestamp,omitempty"`
+	ID            string              `json:"id,omitempty"`
+	Username      string              `json:"username,omitempty"`
+	Enabled       bool                `json:"enabled,omitempty"`
+	EmailVerified bool                `json:"emailVerified,omitempty"`
+	Email         string              `json:"email,omitempty"`
+	FirstName     string              `json:"firstName,omitempty"`
+	LastName      string              `json:"lastName,omitempty"`
+	Groups        []string            `json:"groups,omitempty"`
+	Attributes    map[string][]string `json:"attributes,omitempty"`
+	CreatedAt     string              `json:"createdAt,omitempty"`
+	UpdatedAt     string              `json:"updatedAt,omitempty"`
 }
 
 // OIDCConfiguration is an alias for OpenIDConfiguration for API compatibility.

--- a/packages/idenplane-go/idenplane.go
+++ b/packages/idenplane-go/idenplane.go
@@ -125,14 +125,6 @@ func (c Config) httpClient() *http.Client {
 	return &http.Client{Timeout: timeout}
 }
 
-// scopes returns the scopes, using defaults if not set.
-func (c Config) scopes() []string {
-	if len(c.Scopes) == 0 {
-		return DefaultScopes
-	}
-	return c.Scopes
-}
-
 // Client is the main Idenplane client for server-side operations.
 type Client struct {
 	config Config

--- a/packages/idenplane-go/users.go
+++ b/packages/idenplane-go/users.go
@@ -106,7 +106,7 @@ func (us *UserService) usersURL() string {
 // When body is non-nil it is JSON-encoded and the Content-Type header set.
 // When the client has an AdminToken configured, the Authorization header is
 // attached so admin endpoints don't return 401.
-func (us *UserService) doRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+func (us *UserService) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
 	var reader io.Reader
 	if body != nil {
 		raw, err := json.Marshal(body)
@@ -231,10 +231,7 @@ func (us *UserService) List(ctx context.Context, params ListUsersParams) ([]*Use
 		q.Set("enabled", strconv.FormatBool(*params.Enabled))
 	}
 	// Default to backend's ListUsersQueryDto defaults: page=1, limit=20.
-	page := params.Page
-	if page < 1 {
-		page = 1
-	}
+	page := max(params.Page, 1)
 	limit := params.Limit
 	if limit < 1 {
 		limit = 20
@@ -301,7 +298,7 @@ func (us *UserService) Delete(ctx context.Context, id string) error {
 // ResetPassword sets a new password for the user. If temporary is true, the
 // user is required to change the password on next login.
 func (us *UserService) ResetPassword(ctx context.Context, id, password string, temporary bool) error {
-	body := map[string]interface{}{
+	body := map[string]any{
 		"type":      "password",
 		"value":     password,
 		"temporary": temporary,

--- a/packages/idenplane-go/users.go
+++ b/packages/idenplane-go/users.go
@@ -30,6 +30,10 @@ type UpdateUserRequest struct {
 }
 
 // ListUsersParams holds optional filters and pagination for User.List.
+//
+// Page is 1-based and Limit defaults to 20 to match the backend
+// (ListUsersQueryDto in users.controller.ts). The backend computes
+// skip = (page - 1) * limit internally.
 type ListUsersParams struct {
 	Username  string
 	Email     string
@@ -37,14 +41,17 @@ type ListUsersParams struct {
 	LastName  string
 	Search    string
 	Enabled   *bool
-	First     int
-	Max       int
+	Page      int
+	Limit     int
 }
 
 // UserRepresentation is the wire representation of a user from the admin API.
+// CreatedAt and UpdatedAt are ISO 8601 strings; Prisma serializes DateTime
+// columns to ISO strings rather than Unix-epoch integers.
 type UserRepresentation struct {
 	ID            string              `json:"id"`
-	Created       int64               `json:"createdTimestamp"`
+	CreatedAt     string              `json:"createdAt"`
+	UpdatedAt     string              `json:"updatedAt"`
 	Username      string              `json:"username"`
 	Enabled       bool                `json:"enabled"`
 	EmailVerified bool                `json:"emailVerified"`
@@ -56,22 +63,18 @@ type UserRepresentation struct {
 }
 
 func (r *UserRepresentation) toUser() *User {
-	var ts *int64
-	if r.Created != 0 {
-		c := r.Created
-		ts = &c
-	}
 	return &User{
-		ID:               r.ID,
-		Username:         r.Username,
-		Enabled:          r.Enabled,
-		EmailVerified:    r.EmailVerified,
-		Email:            r.Email,
-		FirstName:        r.FirstName,
-		LastName:         r.LastName,
-		Groups:           r.Groups,
-		Attributes:       r.Attributes,
-		CreatedTimestamp: ts,
+		ID:            r.ID,
+		Username:      r.Username,
+		Enabled:       r.Enabled,
+		EmailVerified: r.EmailVerified,
+		Email:         r.Email,
+		FirstName:     r.FirstName,
+		LastName:      r.LastName,
+		Groups:        r.Groups,
+		Attributes:    r.Attributes,
+		CreatedAt:     r.CreatedAt,
+		UpdatedAt:     r.UpdatedAt,
 	}
 }
 
@@ -227,12 +230,17 @@ func (us *UserService) List(ctx context.Context, params ListUsersParams) ([]*Use
 	if params.Enabled != nil {
 		q.Set("enabled", strconv.FormatBool(*params.Enabled))
 	}
-	if params.First > 0 {
-		q.Set("first", strconv.Itoa(params.First))
+	// Default to backend's ListUsersQueryDto defaults: page=1, limit=20.
+	page := params.Page
+	if page < 1 {
+		page = 1
 	}
-	if params.Max > 0 {
-		q.Set("max", strconv.Itoa(params.Max))
+	limit := params.Limit
+	if limit < 1 {
+		limit = 20
 	}
+	q.Set("page", strconv.Itoa(page))
+	q.Set("limit", strconv.Itoa(limit))
 	u.RawQuery = q.Encode()
 
 	resp, err := us.doRequest(ctx, http.MethodGet, u.String(), nil)

--- a/packages/idenplane-go/users_test.go
+++ b/packages/idenplane-go/users_test.go
@@ -40,7 +40,7 @@ func TestUserServiceCreate(t *testing.T) {
 			createdUserID = "user-123"
 			w.Header().Set("Location", "http://localhost/admin/realms/test-realm/users/"+createdUserID)
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"id":      createdUserID,
 				"username": req.Username,
 				"enabled": true,
@@ -48,7 +48,7 @@ func TestUserServiceCreate(t *testing.T) {
 		},
 		"GET /admin/realms/test-realm/users/user-123": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"id":      createdUserID,
 				"username": "testuser",
 				"enabled": true,
@@ -98,7 +98,7 @@ func TestUserServiceCreateWithoutLocationHeader(t *testing.T) {
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"POST /admin/realms/test-realm/users": func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusCreated)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"id":      "user-456",
 				"username": "newuser",
 				"enabled": true,
@@ -165,7 +165,7 @@ func TestUserServiceGet(t *testing.T) {
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"GET /admin/realms/test-realm/users/user-123": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"id":        "user-123",
 				"username":  "testuser",
 				"enabled":   true,
@@ -280,7 +280,7 @@ func TestUserServiceList(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			users := []map[string]interface{}{
+			users := []map[string]any{
 				{"id": "user-1", "username": "user1", "enabled": true},
 				{"id": "user-2", "username": "user2", "enabled": true},
 				{"id": "user-3", "username": "user3", "enabled": false},
@@ -331,7 +331,7 @@ func TestUserServiceListDefaultPagination(t *testing.T) {
 				t.Errorf("Expected default limit='20', got '%s'", limit)
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode([]map[string]interface{}{})
+			json.NewEncoder(w).Encode([]map[string]any{})
 		},
 	})
 	defer server.Close()
@@ -355,7 +355,7 @@ func TestUserServiceListISOTimestamps(t *testing.T) {
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"GET /admin/realms/test-realm/users": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode([]map[string]interface{}{
+			json.NewEncoder(w).Encode([]map[string]any{
 				{
 					"id":            "u-1",
 					"username":      "alice",
@@ -416,7 +416,7 @@ func TestUserServiceListWithFilters(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode([]map[string]interface{}{
+			json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "user-1", "username": "johndoe", "enabled": true},
 			})
 		},
@@ -456,7 +456,7 @@ func TestUserServiceListEmpty(t *testing.T) {
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"GET /admin/realms/test-realm/users": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode([]map[string]interface{}{})
+			json.NewEncoder(w).Encode([]map[string]any{})
 		},
 	})
 	defer server.Close()
@@ -661,7 +661,7 @@ func TestUserServiceDeleteServerError(t *testing.T) {
 func TestUserServiceResetPassword(t *testing.T) {
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"PUT /admin/realms/test-realm/users/user-123/reset-password": func(w http.ResponseWriter, r *http.Request) {
-			var reqBody map[string]interface{}
+			var reqBody map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 				http.Error(w, "Invalid JSON", http.StatusBadRequest)
 				return
@@ -720,7 +720,7 @@ func TestUserServiceResetPasswordTemporary(t *testing.T) {
 	temporary := true
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"PUT /admin/realms/test-realm/users/user-123/reset-password": func(w http.ResponseWriter, r *http.Request) {
-			var reqBody map[string]interface{}
+			var reqBody map[string]any
 			if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
 				http.Error(w, "Invalid JSON", http.StatusBadRequest)
 				return
@@ -761,7 +761,7 @@ func TestUserServiceConcurrency(t *testing.T) {
 			mu.Unlock()
 
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode([]map[string]interface{}{
+			json.NewEncoder(w).Encode([]map[string]any{
 				{"id": "user-1", "username": "user1", "enabled": true},
 			})
 		},

--- a/packages/idenplane-go/users_test.go
+++ b/packages/idenplane-go/users_test.go
@@ -166,13 +166,14 @@ func TestUserServiceGet(t *testing.T) {
 		"GET /admin/realms/test-realm/users/user-123": func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id":      "user-123",
-				"username": "testuser",
-				"enabled": true,
-				"email":   "test@example.com",
+				"id":        "user-123",
+				"username":  "testuser",
+				"enabled":   true,
+				"email":     "test@example.com",
 				"firstName": "Test",
-				"lastName": "User",
-				"createdTimestamp": 1704067200000,
+				"lastName":  "User",
+				"createdAt": "2026-05-22T08:30:00.000Z",
+				"updatedAt": "2026-05-22T08:30:00.000Z",
 			})
 		},
 	})
@@ -251,17 +252,31 @@ func TestUserServiceGetServerError(t *testing.T) {
 	}
 }
 
-// TestUserServiceList tests listing users with pagination
+// TestUserServiceList tests listing users with pagination. The SDK must send
+// page/limit (not first/max), since the backend's ListUsersQueryDto only
+// understands those.
 func TestUserServiceList(t *testing.T) {
 	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
 		"GET /admin/realms/test-realm/users": func(w http.ResponseWriter, r *http.Request) {
 			query := r.URL.Query()
 
 			// Verify query parameters are passed
-			if username := query.Get("username"); username != "" {
-				if username != "testuser" {
-					t.Errorf("Expected username filter 'testuser', got '%s'", username)
-				}
+			if username := query.Get("username"); username != "testuser" {
+				t.Errorf("Expected username filter 'testuser', got '%s'", username)
+			}
+			if page := query.Get("page"); page != "1" {
+				t.Errorf("Expected page='1', got '%s'", page)
+			}
+			if limit := query.Get("limit"); limit != "10" {
+				t.Errorf("Expected limit='10', got '%s'", limit)
+			}
+			// The legacy first/max names must NOT be sent — backend ignores them
+			// (silent-failure pagination bug fixed in this commit).
+			if got := query.Get("first"); got != "" {
+				t.Errorf("Unexpected 'first' param: %q", got)
+			}
+			if got := query.Get("max"); got != "" {
+				t.Errorf("Unexpected 'max' param: %q", got)
 			}
 
 			w.Header().Set("Content-Type", "application/json")
@@ -284,7 +299,8 @@ func TestUserServiceList(t *testing.T) {
 
 	params := ListUsersParams{
 		Username: "testuser",
-		Max:      10,
+		Page:     1,
+		Limit:    10,
 	}
 
 	users, count, err := client.Users.List(context.Background(), params)
@@ -298,6 +314,82 @@ func TestUserServiceList(t *testing.T) {
 
 	if count != 3 {
 		t.Errorf("Expected count 3, got %d", count)
+	}
+}
+
+// TestUserServiceListDefaultPagination asserts that an empty ListUsersParams
+// falls back to the backend defaults (page=1, limit=20 — matching
+// ListUsersQueryDto in users.controller.ts).
+func TestUserServiceListDefaultPagination(t *testing.T) {
+	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/users": func(w http.ResponseWriter, r *http.Request) {
+			query := r.URL.Query()
+			if page := query.Get("page"); page != "1" {
+				t.Errorf("Expected default page='1', got '%s'", page)
+			}
+			if limit := query.Get("limit"); limit != "20" {
+				t.Errorf("Expected default limit='20', got '%s'", limit)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]interface{}{})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL: server.URL,
+		Realm:     "test-realm",
+		ClientID:  "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, _, err := client.Users.List(context.Background(), ListUsersParams{})
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+}
+
+// TestUserServiceListISOTimestamps locks the wire contract: createdAt/updatedAt
+// are ISO 8601 strings (Prisma DateTime serialization), not Unix epoch ints.
+func TestUserServiceListISOTimestamps(t *testing.T) {
+	server := mockUsersServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/users": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{
+					"id":            "u-1",
+					"username":      "alice",
+					"email":         "a@example.com",
+					"firstName":     "Alice",
+					"enabled":       true,
+					"emailVerified": true,
+					"createdAt":     "2026-05-22T08:30:00.000Z",
+					"updatedAt":     "2026-05-22T09:00:00.000Z",
+				},
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	users, _, err := client.Users.List(context.Background(), ListUsersParams{})
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(users) != 1 {
+		t.Fatalf("Expected 1 user, got %d", len(users))
+	}
+	if users[0].CreatedAt != "2026-05-22T08:30:00.000Z" {
+		t.Errorf("Expected CreatedAt '2026-05-22T08:30:00.000Z', got '%s'", users[0].CreatedAt)
+	}
+	if users[0].UpdatedAt != "2026-05-22T09:00:00.000Z" {
+		t.Errorf("Expected UpdatedAt '2026-05-22T09:00:00.000Z', got '%s'", users[0].UpdatedAt)
 	}
 }
 
@@ -345,8 +437,8 @@ func TestUserServiceListWithFilters(t *testing.T) {
 		LastName:  "Doe",
 		Search:    "john",
 		Enabled:   &enabled,
-		First:     0,
-		Max:       20,
+		Page:      1,
+		Limit:     20,
 	}
 
 	users, _, err := client.Users.List(context.Background(), params)
@@ -704,18 +796,21 @@ func TestUserServiceConcurrency(t *testing.T) {
 	mu.Unlock()
 }
 
-// TestUserRepresentationToUser tests conversion from UserRepresentation to User
+// TestUserRepresentationToUser tests conversion from UserRepresentation to User.
+// The createdAt/updatedAt wire fields are ISO 8601 strings because Prisma
+// serializes DateTime columns to ISO strings, not Unix-epoch integers.
 func TestUserRepresentationToUser(t *testing.T) {
 	rep := &UserRepresentation{
-		ID:      "user-123",
-		Created: 1704067200000,
-		Username: "testuser",
-		Enabled: true,
+		ID:            "user-123",
+		CreatedAt:     "2026-05-22T08:30:00.000Z",
+		UpdatedAt:     "2026-05-22T09:00:00.000Z",
+		Username:      "testuser",
+		Enabled:       true,
 		EmailVerified: true,
-		Email: "test@example.com",
-		FirstName: "Test",
-		LastName: "User",
-		Groups: []string{"admin", "users"},
+		Email:         "test@example.com",
+		FirstName:     "Test",
+		LastName:      "User",
+		Groups:        []string{"admin", "users"},
 		Attributes: map[string][]string{
 			"custom_attr": {"value1", "value2"},
 		},
@@ -755,8 +850,12 @@ func TestUserRepresentationToUser(t *testing.T) {
 		t.Errorf("Expected 2 groups, got %d", len(user.Groups))
 	}
 
-	if user.CreatedTimestamp == nil {
-		t.Error("Expected CreatedTimestamp to be set")
+	if user.CreatedAt != "2026-05-22T08:30:00.000Z" {
+		t.Errorf("Expected CreatedAt '2026-05-22T08:30:00.000Z', got '%s'", user.CreatedAt)
+	}
+
+	if user.UpdatedAt != "2026-05-22T09:00:00.000Z" {
+		t.Errorf("Expected UpdatedAt '2026-05-22T09:00:00.000Z', got '%s'", user.UpdatedAt)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two contract mismatches between the Go SDK and the Idenplane backend that were inherited from the original `idenplane-go` implementation (merged in #901) and surfaced during code review of the Python SDK in #903.

### Bug 1 — Pagination silently broken

`ListUsersParams` carried `First int` / `Max int`, emitted as `?first=…&max=…`. The backend's `ListUsersQueryDto` (`src/users/users.controller.ts:35-72`) only understands `page` (1-based) and `limit` (default 20). The legacy params were silently dropped, so callers always got the first 20 records regardless of what they asked for.

**Fix:** rename to `Page` / `Limit`, emit `?page=…&limit=…`, default to `page=1, limit=20` to match backend defaults exactly.

### Bug 2 — Timestamp type mismatch

`UserRepresentation.Created int64` was tagged `json:"createdTimestamp"`, modeled on Keycloak's wire format. The backend selects `createdAt` / `updatedAt` from Prisma (`src/users/users.service.ts:21-31`), and Prisma serializes `DateTime` columns to **ISO 8601 strings**, not Unix-epoch integers. The old field never decoded anything, so `User.CreatedTimestamp` was always nil.

**Fix:** `UserRepresentation` exposes `CreatedAt string` and `UpdatedAt string`; `User` (the public type in `idenplane.go`) gains `CreatedAt` / `UpdatedAt` and loses `CreatedTimestamp`.

## Changes

- `packages/idenplane-go/idenplane.go` — `User`: drop `CreatedTimestamp *int64`, add `CreatedAt string` and `UpdatedAt string`.
- `packages/idenplane-go/users.go` — `ListUsersParams.{First,Max}` → `{Page,Limit}`; query builder emits `page`/`limit` with defaults `1`/`20`; `UserRepresentation` swaps `Created int64` for `CreatedAt string` + `UpdatedAt string`; `toUser()` simplified (no more nullable pointer).
- `packages/idenplane-go/users_test.go` — updated existing tests; added `TestUserServiceListDefaultPagination` (locks `page=1, limit=20` defaults) and `TestUserServiceListISOTimestamps` (locks ISO 8601 wire contract).

## Test plan

- [x] `go test ./...` — 35 tests pass, 0 failures
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean

## Related

- Python SDK with identical fixes: #903
- Original Go SDK merge that introduced both bugs: #901

🤖 Generated with [Claude Code](https://claude.com/claude-code)