### PR TITLE
ci: auto-build & push Docker image (fix stale image)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,74 @@
+name: Publish Docker image
+
+# Builds and pushes islamawad/idenplane to Docker Hub.
+#
+#   - every push to main  -> :latest and :main-<sha>   (keeps the public image
+#     and the demo deployment from ever going stale again)
+#   - every v* git tag    -> :X.Y.Z and :X.Y           (release images)
+#   - manual dispatch      -> on demand (e.g. to publish the first fresh image)
+#
+# Requires two repo/org secrets:
+#   DOCKERHUB_USERNAME  - Docker Hub account that owns islamawad/idenplane
+#   DOCKERHUB_TOKEN     - a Docker Hub *access token* (Account Settings ->
+#                         Security), NOT the account password.
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'src/**'
+      - 'prisma/**'
+      - 'admin-ui/**'
+      - 'themes/**'
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docker-publish.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build & push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Derive tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: islamawad/idenplane
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=main-,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          # amd64 only for now (the demo/server is x86_64); add linux/arm64
+          # here once we want native Apple-silicon pulls.
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Problem
`islamawad/idenplane:latest` was built **manually** and has gone stale — it's missing fixes already merged to `main`. Deploying from it (e.g. the demo) runs old, buggy code.

## Fix
A GitHub Actions workflow that builds + pushes the image automatically, so it can never drift behind the code again:

- **push to `main`** → `:latest` + `:main-<sha>`
- **`v*` tag** → `:X.Y.Z` + `:X.Y`
- **manual dispatch** → on demand (used to publish the first fresh image)

amd64 only for now (server is x86_64); GHA layer caching for speed.

## Required before it works
Add two secrets (a **fresh** Docker Hub access token — the old one was exposed and should be revoked):
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## Rollout
Additive only — cannot break existing CI. After merge to `main` + secrets, trigger once via `workflow_dispatch` to publish the first up-to-date image, then deploy the demo from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)