### PR TITLE
fix(security): sever remaining CodeQL taint (api-key fingerprint, backup path)

### DIFF
--- a/src/common/guards/admin-api-key.guard.ts
+++ b/src/common/guards/admin-api-key.guard.ts
@@ -9,7 +9,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import type { Request, Response } from 'express';
 import { Reflector } from '@nestjs/core';
-import { timingSafeEqual, createHash } from 'crypto';
+import { timingSafeEqual } from 'crypto';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator.js';
 import { AdminAuthService } from '../../admin-auth/admin-auth.service.js';
 import { RateLimitService } from '../../rate-limit/rate-limit.service.js';
@@ -85,16 +85,13 @@ export class AdminApiKeyGuard implements CanActivate {
         providedApiKey.length === expectedKey.length &&
         timingSafeEqual(Buffer.from(providedApiKey), Buffer.from(expectedKey))
       ) {
-        // Fingerprint the configured key (not the request value) — execution
-        // only reaches here once timingSafeEqual proved they are equal, so the
-        // fingerprint is identical, but the data hashed is now the server-side
-        // constant rather than request input (CodeQL js/insufficient-password-hash).
-        const keyFingerprint = createHash('sha256')
-          .update(expectedKey)
-          .digest('hex')
-          .slice(0, 12);
+        // There is a single configured ADMIN_API_KEY, so a key-derived
+        // fingerprint would always be the same constant — and hashing the key
+        // (request- or config-sourced) trips CodeQL js/insufficient-password-hash.
+        // Use a stable static identifier; the `api-key:` prefix is what
+        // downstream consumers branch on (impersonation/mfa/brute-force).
         adminReq.adminUser = {
-          userId: `api-key:${keyFingerprint}`,
+          userId: 'api-key:admin',
           roles: ['super-admin'],
         };
         return true;

--- a/src/graphql/guards/graphql-auth.guard.ts
+++ b/src/graphql/guards/graphql-auth.guard.ts
@@ -11,7 +11,7 @@ import { Reflector } from '@nestjs/core';
 import { AdminAuthService } from '../../admin-auth/admin-auth.service.js';
 import { RateLimitService } from '../../rate-limit/rate-limit.service.js';
 import { resolveClientIp } from '../../common/utils/proxy-ip.util.js';
-import { createHash, timingSafeEqual } from 'crypto';
+import { timingSafeEqual } from 'crypto';
 
 type AuthRequest = Request & {
   adminUser?: { userId: string; roles: string[] };
@@ -78,16 +78,12 @@ export class GraphQLAuthGuard implements CanActivate {
         providedApiKey.length === expectedKey.length &&
         timingSafeEqual(Buffer.from(providedApiKey), Buffer.from(expectedKey))
       ) {
-        // Fingerprint the configured key (not the request value) — execution
-        // only reaches here once timingSafeEqual proved they are equal, so the
-        // fingerprint is identical, but the data hashed is now the server-side
-        // constant rather than request input (CodeQL js/insufficient-password-hash).
-        const keyFingerprint = createHash('sha256')
-          .update(expectedKey)
-          .digest('hex')
-          .slice(0, 12);
+        // Single configured ADMIN_API_KEY → a key-derived fingerprint is always
+        // the same constant, and hashing the key trips CodeQL
+        // js/insufficient-password-hash. Use a stable static identifier; the
+        // `api-key:` prefix is what downstream consumers branch on.
         request.adminUser = {
-          userId: `api-key:${keyFingerprint}`,
+          userId: 'api-key:admin',
           roles: ['super-admin'],
         };
         return true;

--- a/src/upgrade/database-backup.service.ts
+++ b/src/upgrade/database-backup.service.ts
@@ -379,14 +379,13 @@ export class DatabaseBackupService {
    */
   private getFileSize(filePath: string): string {
     try {
-      // Constrain the stat to the backup directory so a crafted path can't be
-      // used to probe arbitrary files (CodeQL js/path-injection).
+      // Strip any directory component with path.basename so the stat target can
+      // only ever be a file directly inside the backup directory — a crafted
+      // path cannot traverse out (CodeQL js/path-injection). All callers pass a
+      // path already inside backupDirectory, so basename is behaviour-preserving.
       const root = path.resolve(this.backupDirectory);
-      const resolved = path.resolve(filePath);
-      if (resolved !== root && !resolved.startsWith(root + path.sep)) {
-        return 'unknown';
-      }
-      const stats = fs.statSync(resolved);
+      const safePath = path.join(root, path.basename(filePath));
+      const stats = fs.statSync(safePath);
       return this.formatFileSize(stats.size);
     } catch {
       return 'unknown';


### PR DESCRIPTION
Follow-up to B3: CodeQL's PR check on #951 reported 3 new high alerts because the earlier barriers weren't recognized.

- **#17/#19** `js/insufficient-password-hash`: hashing the *configured* `expectedKey` still trips the rule (`configService.get` is itself a password source). With a single `ADMIN_API_KEY`, the fingerprint is a constant anyway → replaced with a static `userId: 'api-key:admin'` and removed the SHA-256 entirely. The `api-key:` prefix (the only thing consumers branch on) is preserved.
- **#39** `js/path-injection`: `startsWith(root)` wasn't credited as a barrier → use `path.join(root, path.basename(filePath))` (basename strips traversal). Behaviour-preserving — all callers pass an in-dir path.

Verified: `nest build` + `eslint` clean; 76 guard/graphql/upgrade tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)