### PR TITLE
chore(deps-dev): upgrade admin-ui ESLint to 10

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -15,7 +15,7 @@
         "react-router-dom": "^7.15.1"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.1",
+        "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -25,7 +25,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
         "@vitest/coverage-v8": "^4.1.7",
-        "eslint": "^9.39.1",
+        "eslint": "^10.4.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^17.6.0",
@@ -1036,118 +1036,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -2289,6 +2260,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2538,45 +2516,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -2630,19 +2569,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2811,9 +2737,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2888,13 +2814,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -2953,11 +2872,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
@@ -2980,14 +2902,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3037,16 +2961,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001770",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
@@ -3076,23 +2990,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/cli-width": {
@@ -3169,13 +3066,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3495,33 +3385,30 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
+        "ajv": "^6.14.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -3531,8 +3418,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3540,7 +3426,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -3585,48 +3471,50 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -4114,23 +4002,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -4260,19 +4131,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -4673,13 +4531,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4800,16 +4651,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -4979,19 +4833,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parse5": {
@@ -5260,16 +5101,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/rettime": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.11.tgz",
@@ -5480,19 +5311,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -20,7 +20,7 @@
     "react-router-dom": "^7.15.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.1",
+    "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -30,7 +30,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "^4.1.7",
-    "eslint": "^9.39.1",
+    "eslint": "^10.4.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^17.6.0",

--- a/admin-ui/src/api/clientScopes.ts
+++ b/admin-ui/src/api/clientScopes.ts
@@ -89,11 +89,19 @@ export async function deleteMapper(
 
 // The API returns join records { id, clientScopeId, clientScope: { ... } }.
 // Flatten them into ClientScope objects so the UI can use scope.id / scope.name directly.
-function flattenScopeAssignments(data: any[]): ClientScope[] {
+type ScopeAssignment = {
+  id: string;
+  clientScopeId?: string;
+  clientScope?: ClientScope;
+};
+
+function flattenScopeAssignments(
+  data: (ScopeAssignment | ClientScope)[],
+): ClientScope[] {
   return data.map((entry) =>
-    entry.clientScope
+    'clientScope' in entry && entry.clientScope
       ? { ...entry.clientScope, assignmentId: entry.id }
-      : entry,
+      : (entry as ClientScope),
   );
 }
 

--- a/admin-ui/src/components/Breadcrumbs.tsx
+++ b/admin-ui/src/components/Breadcrumbs.tsx
@@ -19,6 +19,20 @@ function useBreadcrumbs(): Crumb[] {
   const path = pathname.replace(/^\/console/, '') || '/';
   const segments = path.split('/').filter(Boolean);
 
+  // Reset the resolved flow name when navigating away from an auth-flow detail
+  // page. Done during render (vs. an effect) to avoid a synchronous setState in
+  // the effect body; the effect below only handles the async fetch. We keep the
+  // previous name while navigating between auth-flow pages so it does not flash
+  // to null before the new name resolves.
+  const [prevPathname, setPrevPathname] = useState(pathname);
+  if (pathname !== prevPathname) {
+    setPrevPathname(pathname);
+    const idx = segments.indexOf('auth-flows');
+    if (idx === -1 || segments.length <= idx + 1) {
+      setFlowName(null);
+    }
+  }
+
   // Detect if we are on an auth-flow detail page and fetch the flow name.
   // URL pattern: /console/realms/:name/auth-flows/:flowId[/...]
   useEffect(() => {
@@ -34,7 +48,6 @@ function useBreadcrumbs(): Crumb[] {
         return () => { cancelled = true; };
       }
     }
-    setFlowName(null);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 

--- a/admin-ui/src/components/ConfirmDialog.tsx
+++ b/admin-ui/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 
 interface ConfirmDialogProps {
   isOpen?: boolean;
@@ -26,7 +26,10 @@ export default function ConfirmDialog({
   const cancelRef = useRef<HTMLButtonElement>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const isDialogOpen = isOpen ?? open ?? false;
-  const handleClose = onClose ?? onCancel ?? (() => {});
+  const handleClose = useMemo(
+    () => onClose ?? onCancel ?? (() => {}),
+    [onClose, onCancel],
+  );
 
   // Move focus into the dialog when it opens; restore focus when it closes.
   useEffect(() => {

--- a/admin-ui/src/components/flow-editor/FlowCanvas.tsx
+++ b/admin-ui/src/components/flow-editor/FlowCanvas.tsx
@@ -145,16 +145,18 @@ export default function FlowCanvas({ steps, onChange, isPreview = false }: FlowC
 
   // ── Drag-to-reorder (within canvas) ──────────────────────
 
-  const draggingId = useRef<string | null>(null);
+  // Tracks the node being dragged. Kept in state (not a ref) because it is
+  // read during render to dim the dragged node.
+  const [draggingId, setDraggingId] = useState<string | null>(null);
 
   function handleNodeDragStart(e: React.DragEvent, id: string) {
     if (isPreview) return;
-    draggingId.current = id;
+    setDraggingId(id);
     e.dataTransfer.effectAllowed = 'move';
   }
 
   function handleNodeDragOver(e: React.DragEvent, index: number) {
-    if (isPreview || !draggingId.current) return;
+    if (isPreview || !draggingId) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setDragOverIndex(index);
@@ -163,9 +165,9 @@ export default function FlowCanvas({ steps, onChange, isPreview = false }: FlowC
   function handleNodeDrop(e: React.DragEvent, dropIndex: number) {
     if (isPreview) return;
     e.preventDefault();
-    const dragId = draggingId.current;
+    const dragId = draggingId;
     if (!dragId) return;
-    draggingId.current = null;
+    setDraggingId(null);
     setDragOverIndex(null);
 
     const dragIndex = sorted.findIndex((s) => s.id === dragId);
@@ -291,7 +293,7 @@ export default function FlowCanvas({ steps, onChange, isPreview = false }: FlowC
                   onDragOver={(e) => handleNodeDragOver(e, index)}
                   onDrop={(e) => handleNodeDrop(e, index)}
                   className={`transition-opacity ${
-                    dragOverIndex === index && draggingId.current !== step.id
+                    dragOverIndex === index && draggingId !== step.id
                       ? 'opacity-50'
                       : 'opacity-100'
                   }`}

--- a/admin-ui/src/components/flow-editor/FlowStepEditor.tsx
+++ b/admin-ui/src/components/flow-editor/FlowStepEditor.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { FlowStep, StepType } from '../../api/authFlows';
-import { STEP_TYPE_META } from './FlowStepNode';
+import { STEP_TYPE_META } from './stepTypeMeta';
 import FlowConditionEditor from './FlowConditionEditor';
 
 interface FlowStepEditorProps {

--- a/admin-ui/src/components/flow-editor/FlowStepNode.tsx
+++ b/admin-ui/src/components/flow-editor/FlowStepNode.tsx
@@ -1,51 +1,6 @@
 import { memo } from 'react';
-import type { FlowStep, StepType } from '../../api/authFlows';
-
-// ─── Step type metadata ──────────────────────────────────────
-
-interface StepMeta {
-  label: string;
-  icon: string;
-  color: string;
-}
-
-export const STEP_TYPE_META: Record<StepType, StepMeta> = {
-  password: {
-    label: 'Password',
-    icon: '🔑',
-    color: 'bg-blue-50 border-blue-200',
-  },
-  totp: {
-    label: 'TOTP',
-    icon: '📱',
-    color: 'bg-purple-50 border-purple-200',
-  },
-  webauthn: {
-    label: 'WebAuthn',
-    icon: '🔐',
-    color: 'bg-indigo-50 border-indigo-200',
-  },
-  social: {
-    label: 'Social Login',
-    icon: '🌐',
-    color: 'bg-green-50 border-green-200',
-  },
-  ldap: {
-    label: 'LDAP',
-    icon: '🗂️',
-    color: 'bg-yellow-50 border-yellow-200',
-  },
-  email_otp: {
-    label: 'Email OTP',
-    icon: '📧',
-    color: 'bg-orange-50 border-orange-200',
-  },
-  consent: {
-    label: 'Consent',
-    icon: '✅',
-    color: 'bg-teal-50 border-teal-200',
-  },
-};
+import type { FlowStep } from '../../api/authFlows';
+import { STEP_TYPE_META } from './stepTypeMeta';
 
 // ─── Component ───────────────────────────────────────────────
 

--- a/admin-ui/src/components/flow-editor/FlowStepPalette.tsx
+++ b/admin-ui/src/components/flow-editor/FlowStepPalette.tsx
@@ -1,5 +1,5 @@
 import type { StepType } from '../../api/authFlows';
-import { STEP_TYPE_META } from './FlowStepNode';
+import { STEP_TYPE_META } from './stepTypeMeta';
 
 interface FlowStepPaletteProps {
   onAddStep: (type: StepType) => void;

--- a/admin-ui/src/components/flow-editor/stepTypeMeta.ts
+++ b/admin-ui/src/components/flow-editor/stepTypeMeta.ts
@@ -1,0 +1,47 @@
+import type { StepType } from '../../api/authFlows';
+
+// ─── Step type metadata ──────────────────────────────────────
+
+export interface StepMeta {
+  label: string;
+  icon: string;
+  color: string;
+}
+
+export const STEP_TYPE_META: Record<StepType, StepMeta> = {
+  password: {
+    label: 'Password',
+    icon: '🔑',
+    color: 'bg-blue-50 border-blue-200',
+  },
+  totp: {
+    label: 'TOTP',
+    icon: '📱',
+    color: 'bg-purple-50 border-purple-200',
+  },
+  webauthn: {
+    label: 'WebAuthn',
+    icon: '🔐',
+    color: 'bg-indigo-50 border-indigo-200',
+  },
+  social: {
+    label: 'Social Login',
+    icon: '🌐',
+    color: 'bg-green-50 border-green-200',
+  },
+  ldap: {
+    label: 'LDAP',
+    icon: '🗂️',
+    color: 'bg-yellow-50 border-yellow-200',
+  },
+  email_otp: {
+    label: 'Email OTP',
+    icon: '📧',
+    color: 'bg-orange-50 border-orange-200',
+  },
+  consent: {
+    label: 'Consent',
+    icon: '✅',
+    color: 'bg-teal-50 border-teal-200',
+  },
+};

--- a/admin-ui/src/components/magic-link/MagicLinkSettingsForm.tsx
+++ b/admin-ui/src/components/magic-link/MagicLinkSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Realm } from '../../types';
 import type { MagicLinkSettings } from '../../types';
@@ -20,18 +20,20 @@ export default function MagicLinkSettingsForm({ realm }: MagicLinkSettingsFormPr
     emailTemplate: null,
   });
 
-  useEffect(() => {
-    if (realm) {
-      setForm({
-        enabled: realm.magicLinkEnabled ?? false,
-        expirySeconds: realm.magicLinkExpirySeconds ?? 300,
-        rateLimitPerEmail: realm.magicLinkRateLimitPerEmail ?? 3,
-        rateLimitWindowSeconds: realm.magicLinkRateLimitWindowSeconds ?? 900,
-        emailSubject: realm.magicLinkEmailSubject ?? null,
-        emailTemplate: realm.magicLinkEmailTemplate ?? null,
-      });
-    }
-  }, [realm]);
+  // Seed the editable form from the realm prop when it changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededRealm, setSeededRealm] = useState(realm);
+  if (realm !== seededRealm) {
+    setSeededRealm(realm);
+    setForm({
+      enabled: realm.magicLinkEnabled ?? false,
+      expirySeconds: realm.magicLinkExpirySeconds ?? 300,
+      rateLimitPerEmail: realm.magicLinkRateLimitPerEmail ?? 3,
+      rateLimitWindowSeconds: realm.magicLinkRateLimitWindowSeconds ?? 900,
+      emailSubject: realm.magicLinkEmailSubject ?? null,
+      emailTemplate: realm.magicLinkEmailTemplate ?? null,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () => updateRealm(realm.name, {

--- a/admin-ui/src/components/registration/CaptchaWidget.tsx
+++ b/admin-ui/src/components/registration/CaptchaWidget.tsx
@@ -35,7 +35,7 @@ export default function CaptchaWidget({ provider, siteKey }: CaptchaWidgetProps)
       const grecaptcha = window.grecaptcha;
       grecaptcha.ready(() => {
         grecaptcha.execute(siteKey, { action: 'register' }).then((token) => {
-          (window as any).__captchaToken = token;
+          window.__captchaToken = token;
         }).catch(console.error);
       });
     } else if (provider === 'hcaptcha' && window.hcaptcha && containerRef.current) {
@@ -44,7 +44,7 @@ export default function CaptchaWidget({ provider, siteKey }: CaptchaWidgetProps)
       widgetIdRef.current = window.hcaptcha.render(containerId, {
         sitekey: siteKey,
         callback: (token: string) => {
-          (window as any).__captchaToken = token;
+          window.__captchaToken = token;
         },
       });
     }

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -72,6 +72,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 }
 
 /** Returns the full AuthContext value — must be used inside <AuthProvider>. */
+// eslint-disable-next-line react-refresh/only-export-components -- hook is intentionally co-located with its provider; only affects Fast Refresh granularity.
 export function useAuthContext(): AuthContextValue {
   const ctx = useContext(AuthContext);
   if (!ctx) {

--- a/admin-ui/src/context/WizardContext.tsx
+++ b/admin-ui/src/context/WizardContext.tsx
@@ -210,22 +210,22 @@ export function WizardProvider({
     let completed = false;
     switch (step) {
       case 0:
-        completed = !!wizardStateRef.current.adminAccount;
+        completed = !!wizardState.adminAccount;
         break;
       case 1:
-        completed = !!wizardStateRef.current.realmSettings;
+        completed = !!wizardState.realmSettings;
         break;
       case 2:
-        completed = !!wizardStateRef.current.smtpConfig;
+        completed = !!wizardState.smtpConfig;
         break;
       case 3:
-        completed = !!wizardStateRef.current.client;
+        completed = !!wizardState.client;
         break;
       case 4:
-        completed = wizardStateRef.current.sdkGenerated;
+        completed = wizardState.sdkGenerated;
         break;
       case 5:
-        completed = wizardStateRef.current.wizardCompleted;
+        completed = wizardState.wizardCompleted;
         break;
     }
     return {
@@ -233,7 +233,14 @@ export function WizardProvider({
       completed,
       required: stepInfo.required,
     };
-  }, [wizardStateRef.current.adminAccount, wizardStateRef.current.realmSettings, wizardStateRef.current.smtpConfig, wizardStateRef.current.client, wizardStateRef.current.sdkGenerated, wizardStateRef.current.wizardCompleted]);
+  }, [
+    wizardState.adminAccount,
+    wizardState.realmSettings,
+    wizardState.smtpConfig,
+    wizardState.client,
+    wizardState.sdkGenerated,
+    wizardState.wizardCompleted,
+  ]);
 
   const value = useMemo<WizardContextValue>(
     () => ({

--- a/admin-ui/src/context/WizardContext.tsx
+++ b/admin-ui/src/context/WizardContext.tsx
@@ -287,6 +287,7 @@ export function WizardProvider({
 }
 
 /** Returns the full WizardContext value — must be used inside <WizardProvider>. */
+// eslint-disable-next-line react-refresh/only-export-components -- hook is intentionally co-located with its provider; only affects Fast Refresh granularity.
 export function useWizardContext(): WizardContextValue {
   const ctx = useContext(WizardContext);
   if (!ctx) {
@@ -296,6 +297,7 @@ export function useWizardContext(): WizardContextValue {
 }
 
 /** Hook for easier access to wizard state and common operations */
+// eslint-disable-next-line react-refresh/only-export-components -- hook is intentionally co-located with its provider; only affects Fast Refresh granularity.
 export function useWizard() {
   const context = useWizardContext();
   return {

--- a/admin-ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/LoginPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';

--- a/admin-ui/src/pages/__tests__/MigrationHistoryPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/MigrationHistoryPage.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { screen, waitFor, act } from '@testing-library/react';
-import { fireEvent } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/mocks/server';
 import { render } from '../../test/utils';
@@ -121,7 +120,7 @@ describe('MigrationHistoryPage', () => {
 
   it('displays pagination controls when there are more entries', async () => {
     server.use(
-      http.get('/admin/upgrade/history', ({ request }) => {
+      http.get('/admin/upgrade/history', () => {
         const entries = Array.from({ length: 15 }, (_, i) => ({
           id: `upgrade-${i}`,
           fromVersion: '1.0.0',
@@ -145,7 +144,7 @@ describe('MigrationHistoryPage', () => {
 
   it('navigates to previous page when Previous is clicked', async () => {
     server.use(
-      http.get('/admin/upgrade/history', ({ request }) => {
+      http.get('/admin/upgrade/history', () => {
         const entries = Array.from({ length: 15 }, (_, i) => ({
           id: `upgrade-${i}`,
           fromVersion: '1.0.0',

--- a/admin-ui/src/pages/auth-flows/AuthFlowEditorPage.tsx
+++ b/admin-ui/src/pages/auth-flows/AuthFlowEditorPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
@@ -33,15 +33,17 @@ export default function AuthFlowEditorPage() {
   const [isPreview, setIsPreview] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (remoteFlow) {
-      setDraftName(remoteFlow.name);
-      setDraftDescription(remoteFlow.description ?? '');
-      setDraftIsDefault(remoteFlow.isDefault);
-      setDraftSteps(remoteFlow.steps);
-      setIsDirty(false);
-    }
-  }, [remoteFlow]);
+  // Seed the editable draft from fetched data when the loaded flow changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededFlow, setSeededFlow] = useState(remoteFlow);
+  if (remoteFlow && remoteFlow !== seededFlow) {
+    setSeededFlow(remoteFlow);
+    setDraftName(remoteFlow.name);
+    setDraftDescription(remoteFlow.description ?? '');
+    setDraftIsDefault(remoteFlow.isDefault);
+    setDraftSteps(remoteFlow.steps);
+    setIsDirty(false);
+  }
 
   // ── Save mutation ────────────────────────────────────────
 

--- a/admin-ui/src/pages/client-scopes/ClientScopeCreatePage.tsx
+++ b/admin-ui/src/pages/client-scopes/ClientScopeCreatePage.tsx
@@ -33,7 +33,7 @@ export default function ClientScopeCreatePage() {
       queryClient.invalidateQueries({ queryKey: ['clientScopes', name] });
       navigate(`/console/realms/${name}/client-scopes`);
     },
-    onError: (err: any) => {
+    onError: (err: Error) => {
       setError(err.message || 'Failed to create client scope');
     },
   });

--- a/admin-ui/src/pages/client-scopes/ClientScopeDetailPage.tsx
+++ b/admin-ui/src/pages/client-scopes/ClientScopeDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react'
+import { useState, type FormEvent } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getClientScopeById, updateClientScope, deleteClientScope, addMapper, deleteMapper } from '../../api/clientScopes'
@@ -27,11 +27,13 @@ export default function ClientScopeDetailPage() {
     enabled: !!name && !!scopeId
   })
 
-  useEffect(() => {
-    if (scope) {
-      setForm({ name: scope.name, description: scope.description || '' })
-    }
-  }, [scope])
+  // Seed the editable form from fetched data when the loaded scope changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededScope, setSeededScope] = useState(scope)
+  if (scope && scope !== seededScope) {
+    setSeededScope(scope)
+    setForm({ name: scope.name, description: scope.description || '' })
+  }
 
   const updateMutation = useMutation({
     mutationFn: (data: { name: string; description: string }) =>
@@ -43,7 +45,7 @@ export default function ClientScopeDetailPage() {
       setErrorMessage('')
       setTimeout(() => setSuccessMessage(''), 3000)
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to update client scope')
       setSuccessMessage('')
     }
@@ -55,7 +57,7 @@ export default function ClientScopeDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['clientScopes', name] })
       navigate(`/console/realms/${name}/client-scopes`)
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to delete client scope')
       setSuccessMessage('')
       setShowDeleteDialog(false)
@@ -63,7 +65,7 @@ export default function ClientScopeDetailPage() {
   })
 
   const addMapperMutation = useMutation({
-    mutationFn: (data: { name: string; mapperType: string; config: any }) =>
+    mutationFn: (data: { name: string; mapperType: string; config: Record<string, unknown> }) =>
       addMapper(name!, scopeId!, data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['clientScope', name, scopeId] })
@@ -72,7 +74,7 @@ export default function ClientScopeDetailPage() {
       setErrorMessage('')
       setTimeout(() => setSuccessMessage(''), 3000)
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to add mapper')
       setSuccessMessage('')
     }
@@ -88,7 +90,7 @@ export default function ClientScopeDetailPage() {
       setMapperToDelete(null)
       setTimeout(() => setSuccessMessage(''), 3000)
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to delete mapper')
       setSuccessMessage('')
       setShowDeleteMapperDialog(false)
@@ -110,7 +112,7 @@ export default function ClientScopeDetailPage() {
         mapperType: mapperForm.mapperType,
         config
       })
-    } catch (err) {
+    } catch {
       setErrorMessage('Invalid JSON in config field')
       setSuccessMessage('')
     }

--- a/admin-ui/src/pages/clients/ClientDetailPage.tsx
+++ b/admin-ui/src/pages/clients/ClientDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getClientById, updateClient, deleteClient, regenerateSecret, getServiceAccountUser } from '../../api/clients';
@@ -66,21 +66,23 @@ export default function ClientDetailPage() {
     backchannelLogoutSessionRequired: true,
   });
 
-  useEffect(() => {
-    if (client) {
-      setForm({
-        name: client.name || '',
-        description: client.description || '',
-        redirectUris: (client.redirectUris || []).join('\n'),
-        webOrigins: (client.webOrigins || []).join('\n'),
-        grantTypes: (client.grantTypes || []).join(', '),
-        requireConsent: client.requireConsent,
-        enabled: client.enabled,
-        backchannelLogoutUri: client.backchannelLogoutUri || '',
-        backchannelLogoutSessionRequired: client.backchannelLogoutSessionRequired ?? true,
-      });
-    }
-  }, [client]);
+  // Seed the editable form from fetched data when the loaded client changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededClient, setSeededClient] = useState(client);
+  if (client && client !== seededClient) {
+    setSeededClient(client);
+    setForm({
+      name: client.name || '',
+      description: client.description || '',
+      redirectUris: (client.redirectUris || []).join('\n'),
+      webOrigins: (client.webOrigins || []).join('\n'),
+      grantTypes: (client.grantTypes || []).join(', '),
+      requireConsent: client.requireConsent,
+      enabled: client.enabled,
+      backchannelLogoutUri: client.backchannelLogoutUri || '',
+      backchannelLogoutSessionRequired: client.backchannelLogoutSessionRequired ?? true,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () =>

--- a/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -32,15 +32,17 @@ export default function ConsentCategoryDetailPage() {
     enabled: !isCreateMode(categoryId) && !!name && !!categoryId,
   });
 
-  useEffect(() => {
-    if (category) {
-      setForm({
-        name: category.name,
-        description: category.description || '',
-        required: category.required,
-      });
-    }
-  }, [category]);
+  // Seed the editable form from fetched data when the loaded category changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededCategory, setSeededCategory] = useState(category);
+  if (category && category !== seededCategory) {
+    setSeededCategory(category);
+    setForm({
+      name: category.name,
+      description: category.description || '',
+      required: category.required,
+    });
+  }
 
   const createMutation = useMutation({
     mutationFn: (data: { name: string; description: string; required: boolean }) =>
@@ -51,7 +53,7 @@ export default function ConsentCategoryDetailPage() {
       setErrorMessage('');
       setTimeout(() => navigate(`/console/realms/${name}/consent-categories`), 1500);
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to create consent category');
       setSuccessMessage('');
     },
@@ -67,7 +69,7 @@ export default function ConsentCategoryDetailPage() {
       setErrorMessage('');
       setTimeout(() => setSuccessMessage(''), 3000);
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to update consent category');
       setSuccessMessage('');
     },
@@ -79,7 +81,7 @@ export default function ConsentCategoryDetailPage() {
       queryClient.invalidateQueries({ queryKey: ['consentCategories', name] });
       navigate(`/console/realms/${name}/consent-categories`);
     },
-    onError: (error: any) => {
+    onError: (error: Error) => {
       setErrorMessage(error.message || 'Failed to delete consent category');
       setSuccessMessage('');
       setShowDeleteDialog(false);

--- a/admin-ui/src/pages/groups/GroupDetailPage.tsx
+++ b/admin-ui/src/pages/groups/GroupDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -55,15 +55,17 @@ export default function GroupDetailPage() {
 
   const [form, setForm] = useState({ name: '', description: '', parentId: '' });
 
-  useEffect(() => {
-    if (group) {
-      setForm({
-        name: group.name,
-        description: group.description ?? '',
-        parentId: group.parentId ?? '',
-      });
-    }
-  }, [group]);
+  // Seed the editable form from fetched data when the loaded group changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededGroup, setSeededGroup] = useState(group);
+  if (group && group !== seededGroup) {
+    setSeededGroup(group);
+    setForm({
+      name: group.name,
+      description: group.description ?? '',
+      parentId: group.parentId ?? '',
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () =>

--- a/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -38,26 +38,28 @@ export default function IdpDetailPage() {
     syncUserProfile: true,
   });
 
-  useEffect(() => {
-    if (idp) {
-      setForm({
-        displayName: idp.displayName ?? '',
-        providerType: idp.providerType,
-        clientId: idp.clientId,
-        clientSecret: idp.clientSecret,
-        authorizationUrl: idp.authorizationUrl,
-        tokenUrl: idp.tokenUrl,
-        userinfoUrl: idp.userinfoUrl ?? '',
-        jwksUrl: idp.jwksUrl ?? '',
-        issuer: idp.issuer ?? '',
-        defaultScopes: idp.defaultScopes,
-        enabled: idp.enabled,
-        trustEmail: idp.trustEmail,
-        linkOnly: idp.linkOnly,
-        syncUserProfile: idp.syncUserProfile,
-      });
-    }
-  }, [idp]);
+  // Seed the editable form from fetched data when the loaded IdP changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededIdp, setSeededIdp] = useState(idp);
+  if (idp && idp !== seededIdp) {
+    setSeededIdp(idp);
+    setForm({
+      displayName: idp.displayName ?? '',
+      providerType: idp.providerType,
+      clientId: idp.clientId,
+      clientSecret: idp.clientSecret,
+      authorizationUrl: idp.authorizationUrl,
+      tokenUrl: idp.tokenUrl,
+      userinfoUrl: idp.userinfoUrl ?? '',
+      jwksUrl: idp.jwksUrl ?? '',
+      issuer: idp.issuer ?? '',
+      defaultScopes: idp.defaultScopes,
+      enabled: idp.enabled,
+      trustEmail: idp.trustEmail,
+      linkOnly: idp.linkOnly,
+      syncUserProfile: idp.syncUserProfile,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () =>

--- a/admin-ui/src/pages/nhi/NhiDetailPage.tsx
+++ b/admin-ui/src/pages/nhi/NhiDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -77,16 +77,18 @@ export default function NhiDetailPage() {
     enabled: true,
   });
 
-  useEffect(() => {
-    if (identity) {
-      setForm({
-        name: identity.name || '',
-        description: identity.description || '',
-        agentPurpose: identity.agentPurpose || '',
-        enabled: identity.enabled,
-      });
-    }
-  }, [identity]);
+  // Seed the editable form from fetched data when the loaded identity changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededIdentity, setSeededIdentity] = useState(identity);
+  if (identity && identity !== seededIdentity) {
+    setSeededIdentity(identity);
+    setForm({
+      name: identity.name || '',
+      description: identity.description || '',
+      agentPurpose: identity.agentPurpose || '',
+      enabled: identity.enabled,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () =>

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -122,9 +122,12 @@ export default function RealmDetailPage() {
     emailTheme: 'idenplane',
   });
 
-  useEffect(() => {
-    if (realm) {
-      setForm({
+  // Seed the editable form from fetched data when the loaded realm changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededRealm, setSeededRealm] = useState(realm);
+  if (realm && realm !== seededRealm) {
+    setSeededRealm(realm);
+    setForm({
         displayName: realm.displayName ?? '',
         enabled: realm.enabled,
         registrationAllowed: realm.registrationAllowed ?? true,
@@ -162,9 +165,8 @@ export default function RealmDetailPage() {
         loginTheme: realm.loginTheme ?? 'idenplane',
         accountTheme: realm.accountTheme ?? 'idenplane',
         emailTheme: realm.emailTheme ?? 'idenplane',
-      });
-    }
-  }, [realm]);
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () => updateRealm(name!, form),

--- a/admin-ui/src/pages/realms/RealmListPage.tsx
+++ b/admin-ui/src/pages/realms/RealmListPage.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { getAllRealms, importRealm } from '../../api/realms';
+import { getErrorMessage } from '../../utils/getErrorMessage';
 
 export default function RealmListPage() {
   const navigate = useNavigate();
@@ -22,11 +23,10 @@ export default function RealmListPage() {
       const text = await file.text();
       const payload = JSON.parse(text);
       const result = await importRealm(payload);
-      setImportStatus({ type: 'success', message: `Realm "${(result as any).realmName}" imported successfully.` });
+      setImportStatus({ type: 'success', message: `Realm "${String(result.realmName ?? '')}" imported successfully.` });
       queryClient.invalidateQueries({ queryKey: ['realms'] });
-    } catch (err: any) {
-      const msg = err?.response?.data?.message ?? err.message ?? 'Import failed.';
-      setImportStatus({ type: 'error', message: msg });
+    } catch (err: unknown) {
+      setImportStatus({ type: 'error', message: getErrorMessage(err, 'Import failed.') });
     }
     // Reset file input
     if (fileInputRef.current) fileInputRef.current.value = '';

--- a/admin-ui/src/pages/registration/PublicRegistrationPage.tsx
+++ b/admin-ui/src/pages/registration/PublicRegistrationPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import type { Realm } from '../../types';
 import { getRealmByName } from '../../api/realms';
 import { getPublicRegistrationFields } from '../../api/registration';
 import CaptchaWidget from '../../components/registration/CaptchaWidget';
@@ -16,7 +17,7 @@ interface RegistrationField {
 
 export default function PublicRegistrationPage() {
   const { realm: realmName } = useParams<{ realm: string }>();
-  const [realm, setRealm] = useState<any>(null);
+  const [realm, setRealm] = useState<Realm | null>(null);
   const [fields, setFields] = useState<Partial<RegistrationField>[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +69,7 @@ export default function PublicRegistrationPage() {
         body: JSON.stringify({
           ...form,
           attributes: customAttributes,
-          captchaToken: (window as any).__captchaToken,
+          captchaToken: window.__captchaToken,
         }),
       });
 

--- a/admin-ui/src/pages/registration/RegistrationSettingsPage.tsx
+++ b/admin-ui/src/pages/registration/RegistrationSettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getRealmByName, updateRealm } from '../../api/realms';
@@ -30,25 +30,27 @@ export default function RegistrationSettingsPage() {
     captchaScoreThreshold: 0.5,
   });
 
-  useEffect(() => {
-    if (realm) {
-      setForm({
-        registrationAllowed: realm.registrationAllowed ?? true,
-        registrationApprovalRequired: realm.registrationApprovalRequired ?? false,
-        requireEmailVerification: realm.requireEmailVerification ?? false,
-        allowedEmailDomains: (realm.allowedEmailDomains || []).join(', '),
-        termsOfServiceUrl: realm.termsOfServiceUrl || '',
-        privacyPolicyUrl: realm.privacyPolicyUrl || '',
-        captchaEnabled: realm.captchaEnabled ?? false,
-        captchaProvider: realm.captchaProvider || 'recaptcha',
-        recaptchaSiteKey: realm.recaptchaSiteKey || '',
-        recaptchaSecretKey: realm.recaptchaSecretKey || '',
-        hcaptchaSiteKey: realm.hcaptchaSiteKey || '',
-        hcaptchaSecretKey: realm.hcaptchaSecretKey || '',
-        captchaScoreThreshold: realm.captchaScoreThreshold ?? 0.5,
-      });
-    }
-  }, [realm]);
+  // Seed the editable form from fetched data when the loaded realm changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededRealm, setSeededRealm] = useState(realm);
+  if (realm && realm !== seededRealm) {
+    setSeededRealm(realm);
+    setForm({
+      registrationAllowed: realm.registrationAllowed ?? true,
+      registrationApprovalRequired: realm.registrationApprovalRequired ?? false,
+      requireEmailVerification: realm.requireEmailVerification ?? false,
+      allowedEmailDomains: (realm.allowedEmailDomains || []).join(', '),
+      termsOfServiceUrl: realm.termsOfServiceUrl || '',
+      privacyPolicyUrl: realm.privacyPolicyUrl || '',
+      captchaEnabled: realm.captchaEnabled ?? false,
+      captchaProvider: realm.captchaProvider || 'recaptcha',
+      recaptchaSiteKey: realm.recaptchaSiteKey || '',
+      recaptchaSecretKey: realm.recaptchaSecretKey || '',
+      hcaptchaSiteKey: realm.hcaptchaSiteKey || '',
+      hcaptchaSecretKey: realm.hcaptchaSecretKey || '',
+      captchaScoreThreshold: realm.captchaScoreThreshold ?? 0.5,
+    });
+  }
 
   const mutation = useMutation({
     mutationFn: (data: typeof form) => {

--- a/admin-ui/src/pages/saml/SamlSpDetailPage.tsx
+++ b/admin-ui/src/pages/saml/SamlSpDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -32,21 +32,23 @@ export default function SamlSpDetailPage() {
     nameIdFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
   });
 
-  useEffect(() => {
-    if (sp) {
-      setForm({
-        name: sp.name,
-        entityId: sp.entityId,
-        enabled: sp.enabled,
-        acsUrl: sp.acsUrl,
-        sloUrl: sp.sloUrl ?? '',
-        certificate: sp.certificate ?? '',
-        signAssertions: sp.signAssertions,
-        signResponses: sp.signResponses,
-        nameIdFormat: sp.nameIdFormat,
-      });
-    }
-  }, [sp]);
+  // Seed the editable form from fetched data when the loaded SP changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededSp, setSeededSp] = useState(sp);
+  if (sp && sp !== seededSp) {
+    setSeededSp(sp);
+    setForm({
+      name: sp.name,
+      entityId: sp.entityId,
+      enabled: sp.enabled,
+      acsUrl: sp.acsUrl,
+      sloUrl: sp.sloUrl ?? '',
+      certificate: sp.certificate ?? '',
+      signAssertions: sp.signAssertions,
+      signResponses: sp.signResponses,
+      nameIdFormat: sp.nameIdFormat,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () =>

--- a/admin-ui/src/pages/setup-wizard/steps/AdminAccountStep.tsx
+++ b/admin-ui/src/pages/setup-wizard/steps/AdminAccountStep.tsx
@@ -24,7 +24,7 @@ function evaluatePasswordStrength(password: string): PasswordStrengthInfo {
     uppercase: /[A-Z]/.test(password),
     lowercase: /[a-z]/.test(password),
     number: /[0-9]/.test(password),
-    special: /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(password),
+    special: /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/.test(password),
   };
 
   if (checks.length) score += 20;

--- a/admin-ui/src/pages/theme-builder/LivePreview.tsx
+++ b/admin-ui/src/pages/theme-builder/LivePreview.tsx
@@ -16,22 +16,27 @@ interface LivePreviewProps {
 }
 
 // Debounce helper for avoiding excessive re-renders
-function useDebounce<T extends (...args: any[]) => void>(callback: T, delay: number): T {
+function useDebounce<TArgs extends unknown[]>(
+  callback: (...args: TArgs) => void,
+  delay: number,
+): (...args: TArgs) => void {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const callbackRef = useRef(callback);
 
-  // Keep callback ref updated
-  callbackRef.current = callback;
+  // Keep the callback ref updated without mutating it during render.
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
 
   return useCallback(
-    ((...args: any[]) => {
+    (...args: TArgs) => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
       timeoutRef.current = setTimeout(() => {
         callbackRef.current(...args);
       }, delay);
-    }) as T,
+    },
     [delay],
   );
 }
@@ -363,7 +368,7 @@ function generatePreviewHtml(
         `;
         break;
 
-      case 'form':
+      case 'form': {
         const formProps = component.props as {
           showUsername?: boolean;
           showEmail?: boolean;
@@ -403,6 +408,7 @@ function generatePreviewHtml(
 
         componentsHtml += `</form>`;
         break;
+      }
 
       case 'rememberMe':
         if (settings.showRememberMe) {
@@ -417,7 +423,7 @@ function generatePreviewHtml(
         }
         break;
 
-      case 'button':
+      case 'button': {
         const btnProps = component.props as { label?: string; variant?: string };
         componentsHtml += `
           <div class="form-group">
@@ -425,6 +431,7 @@ function generatePreviewHtml(
           </div>
         `;
         break;
+      }
 
       case 'forgotPassword':
         if (settings.showForgotPassword) {
@@ -458,7 +465,7 @@ function generatePreviewHtml(
         }
         break;
 
-      case 'footer':
+      case 'footer': {
         const footerProps = component.props as {
           showPrivacyPolicy?: boolean;
           showTermsOfService?: boolean;
@@ -472,13 +479,15 @@ function generatePreviewHtml(
           </div>
         `;
         break;
+      }
 
-      case 'spacer':
+      case 'spacer': {
         const spacerHeight = (component.props as { height?: number }).height || 16;
         componentsHtml += `<div style="height: ${spacerHeight}px;"></div>`;
         break;
+      }
 
-      case 'alert':
+      case 'alert': {
         const alertProps = component.props as { type?: string; message?: string };
         if (alertProps.message) {
           componentsHtml += `
@@ -486,15 +495,17 @@ function generatePreviewHtml(
           `;
         }
         break;
+      }
 
-      case 'text':
+      case 'text': {
         const textProps = component.props as { content?: string; alignment?: string };
         componentsHtml += `
           <p style="text-align: ${textProps.alignment || 'center'};">${textProps.content || ''}</p>
         `;
         break;
+      }
 
-      case 'heading':
+      case 'heading': {
         const headingProps = component.props as {
           content?: string;
           level?: number;
@@ -505,13 +516,15 @@ function generatePreviewHtml(
           <${Tag} style="text-align: ${headingProps.alignment || 'center'};">${headingProps.content || ''}</${Tag}>
         `;
         break;
+      }
 
-      case 'divider':
+      case 'divider': {
         const dividerProps = component.props as { label?: string };
         componentsHtml += `
           <div class="divider">${dividerProps.label || ''}</div>
         `;
         break;
+      }
 
       default:
         break;

--- a/admin-ui/src/pages/theme-builder/ThemeCanvas.tsx
+++ b/admin-ui/src/pages/theme-builder/ThemeCanvas.tsx
@@ -96,16 +96,18 @@ export default function ThemeCanvas({
 
   // ── Drag-to-reorder (within canvas) ──────────────────────
 
-  const draggingId = useRef<string | null>(null);
+  // Tracks the component being dragged. Kept in state (not a ref) because it is
+  // read during render to dim the dragged component.
+  const [draggingId, setDraggingId] = useState<string | null>(null);
 
   function handleNodeDragStart(e: React.DragEvent, id: string) {
     if (isPreview) return;
-    draggingId.current = id;
+    setDraggingId(id);
     e.dataTransfer.effectAllowed = 'move';
   }
 
   function handleNodeDragOver(e: React.DragEvent, index: number) {
-    if (isPreview || !draggingId.current) return;
+    if (isPreview || !draggingId) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setDragOverIndex(index);
@@ -114,9 +116,9 @@ export default function ThemeCanvas({
   function handleNodeDrop(e: React.DragEvent, dropIndex: number) {
     if (isPreview) return;
     e.preventDefault();
-    const dragId = draggingId.current;
+    const dragId = draggingId;
     if (!dragId) return;
-    draggingId.current = null;
+    setDraggingId(null);
     setDragOverIndex(null);
 
     const dragIndex = sorted.findIndex((c) => c.id === dragId);
@@ -219,7 +221,7 @@ export default function ThemeCanvas({
                   className={`cursor-pointer rounded-lg border-2 p-4 transition-all ${
                     selectedComponentId === component.id
                       ? 'border-indigo-500 bg-indigo-50 shadow-md'
-                      : dragOverIndex === index && draggingId.current !== component.id
+                      : dragOverIndex === index && draggingId !== component.id
                         ? 'border-indigo-300 bg-indigo-50 opacity-75'
                         : 'border-gray-200 bg-white hover:border-indigo-300 hover:shadow-md'
                   }`}

--- a/admin-ui/src/pages/theme-builder/ThemeVersionHistory.tsx
+++ b/admin-ui/src/pages/theme-builder/ThemeVersionHistory.tsx
@@ -40,7 +40,12 @@ export default function ThemeVersionHistory({
     }
   }, [themeId, realmName]);
 
+  // Fetch the version history on mount and whenever the target theme changes.
+  // This is a genuine "synchronize with an external system" effect; the
+  // synchronous setLoading/setError inside fetchVersions are the start of an
+  // async data load, not derived state, so the rule's warning does not apply.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     fetchVersions();
   }, [fetchVersions]);
 

--- a/admin-ui/src/pages/theme-builder/__tests__/ComponentPalette.test.tsx
+++ b/admin-ui/src/pages/theme-builder/__tests__/ComponentPalette.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect, vi } from 'vitest';
 import { screen, fireEvent } from '@testing-library/react';
 import { render } from '../../../test/utils';
 import ComponentPalette from '../ComponentPalette';
-import type { ComponentType } from '../../../types/theme';
 
 describe('ComponentPalette', () => {
   it('renders the palette with a header', () => {

--- a/admin-ui/src/pages/theme-builder/__tests__/ImageUploader.test.tsx
+++ b/admin-ui/src/pages/theme-builder/__tests__/ImageUploader.test.tsx
@@ -20,7 +20,7 @@ describe('ImageUploader', () => {
   });
 
   const createMockFile = (name: string, type: string, size: number) => {
-    return new File([], name, { type });
+    return new File([new Uint8Array(size)], name, { type });
   };
 
   describe('Rendering', () => {

--- a/admin-ui/src/pages/theme-builder/__tests__/ThemeBuilderE2E.test.tsx
+++ b/admin-ui/src/pages/theme-builder/__tests__/ThemeBuilderE2E.test.tsx
@@ -35,7 +35,7 @@ import {
   DEFAULT_THEME_SETTINGS,
   COMPONENT_DEFINITIONS,
 } from '../../../types/theme';
-import type { ThemeComponent, ThemeStyles, ThemeAssets, ThemeSettings } from '../../../types/theme';
+import type { ThemeComponent } from '../../../types/theme';
 
 // ─── Mock API functions ────────────────────────────────────────────────────────
 
@@ -278,7 +278,6 @@ describe('ThemeBuilderPage E2E Tests', () => {
     });
 
     it('accepts viewport size changes', async () => {
-      const user = userEvent.setup();
       const onViewportChange = vi.fn();
 
       render(

--- a/admin-ui/src/pages/user-federation/FederationDetailPage.tsx
+++ b/admin-ui/src/pages/user-federation/FederationDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -48,30 +48,32 @@ export default function FederationDetailPage() {
     editMode: 'READ_ONLY',
   });
 
-  useEffect(() => {
-    if (federation) {
-      setForm({
-        name: federation.name,
-        enabled: federation.enabled,
-        priority: federation.priority,
-        connectionUrl: federation.connectionUrl,
-        bindDn: federation.bindDn,
-        bindCredential: federation.bindCredential,
-        startTls: federation.startTls,
-        connectionTimeout: federation.connectionTimeout,
-        usersDn: federation.usersDn,
-        userObjectClass: federation.userObjectClass,
-        usernameLdapAttr: federation.usernameLdapAttr,
-        rdnLdapAttr: federation.rdnLdapAttr,
-        uuidLdapAttr: federation.uuidLdapAttr,
-        searchFilter: federation.searchFilter ?? '',
-        syncMode: federation.syncMode,
-        syncPeriod: federation.syncPeriod,
-        importEnabled: federation.importEnabled,
-        editMode: federation.editMode,
-      });
-    }
-  }, [federation]);
+  // Seed the editable form from fetched data when the loaded federation changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededFederation, setSeededFederation] = useState(federation);
+  if (federation && federation !== seededFederation) {
+    setSeededFederation(federation);
+    setForm({
+      name: federation.name,
+      enabled: federation.enabled,
+      priority: federation.priority,
+      connectionUrl: federation.connectionUrl,
+      bindDn: federation.bindDn,
+      bindCredential: federation.bindCredential,
+      startTls: federation.startTls,
+      connectionTimeout: federation.connectionTimeout,
+      usersDn: federation.usersDn,
+      userObjectClass: federation.userObjectClass,
+      usernameLdapAttr: federation.usernameLdapAttr,
+      rdnLdapAttr: federation.rdnLdapAttr,
+      uuidLdapAttr: federation.uuidLdapAttr,
+      searchFilter: federation.searchFilter ?? '',
+      syncMode: federation.syncMode,
+      syncPeriod: federation.syncPeriod,
+      importEnabled: federation.importEnabled,
+      editMode: federation.editMode,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () =>

--- a/admin-ui/src/pages/users/UserDetailPage.tsx
+++ b/admin-ui/src/pages/users/UserDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getUserById, updateUser, deleteUser, resetPassword, getMfaStatus, resetMfa, getOfflineSessions, revokeOfflineSession } from '../../api/users';
@@ -64,17 +64,19 @@ export default function UserDetailPage() {
     enabled: true,
   });
 
-  useEffect(() => {
-    if (user) {
-      setForm({
-        email: user.email ?? '',
-        emailVerified: user.emailVerified,
-        firstName: user.firstName ?? '',
-        lastName: user.lastName ?? '',
-        enabled: user.enabled,
-      });
-    }
-  }, [user]);
+  // Seed the editable form from fetched data when the loaded user changes.
+  // Adjusting state during render (vs. an effect) avoids an extra render pass.
+  const [seededUser, setSeededUser] = useState(user);
+  if (user && user !== seededUser) {
+    setSeededUser(user);
+    setForm({
+      email: user.email ?? '',
+      emailVerified: user.emailVerified,
+      firstName: user.firstName ?? '',
+      lastName: user.lastName ?? '',
+      enabled: user.enabled,
+    });
+  }
 
   const updateMutation = useMutation({
     mutationFn: () => updateUser(name!, id!, form),

--- a/admin-ui/src/test/utils.tsx
+++ b/admin-ui/src/test/utils.tsx
@@ -67,6 +67,7 @@ export function renderWithProviders(
   };
 }
 
-// Re-export everything from @testing-library/react for convenience
+// Re-export everything from @testing-library/react for convenience.
+// eslint-disable-next-line react-refresh/only-export-components -- test-only helper module; Fast Refresh does not apply.
 export * from '@testing-library/react';
 export { renderWithProviders as render };


### PR DESCRIPTION
Bumps `admin-ui` `eslint` 9.39.1 -> 10.4.0 and `@eslint/js` 9.39.1 -> 10.0.1. **Supersedes #919.**

ESLint 10 (with the existing typescript-eslint 8 / eslint-plugin-react-hooks 7 / react-refresh plugins) surfaced ~65 errors. All fixed at the root cause — no rule disables except where a pattern is genuinely correct and the rule only false-flags it (each such disable has a one-line rationale).

## Fixes by rule
- **`@typescript-eslint/no-explicit-any` (18)** — real types: mutation `onError` handlers typed as `Error` (react-query), mapper config as `Record<string, unknown>`, `useDebounce` generics, scope-assignment join records typed, realm state typed as `Realm | null`, `window.__captchaToken` via the existing global augmentation, and `getErrorMessage()` for a caught import error.
- **`react-hooks/set-state-in-effect` (15)** — the 12 detail-page form-seed effects now use the React-recommended render-phase state adjustment (store-previous-value). Breadcrumbs resets during render and keeps only the async fetch in its effect. ThemeVersionHistory keeps a genuine fetch-on-mount effect with a scoped disable + rationale.
- **`@typescript-eslint/no-unused-vars` (12)** — removed dead imports / unused vars in test files; dropped an unused catch binding.
- **`react-refresh/only-export-components` (5)** — extracted `STEP_TYPE_META` into its own module so `FlowStepNode` exports only a component; disabled (with rationale) on context hooks co-located with their providers and the test-only re-export helper.
- **`react-hooks/refs` (3)** — FlowCanvas/ThemeCanvas track the dragged id in state (read during render); LivePreview updates its callback ref in an effect instead of during render.
- **`react-hooks/exhaustive-deps` (2)** — ConfirmDialog wraps `handleClose` in `useMemo`; WizardContext `getStepInfo` depends on the reactive state fields.
- **`react-hooks/use-memo` (1)** — LivePreview passes an inline function to `useCallback`.
- **`no-useless-escape` (2) / `no-case-declarations` (9)** — surfaced by the flat-config recommended set; regex escapes cleaned, case bodies braced.

## Peer-dep bumps
None required — typescript-eslint 8.59.4 (TS6 already in admin-ui via #907), eslint-plugin-react-hooks 7.x and eslint-plugin-react-refresh 0.4.x are all compatible with ESLint 10.

## Local verification
- `npm run lint`: 0 errors
- `npm run build`: succeeds
- `npm test`: 292 passed, 2 skipped (23 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)