### PR TITLE
Merge dev → main: admin perf/limit fixes (B2)

### DIFF
--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { NavLink, Outlet, useParams, useNavigate } from 'react-router-dom';
+import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { getAllRealms } from '../api/realms';
 import { useAuth } from '../hooks/useAuth';
@@ -10,7 +10,14 @@ import type { IconProps } from './ui';
 type NavItem = { to: string; label: string; icon: (p: IconProps) => React.JSX.Element; end?: boolean };
 
 export default function Layout() {
-  const { name: currentRealm } = useParams<{ name: string }>();
+  const { name: routeRealm } = useParams<{ name: string }>();
+  const location = useLocation();
+  // The in-Layout 404 catch-all (`*`) doesn't match the `:name` param, so fall
+  // back to the realm in the URL. This keeps the realm sidebar present on a
+  // realm-scoped 404 (F-15); the `realms.some(...)` guard below still rejects
+  // non-realm segments such as `/console/realms/create`.
+  const currentRealm =
+    routeRealm ?? location.pathname.match(/^\/console\/realms\/([^/]+)/)?.[1];
   const navigate = useNavigate();
   const { logout } = useAuth();
   const [realmDropdownOpen, setRealmDropdownOpen] = useState(false);

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -35,51 +35,57 @@ export default function RealmDetailPage() {
     enabled: !!name,
   });
 
+  // Sub-resource lists are loaded lazily per tab so opening a realm doesn't fire
+  // a thundering herd of parallel list calls on mount. The overview counts below
+  // are only shown on the General tab; the theme list only on the Theme tab.
+  const overviewEnabled = !!name && !!realm && activeTab === 'general';
+
   const { data: users } = useQuery({
     queryKey: ['users', name],
     queryFn: () => getUsers(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: clients } = useQuery({
     queryKey: ['clients', name],
     queryFn: () => getClients(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: roles } = useQuery({
     queryKey: ['roles', name],
     queryFn: () => getRealmRoles(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: groups } = useQuery({
     queryKey: ['groups', name],
     queryFn: () => getGroups(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: clientScopes } = useQuery({
     queryKey: ['clientScopes', name],
     queryFn: () => getClientScopes(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: sessions } = useQuery({
     queryKey: ['sessions', name],
     queryFn: () => getRealmSessions(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: identityProviders } = useQuery({
     queryKey: ['identity-providers', name],
     queryFn: () => getIdentityProviders(name!),
-    enabled: !!name && !!realm,
+    enabled: overviewEnabled,
   });
 
   const { data: themes } = useQuery({
     queryKey: ['themes'],
     queryFn: () => getThemes(),
+    enabled: activeTab === 'theme',
   });
 
   const [form, setForm] = useState({

--- a/src/rate-limit/rate-limit.service.ts
+++ b/src/rate-limit/rate-limit.service.ts
@@ -77,10 +77,15 @@ export class RateLimitService {
   }
 
   async checkAdminApiKeyLimit(ip: string): Promise<RateLimitResult> {
-    // Production defaults preserved (15/min, 100/hour); overridable via env so
-    // test/CI harnesses are not throttled. Non-numeric/absent env => default.
-    const perMinute = this.envInt('ADMIN_API_KEY_RL_PER_MINUTE', 15);
-    const perHour = this.envInt('ADMIN_API_KEY_RL_PER_HOUR', 100);
+    // Defaults sized for real admin-console use: the console authenticates with
+    // an admin API key and a single page (e.g. the realm overview) legitimately
+    // issues a burst of parallel requests. The previous 15/min default throttled
+    // the console into 429 cascades on a normal page load. 60/min + 1000/hour
+    // still bounds brute-force/abuse while leaving headroom for interactive use.
+    // Overridable via env so test/CI harnesses are not throttled; non-numeric or
+    // absent env => default.
+    const perMinute = this.envInt('ADMIN_API_KEY_RL_PER_MINUTE', 60);
+    const perHour = this.envInt('ADMIN_API_KEY_RL_PER_HOUR', 1000);
     return this.check(`admin:apikey:${ip}`, perMinute, perHour);
   }
 


### PR DESCRIPTION
Promotes B2 (PR #942) from `dev` to `main`: F-10 (admin API-key rate-limit defaults 15→60/min, 100→1000/hr), F-11 (RealmDetailPage lazy-per-tab loading), F-15 (realm sidebar persists on realm-scoped 404). CI green on source PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)