### PR TITLE
fix(admin): API-key console usable + lazy realm overview + 404 realm nav (F-10,11,15)

### DIFF
--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { NavLink, Outlet, useParams, useNavigate } from 'react-router-dom';
+import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getAllRealms } from '../api/realms';
 import { useAuth } from '../hooks/useAuth';
@@ -10,7 +10,14 @@ import type { IconProps } from './ui';
 type NavItem = { to: string; label: string; icon: (p: IconProps) => React.JSX.Element; end?: boolean };
 
 export default function Layout() {
-  const { name: currentRealm } = useParams<{ name: string }>();
+  const { name: routeRealm } = useParams<{ name: string }>();
+  const location = useLocation();
+  // The in-Layout 404 catch-all (`*`) doesn't match the `:name` param, so fall
+  // back to the realm in the URL. This keeps the realm sidebar present on a
+  // realm-scoped 404 (F-15); the `realms.some(...)` guard below still rejects
+  // non-realm segments such as `/console/realms/create`.
+  const currentRealm =
+    routeRealm ?? location.pathname.match(/^\/console\/realms\/([^/]+)/)?.[1];
   const navigate = useNavigate();
   const { logout } = useAuth();
   const [realmDropdownOpen, setRealmDropdownOpen] = useState(false);

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -35,51 +35,57 @@ export default function RealmDetailPage() {
     enabled: !!name,
   });
 
+  // Sub-resource lists are loaded lazily per tab so opening a realm doesn't fire
+  // a thundering herd of parallel list calls on mount. The overview counts below
+  // are only shown on the General tab; the theme list only on the Theme tab.
+  const overviewEnabled = !!name && !!realm && activeTab === 'general';
+
   const { data: users } = useQuery({
     queryKey: ['users', name],
     queryFn: () => getUsers(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: clients } = useQuery({
     queryKey: ['clients', name],
     queryFn: () => getClients(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: roles } = useQuery({
     queryKey: ['roles', name],
     queryFn: () => getRealmRoles(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: groups } = useQuery({
     queryKey: ['groups', name],
     queryFn: () => getGroups(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: clientScopes } = useQuery({
     queryKey: ['clientScopes', name],
     queryFn: () => getClientScopes(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: sessions } = useQuery({
     queryKey: ['sessions', name],
     queryFn: () => getRealmSessions(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: identityProviders } = useQuery({
     queryKey: ['identity-providers', name],
     queryFn: () => getIdentityProviders(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: themes } = useQuery({
     queryKey: ['themes'],
     queryFn: () => getThemes(),
+    enabled: activeTab === 'theme',
   });
 
   const [form, setForm] = useState({

--- a/src/rate-limit/rate-limit.service.ts
+++ b/src/rate-limit/rate-limit.service.ts
@@ -77,10 +77,15 @@ export class RateLimitService {
   }
 
   async checkAdminApiKeyLimit(ip: string): Promise<RateLimitResult> {
-    // Production defaults preserved (15/min, 100/hour); overridable via env so
-    // test/CI harnesses are not throttled. Non-numeric/absent env => default.
-    const perMinute = this.envInt('ADMIN_API_KEY_RL_PER_MINUTE', 15);
-    const perHour = this.envInt('ADMIN_API_KEY_RL_PER_HOUR', 100);
+    // Defaults sized for real admin-console use: the console authenticates with
+    // an admin API key and a single page (e.g. the realm overview) legitimately
+    // issues a burst of parallel requests. The previous 15/min default throttled
+    // the console into 429 cascades on a normal page load. 60/min + 1000/hour
+    // still bounds brute-force/abuse while leaving headroom for interactive use.
+    // Overridable via env so test/CI harnesses are not throttled; non-numeric or
+    // absent env => default.
+    const perMinute = this.envInt('ADMIN_API_KEY_RL_PER_MINUTE', 60);
+    const perHour = this.envInt('ADMIN_API_KEY_RL_PER_HOUR', 1000);
     return this.check(`admin:apikey:${ip}`, perMinute, perHour);
   }
 


### PR DESCRIPTION
## Summary
Perf/UX batch from `SYSTEM_AUDIT.md`.

| Finding | Fix |
|---|---|
| **F-10** (High) | Per-IP admin **API-key** rate limit raised from **15/min + 100/hr → 60/min + 1000/hr** (`rate-limit.service.ts`). The console authenticates via an admin API key and a single realm-overview load bursts several parallel calls; the old default 429-cascaded the page and locked the console out within a few loads. New defaults stay bounded against brute-force/abuse and remain env-overridable. (JWT/password login was never throttled by this limiter.) |
| **F-11** (Medium) | `RealmDetailPage` eager-loaded **8 sub-resource lists in parallel on mount**. Each query is now gated on its owning tab — the 7 overview counts on the **General** tab, the theme list on the **Theme** tab — so navigating a realm no longer fires a thundering herd. |
| **F-15** (Nit) | The in-Layout `*` catch-all doesn't match `:name`, so the realm sidebar vanished on a realm-scoped 404. Layout now derives the realm from the URL as a fallback; the existing `realms.some(...)` guard still rejects non-realm segments like `/realms/create`. |

## Verification (local stack, real Chromium, **API-key auth**)
- Realm overview under API-key login: all requests **200, zero 429** (limit header now `60`).
- `themes` fires **only** when the Theme tab is opened (lazy); general-tab load no longer requests it.
- Realm-scoped 404 (`/console/realms/master/consent-management`): shows 404 **and** keeps all 13 realm sidebar links.
- `tsc -b`, `vite build`, `eslint` (FE + the changed BE file), `vitest` (330 passed), backend rate-limit + guard specs all green.

## Notes
- Deeper aggregation (a single realm-counts endpoint) would let even the General tab avoid N list calls, but that needs a new backend endpoint — out of scope here; the raised limit already removes the 429 risk.
- DO-NOT-TOUCH per goal: F-13 (in-memory creds), F-14 (staged restyle), F-06/F-08/F-09 (orphaned features).

🤖 Generated with [Claude Code](https://claude.com/claude-code)