### PR TITLE
fix(admin-ui): repair frontend↔backend contract & routing mismatches (F-01,02,03,04,07,12)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -96,7 +96,7 @@ export default function App() {
           <Route path="/console/realms/:name/saml-providers/:id" element={<SamlSpDetailPage />} />
           <Route path="/console/realms/:name/auth-flows" element={<AuthFlowListPage />} />
           <Route path="/console/realms/:name/auth-flows/:flowId" element={<AuthFlowEditorPage />} />
-          <Route path="/console/registration-approvals" element={<PendingRegistrationsPage />} />
+          <Route path="/console/realms/:name/registration-approvals" element={<PendingRegistrationsPage />} />
           <Route path="/console/realms/:name/registration-fields" element={<RegistrationFieldsPage />} />
           <Route path="/console/realms/:name/registration-settings" element={<RegistrationSettingsPage />} />
           {/* Catch-all for unknown /console/... paths — rendered inside the Layout shell */}

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -33,32 +33,44 @@ export function hasCredentials(): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Axios instance
+// Axios instances
 // ---------------------------------------------------------------------------
-const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE || '/admin',
-});
+// Both instances share the same in-memory credential injection and 401
+// handling; they differ only in baseURL. `apiClient` targets the admin API
+// (mounted under `/admin/...`), while `rootClient` targets root-mounted
+// controllers that have no `/admin` prefix (e.g. setup-wizard, the realm
+// registration endpoints) — mirroring how getHealthStatus reaches `/health`.
+function createClient(baseURL: string) {
+  const instance = axios.create({ baseURL });
 
-apiClient.interceptors.request.use((config) => {
-  if (_token) {
-    config.headers['Authorization'] = `Bearer ${_token}`;
-  }
-  if (_apiKey) {
-    config.headers['x-admin-api-key'] = _apiKey;
-  }
-  return config;
-});
-
-apiClient.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    const isOnLoginPage = window.location.pathname === '/console/login';
-    if (error.response?.status === 401 && !isOnLoginPage) {
-      clearCredentials();
-      window.location.href = '/console/login';
+  instance.interceptors.request.use((config) => {
+    if (_token) {
+      config.headers['Authorization'] = `Bearer ${_token}`;
     }
-    return Promise.reject(error);
-  },
-);
+    if (_apiKey) {
+      config.headers['x-admin-api-key'] = _apiKey;
+    }
+    return config;
+  });
+
+  instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      const isOnLoginPage = window.location.pathname === '/console/login';
+      if (error.response?.status === 401 && !isOnLoginPage) {
+        clearCredentials();
+        window.location.href = '/console/login';
+      }
+      return Promise.reject(error);
+    },
+  );
+
+  return instance;
+}
+
+const apiClient = createClient(import.meta.env.VITE_API_BASE || '/admin');
+
+/** Targets root-mounted controllers (no `/admin` prefix). */
+export const rootClient = createClient('/');
 
 export default apiClient;

