### PR TITLE
fix(security): backup cmd/path injection + email HTML escaping + scheme check (CodeQL #26,#29,#30,#38,#39)

### DIFF
--- a/src/common/utils/html-escape.util.spec.ts
+++ b/src/common/utils/html-escape.util.spec.ts
@@ -1,0 +1,31 @@
+import { escapeHtml } from './html-escape.util';
+
+describe('escapeHtml', () => {
+  it('escapes all HTML metacharacters', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+    expect(escapeHtml(`"&'<>`)).toBe('&quot;&amp;&#39;&lt;&gt;');
+  });
+
+  it('neutralizes an attribute-breakout payload', () => {
+    // A User-Agent / display name like this must not be able to close the
+    // double-quoted href and inject an onerror handler.
+    const payload = '"><img src=x onerror=alert(1)>';
+    const escaped = escapeHtml(payload);
+    expect(escaped).not.toContain('"');
+    expect(escaped).not.toContain('<');
+    expect(escaped).toBe(
+      '&quot;&gt;&lt;img src=x onerror=alert(1)&gt;',
+    );
+  });
+
+  it('handles null/undefined as empty string', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeHtml('Acme Corp')).toBe('Acme Corp');
+  });
+});

--- a/src/common/utils/html-escape.util.ts
+++ b/src/common/utils/html-escape.util.ts
@@ -1,0 +1,14 @@
+/**
+ * Escape a string for safe interpolation into HTML text or a double-quoted
+ * attribute. Used when building HTML email bodies from values that may contain
+ * user-controlled data (display names, IP addresses, User-Agent, URLs, etc.)
+ * to prevent HTML/script injection (CodeQL js/xss).
+ */
+export function escapeHtml(value: string | number | null | undefined): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/registration/registration.service.ts
+++ b/src/registration/registration.service.ts
@@ -9,6 +9,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
+import { escapeHtml } from '../common/utils/html-escape.util.js';
 import { VerificationService } from '../verification/verification.service.js';
 import { EmailService } from '../email/email.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
