### PR TITLE
chore(deps-dev): upgrade ESLint to 10 (backend)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "^9.39.0",
+        "@eslint/js": "10.0.1",
         "@nestjs/cli": "^11.0.16",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.1.24",
@@ -1289,16 +1289,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
-    "@eslint/js": "^9.39.0",
+    "@eslint/js": "10.0.1",
     "@nestjs/cli": "^11.0.16",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.1.24",

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -45,7 +45,9 @@ export class AccountController {
   ) {}
 
   private async getSessionUser(realm: Realm, req: Request) {
-    const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as string | undefined;
+    const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as
+      | string
+      | undefined;
     if (!sessionToken) return null;
     return this.loginService.validateLoginSession(realm, sessionToken);
   }

--- a/src/auth-flow/flow-executor.service.ts
+++ b/src/auth-flow/flow-executor.service.ts
@@ -110,7 +110,7 @@ export class FlowExecutorService {
       return this.advanceSession(session, step, true);
     }
 
-    let success = false;
+    let success: boolean;
     let extraData: Record<string, unknown> | undefined;
 
     try {

--- a/src/continuous-verification/continuous-risk.service.ts
+++ b/src/continuous-verification/continuous-risk.service.ts
@@ -664,7 +664,7 @@ export class ContinuousRiskAssessmentService {
     const decay = Math.min(hoursSinceLastEval * 0.05, 0.5);
 
     // Risk level affects trust adjustment
-    let riskAdjustment = 0;
+    let riskAdjustment: number;
     if (riskLevel === 'CRITICAL') riskAdjustment = -30;
     else if (riskLevel === 'HIGH') riskAdjustment = -15;
     else if (riskLevel === 'MEDIUM') riskAdjustment = -5;

--- a/src/continuous-verification/session-risk-evaluator.ts
+++ b/src/continuous-verification/session-risk-evaluator.ts
@@ -679,7 +679,7 @@ export class SessionRiskEvaluator {
       (now.getTime() - lastEvaluatedAt.getTime()) / (1000 * 60 * 60);
     const decay = Math.min(hoursSinceLastEval * 0.05, 0.5);
 
-    let riskAdjustment = 0;
+    let riskAdjustment: number;
     if (riskLevel === 'CRITICAL') riskAdjustment = -30;
     else if (riskLevel === 'HIGH') riskAdjustment = -15;
     else if (riskLevel === 'MEDIUM') riskAdjustment = -5;

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -600,7 +600,9 @@ export class LoginController {
 
     // MFA verified — consume the challenge and clear the cookie
     await this.mfaService.consumeMfaChallenge(challengeToken);
-    res.clearCookie('IDENPLANE_MFA_CHALLENGE', { path: `/realms/${realm.name}` });
+    res.clearCookie('IDENPLANE_MFA_CHALLENGE', {
+      path: `/realms/${realm.name}`,
+    });
 
     // Reset TOTP failure tracking on successful verification
     await this.bruteForceService.resetTotpFailures(realm.id, challenge.userId);

--- a/src/mfa/mfa.controller.ts
+++ b/src/mfa/mfa.controller.ts
@@ -126,7 +126,9 @@ export class MfaController {
       );
     }
 
-    const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as string | undefined;
+    const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as
+      | string
+      | undefined;
     if (!sessionToken) {
       throw new UnauthorizedException(
         'MFA step-up is required. No active session found. Please log in via the user login flow to establish an MFA-verified session.',

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -346,7 +346,7 @@ export class OrganizationsService {
     const expectedTxt = this.generateDomainVerificationToken(org.id, domain);
     const txtHost = `_idenplane-challenge.${domain}`;
 
-    let records: string[][] = [];
+    let records: string[][];
     try {
       records = await dns.resolveTxt(txtHost);
     } catch {

--- a/src/plugins/plugin-loader.service.ts
+++ b/src/plugins/plugin-loader.service.ts
@@ -100,7 +100,9 @@ export class PluginLoaderService {
 
     try {
       entries = readdirSync(nmDir, { withFileTypes: true })
-        .filter((d) => d.isDirectory() && d.name.startsWith('idenplane-plugin-'))
+        .filter(
+          (d) => d.isDirectory() && d.name.startsWith('idenplane-plugin-'),
+        )
         .map((d) => d.name);
     } catch (err) {
       this.logger.warn(

--- a/src/plugins/plugin.interface.ts
+++ b/src/plugins/plugin.interface.ts
@@ -92,7 +92,9 @@ export interface ThemePlugin extends IdenplanePlugin {
 
 // ─── Type Guards ──────────────────────────────────────────────────────────────
 
-export function isAuthProviderPlugin(p: IdenplanePlugin): p is AuthProviderPlugin {
+export function isAuthProviderPlugin(
+  p: IdenplanePlugin,
+): p is AuthProviderPlugin {
   return p.type === 'auth-provider';
 }
 

--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -328,13 +328,19 @@ export class CreateRealmDto {
   @IsObject()
   theme?: Record<string, unknown>;
 
-  @ApiPropertyOptional({ default: 'idenplane', description: 'Login page theme' })
+  @ApiPropertyOptional({
+    default: 'idenplane',
+    description: 'Login page theme',
+  })
   @IsOptional()
   @IsString()
   @MinLength(1)
   loginTheme?: string;
 
-  @ApiPropertyOptional({ default: 'idenplane', description: 'Account page theme' })
+  @ApiPropertyOptional({
+    default: 'idenplane',
+    description: 'Account page theme',
+  })
   @IsOptional()
   @IsString()
   @MinLength(1)

--- a/src/saml/saml-idp.controller.ts
+++ b/src/saml/saml-idp.controller.ts
@@ -166,7 +166,9 @@ export class SamlIdpController {
     );
 
     // Check if the user already has an active login session
-    const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as string | undefined;
+    const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as
+      | string
+      | undefined;
     if (sessionToken) {
       const user = await this.loginService.validateLoginSession(
         realm,
@@ -212,7 +214,9 @@ export class SamlIdpController {
     );
 
     // Clear the SAML request cookie
-    res.clearCookie('IDENPLANE_SAML_REQUEST', { path: `/realms/${realm.name}` });
+    res.clearCookie('IDENPLANE_SAML_REQUEST', {
+      path: `/realms/${realm.name}`,
+    });
 
     // Send an auto-submitting HTML form (POST binding)
     const html = `<!DOCTYPE html>

--- a/src/saml/saml-idp.service.ts
+++ b/src/saml/saml-idp.service.ts
@@ -118,7 +118,7 @@ export class SamlIdpService {
 
     const sig = new SignedXml({ publicCert: certificate });
     sig.loadSignature(signatures[0]);
-    let valid = false;
+    let valid: boolean;
     try {
       valid = sig.checkSignature(xml);
     } catch (err) {

--- a/src/sms/providers/aws-sns.provider.ts
+++ b/src/sms/providers/aws-sns.provider.ts
@@ -245,7 +245,7 @@ export class AwsSnsProvider implements SmsProvider {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to send SMS to ${to}: ${errorMessage}`);
-      throw new Error(`AWS SNS SMS failed: ${errorMessage}`);
+      throw new Error(`AWS SNS SMS failed: ${errorMessage}`, { cause: error });
     }
   }
 

--- a/src/sms/providers/twilio.provider.ts
+++ b/src/sms/providers/twilio.provider.ts
@@ -53,7 +53,7 @@ export class TwilioSmsProvider implements SmsProvider {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to send SMS to ${to}: ${errorMessage}`);
-      throw new Error(`Twilio SMS failed: ${errorMessage}`);
+      throw new Error(`Twilio SMS failed: ${errorMessage}`, { cause: error });
     }
   }
 

--- a/src/sms/providers/vonage.provider.ts
+++ b/src/sms/providers/vonage.provider.ts
@@ -77,7 +77,7 @@ export class VonageSmsProvider implements SmsProvider {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to send SMS to ${to}: ${errorMessage}`);
-      throw new Error(`Vonage SMS failed: ${errorMessage}`);
+      throw new Error(`Vonage SMS failed: ${errorMessage}`, { cause: error });
     }
   }
 

--- a/src/sms/providers/webhook.provider.ts
+++ b/src/sms/providers/webhook.provider.ts
@@ -100,14 +100,17 @@ export class WebhookSmsProvider implements SmsProvider {
         if (error.name === 'AbortError') {
           throw new Error(
             `Webhook SMS failed: Request timeout after ${this.timeoutMs}ms`,
+            { cause: error },
           );
         }
         if (error.message.startsWith('Webhook')) {
           throw error;
         }
-        throw new Error(`Webhook SMS failed: ${error.message}`);
+        throw new Error(`Webhook SMS failed: ${error.message}`, {
+          cause: error,
+        });
       }
-      throw new Error('Webhook SMS failed: Unknown error');
+      throw new Error('Webhook SMS failed: Unknown error', { cause: error });
     }
   }
 


### PR DESCRIPTION
Upgrades the **backend (root)** workspace to ESLint 10.4.0 / @eslint/js 10.0.1.

The stricter v10 ruleset surfaced real issues — fixed across 9 source files (auth-flow, continuous-verification ×2, organizations, saml-idp, and the 4 SMS providers). **No rule suppressions** — root causes fixed.

**Verified locally:** lint clean ✓ · build clean ✓ · 1760 unit tests pass ✓

Supersedes the backend eslint bump in #928 (already merged) consistency-wise.

> admin-ui ESLint 10 is **not** in this PR — it surfaces ~65 errors (no-explicit-any, no-unused-vars, react-hooks/set-state-in-effect, etc.) that need a careful dedicated pass. Tracked separately. Supersedes #919.

Targets \`dev\` per the branch flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)