### PR TITLE
fix(security): always-secure auth cookies + redact stored creds in CLI (CodeQL #31-37)

### DIFF
--- a/packages/idenplane-cli/src/commands/config.ts
+++ b/packages/idenplane-cli/src/commands/config.ts
@@ -17,10 +17,12 @@ export function registerConfigCommands(program: Command): void {
         console.log(chalk.yellow('No config found. Run `idenplane init` or `idenplane login` first.'));
         return;
       }
+      // Stored credentials are redacted centrally by printResult
+      // (output.ts redactCredentials), so pass them through as-is.
       const display: Record<string, unknown> = {
         serverUrl: config.serverUrl,
-        apiKey: config.apiKey ? `${config.apiKey.slice(0, 6)}${'*'.repeat(Math.max(0, config.apiKey.length - 6))}` : undefined,
-        accessToken: config.accessToken ? '(token saved)' : undefined,
+        apiKey: config.apiKey ?? undefined,
+        accessToken: config.accessToken ?? undefined,
         defaultRealm: config.defaultRealm ?? '(not set)',
       };
       // Remove undefined entries

--- a/packages/idenplane-cli/src/output.ts
+++ b/packages/idenplane-cli/src/output.ts
@@ -1,17 +1,45 @@
 import chalk from 'chalk';
 
+// Stored auth credentials (persisted in the user's config file) — never useful
+// to echo back and a leak risk via shell history / CI logs. They are replaced
+// with a constant so the printed value carries no bytes of the secret (CodeQL
+// js/clear-text-logging). Response-payload secrets such as `clientSecret` from
+// `client rotate-secret` are intentionally NOT redacted — the user ran the
+// command specifically to retrieve that value.
+const STORED_CREDENTIAL_KEYS = new Set(['apiKey', 'accessToken']);
+const REDACTED = '<redacted — see ~/.idenplane/config>';
+
+function redactCredentials<T>(data: T): T {
+  if (Array.isArray(data)) {
+    return data.map((item) => redactCredentials(item)) as T;
+  }
+  if (data && typeof data === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(data as Record<string, unknown>)) {
+      out[key] =
+        STORED_CREDENTIAL_KEYS.has(key) && typeof val === 'string'
+          ? REDACTED
+          : redactCredentials(val);
+    }
+    return out as T;
+  }
+  return data;
+}
+
 export function printResult(data: unknown, opts: { json?: boolean }): void {
+  const safe = redactCredentials(data);
+
   if (opts.json) {
-    console.log(JSON.stringify(data, null, 2));
+    console.log(JSON.stringify(safe, null, 2));
     return;
   }
 
-  if (Array.isArray(data)) {
-    printTable(data);
-  } else if (typeof data === 'object' && data !== null) {
-    printKeyValue(data as Record<string, unknown>);
+  if (Array.isArray(safe)) {
+    printTable(safe);
+  } else if (typeof safe === 'object' && safe !== null) {
+    printKeyValue(safe as Record<string, unknown>);
   } else {
-    console.log(data);
+    console.log(safe);
   }
 }
 

--- a/src/device/device.controller.ts
+++ b/src/device/device.controller.ts
@@ -50,7 +50,7 @@ export class DeviceController {
     const token = this.csrfService.generateToken();
     res.cookie(this.csrfService.cookieName(realm.name), token, {
       httpOnly: true,
-      secure: process.env['NODE_ENV'] === 'production',
+      secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
       sameSite: 'strict',
       path: `/realms/${realm.name}`,
     });

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -91,7 +91,7 @@ export class LoginController {
     const token = this.csrfService.generateToken();
     res.cookie(this.csrfService.cookieName(realm.name), token, {
       httpOnly: true,
-      secure: process.env['NODE_ENV'] === 'production',
+      secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
       sameSite: 'strict',
       path: `/realms/${realm.name}`,
     });
@@ -248,7 +248,7 @@ export class LoginController {
 
             res.cookie('IDENPLANE_MFA_CHALLENGE', challengeToken, {
               httpOnly: true,
-              secure: process.env['NODE_ENV'] === 'production',
+              secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
               sameSite: 'strict',
               maxAge: 5 * 60 * 1000,
               path: `/realms/${realm.name}`,
@@ -336,7 +336,7 @@ export class LoginController {
 
         res.cookie('IDENPLANE_MFA_CHALLENGE', challengeToken, {
           httpOnly: true,
-          secure: process.env['NODE_ENV'] === 'production',
+          secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
           sameSite: 'strict',
           maxAge: 5 * 60 * 1000,
           path: `/realms/${realm.name}`,
@@ -358,7 +358,7 @@ export class LoginController {
 
         res.cookie('IDENPLANE_SESSION', sessionToken, {
           httpOnly: true,
-          secure: process.env['NODE_ENV'] === 'production',
+          secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
           sameSite: 'strict',
           path: `/realms/${realm.name}`,
         });
@@ -426,7 +426,7 @@ export class LoginController {
 
     res.cookie('IDENPLANE_SESSION', sessionToken, {
       httpOnly: true,
-      secure: process.env['NODE_ENV'] === 'production',
+      secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
       sameSite: 'strict',
       maxAge: body['rememberMe'] ? 30 * 24 * 60 * 60 * 1000 : undefined,
       path: `/realms/${realm.name}`,

--- a/src/saml/saml-idp.controller.ts
+++ b/src/saml/saml-idp.controller.ts
@@ -158,7 +158,7 @@ export class SamlIdpController {
       Buffer.from(samlSessionData).toString('base64'),
       {
         httpOnly: true,
-        secure: process.env['NODE_ENV'] === 'production',
+        secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
         sameSite: 'lax',
         maxAge: 10 * 60 * 1000, // 10 minutes
         path: `/realms/${realm.name}`,

--- a/src/webauthn/webauthn.controller.ts
+++ b/src/webauthn/webauthn.controller.ts
@@ -203,7 +203,7 @@ export class WebAuthnController {
 
     res.cookie('IDENPLANE_SESSION', sessionToken, {
       httpOnly: true,
-      secure: process.env['NODE_ENV'] === 'production',
+      secure: true, // session/auth cookies must never traverse plain HTTP (localhost is a secure context)
       sameSite: 'lax',
       path: `/realms/${realm.name}`,
     });


### PR DESCRIPTION
## Summary
Resolves the clear-text CodeQL alerts — all root-caused, no dismissals.

| Alerts | Rule | Fix |
|---|---|---|
| **#33–#37** | `js/clear-text-storage-of-sensitive-data` | Session / MFA-challenge cookies used `secure: NODE_ENV==='production'`. Set **`secure: true`** unconditionally. |
| **#31/#32** | `js/clear-text-logging` | CLI `printResult` echoed stored creds (`apiKey`/`accessToken`) from the config file. Redact those keys with a constant placeholder. |

### Cookies (#33–#37)
Auth/session cookies must never traverse plain HTTP. `localhost`/loopback are secure contexts, so local dev is unaffected; demo & prod are HTTPS. The same conditional in `saml-idp` and `device` cookies got the same hardening for consistency (not individually flagged). DB stores only the SHA-256 hash of these high-entropy tokens — the cookie is the (now HTTPS-only) delivery channel.

### CLI redaction (#31/#32)
`apiKey`/`accessToken` are persisted in `~/.idenplane/config` and never useful to echo — redacted with a constant (breaks the taint; the old `slice()`-mask didn't). **`clientSecret` from `rotate-secret` is intentionally NOT redacted** — the user runs that command specifically to retrieve the value (stored-credential vs transactional-secret distinction). Dropped the now-redundant slice-mask in `config.ts`.

## Verification
- Functional login flow is covered by the supertest e2e suite (in-process; unaffected by the `Secure` flag).
- No test asserts a cookie `secure` value.
- Backend `nest build` + `eslint` clean; CLI `tsc --noEmit` + 30 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)