@@ -270,11 +271,16 @@ export class RegistrationService {
     const verifyUrl = `${baseUrl}/realms/${realm.name}/verify-email?token=${rawToken}`;
 
     const subject = `${realm.displayName || realm.name} - Verify your email`;
+    // Escape interpolations into the HTML body (CodeQL js/xss). The realm
+    // display name is operator-controlled and the URL is app-built, but both
+    // are escaped defensively so no value can break out of the markup.
+    const safeRealm = escapeHtml(realm.displayName || realm.name);
+    const safeVerifyUrl = escapeHtml(verifyUrl);
     const html = `
-      <h1>Welcome to ${realm.displayName || realm.name}!</h1>
+      <h1>Welcome to ${safeRealm}!</h1>
       <p>Please verify your email address by clicking the link below:</p>
-      <p><a href="${verifyUrl}">Verify Email</a></p>
-      <p>Or copy and paste this URL: ${verifyUrl}</p>
+      <p><a href="${safeVerifyUrl}">Verify Email</a></p>
+      <p>Or copy and paste this URL: ${safeVerifyUrl}</p>
       <p>This link will expire in 24 hours.</p>
     `;
 
@@ -296,9 +302,13 @@ export class RegistrationService {
     if (!configured) return;
 
     const subject = `Welcome to ${realm.displayName || realm.name}!`;
+    // username is user-chosen and realm display name operator-set — escape both
+    // before interpolating into the HTML body (CodeQL js/xss).
+    const safeUsername = escapeHtml(username);
+    const safeRealm = escapeHtml(realm.displayName || realm.name);
     const html = `
-      <h1>Welcome, ${username}!</h1>
-      <p>Your account has been successfully created in ${realm.displayName || realm.name}.</p>
+      <h1>Welcome, ${safeUsername}!</h1>
+      <p>Your account has been successfully created in ${safeRealm}.</p>
       <p>You can now log in and start using the system.</p>
     `;
 

--- a/src/risk-assessment/risk-assessment.service.ts
+++ b/src/risk-assessment/risk-assessment.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { EmailService } from '../email/email.service.js';
+import { escapeHtml } from '../common/utils/html-escape.util.js';
 import { ImpossibleTravelService } from './impossible-travel.service.js';
 import {
   RiskSignal,
@@ -242,9 +243,12 @@ export class RiskAssessmentService {
   ): Promise<void> {
     if (!this.emailService) return;
 
-    const time = context.timestamp.toUTCString();
-    const location = geoLocation ?? 'Unknown location';
-    const ip = context.ipAddress ?? 'Unknown';
+    // Escape every interpolated value — IP, geo-location, and User-Agent are
+    // attacker-controlled request data going into an HTML email (CodeQL js/xss).
+    const time = escapeHtml(context.timestamp.toUTCString());
+    const location = escapeHtml(geoLocation ?? 'Unknown location');
+    const ip = escapeHtml(context.ipAddress ?? 'Unknown');
+    const device = escapeHtml(context.userAgent ?? 'Unknown');
 
     const html = `
       <h2>Suspicious Login Attempt Blocked</h2>
@@ -253,7 +257,7 @@ export class RiskAssessmentService {
         <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Time</td><td>${time}</td></tr>
         <tr><td style="padding:4px 12px 4px 0;font-weight:bold">IP Address</td><td>${ip}</td></tr>
         <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Location</td><td>${location}</td></tr>
-        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Device</td><td>${context.userAgent ?? 'Unknown'}</td></tr>
+        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Device</td><td>${device}</td></tr>
       </table>
       <p style="margin-top:16px">
         If this was you, please contact your administrator.<br/>

--- a/src/upgrade/database-backup.service.ts
+++ b/src/upgrade/database-backup.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as zlib from 'zlib';
 import { PrismaClient } from '@prisma/client';
 
 export interface BackupResult {
@@ -72,17 +73,18 @@ export class DatabaseBackupService {
       const databaseUrl = process.env.DATABASE_URL || '';
       const dbName = this.extractDatabaseName(databaseUrl);
 
-      // Build pg_dump command
-      const pgDumpCmd = this.buildPgDumpCommand(dbName, backupPath);
+      // Build pg_dump argument vector and run it WITHOUT a shell. Passing args
+      // as an array to execFileSync means no value is ever interpreted by a
+      // shell, eliminating command injection (CodeQL js/command-line-injection).
+      const pgDumpArgs = this.buildPgDumpArgs(dbName, backupPath);
 
-      this.logger.debug(
-        `Executing: ${pgDumpCmd.replace(/--password=\S+/g, '--password=******')}`,
-      );
+      this.logger.debug(`Executing: pg_dump ${pgDumpArgs.join(' ')}`);
 
-      // Execute pg_dump
-      execSync(pgDumpCmd, {
+      // Execute pg_dump (password supplied via PGPASSWORD env, never argv).
+      execFileSync('pg_dump', pgDumpArgs, {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        env: this.pgEnv(),
       });
 
       const duration = Date.now() - startTime;
@@ -141,18 +143,29 @@ export class DatabaseBackupService {
       const databaseUrl = process.env.DATABASE_URL || '';
       const dbName = this.extractDatabaseName(databaseUrl);
 
-      // Build pg_restore or psql command based on file extension
-      const restoreCmd = this.buildRestoreCommand(backupPath, dbName);
+      // Run pg_restore WITHOUT a shell (arg array → no command injection).
+      // Compressed (.gz) backups are decompressed in-process with zlib and fed
+      // to pg_restore over stdin, replacing the previous `gunzip -c | pg_restore`
+      // shell pipe (CodeQL js/command-line-injection / shell-command-injection).
+      const restoreArgs = this.buildRestoreArgs(dbName);
+      const env = this.pgEnv();
 
-      this.logger.debug(
-        `Executing: ${restoreCmd.replace(/--password=\S+/g, '--password=******')}`,
-      );
+      this.logger.debug(`Executing: pg_restore ${restoreArgs.join(' ')}`);
 
-      // Execute restore command
-      execSync(restoreCmd, {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+      if (backupPath.endsWith('.gz')) {
+        const decompressed = zlib.gunzipSync(fs.readFileSync(backupPath));
+        execFileSync('pg_restore', restoreArgs, {
+          input: decompressed,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+        });
+      } else {
+        execFileSync('pg_restore', [...restoreArgs, backupPath], {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+        });
+      }
 
       const duration = Date.now() - startTime;
 
@@ -298,68 +311,57 @@ export class DatabaseBackupService {
   /**
    * Build pg_dump command with appropriate options for backup.
    */
-  private buildPgDumpCommand(databaseName: string, outputPath: string): string {
+  /** Connection params for the pg_* tools, sourced from the environment. */
+  private pgConnParams(): {
+    host: string;
+    port: string;
+    user: string;
+    password: string;
+  } {
     const env = process.env;
-    const host = env.PGHOST || 'localhost';
-    const port = env.PGPORT || '5432';
-    const user = env.PGUSER || env.DATABASE_USERNAME || 'postgres';
-    const password = env.PGPASSWORD || env.DATABASE_PASSWORD || '';
-
-    // pg_dump with compression for PostgreSQL
-    const cmd = [
-      'pg_dump',
-      `-h ${host}`,
-      `-p ${port}`,
-      `-U ${user}`,
-      `-d ${databaseName}`,
-      '-Fc', // Custom format for compression
-      '-Z 6', // Compression level 6
-      '-f',
-      outputPath,
-    ];
-
-    if (password) {
-      cmd.push(`--password=${password}`);
-    }
-
-    return cmd.join(' ');
+    return {
+      host: env.PGHOST || 'localhost',
+      port: env.PGPORT || '5432',
+      user: env.PGUSER || env.DATABASE_USERNAME || 'postgres',
+      password: env.PGPASSWORD || env.DATABASE_PASSWORD || '',
+    };
   }
 
   /**
-   * Build pg_restore command for restoring from backup.
+   * Environment for pg_* child processes: the connection password is passed via
+   * PGPASSWORD rather than on the command line (avoids leaking it in argv / ps).
    */
-  private buildRestoreCommand(
-    backupPath: string,
-    databaseName: string,
-  ): string {
-    const env = process.env;
-    const host = env.PGHOST || 'localhost';
-    const port = env.PGPORT || '5432';
-    const user = env.PGUSER || env.DATABASE_USERNAME || 'postgres';
-    const password = env.PGPASSWORD || env.DATABASE_PASSWORD || '';
+  private pgEnv(): NodeJS.ProcessEnv {
+    const { password } = this.pgConnParams();
+    return password
+      ? { ...process.env, PGPASSWORD: password }
+      : { ...process.env };
+  }
 
-    const isCompressed = backupPath.endsWith('.gz');
-
-    if (isCompressed) {
-      // Decompress and pipe to pg_restore
-      return `gunzip -c "${backupPath}" | pg_restore -h ${host} -p ${port} -U ${user} -d ${databaseName}${password ? ` --password=${password}` : ''}`;
-    }
-
-    // pg_restore for custom format
-    const cmd = [
-      'pg_restore',
-      `-h ${host}`,
-      `-p ${port}`,
-      `-U ${user}`,
-      `-d ${databaseName}`,
-      backupPath,
+  /** pg_dump argument vector (no shell — passed straight to execFileSync). */
+  private buildPgDumpArgs(databaseName: string, outputPath: string): string[] {
+    const { host, port, user } = this.pgConnParams();
+    return [
+      '-h',
+      host,
+      '-p',
+      port,
+      '-U',
+      user,
+      '-d',
+      databaseName,
+      '-Fc', // Custom format for compression
+      '-Z',
+      '6', // Compression level 6
+      '-f',
+      outputPath,
     ];
+  }
 
-    if (password) {
-      cmd.push(`--password=${password}`);
-    }
-
-    return cmd.join(' ');
+  /** pg_restore argument vector (target db); the source is the file/stdin. */
+  private buildRestoreArgs(databaseName: string): string[] {
+    const { host, port, user } = this.pgConnParams();
+    return ['-h', host, '-p', port, '-U', user, '-d', databaseName];
   }
 
   /**
@@ -377,7 +379,14 @@ export class DatabaseBackupService {
    */
   private getFileSize(filePath: string): string {
     try {
-      const stats = fs.statSync(filePath);
+      // Constrain the stat to the backup directory so a crafted path can't be
+      // used to probe arbitrary files (CodeQL js/path-injection).
+      const root = path.resolve(this.backupDirectory);
+      const resolved = path.resolve(filePath);
+      if (resolved !== root && !resolved.startsWith(root + path.sep)) {
+        return 'unknown';
+      }
+      const stats = fs.statSync(resolved);
       return this.formatFileSize(stats.size);
     } catch {
       return 'unknown';

--- a/test/bug-reproduction-round2.e2e-spec.ts
+++ b/test/bug-reproduction-round2.e2e-spec.ts
@@ -115,11 +115,14 @@ describe('Bug Reproduction Tests - Round 2 (e2e)', () => {
       // ACTUAL: May redirect to javascript: URL - OPEN REDIRECT
       if (res.status === 302 || res.status === 303) {
         const location = res.get('Location') || '';
-        if (location.startsWith('javascript:')) {
-          console.log('BUG CONFIRMED: Open redirect to javascript: URL!');
+        // Check all dangerous URL schemes, not just javascript: (CodeQL
+        // js/incomplete-url-scheme-check) — data: and vbscript: are equally unsafe.
+        if (/^(javascript|data|vbscript):/i.test(location)) {
+          console.log('BUG CONFIRMED: Open redirect to dangerous-scheme URL!');
         }
         expect(location).not.toMatch(/^javascript:/i);
         expect(location).not.toMatch(/^data:/i);
+        expect(location).not.toMatch(/^vbscript:/i);
       }
     });
 


### PR DESCRIPTION
## Summary
Final cluster of CodeQL alerts, all root-caused.

| Alert | Rule | Fix |
|---|---|---|
| **#29** (Critical) | `js/command-line-injection` | `database-backup.service.ts`: pg_dump built as a shell string → run via `execFileSync` with an **arg vector** (no shell). |
| **#30** | `js/shell-command-injection-from-environment` | pg_restore likewise; the `gunzip -c \| pg_restore` shell pipe → in-process `zlib.gunzipSync` piped to pg_restore over **stdin**. DB password now via `PGPASSWORD` env, never argv. |
| **#39** | `js/path-injection` | `getFileSize` constrains `statSync` to within the backup directory (`path.resolve` + prefix check). |
| **#26** | `js/xss` | HTML email bodies interpolated user-controlled values unescaped (registration `username`/realm name/verify URL; risk-assessment client IP / geo / **User-Agent**). New shared `escapeHtml` util applied at each interpolation. |
| **#38** | `js/incomplete-url-scheme-check` | Open-redirect repro test only branched on `javascript:` → now `javascript:`/`data:`/`vbscript:`. |

## Verification
- `nest build` + `eslint` clean.
- 113 registration / risk-assessment / upgrade jest tests pass; new `escapeHtml` unit tests (incl. attribute-breakout payload) pass.

Note: the **upgrade** module stays orphaned/unwired (F-08) — only the vulnerabilities are fixed; the feature is neither wired nor removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)