### PR TITLE
ci: least-privilege GITHUB_TOKEN permissions (CodeQL alerts #1–#7)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+# Minimal default token permissions; jobs only read repo contents.
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Run Benchmarks & Generate Report

--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -11,6 +11,10 @@ on:
       - 'src/**'
       - 'prisma/**'
 
+# Minimal default token permissions; the job only reads repo contents.
+permissions:
+  contents: read
+
 jobs:
   breaking-change-check:
     name: API Breaking Change Detection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Minimal default token permissions; all jobs only read repo contents
+# (checkout, install, test, build, upload-artifact). Elevate per-job if a
+# future job needs write access.
+permissions:
+  contents: read
+
 jobs:
   lint-and-unit-tests:
     name: Lint & Unit Tests

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [main]
 
+# Minimal default token permissions; the job only reads the diff.
+permissions:
+  contents: read
+
 jobs:
   hygiene:
     name: PR hygiene


### PR DESCRIPTION
## Summary
Resolves the 7 CodeQL `actions/missing-workflow-permissions` alerts (#1–#7) by adding a least-privilege top-level `permissions: { contents: read }` to every workflow.

| Alert(s) | Workflow |
|---|---|
| #2, #4, #5, #7 | `ci.yml` (covers all 4 jobs: lint/unit, e2e, admin-ui, build) |
| #1 | `benchmark.yml` |
| #3 | `breaking-change-check.yml` |
| #6 | `pr-hygiene.yml` |

All these jobs are read-only (checkout, install, test, build, `upload-artifact`, `$GITHUB_STEP_SUMMARY`); none push commits, comment on PRs, or publish packages, so `contents: read` is sufficient and drops every other default `GITHUB_TOKEN` scope. The CI run on this PR is itself the verification that the jobs still function under the restricted token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)