--- a/admin-ui/src/api/consent.ts
+++ b/admin-ui/src/api/consent.ts
@@ -10,7 +10,7 @@ export async function getConsentCategories(
   includeDisabled = false,
 ): Promise<ConsentCategory[]> {
   const { data } = await apiClient.get<ConsentCategory[]>(
-    `/admin/realms/${realmName}/consent-categories`,
+    `/realms/${realmName}/consent-categories`,
     { params: { includeDisabled } },
   );
   return data;
@@ -21,7 +21,7 @@ export async function getConsentCategoryById(
   categoryId: string,
 ): Promise<ConsentCategory> {
   const { data } = await apiClient.get<ConsentCategory>(
-    `/admin/realms/${realmName}/consent-categories/${categoryId}`,
+    `/realms/${realmName}/consent-categories/${categoryId}`,
   );
   return data;
 }
@@ -31,7 +31,7 @@ export async function createConsentCategory(
   category: Partial<ConsentCategory>,
 ): Promise<ConsentCategory> {
   const { data } = await apiClient.post<ConsentCategory>(
-    `/admin/realms/${realmName}/consent-categories`,
+    `/realms/${realmName}/consent-categories`,
     category,
   );
   return data;
@@ -43,7 +43,7 @@ export async function updateConsentCategory(
   category: Partial<ConsentCategory>,
 ): Promise<ConsentCategory> {
   const { data } = await apiClient.put<ConsentCategory>(
-    `/admin/realms/${realmName}/consent-categories/${categoryId}`,
+    `/realms/${realmName}/consent-categories/${categoryId}`,
     category,
   );
   return data;
@@ -53,7 +53,7 @@ export async function deleteConsentCategory(
   realmName: string,
   categoryId: string,
 ): Promise<void> {
-  await apiClient.delete(`/admin/realms/${realmName}/consent-categories/${categoryId}`);
+  await apiClient.delete(`/realms/${realmName}/consent-categories/${categoryId}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -148,35 +148,11 @@ export interface ConsentStatistics {
   pendingDeletions: number;
 }
 
-export interface CategoryStatistics {
-  categoryId: string;
-  categoryName: string;
-  required: boolean;
-  totalGrants: number;
-  totalRevokes: number;
-  grantsLast24h: number;
-  grantsLast7d: number;
-  grantsLast30d: number;
-  activeUsers24h: number;
-  activeUsers7d: number;
-  activeUsers30d: number;
-}
-
 export async function getConsentStatistics(
   realmName: string,
 ): Promise<ConsentStatistics> {
   const { data } = await apiClient.get<ConsentStatistics>(
-    `/admin/realms/${realmName}/stats/consents`,
-  );
-  return data;
-}
-
-export async function getCategoryStatistics(
-  realmName: string,
-  categoryId: string,
-): Promise<CategoryStatistics> {
-  const { data } = await apiClient.get<CategoryStatistics>(
-    `/admin/realms/${realmName}/stats/consents/categories/${categoryId}`,
+    `/realms/${realmName}/stats/consents`,
   );
   return data;
 }

--- a/admin-ui/src/api/registration.ts
+++ b/admin-ui/src/api/registration.ts
@@ -1,4 +1,4 @@
-import apiClient from './client';
+import { rootClient } from './client';
 
 export interface RegistrationField {
   id: string;
@@ -32,7 +32,7 @@ export async function getPendingRegistrations(
   skip = 0,
   take = 20,
 ): Promise<{ users: PendingRegistration[]; total: number }> {
-  const { data } = await apiClient.get<{ users: PendingRegistration[]; total: number }>(
+  const { data } = await rootClient.get<{ users: PendingRegistration[]; total: number }>(
     `/realms/${realmName}/registration/pending`,
     { params: { skip, take } },
   );
@@ -44,7 +44,7 @@ export async function approveRegistration(
   userId: string,
   note?: string,
 ): Promise<{ success: boolean; note?: string }> {
-  const { data } = await apiClient.post<{ success: boolean; note?: string }>(
+  const { data } = await rootClient.post<{ success: boolean; note?: string }>(
     `/realms/${realmName}/registration/approve/${userId}`,
     { note },
   );
@@ -56,7 +56,7 @@ export async function rejectRegistration(
   userId: string,
   reason?: string,
 ): Promise<{ success: boolean }> {
-  const { data } = await apiClient.post<{ success: boolean }>(
+  const { data } = await rootClient.post<{ success: boolean }>(
     `/realms/${realmName}/registration/reject/${userId}`,
     { reason },
   );
@@ -64,7 +64,7 @@ export async function rejectRegistration(
 }
 
 export async function getRegistrationFields(realmName: string): Promise<RegistrationField[]> {
-  const { data } = await apiClient.get<RegistrationField[]>(
+  const { data } = await rootClient.get<RegistrationField[]>(
     `/realms/${realmName}/registration/admin/fields`,
   );
   return data;
@@ -74,7 +74,7 @@ export async function createRegistrationField(
   realmName: string,
   field: Partial<RegistrationField>,
 ): Promise<RegistrationField> {
-  const { data } = await apiClient.post<RegistrationField>(
+  const { data } = await rootClient.post<RegistrationField>(
     `/realms/${realmName}/registration/admin/fields`,
     field,
   );
@@ -86,7 +86,7 @@ export async function updateRegistrationField(
   fieldId: string,
   field: Partial<RegistrationField>,
 ): Promise<RegistrationField> {
-  const { data } = await apiClient.put<RegistrationField>(
+  const { data } = await rootClient.put<RegistrationField>(
     `/realms/${realmName}/registration/admin/fields/${fieldId}`,
     field,
   );
@@ -97,11 +97,11 @@ export async function deleteRegistrationField(
   realmName: string,
   fieldId: string,
 ): Promise<void> {
-  await apiClient.delete(`/realms/${realmName}/registration/admin/fields/${fieldId}`);
+  await rootClient.delete(`/realms/${realmName}/registration/admin/fields/${fieldId}`);
 }
 
 export async function getPublicRegistrationFields(realmName: string): Promise<Partial<RegistrationField>[]> {
-  const { data } = await apiClient.get<Partial<RegistrationField>[]>(
+  const { data } = await rootClient.get<Partial<RegistrationField>[]>(
     `/realms/${realmName}/registration/fields`,
   );
   return data;

--- a/admin-ui/src/api/wizard.ts
+++ b/admin-ui/src/api/wizard.ts
@@ -1,4 +1,4 @@
-import apiClient from './client';
+import { rootClient } from './client';
 
 export interface WizardStatus {
   isFirstRun: boolean;
@@ -86,19 +86,19 @@ export interface WizardCompleteResult {
 }
 
 export async function getWizardStatus(): Promise<WizardStatus> {
-  const { data } = await apiClient.get<WizardStatus>('/setup-wizard/status');
+  const { data } = await rootClient.get<WizardStatus>('/setup-wizard/status');
   return data;
 }
 
 export async function getWizardState(): Promise<WizardState> {
-  const { data } = await apiClient.get<WizardState>('/setup-wizard/state');
+  const { data } = await rootClient.get<WizardState>('/setup-wizard/state');
   return data;
 }
 
 export async function saveAdminAccount(
   account: AdminAccountData,
 ): Promise<WizardState> {
-  const { data } = await apiClient.post<WizardState>(
+  const { data } = await rootClient.post<WizardState>(
     '/setup-wizard/admin-account',
     account,
   );
@@ -108,7 +108,7 @@ export async function saveAdminAccount(
 export async function saveRealmSettings(
   settings: RealmSettingsData,
 ): Promise<WizardState> {
-  const { data } = await apiClient.post<WizardState>(
+  const { data } = await rootClient.post<WizardState>(
     '/setup-wizard/realm-settings',
     settings,
   );
@@ -118,7 +118,7 @@ export async function saveRealmSettings(
 export async function saveSmtpConfig(
   config: SmtpConfigData,
 ): Promise<WizardState> {
-  const { data } = await apiClient.post<WizardState>(
+  const { data } = await rootClient.post<WizardState>(
     '/setup-wizard/smtp-config',
     config,
   );
@@ -126,7 +126,7 @@ export async function saveSmtpConfig(
 }
 
 export async function testSmtp(testData: SmtpTestData): Promise<SmtpTestResult> {
-  const { data } = await apiClient.post<SmtpTestResult>(
+  const { data } = await rootClient.post<SmtpTestResult>(
     '/setup-wizard/smtp/test',
     testData,
   );
@@ -134,7 +134,7 @@ export async function testSmtp(testData: SmtpTestData): Promise<SmtpTestResult> 
 }
 
 export async function saveClient(client: ClientData): Promise<WizardState> {
-  const { data } = await apiClient.post<WizardState>(
+  const { data } = await rootClient.post<WizardState>(
     '/setup-wizard/client',
     client,
   );
@@ -142,24 +142,24 @@ export async function saveClient(client: ClientData): Promise<WizardState> {
 }
 
 export async function markSdkGenerated(): Promise<WizardState> {
-  const { data } = await apiClient.post<WizardState>('/setup-wizard/sdk-generated');
+  const { data } = await rootClient.post<WizardState>('/setup-wizard/sdk-generated');
   return data;
 }
 
 export async function completeWizard(): Promise<WizardCompleteResult> {
-  const { data } = await apiClient.post<WizardCompleteResult>(
+  const { data } = await rootClient.post<WizardCompleteResult>(
     '/setup-wizard/complete',
   );
   return data;
 }
 
 export async function skipWizard(): Promise<WizardState> {
-  const { data } = await apiClient.post<WizardState>('/setup-wizard/skip');
+  const { data } = await rootClient.post<WizardState>('/setup-wizard/skip');
   return data;
 }
 
 export async function resetWizard(): Promise<{ message: string }> {
-  const { data } = await apiClient.post<{ message: string }>(
+  const { data } = await rootClient.post<{ message: string }>(
     '/setup-wizard/reset',
   );
   return data;

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -41,7 +41,6 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/groups`, label: 'Groups', icon: Icons.Groups },
         { to: `/console/realms/${currentRealm}/client-scopes`, label: 'Client Scopes', icon: Icons.Code },
         { to: `/console/realms/${currentRealm}/consent-categories`, label: 'Consent Categories', icon: Icons.ShieldCheck },
-        { to: `/console/realms/${currentRealm}/consent-management`, label: 'Consent Management', icon: Icons.Shield },
         { to: `/console/realms/${currentRealm}/sessions`, label: 'Sessions', icon: Icons.Sessions },
         { to: `/console/realms/${currentRealm}/events`, label: 'Events', icon: Icons.Events },
         { to: `/console/realms/${currentRealm}/admin-events`, label: 'Admin Events', icon: Icons.Clock },

--- a/admin-ui/src/pages/consent/ConsentCategoriesListPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoriesListPage.tsx
@@ -41,7 +41,7 @@ export default function ConsentCategoriesListPage() {
         </div>
         <button
           onClick={() =>
-            navigate(`/console/realms/${name}/consent-categories/create`)
+            navigate(`/console/realms/${name}/consent-categories/new`)
           }
           className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
         >

--- a/admin-ui/vite.config.ts
+++ b/admin-ui/vite.config.ts
@@ -8,11 +8,24 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
+      // Admin API — controllers are mounted under `admin/...`, so forward the
+      // path unchanged (do NOT strip `/admin`, or every admin call 404s).
       '/admin': {
         target: 'http://localhost:3000',
         changeOrigin: true,
         secure: false,
-        rewrite: (path) => path.replace(/^\/admin/, ''),
+      },
+      // Root-mounted controllers the admin-ui also calls (no `/admin` prefix):
+      // realm registration endpoints and the first-run setup wizard.
+      '/realms': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false,
+      },
+      '/setup-wizard': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+        secure: false,
       },
       '/health': {
         target: 'http://localhost:3000',


### PR DESCRIPTION
## Summary
Repairs a family of **pre-existing** frontend↔backend contract and routing bugs in the admin console, found in `SYSTEM_AUDIT.md`. All of these exist byte-for-byte on `origin/main` — **none were introduced by the redesign branch.** Frontend-only changes; no backend behavior touched.

| Finding | Fix |
|---|---|
| **F-01** (Critical) | `vite.config.ts` dev proxy stripped `/admin` via `rewrite`, so every admin call 404'd in `npm run dev` (controllers mount at `admin/...`). Removed the rewrite; also proxy root-mounted `/realms` + `/setup-wizard`. |
| **F-02** (High) | `consent.ts` double-prefixed `/admin` (baseURL is already `/admin`) → `/admin/admin/...` 404 on 7 category+stats calls. Dropped the prefix; removed dead `getCategoryStatistics` (no backend route). |
| **F-04 / F-07** (High) | setup-wizard (`/setup-wizard/*`) and realm registration (`/realms/:realm/registration/*`) are root-mounted, but wizard.ts/registration.ts went through the `/admin` baseURL → 404. Added a `rootClient` axios instance (baseURL `/`, same auth + 401 interceptor) — mirrors the existing `getHealthStatus` pattern. |
| **F-03** (High) | Removed dead "Consent Management" sidebar link (no matching route). |
| **F-12** (Medium) | Mounted `PendingRegistrations` under `/console/realms/:name/registration-approvals` so it receives `:name` (was realm-less → query disabled → never fired). |
| _adjacent_ | Consent Categories "Create" button pointed at non-existent `/consent-categories/create` route (create-mode key is `/new`) → spurious GET 404. Pointed at `/new`. |

## Verification (local throwaway stack: Postgres + Nest :3007 + Vite, real Chromium)
- `/admin/realms` reaches the admin controller through the fixed proxy → **200** (was 404).
- Consent Categories list + create form load; POST reaches `/admin/realms/.../consent-categories` (controller, not `/admin/admin/...`).
- Consent Statistics call → **200**.
- Registration approvals fires `GET /realms/master/registration/pending` → **200**.
- "Consent Management" no longer in the sidebar.
- `tsc -b`, `vite build`, `eslint .`, `vitest` (330 passed) all green.

## Out of scope / deferred (noted, not fixed here)
- Once F-02 unblocked the 404s, a **deeper FE↔BE response-shape divergence** surfaced on the consent feature (FE `ConsentCategory` uses `name`; backend uses `key`/`displayName`, and `ConsentStatistics` expects 7d/30d action metrics the backend doesn't return → stats page crashes). This is a separate design-level issue, **not** the prefix bug F-02 scopes, and a proper fix needs backend metrics / type reconciliation. Tracked for follow-up.
- DO-NOT-TOUCH per goal: F-13 (in-memory creds = intentional XSS hardening), F-14 (staged restyle), F-06/F-08/F-09 (orphaned upgrade/nhi/theme-builder/CV features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)