### PR TITLE
fix(scim): ReDoS + biased token RNG + prototype-pollution (CodeQL #15,#16,#27,#28)

### DIFF
--- a/src/scim/filter-parser.redos.spec.ts
+++ b/src/scim/filter-parser.redos.spec.ts
@@ -1,0 +1,39 @@
+import { parseScimFilter } from './filter-parser.service';
+
+/**
+ * Regression test for the polynomial-ReDoS fix in parseScimFilter
+ * (CodeQL js/polynomial-redos, alert #15). The value group is now `\S.*`
+ * instead of `.+`, removing the overlap with the preceding `\s+`. Adversarial
+ * input must parse/throw in linear time, and valid filters must still parse.
+ */
+describe('parseScimFilter ReDoS hardening', () => {
+  it('handles a long whitespace-heavy adversarial filter quickly', () => {
+    const adversarial = '. eq ' + '  '.repeat(100_000);
+    const start = Date.now();
+    // Either parses or throws — must not hang.
+    try {
+      parseScimFilter(adversarial);
+    } catch {
+      /* invalid filter is an acceptable outcome */
+    }
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it('still parses a well-formed equality filter', () => {
+    const res = parseScimFilter('userName eq "john"');
+    expect(res.attribute).toBe('userName');
+    expect(res.operator).toBe('eq');
+    // value retains its (quoted) content
+    expect(res.value).toContain('john');
+  });
+
+  it('parses other operators', () => {
+    expect(parseScimFilter('displayName co "Doe"').operator).toBe('co');
+    expect(parseScimFilter('userName sw "jo"').operator).toBe('sw');
+  });
+
+  it('rejects a value that is only whitespace', () => {
+    // `\S.*` requires a non-space first char; a whitespace-only value is invalid.
+    expect(() => parseScimFilter('userName eq    ')).toThrow();
+  });
+});

--- a/src/scim/filter-parser.service.ts
+++ b/src/scim/filter-parser.service.ts
@@ -29,8 +29,12 @@ export function parseScimFilter(filter: string): FilterParseResult {
 
   // Match filter pattern: attribute operator value
   // Operators: eq, ne, co (contains), sw (starts with), ew (ends with), gt, ge, lt, le
+  // The value group is `\S.*` rather than `.+`: forcing the first character to
+  // be non-whitespace removes the overlap with the preceding `\s+`, which was
+  // the source of the polynomial backtracking (CodeQL js/polynomial-redos). The
+  // leading `\s+` already consumed any whitespace before the value.
   const operatorMatch = trimmed.match(
-    /^([\w.]+)\s+(eq|ne|co|sw|ew|gt|ge|lt|le)\s+(.+)$/i,
+    /^([\w.]+)\s+(eq|ne|co|sw|ew|gt|ge|lt|le)\s+(\S.*)$/i,
   );
 
   if (!operatorMatch) {

--- a/src/scim/scim-tokens.service.ts
+++ b/src/scim/scim-tokens.service.ts
@@ -288,10 +288,19 @@ export class ScimTokensService {
     const chars =
       'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~';
     const length = 32;
-    const buffer = randomBytes(length);
+    // Rejection sampling: discard bytes at or above the largest multiple of
+    // chars.length that fits in a byte, so `byte % chars.length` is unbiased
+    // (CodeQL js/biased-cryptographic-random — a plain modulo over-weights the
+    // first 256 % chars.length symbols).
+    const limit = Math.floor(256 / chars.length) * chars.length;
     let token = '';
-    for (let i = 0; i < length; i++) {
-      token += chars[buffer[i] % chars.length];
+    while (token.length < length) {
+      const buffer = randomBytes(length);
+      for (let i = 0; i < buffer.length && token.length < length; i++) {
+        if (buffer[i] < limit) {
+          token += chars[buffer[i] % chars.length];
+        }
+      }
     }
     return token;
   }

--- a/src/scim/scim-users.service.ts
+++ b/src/scim/scim-users.service.ts
@@ -8,7 +8,7 @@ import {
   NotFoundException,
   ConflictException,
   Logger,
-  BadRequestException as _BadRequestException,
+  BadRequestException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
@@ -481,6 +481,13 @@ export class ScimUsersService {
    */
   private setNestedValue(obj: unknown, path: string, value: unknown): void {
     const keys = path.split('.');
+    // Reject prototype-polluting segments from the (user-controlled) SCIM path
+    // before any assignment (CodeQL js/prototype-polluting-assignment). These
+    // are never valid SCIM attribute names.
+    const FORBIDDEN_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+    if (keys.some((key) => FORBIDDEN_KEYS.has(key))) {
+      throw new BadRequestException(`Invalid attribute path: ${path}`);
+    }
     const lastKey = keys.pop()!;
     const target = keys.reduce(
       (current, key) => {


### PR DESCRIPTION
## Summary
Three CodeQL alerts in the SCIM module, all root-caused (no scan suppression).

| Alert | File | Fix |
|---|---|---|
| **#15** `js/polynomial-redos` | `filter-parser.service.ts` | Filter value group `(.+)$` overlapped the preceding `\s+` → super-linear backtracking. Changed to `(\S.*)$` (value starts non-space; `\s+` already ate leading whitespace). |
| **#16** `js/biased-cryptographic-random` | `scim-tokens.service.ts` | Token gen used `byte % 65` directly, over-weighting the first `256 % 65` symbols. Added rejection sampling for an unbiased mapping. |
| **#27/#28** `js/prototype-polluting-assignment` | `scim-users.service.ts` | `setNestedValue` walked a user-controlled SCIM PATCH path; `__proto__`/`prototype`/`constructor` segments are now rejected before any assignment. |

## Verification
- `nest build`, `eslint`, all backend jest pass.
- New `filter-parser.redos.spec.ts`: adversarial whitespace-heavy filter parses in <1 s; valid `eq/co/sw` filters still parse; whitespace-only value rejected.
- CodeQL re-analysis on the dev→main promotion confirms the alerts clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)