### PR TITLE
ci(dependabot): watch /docs (fixes the unmonitored uuid advisory)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,3 +77,23 @@ updates:
     labels:
       - dependencies
       - docker
+
+  # Documentation site (was unmonitored — a transitive uuid advisory sat here
+  # with no fix PR because Dependabot wasn't watching this directory).
+  - package-ecosystem: npm
+    directory: "/docs"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: "Africa/Cairo"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docs
+    groups:
+      docs-dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
The `/docs` site dependencies were not covered by Dependabot, so the transitive **uuid** advisory (fixed in 11.1.1) sat in `docs/package-lock.json` with no fix PR.

Adds `/docs` to Dependabot's npm coverage (weekly, dev-dependency grouping). Going forward, Dependabot will open update/security PRs for the docs site — including the uuid fix.

Targets `dev` per the branch flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)