### PR TITLE
fix(consent): reconcile FE↔BE contract + full consent statistics (F-16)

### DIFF
--- a/admin-ui/src/api/consent.ts
+++ b/admin-ui/src/api/consent.ts
@@ -60,47 +60,28 @@ export async function deleteConsentCategory(
 // User Consents
 // ---------------------------------------------------------------------------
 
+// A consent is an OAuth scope grant per client (no GDPR-category link); the
+// shape mirrors users.service.getUserConsents exactly.
 export interface UserConsent {
   id: string;
-  userId: string;
   clientId: string;
-  categoryId: string;
-  grantedAt: string;
-  grantedVia: string;
-  policyVersion: string | null;
-  client?: {
-    id: string;
-    clientId: string;
-    name: string | null;
-  };
-  category?: {
-    id: string;
-    name: string;
-    required: boolean;
-  };
+  clientName: string;
+  scopes: string[];
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface UserConsentHistoryEntry {
   id: string;
-  userId: string;
   clientId: string;
-  categoryId: string;
+  clientName: string;
   action: string;
-  performedBy: string | null;
-  performedAt: string;
+  scopes: string[];
+  policyVersion: string | null;
   ipAddress: string | null;
   userAgent: string | null;
-  policyVersion: string | null;
-  client?: {
-    id: string;
-    clientId: string;
-    name: string | null;
-  };
-  category?: {
-    id: string;
-    name: string;
-    required: boolean;
-  };
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
 }
 
 export async function getUserConsents(
@@ -113,24 +94,38 @@ export async function getUserConsents(
   return data;
 }
 
+export interface UserConsentHistoryResponse {
+  history: UserConsentHistoryEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 export async function getUserConsentHistory(
   realmName: string,
   userId: string,
   page = 1,
   limit = 20,
-): Promise<{ history: UserConsentHistoryEntry[]; total: number }> {
-  const { data } = await apiClient.get<{
-    history: UserConsentHistoryEntry[];
-    total: number;
-  }>(`/realms/${realmName}/users/${userId}/consents/history`, {
-    params: { page, limit },
-  });
+): Promise<UserConsentHistoryResponse> {
+  const { data } = await apiClient.get<UserConsentHistoryResponse>(
+    `/realms/${realmName}/users/${userId}/consents/history`,
+    { params: { page, limit } },
+  );
   return data;
 }
 
 // ---------------------------------------------------------------------------
 // Consent Statistics
 // ---------------------------------------------------------------------------
+
+export interface ConsentCategoryCount {
+  categoryId: string;
+  categoryKey: string;
+  categoryName: string;
+  required: boolean;
+  totalGrants: number;
+  distinctUsers: number;
+}
 
 export interface ConsentStatistics {
   totalConsents: number;
@@ -140,12 +135,12 @@ export interface ConsentStatistics {
   consentActionsLast24h: number;
   consentActionsLast7d: number;
   consentActionsLast30d: number;
-  consentsByCategory: Array<{
-    categoryId: string;
-    categoryName: string;
-    totalGrants: number;
-  }>;
+  consentsGranted24h: number;
+  consentsRevoked24h: number;
+  consentsUpdated24h: number;
+  consentsByCategory: ConsentCategoryCount[];
   pendingDeletions: number;
+  pendingDeletionsGracePeriod: number;
 }
 
 export async function getConsentStatistics(
@@ -153,6 +148,34 @@ export async function getConsentStatistics(
 ): Promise<ConsentStatistics> {
   const { data } = await apiClient.get<ConsentStatistics>(
     `/realms/${realmName}/stats/consents`,
+  );
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Per-category statistics
+// ---------------------------------------------------------------------------
+
+export interface CategoryStatistics {
+  categoryId: string;
+  categoryKey: string;
+  categoryName: string;
+  totalGrants: number;
+  totalRevokes: number;
+  grants24h: number;
+  grants7d: number;
+  grants30d: number;
+  activeUsers24h: number;
+  activeUsers7d: number;
+  activeUsers30d: number;
+}
+
+export async function getCategoryStatistics(
+  realmName: string,
+  categoryId: string,
+): Promise<CategoryStatistics> {
+  const { data } = await apiClient.get<CategoryStatistics>(
+    `/realms/${realmName}/consent-categories/${categoryId}/stats`,
   );
   return data;
 }

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -48,6 +48,7 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/groups`, label: 'Groups', icon: Icons.Groups },
         { to: `/console/realms/${currentRealm}/client-scopes`, label: 'Client Scopes', icon: Icons.Code },
         { to: `/console/realms/${currentRealm}/consent-categories`, label: 'Consent Categories', icon: Icons.ShieldCheck },
+        { to: `/console/realms/${currentRealm}/consent-statistics`, label: 'Consent Statistics', icon: Icons.Trend },
         { to: `/console/realms/${currentRealm}/sessions`, label: 'Sessions', icon: Icons.Sessions },
         { to: `/console/realms/${currentRealm}/events`, label: 'Events', icon: Icons.Events },
         { to: `/console/realms/${currentRealm}/admin-events`, label: 'Admin Events', icon: Icons.Clock },

--- a/admin-ui/src/components/consent/UserConsentPanel.tsx
+++ b/admin-ui/src/components/consent/UserConsentPanel.tsx
@@ -8,6 +8,8 @@ interface UserConsentPanelProps {
   username: string;
 }
 
+const PAGE_SIZE = 20;
+
 export default function UserConsentPanel({ realmName, userId, username }: UserConsentPanelProps) {
   const [activeTab, setActiveTab] = useState<'current' | 'history'>('current');
   const [historyPage, setHistoryPage] = useState(1);
@@ -20,7 +22,7 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
 
   const { data: historyData, isLoading: loadingHistory } = useQuery({
     queryKey: ['userConsentHistory', realmName, userId, historyPage],
-    queryFn: () => getUserConsentHistory(realmName, userId, historyPage),
+    queryFn: () => getUserConsentHistory(realmName, userId, historyPage, PAGE_SIZE),
     enabled: !!realmName && !!userId,
   });
 
@@ -32,9 +34,10 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
     );
   }
 
-  const groupedConsents = groupConsentsByClient(consents ?? []);
   const hasConsents = consents && consents.length > 0;
-  const hasHistory = historyData && historyData.history && historyData.history.length > 0;
+  const hasHistory = historyData && historyData.history.length > 0;
+  const pageSize = historyData?.pageSize ?? PAGE_SIZE;
+  const total = historyData?.total ?? 0;
 
   return (
     <div className="space-y-6">
@@ -74,81 +77,49 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
         </nav>
       </div>
 
-      {/* Current Consents Tab */}
+      {/* Current Consents Tab — one card per client, listing granted scopes */}
       {activeTab === 'current' && (
         <div className="space-y-4">
           {hasConsents ? (
-            <div className="space-y-6">
-              {Object.entries(groupedConsents).map(([clientId, clientConsents]) => (
+            <div className="space-y-4">
+              {consents.map((consent: UserConsent) => (
                 <div
-                  key={clientId}
+                  key={consent.id}
                   className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
                 >
-                  <div className="mb-4 flex items-center justify-between">
+                  <div className="mb-3 flex items-center justify-between">
                     <h3 className="text-base font-medium text-gray-900">
-                      {clientConsents[0].client?.name ?? clientConsents[0].client?.clientId ?? clientId}
+                      {consent.clientName}
                     </h3>
-                    <span className="text-xs text-gray-500">
-                      {clientConsents[0].client?.clientId ?? clientId}
+                    <span className="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
+                      Active
                     </span>
                   </div>
-                  <div className="divide-y divide-gray-100">
-                    {clientConsents.map((consent) => (
-                      <div key={consent.id} className="flex items-center justify-between py-3">
-                        <div className="flex items-center gap-3">
-                          <div
-                            className={`h-2.5 w-2.5 rounded-full ${
-                              consent.category?.required
-                                ? 'bg-amber-400'
-                                : 'bg-green-400'
-                            }`}
-                          />
-                          <div>
-                            <p className="text-sm font-medium text-gray-900">
-                              {consent.category?.name ?? 'Unknown Category'}
-                              {consent.category?.required && (
-                                <span className="ml-2 text-xs text-amber-600">(Required)</span>
-                              )}
-                            </p>
-                            <p className="text-xs text-gray-500">
-                              Granted on {formatDate(consent.grantedAt)} via {consent.grantedVia}
-                              {consent.policyVersion && ` · Policy v${consent.policyVersion}`}
-                            </p>
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="inline-flex rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700">
-                            Active
-                          </span>
-                        </div>
-                      </div>
-                    ))}
+                  <div className="flex flex-wrap gap-1.5">
+                    {consent.scopes.length > 0 ? (
+                      consent.scopes.map((scope) => (
+                        <span
+                          key={scope}
+                          className="inline-flex rounded-md bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700"
+                        >
+                          {scope}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="text-xs text-gray-400">No scopes</span>
+                    )}
                   </div>
+                  <p className="mt-3 text-xs text-gray-500">
+                    Granted {formatDate(consent.createdAt)}
+                  </p>
                 </div>
               ))}
             </div>
           ) : (
-            <div className="rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
-              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
-                <svg
-                  className="h-6 w-6 text-gray-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <h3 className="mt-4 text-sm font-medium text-gray-900">No consents found</h3>
-              <p className="mt-1 text-sm text-gray-500">
-                This user has not granted any consents yet.
-              </p>
-            </div>
+            <EmptyState
+              title="No consents found"
+              message="This user has not granted any consents yet."
+            />
           )}
         </div>
       )}
@@ -166,46 +137,36 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
                         Action
                       </th>
                       <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Category
+                        Client
                       </th>
                       <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Client
+                        Scopes
                       </th>
                       <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
                         Date
                       </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-                        Performed By
-                      </th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-200">
-                    {historyData?.history.map((entry) => (
+                    {historyData.history.map((entry) => (
                       <tr key={entry.id} className="hover:bg-gray-50">
                         <td className="whitespace-nowrap px-4 py-3 text-sm">
                           <span
-                            className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
-                              entry.action === 'GRANTED'
-                                ? 'bg-green-100 text-green-700'
-                                : entry.action === 'REVOKED'
-                                ? 'bg-red-100 text-red-700'
-                                : 'bg-blue-100 text-blue-700'
-                            }`}
+                            className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${actionClass(
+                              entry.action,
+                            )}`}
                           >
                             {formatAction(entry.action)}
                           </span>
                         </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-900">
-                          {entry.category?.name ?? 'Unknown'}
+                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
+                          {entry.clientName}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-500">
+                          {entry.scopes.length > 0 ? entry.scopes.join(', ') : '-'}
                         </td>
                         <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
-                          {entry.client?.name ?? entry.client?.clientId ?? '-'}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
-                          {formatDate(entry.performedAt)}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
-                          {entry.performedBy ?? 'User'}
+                          {formatDate(entry.createdAt)}
                         </td>
                       </tr>
                     ))}
@@ -216,9 +177,8 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
               {/* Pagination */}
               <div className="flex items-center justify-between">
                 <p className="text-sm text-gray-500">
-                  Showing {((historyPage - 1) * 20) + 1} to{' '}
-                  {Math.min(historyPage * 20, historyData?.total ?? 0)} of{' '}
-                  {historyData?.total ?? 0} entries
+                  Showing {(historyPage - 1) * pageSize + 1} to{' '}
+                  {Math.min(historyPage * pageSize, total)} of {total} entries
                 </p>
                 <div className="flex gap-2">
                   <button
@@ -230,7 +190,7 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
                   </button>
                   <button
                     onClick={() => setHistoryPage((p) => p + 1)}
-                    disabled={!historyData || historyPage * 20 >= historyData.total}
+                    disabled={historyPage * pageSize >= total}
                     className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                   >
                     Next
@@ -239,27 +199,10 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
               </div>
             </>
           ) : (
-            <div className="rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
-              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
-                <svg
-                  className="h-6 w-6 text-gray-400"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-              </div>
-              <h3 className="mt-4 text-sm font-medium text-gray-900">No consent history</h3>
-              <p className="mt-1 text-sm text-gray-500">
-                This user has no recorded consent activity.
-              </p>
-            </div>
+            <EmptyState
+              title="No consent history"
+              message="This user has no recorded consent activity."
+            />
           )}
         </div>
       )}
@@ -267,18 +210,30 @@ export default function UserConsentPanel({ realmName, userId, username }: UserCo
   );
 }
 
-function groupConsentsByClient(consents: UserConsent[]): Record<string, UserConsent[]> {
-  return consents.reduce(
-    (acc, consent) => {
-      const key = consent.clientId;
-      if (!acc[key]) {
-        acc[key] = [];
-      }
-      acc[key].push(consent);
-      return acc;
-    },
-    {} as Record<string, UserConsent[]>,
+function EmptyState({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-8 text-center shadow-sm">
+      <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
+        <svg className="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      </div>
+      <h3 className="mt-4 text-sm font-medium text-gray-900">{title}</h3>
+      <p className="mt-1 text-sm text-gray-500">{message}</p>
+    </div>
   );
+}
+
+function actionClass(action: string): string {
+  const a = action.toLowerCase();
+  if (a === 'granted') return 'bg-green-100 text-green-700';
+  if (a === 'revoked') return 'bg-red-100 text-red-700';
+  return 'bg-blue-100 text-blue-700';
 }
 
 function formatDate(dateString: string): string {
@@ -296,11 +251,11 @@ function formatDate(dateString: string): string {
 }
 
 function formatAction(action: string): string {
-  const actionLabels: Record<string, string> = {
-    GRANTED: 'Granted',
-    REVOKED: 'Revoked',
-    UPDATED: 'Updated',
-    EXPIRED: 'Expired',
+  const labels: Record<string, string> = {
+    granted: 'Granted',
+    revoked: 'Revoked',
+    updated: 'Updated',
+    expired: 'Expired',
   };
-  return actionLabels[action] ?? action;
+  return labels[action.toLowerCase()] ?? action;
 }

--- a/admin-ui/src/components/consent/__tests__/UserConsentPanel.test.tsx
+++ b/admin-ui/src/components/consent/__tests__/UserConsentPanel.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test/utils';
+import UserConsentPanel from '../UserConsentPanel';
+
+describe('UserConsentPanel', () => {
+  const renderPanel = () =>
+    render(
+      <UserConsentPanel realmName="test-realm" userId="user-1" username="alice" />,
+    );
+
+  it('renders current consents with client name and scopes', async () => {
+    renderPanel();
+    await screen.findByText('Test Client');
+    // scopes render as chips
+    expect(screen.getByText('openid')).toBeInTheDocument();
+    expect(screen.getByText('profile')).toBeInTheDocument();
+    // no fictional "Invalid Date" / "undefined" leaks
+    expect(screen.queryByText(/invalid date/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/undefined/i)).not.toBeInTheDocument();
+  });
+
+  it('renders consent history with action, client and scopes', async () => {
+    renderPanel();
+    // switch to the history tab
+    const historyTab = await screen.findByRole('button', { name: /consent history/i });
+    historyTab.click();
+    await screen.findByText('Granted');
+    expect(screen.getByText('openid, profile')).toBeInTheDocument();
+    // pagination summary uses the real total
+    expect(screen.getByText(/of 1 entries/i)).toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/pages/consent/ConsentCategoriesListPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoriesListPage.tsx
@@ -57,6 +57,9 @@ export default function ConsentCategoriesListPage() {
                 Name
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                Key
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
                 Description
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
@@ -80,7 +83,12 @@ export default function ConsentCategoriesListPage() {
                   className="cursor-pointer hover:bg-gray-50"
                 >
                   <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-indigo-600">
-                    {category.name}
+                    {category.displayName}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <code className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700">
+                      {category.key}
+                    </code>
                   </td>
                   <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-700">
                     {category.description || '-'}
@@ -104,7 +112,7 @@ export default function ConsentCategoriesListPage() {
             ) : (
               <tr>
                 <td
-                  colSpan={4}
+                  colSpan={5}
                   className="px-6 py-8 text-center text-sm text-gray-500"
                 >
                   No consent categories found in this realm.

--- a/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
@@ -3,25 +3,44 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getConsentCategoryById,
+  getCategoryStatistics,
   createConsentCategory,
   updateConsentCategory,
   deleteConsentCategory,
 } from '../../api/consent';
+import type { ConsentCategory } from '../../types';
 import ConfirmDialog from '../../components/ConfirmDialog';
 
 const isCreateMode = (categoryId: string | undefined) =>
   !categoryId || categoryId === 'new';
 
+interface CategoryForm {
+  key: string;
+  displayName: string;
+  description: string;
+  required: boolean;
+  configurableByUser: boolean;
+  showInAccountPortal: boolean;
+  order: number;
+}
+
+const EMPTY_FORM: CategoryForm = {
+  key: '',
+  displayName: '',
+  description: '',
+  required: false,
+  configurableByUser: true,
+  showInAccountPortal: true,
+  order: 0,
+};
+
 export default function ConsentCategoryDetailPage() {
   const { name, categoryId } = useParams<{ name: string; categoryId?: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const isEdit = !isCreateMode(categoryId);
 
-  const [form, setForm] = useState({
-    name: '',
-    description: '',
-    required: false,
-  });
+  const [form, setForm] = useState<CategoryForm>(EMPTY_FORM);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [successMessage, setSuccessMessage] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
@@ -29,7 +48,13 @@ export default function ConsentCategoryDetailPage() {
   const { data: category, isLoading } = useQuery({
     queryKey: ['consentCategory', name, categoryId],
     queryFn: () => getConsentCategoryById(name!, categoryId!),
-    enabled: !isCreateMode(categoryId) && !!name && !!categoryId,
+    enabled: isEdit && !!name && !!categoryId,
+  });
+
+  const { data: stats } = useQuery({
+    queryKey: ['consentCategoryStats', name, categoryId],
+    queryFn: () => getCategoryStatistics(name!, categoryId!),
+    enabled: isEdit && !!name && !!categoryId,
   });
 
   // Seed the editable form from fetched data when the loaded category changes.
@@ -38,15 +63,34 @@ export default function ConsentCategoryDetailPage() {
   if (category && category !== seededCategory) {
     setSeededCategory(category);
     setForm({
-      name: category.name,
-      description: category.description || '',
+      key: category.key,
+      displayName: category.displayName,
+      description: category.description ?? '',
       required: category.required,
+      configurableByUser: category.configurableByUser,
+      showInAccountPortal: category.showInAccountPortal,
+      order: category.order,
     });
   }
 
+  // Create accepts the full shape; update keeps the key immutable.
+  const toCreatePayload = (f: CategoryForm): Partial<ConsentCategory> => ({
+    key: f.key,
+    displayName: f.displayName,
+    description: f.description || null,
+    required: f.required,
+    configurableByUser: f.configurableByUser,
+    showInAccountPortal: f.showInAccountPortal,
+    order: f.order,
+  });
+  const toUpdatePayload = (f: CategoryForm): Partial<ConsentCategory> => {
+    const { key: _key, ...rest } = toCreatePayload(f);
+    void _key;
+    return rest;
+  };
+
   const createMutation = useMutation({
-    mutationFn: (data: { name: string; description: string; required: boolean }) =>
-      createConsentCategory(name!, data),
+    mutationFn: () => createConsentCategory(name!, toCreatePayload(form)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['consentCategories', name] });
       setSuccessMessage('Consent category created successfully');
@@ -60,8 +104,7 @@ export default function ConsentCategoryDetailPage() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: (data: { name: string; description: string; required: boolean }) =>
-      updateConsentCategory(name!, categoryId!, data),
+    mutationFn: () => updateConsentCategory(name!, categoryId!, toUpdatePayload(form)),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['consentCategory', name, categoryId] });
       queryClient.invalidateQueries({ queryKey: ['consentCategories', name] });
@@ -90,22 +133,14 @@ export default function ConsentCategoryDetailPage() {
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
-    if (isCreateMode(categoryId)) {
-      createMutation.mutate({
-        name: form.name,
-        description: form.description,
-        required: form.required,
-      });
+    if (isEdit) {
+      updateMutation.mutate();
     } else {
-      updateMutation.mutate({
-        name: form.name,
-        description: form.description,
-        required: form.required,
-      });
+      createMutation.mutate();
     }
   };
 
-  if (!isCreateMode(categoryId) && isLoading) {
+  if (isEdit && isLoading) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="text-gray-500">Loading...</div>
@@ -113,7 +148,7 @@ export default function ConsentCategoryDetailPage() {
     );
   }
 
-  if (!isCreateMode(categoryId) && !category) {
+  if (isEdit && !category) {
     return (
       <div className="flex items-center justify-center py-12">
         <div className="text-gray-500">Consent category not found</div>
@@ -121,8 +156,9 @@ export default function ConsentCategoryDetailPage() {
     );
   }
 
-  const isEdit = !isCreateMode(categoryId);
-  const pageTitle = isEdit ? category?.name ?? 'Edit Category' : 'Create Consent Category';
+  const pageTitle = isEdit
+    ? category?.displayName ?? 'Edit Category'
+    : 'Create Consent Category';
 
   return (
     <div className="space-y-6">
@@ -163,14 +199,34 @@ export default function ConsentCategoryDetailPage() {
         <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label htmlFor="name" className="block text-sm font-medium text-gray-700">
-              Name
+            <label htmlFor="key" className="block text-sm font-medium text-gray-700">
+              Key
             </label>
             <input
               type="text"
-              id="name"
-              value={form.name}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              id="key"
+              value={form.key}
+              onChange={(e) => setForm({ ...form, key: e.target.value })}
+              required
+              disabled={isEdit}
+              placeholder="marketing_emails"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500"
+            />
+            <p className="mt-1 text-xs text-gray-400">
+              {isEdit
+                ? 'The key is immutable once created.'
+                : 'Stable, unique identifier within this realm.'}
+            </p>
+          </div>
+          <div>
+            <label htmlFor="displayName" className="block text-sm font-medium text-gray-700">
+              Display Name
+            </label>
+            <input
+              type="text"
+              id="displayName"
+              value={form.displayName}
+              onChange={(e) => setForm({ ...form, displayName: e.target.value })}
               required
               className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
             />
@@ -187,19 +243,57 @@ export default function ConsentCategoryDetailPage() {
               className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
             />
           </div>
-          <div className="flex items-center gap-4">
-            <div className="flex items-center gap-2">
+          <div>
+            <label htmlFor="order" className="block text-sm font-medium text-gray-700">
+              Display Order
+            </label>
+            <input
+              type="number"
+              id="order"
+              min={0}
+              value={form.order}
+              onChange={(e) =>
+                setForm({ ...form, order: Number(e.target.value) || 0 })
+              }
+              className="w-32 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div className="flex flex-col gap-3">
+            <label className="flex items-center gap-2">
               <input
                 type="checkbox"
-                id="required"
                 checked={form.required}
                 onChange={(e) => setForm({ ...form, required: e.target.checked })}
                 className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
               />
-              <label htmlFor="required" className="text-sm font-medium text-gray-700">
-                Required
-              </label>
-            </div>
+              <span className="text-sm font-medium text-gray-700">Required</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.configurableByUser}
+                onChange={(e) =>
+                  setForm({ ...form, configurableByUser: e.target.checked })
+                }
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm font-medium text-gray-700">
+                Configurable by user
+              </span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.showInAccountPortal}
+                onChange={(e) =>
+                  setForm({ ...form, showInAccountPortal: e.target.checked })
+                }
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm font-medium text-gray-700">
+                Show in account portal
+              </span>
+            </label>
           </div>
           <div>
             <button
@@ -218,6 +312,23 @@ export default function ConsentCategoryDetailPage() {
           </div>
         </form>
       </div>
+
+      {/* Usage statistics (edit mode) */}
+      {isEdit && stats && (
+        <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+          <h2 className="mb-4 text-lg font-semibold text-gray-900">Usage</h2>
+          <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <CategoryStat label="Total Grants" value={stats.totalGrants} />
+            <CategoryStat label="Total Revokes" value={stats.totalRevokes} />
+            <CategoryStat label="Grants (24h)" value={stats.grants24h} />
+            <CategoryStat label="Grants (7d)" value={stats.grants7d} />
+            <CategoryStat label="Grants (30d)" value={stats.grants30d} />
+            <CategoryStat label="Active Users (24h)" value={stats.activeUsers24h} />
+            <CategoryStat label="Active Users (7d)" value={stats.activeUsers7d} />
+            <CategoryStat label="Active Users (30d)" value={stats.activeUsers30d} />
+          </dl>
+        </div>
+      )}
 
       {/* Metadata (only in edit mode) */}
       {isEdit && category && (
@@ -238,10 +349,21 @@ export default function ConsentCategoryDetailPage() {
       <ConfirmDialog
         isOpen={showDeleteDialog}
         title="Delete Consent Category"
-        message={`Are you sure you want to delete the consent category "${category?.name}"? This action cannot be undone.`}
+        message={`Are you sure you want to delete the consent category "${category?.displayName}"? This action cannot be undone.`}
         onConfirm={() => deleteMutation.mutate()}
         onCancel={() => setShowDeleteDialog(false)}
       />
+    </div>
+  );
+}
+
+function CategoryStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md bg-gray-50 p-3">
+      <dt className="text-xs font-medium text-gray-500">{label}</dt>
+      <dd className="mt-1 text-xl font-bold text-gray-900">
+        {value.toLocaleString()}
+      </dd>
     </div>
   );
 }

--- a/admin-ui/src/pages/consent/__tests__/ConsentPages.test.tsx
+++ b/admin-ui/src/pages/consent/__tests__/ConsentPages.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test/utils';
+import ConsentCategoriesListPage from '../ConsentCategoriesListPage';
+import ConsentStatisticsPage from '../ConsentStatisticsPage';
+import ConsentCategoryDetailPage from '../ConsentCategoryDetailPage';
+
+const REALM = 'test-realm';
+
+describe('ConsentCategoriesListPage', () => {
+  const renderPage = () =>
+    render(<ConsentCategoriesListPage />, {
+      initialUrl: `/console/realms/${REALM}/consent-categories`,
+      routePattern: '/console/realms/:name/consent-categories',
+    });
+
+  it('renders categories by display name and key', async () => {
+    renderPage();
+    await screen.findByText('Marketing');
+    expect(screen.getByText('Analytics')).toBeInTheDocument();
+    // keys rendered in their own column
+    expect(screen.getByText('marketing')).toBeInTheDocument();
+    expect(screen.getByText('analytics')).toBeInTheDocument();
+  });
+});
+
+describe('ConsentStatisticsPage', () => {
+  const renderPage = () =>
+    render(<ConsentStatisticsPage />, {
+      initialUrl: `/console/realms/${REALM}/consent-statistics`,
+      routePattern: '/console/realms/:name/consent-statistics',
+    });
+
+  it('renders the action-window metrics and per-category grants', async () => {
+    renderPage();
+    // total consents
+    await screen.findByText('42');
+    // action window values (24h=8, 7d=25, 30d=60)
+    expect(screen.getByText('25')).toBeInTheDocument();
+    expect(screen.getByText('60')).toBeInTheDocument();
+    // category breakdown: name + totalGrants
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+  });
+});
+
+describe('ConsentCategoryDetailPage', () => {
+  it('create mode shows editable key + display name fields', async () => {
+    render(<ConsentCategoryDetailPage />, {
+      initialUrl: `/console/realms/${REALM}/consent-categories/new`,
+      routePattern: '/console/realms/:name/consent-categories/:categoryId',
+    });
+    expect(
+      screen.getByRole('heading', { name: /create consent category/i }),
+    ).toBeInTheDocument();
+    const key = screen.getByLabelText('Key') as HTMLInputElement;
+    expect(key).toBeEnabled();
+    expect(screen.getByLabelText('Display Name')).toBeInTheDocument();
+  });
+
+  it('edit mode loads the category and shows usage statistics', async () => {
+    render(<ConsentCategoryDetailPage />, {
+      initialUrl: `/console/realms/${REALM}/consent-categories/cat-1`,
+      routePattern: '/console/realms/:name/consent-categories/:categoryId',
+    });
+    // displayName seeded into the form
+    await screen.findByDisplayValue('Marketing');
+    // key field is immutable in edit mode
+    const key = screen.getByLabelText('Key') as HTMLInputElement;
+    expect(key).toBeDisabled();
+    // per-category stats panel
+    await screen.findByText('Usage');
+    expect(screen.getByText('Total Grants')).toBeInTheDocument();
+    expect(screen.getByText('120')).toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/test/mocks/data.ts
+++ b/admin-ui/src/test/mocks/data.ts
@@ -1,4 +1,4 @@
-import type { Realm, User, Client, Role, NhiIdentity } from '../../types';
+import type { Realm, User, Client, Role, NhiIdentity, ConsentCategory } from '../../types';
 import type { LoginEvent, AdminEvent } from '../../api/events';
 import type { RealmStats } from '../../api/stats';
 import type { AuthFlow } from '../../api/authFlows';
@@ -239,6 +239,26 @@ export function makeNhiIdentity(overrides: Partial<NhiIdentity> = {}): NhiIdenti
     certificateNotAfter: null,
     suspendedAt: null,
     decommissionedAt: null,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function makeConsentCategory(
+  overrides: Partial<ConsentCategory> = {},
+): ConsentCategory {
+  return {
+    id: 'cat-1',
+    realmId: 'realm-1',
+    key: 'marketing',
+    displayName: 'Marketing',
+    description: 'Marketing communications',
+    required: false,
+    configurableByUser: true,
+    showInAccountPortal: true,
+    order: 0,
+    enabled: true,
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     ...overrides,

--- a/admin-ui/src/test/mocks/handlers.ts
+++ b/admin-ui/src/test/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { makeRealm, makeUser, makeClient, makeLoginEvent, makeAdminEvent, makeStats, makeAuthFlow, makeUpgradeAuditEntry, makePreUpgradeValidationResult, makeUpgradeHealthResult, makeRollbackCapability, makeNhiIdentity } from './data';
+import { makeRealm, makeUser, makeClient, makeLoginEvent, makeAdminEvent, makeStats, makeAuthFlow, makeUpgradeAuditEntry, makePreUpgradeValidationResult, makeUpgradeHealthResult, makeRollbackCapability, makeNhiIdentity, makeConsentCategory } from './data';
 
 const BASE = '/admin';
 
@@ -261,5 +261,86 @@ export const handlers = [
         createdBy: 'admin',
       },
     ]);
+  }),
+
+  // Consent categories
+  http.get(`${BASE}/realms/:name/consent-categories`, () => {
+    return HttpResponse.json([
+      makeConsentCategory({ id: 'cat-1', key: 'marketing', displayName: 'Marketing' }),
+      makeConsentCategory({
+        id: 'cat-2',
+        key: 'analytics',
+        displayName: 'Analytics',
+        required: true,
+      }),
+    ]);
+  }),
+
+  http.get(`${BASE}/realms/:name/consent-categories/:id/stats`, ({ params }) => {
+    return HttpResponse.json({
+      categoryId: params.id,
+      categoryKey: 'marketing',
+      categoryName: 'Marketing',
+      totalGrants: 120,
+      totalRevokes: 8,
+      grants24h: 5,
+      grants7d: 30,
+      grants30d: 95,
+      activeUsers24h: 4,
+      activeUsers7d: 22,
+      activeUsers30d: 70,
+    });
+  }),
+
+  http.get(`${BASE}/realms/:name/consent-categories/:id`, ({ params }) => {
+    return HttpResponse.json(
+      makeConsentCategory({ id: params.id as string }),
+    );
+  }),
+
+  http.post(`${BASE}/realms/:name/consent-categories`, async ({ request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json(makeConsentCategory({ id: 'cat-new', ...body }), {
+      status: 201,
+    });
+  }),
+
+  http.put(`${BASE}/realms/:name/consent-categories/:id`, async ({ params, request }) => {
+    const body = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json(
+      makeConsentCategory({ id: params.id as string, ...body }),
+    );
+  }),
+
+  http.delete(`${BASE}/realms/:name/consent-categories/:id`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // Consent statistics (realm)
+  http.get(`${BASE}/realms/:name/stats/consents`, () => {
+    return HttpResponse.json({
+      totalConsents: 42,
+      activeUsersWithConsents24h: 5,
+      activeUsersWithConsents7d: 12,
+      activeUsersWithConsents30d: 30,
+      consentActionsLast24h: 8,
+      consentActionsLast7d: 25,
+      consentActionsLast30d: 60,
+      consentsGranted24h: 6,
+      consentsRevoked24h: 1,
+      consentsUpdated24h: 1,
+      consentsByCategory: [
+        {
+          categoryId: 'cat-1',
+          categoryKey: 'marketing',
+          categoryName: 'Marketing',
+          required: false,
+          totalGrants: 120,
+          distinctUsers: 70,
+        },
+      ],
+      pendingDeletions: 3,
+      pendingDeletionsGracePeriod: 1,
+    });
   }),
 ];

--- a/admin-ui/src/test/mocks/handlers.ts
+++ b/admin-ui/src/test/mocks/handlers.ts
@@ -316,6 +316,45 @@ export const handlers = [
     return new HttpResponse(null, { status: 204 });
   }),
 
+  // User consents (per-client scope grants) + history
+  http.get(`${BASE}/realms/:name/users/:id/consents`, () => {
+    return HttpResponse.json([
+      {
+        id: 'uc-1',
+        clientId: 'client-1',
+        clientName: 'Test Client',
+        scopes: ['openid', 'profile'],
+        createdAt: '2026-05-20T10:00:00.000Z',
+        updatedAt: '2026-05-20T10:00:00.000Z',
+      },
+    ]);
+  }),
+
+  http.get(`${BASE}/realms/:name/users/:id/consents/history`, ({ request }) => {
+    const url = new URL(request.url);
+    const page = Number(url.searchParams.get('page') ?? 1);
+    const limit = Number(url.searchParams.get('limit') ?? 20);
+    return HttpResponse.json({
+      history: [
+        {
+          id: 'uch-1',
+          clientId: 'client-1',
+          clientName: 'Test Client',
+          action: 'granted',
+          scopes: ['openid', 'profile'],
+          policyVersion: null,
+          ipAddress: '127.0.0.1',
+          userAgent: 'test',
+          metadata: null,
+          createdAt: '2026-05-20T10:00:00.000Z',
+        },
+      ],
+      total: 1,
+      page,
+      pageSize: limit,
+    });
+  }),
+
   // Consent statistics (realm)
   http.get(`${BASE}/realms/:name/stats/consents`, () => {
     return HttpResponse.json({

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -339,11 +339,17 @@ export interface NhiAuditLog {
 
 export interface ConsentCategory {
   id: string;
-  name: string;
+  realmId: string;
+  /** Stable, unique-per-realm identifier (immutable in practice). */
+  key: string;
+  /** Human-readable label. */
+  displayName: string;
   description: string | null;
   required: boolean;
+  configurableByUser: boolean;
+  showInAccountPortal: boolean;
+  order: number;
   enabled: boolean;
-  policyVersion: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/consent/consent-categories.controller.ts
+++ b/src/consent/consent-categories.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import type { Realm } from '@prisma/client';
 import { ConsentCategoryService } from './consent-category.service.js';
+import { ConsentStatisticsService } from './consent-stats.service.js';
 import { CreateConsentCategoryDto } from './dto/create-consent-category.dto.js';
 import { UpdateConsentCategoryDto } from './dto/update-consent-category.dto.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
@@ -30,7 +31,10 @@ import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 @UseGuards(RealmGuard, AdminApiKeyGuard)
 @ApiSecurity('admin-api-key')
 export class ConsentCategoriesController {
-  constructor(private readonly service: ConsentCategoryService) {}
+  constructor(
+    private readonly service: ConsentCategoryService,
+    private readonly statsService: ConsentStatisticsService,
+  ) {}
 
   @Get('consent-categories')
   @ApiOperation({ summary: 'List consent categories in a realm' })
@@ -53,6 +57,18 @@ export class ConsentCategoriesController {
     @Param('categoryId') categoryId: string,
   ) {
     return this.service.findById(realm, categoryId);
+  }
+
+  @Get('consent-categories/:categoryId/stats')
+  @ApiOperation({ summary: 'Get usage statistics for a consent category' })
+  @ApiResponse({ status: 200, description: 'Consent category statistics' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Not found' })
+  stats(
+    @CurrentRealm() realm: Realm,
+    @Param('categoryId') categoryId: string,
+  ) {
+    return this.statsService.getCategoryStats(realm, categoryId);
   }
 
   @Post('consent-categories')

--- a/src/consent/consent-stats.service.spec.ts
+++ b/src/consent/consent-stats.service.spec.ts
@@ -1,0 +1,149 @@
+import { NotFoundException } from '@nestjs/common';
+import type { Realm } from '@prisma/client';
+import { ConsentStatisticsService } from './consent-stats.service.js';
+import {
+  createMockPrismaService,
+  type MockPrismaService,
+} from '../prisma/prisma.mock.js';
+
+describe('ConsentStatisticsService', () => {
+  let service: ConsentStatisticsService;
+  let prisma: MockPrismaService;
+
+  const realm = { id: 'realm-1', name: 'test' } as Realm;
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+    service = new ConsentStatisticsService(prisma as any);
+  });
+
+  describe('getRealmConsentStats', () => {
+    it('aggregates totals, action windows, per-type 24h and category breakdown', async () => {
+      // count() is used for: totalConsents, 3 action windows, 3 per-type 24h,
+      // 2 pending-deletion counts, and per-category totalGrants.
+      prisma.userConsent.count.mockResolvedValue(42);
+
+      // distinct-user windows use groupBy().length
+      prisma.userConsentHistory.groupBy
+        .mockResolvedValueOnce([{ userId: 'u1' }, { userId: 'u2' }]) // active 24h
+        .mockResolvedValueOnce([{ userId: 'u1' }, { userId: 'u2' }, { userId: 'u3' }]) // active 7d
+        .mockResolvedValueOnce([
+          { userId: 'u1' },
+          { userId: 'u2' },
+          { userId: 'u3' },
+          { userId: 'u4' },
+        ]) // active 30d
+        .mockResolvedValue([{ userId: 'u1' }]); // per-category distinctUsers
+
+      prisma.userConsentHistory.count
+        .mockResolvedValueOnce(10) // actions 24h
+        .mockResolvedValueOnce(25) // actions 7d
+        .mockResolvedValueOnce(60) // actions 30d
+        .mockResolvedValueOnce(7) // granted 24h
+        .mockResolvedValueOnce(2) // revoked 24h
+        .mockResolvedValueOnce(1) // updated 24h
+        .mockResolvedValue(5); // per-category totalGrants
+
+      prisma.consentCategory.findMany.mockResolvedValue([
+        { id: 'c1', key: 'marketing', displayName: 'Marketing', required: false },
+      ]);
+
+      prisma.pendingDeletion.count
+        .mockResolvedValueOnce(3) // pendingDeletions
+        .mockResolvedValueOnce(1); // within grace period
+
+      const stats = await service.getRealmConsentStats(realm);
+
+      expect(stats.totalConsents).toBe(42);
+      expect(stats.activeUsersWithConsents24h).toBe(2);
+      expect(stats.activeUsersWithConsents7d).toBe(3);
+      expect(stats.activeUsersWithConsents30d).toBe(4);
+      expect(stats.consentActionsLast24h).toBe(10);
+      expect(stats.consentActionsLast7d).toBe(25);
+      expect(stats.consentActionsLast30d).toBe(60);
+      expect(stats.consentsGranted24h).toBe(7);
+      expect(stats.consentsRevoked24h).toBe(2);
+      expect(stats.consentsUpdated24h).toBe(1);
+      expect(stats.pendingDeletions).toBe(3);
+      expect(stats.pendingDeletionsGracePeriod).toBe(1);
+      expect(stats.consentsByCategory).toEqual([
+        {
+          categoryId: 'c1',
+          categoryKey: 'marketing',
+          categoryName: 'Marketing',
+          required: false,
+          totalGrants: 5,
+          distinctUsers: 1,
+        },
+      ]);
+    });
+
+    it('returns an empty category breakdown when no categories exist', async () => {
+      prisma.userConsent.count.mockResolvedValue(0);
+      prisma.userConsentHistory.groupBy.mockResolvedValue([]);
+      prisma.userConsentHistory.count.mockResolvedValue(0);
+      prisma.consentCategory.findMany.mockResolvedValue([]);
+      prisma.pendingDeletion.count.mockResolvedValue(0);
+
+      const stats = await service.getRealmConsentStats(realm);
+      expect(stats.consentsByCategory).toEqual([]);
+    });
+  });
+
+  describe('getCategoryStats', () => {
+    it('throws NotFound for a category in another realm', async () => {
+      prisma.consentCategory.findUnique.mockResolvedValue({
+        id: 'c1',
+        realmId: 'other-realm',
+        key: 'marketing',
+        displayName: 'Marketing',
+      });
+      await expect(service.getCategoryStats(realm, 'c1')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('returns grant/revoke totals and grant + active-user windows', async () => {
+      prisma.consentCategory.findUnique.mockResolvedValue({
+        id: 'c1',
+        realmId: 'realm-1',
+        key: 'marketing',
+        displayName: 'Marketing',
+      });
+
+      prisma.userConsentHistory.count
+        .mockResolvedValueOnce(20) // totalGrants
+        .mockResolvedValueOnce(4) // totalRevokes
+        .mockResolvedValueOnce(3) // grants 24h
+        .mockResolvedValueOnce(8) // grants 7d
+        .mockResolvedValueOnce(15); // grants 30d
+
+      prisma.userConsentHistory.groupBy
+        .mockResolvedValueOnce([{ userId: 'u1' }, { userId: 'u2' }]) // active 24h
+        .mockResolvedValueOnce([{ userId: 'u1' }, { userId: 'u2' }, { userId: 'u3' }]) // active 7d
+        .mockResolvedValueOnce([
+          { userId: 'u1' },
+          { userId: 'u2' },
+          { userId: 'u3' },
+          { userId: 'u4' },
+          { userId: 'u5' },
+        ]); // active 30d
+
+      const stats = await service.getCategoryStats(realm, 'c1');
+
+      expect(stats).toEqual({
+        categoryId: 'c1',
+        categoryKey: 'marketing',
+        categoryName: 'Marketing',
+        totalGrants: 20,
+        totalRevokes: 4,
+        grants24h: 3,
+        grants7d: 8,
+        grants30d: 15,
+        activeUsers24h: 2,
+        activeUsers7d: 3,
+        activeUsers30d: 5,
+      });
+    });
+  });
+});

--- a/src/consent/consent-stats.service.ts
+++ b/src/consent/consent-stats.service.ts
@@ -1,54 +1,111 @@
 /**
- * This service provides statistical data for consent management.
- * It includes metrics like consent counts by category, history events, and pending actions.
+ * Statistical data for consent management.
+ *
+ * Two views are produced:
+ *  - realm-wide stats (totals, active-user and action windows, per-category
+ *    breakdown, pending deletions) — for the Consent Statistics dashboard;
+ *  - per-category stats (grant/revoke totals, grant and active-user windows) —
+ *    for a single consent category's detail page.
+ *
+ * The only link between a consent event and a GDPR consent category is the
+ * `categoryKey` stored in `UserConsentHistory.metadata`. Aggregations below
+ * filter history on that JSON path. They are correct for any category-tagged
+ * event; the live OAuth grant path does not yet tag events with a category, so
+ * category-scoped numbers stay at zero until that tagging is wired in (a
+ * separate feature — see F-16 notes). No metric is faked or hard-coded.
  */
-import { Injectable } from '@nestjs/common';
-import type { Realm } from '@prisma/client';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import type { Prisma, Realm } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
 
+/** A single row of the realm's per-category consent breakdown. */
+export interface CategoryConsentCount {
+  categoryId: string;
+  categoryKey: string;
+  categoryName: string;
+  required: boolean;
+  /** Count of `granted` history events tagged with this category. */
+  totalGrants: number;
+  /** Distinct users who have granted this category. */
+  distinctUsers: number;
+}
+
+/** Realm-wide consent statistics (Consent Statistics dashboard). */
 export interface ConsentStats {
   totalConsents: number;
   activeUsersWithConsents24h: number;
   activeUsersWithConsents7d: number;
   activeUsersWithConsents30d: number;
+  /** All consent history actions (grant/revoke/update) within the window. */
+  consentActionsLast24h: number;
+  consentActionsLast7d: number;
+  consentActionsLast30d: number;
+  /** Per-type breakdown for the last 24h (richer detail for the dashboard). */
   consentsGranted24h: number;
   consentsRevoked24h: number;
   consentsUpdated24h: number;
   consentsByCategory: CategoryConsentCount[];
   pendingDeletions: number;
   pendingDeletionsGracePeriod: number;
-  consentsRequiringReConsent: number;
 }
 
-export interface CategoryConsentCount {
+/** Detailed statistics for a single consent category. */
+export interface CategoryStats {
   categoryId: string;
   categoryKey: string;
-  categoryDisplayName: string;
-  consentCount: number;
-  requiredConsentCount: number;
-  optionalConsentCount: number;
+  categoryName: string;
+  totalGrants: number;
+  totalRevokes: number;
+  grants24h: number;
+  grants7d: number;
+  grants30d: number;
+  activeUsers24h: number;
+  activeUsers7d: number;
+  activeUsers30d: number;
 }
-
-const CONSENT_GRANTED_TYPES = ['granted'];
-const CONSENT_REVOKED_TYPES = ['revoked'];
-const CONSENT_UPDATED_TYPES = ['updated'];
 
 @Injectable()
 export class ConsentStatisticsService {
   constructor(private readonly prisma: PrismaService) {}
 
+  /** Cutoff timestamps for the standard 24h / 7d / 30d windows. */
+  private windows(now = new Date()) {
+    return {
+      cutoff24h: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+      cutoff7d: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
+      cutoff30d: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000),
+    };
+  }
+
+  /** Prisma JSON-path filter matching history tagged with a category key. */
+  private categoryKeyFilter(key: string): Prisma.JsonFilter {
+    return { path: ['categoryKey'], equals: key };
+  }
+
+  /** Count distinct users in a history query. */
+  private async countDistinctUsers(
+    where: Prisma.UserConsentHistoryWhereInput,
+  ): Promise<number> {
+    const rows = await this.prisma.userConsentHistory.groupBy({
+      by: ['userId'],
+      where,
+    });
+    return rows.length;
+  }
+
   async getRealmConsentStats(realm: Realm): Promise<ConsentStats> {
     const now = new Date();
-
-    const cutoff24h = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    const cutoff7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-    const cutoff30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const { cutoff24h, cutoff7d, cutoff30d } = this.windows(now);
+    const realmScope = { user: { realmId: realm.id } };
 
     const [
       totalConsents,
       activeUsersWithConsents24h,
       activeUsersWithConsents7d,
       activeUsersWithConsents30d,
+      consentActionsLast24h,
+      consentActionsLast7d,
+      consentActionsLast30d,
       consentsGranted24h,
       consentsRevoked24h,
       consentsUpdated24h,
@@ -56,92 +113,42 @@ export class ConsentStatisticsService {
       pendingDeletions,
       pendingDeletionsGracePeriod,
     ] = await Promise.all([
-      // Total active consents for this realm's users
-      this.prisma.userConsent.count({
-        where: {
-          user: { realmId: realm.id },
-        },
-      }),
+      this.prisma.userConsent.count({ where: realmScope }),
 
-      // Distinct users with consent events in the last 24h
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            createdAt: { gte: cutoff24h },
-          },
-        })
-        .then((rows) => rows.length),
+      this.countDistinctUsers({ ...realmScope, createdAt: { gte: cutoff24h } }),
+      this.countDistinctUsers({ ...realmScope, createdAt: { gte: cutoff7d } }),
+      this.countDistinctUsers({ ...realmScope, createdAt: { gte: cutoff30d } }),
 
-      // Distinct users with consent events in the last 7d
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            createdAt: { gte: cutoff7d },
-          },
-        })
-        .then((rows) => rows.length),
-
-      // Distinct users with consent events in the last 30d
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            createdAt: { gte: cutoff30d },
-          },
-        })
-        .then((rows) => rows.length),
-
-      // Consents granted in the last 24h
       this.prisma.userConsentHistory.count({
-        where: {
-          user: { realmId: realm.id },
-          action: { in: CONSENT_GRANTED_TYPES },
-          createdAt: { gte: cutoff24h },
-        },
+        where: { ...realmScope, createdAt: { gte: cutoff24h } },
       }),
-
-      // Consents revoked in the last 24h
       this.prisma.userConsentHistory.count({
-        where: {
-          user: { realmId: realm.id },
-          action: { in: CONSENT_REVOKED_TYPES },
-          createdAt: { gte: cutoff24h },
-        },
+        where: { ...realmScope, createdAt: { gte: cutoff7d } },
       }),
-
-      // Consents updated in the last 24h
       this.prisma.userConsentHistory.count({
-        where: {
-          user: { realmId: realm.id },
-          action: { in: CONSENT_UPDATED_TYPES },
-          createdAt: { gte: cutoff24h },
-        },
+        where: { ...realmScope, createdAt: { gte: cutoff30d } },
       }),
 
-      // Consents by category
+      this.prisma.userConsentHistory.count({
+        where: { ...realmScope, action: 'granted', createdAt: { gte: cutoff24h } },
+      }),
+      this.prisma.userConsentHistory.count({
+        where: { ...realmScope, action: 'revoked', createdAt: { gte: cutoff24h } },
+      }),
+      this.prisma.userConsentHistory.count({
+        where: { ...realmScope, action: 'updated', createdAt: { gte: cutoff24h } },
+      }),
+
       this.getConsentsByCategory(realm.id),
 
-      // Pending deletions count
       this.prisma.pendingDeletion.count({
-        where: {
-          user: { realmId: realm.id },
-          status: 'pending',
-        },
+        where: { user: { realmId: realm.id }, status: 'pending' },
       }),
-
-      // Pending deletions within grace period (next 7 days)
       this.prisma.pendingDeletion.count({
         where: {
           user: { realmId: realm.id },
           status: 'pending',
-          scheduledAt: {
-            lte: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
-          },
+          scheduledAt: { lte: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000) },
         },
       }),
     ]);
@@ -151,214 +158,115 @@ export class ConsentStatisticsService {
       activeUsersWithConsents24h,
       activeUsersWithConsents7d,
       activeUsersWithConsents30d,
+      consentActionsLast24h,
+      consentActionsLast7d,
+      consentActionsLast30d,
       consentsGranted24h,
       consentsRevoked24h,
       consentsUpdated24h,
       consentsByCategory,
       pendingDeletions,
       pendingDeletionsGracePeriod,
-      consentsRequiringReConsent: 0, // Computed separately if needed
     };
   }
 
-  /**
-   * Get consent counts grouped by consent category.
-   */
+  /** Per-category breakdown of granted consents for a realm. */
   private async getConsentsByCategory(
     realmId: string,
   ): Promise<CategoryConsentCount[]> {
     const categories = await this.prisma.consentCategory.findMany({
       where: { realmId, enabled: true },
-      include: {
-        policies: {
-          where: { isActive: true },
-        },
-      },
+      orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
     });
+    if (categories.length === 0) return [];
 
-    if (categories.length === 0) {
-      return [];
-    }
+    return Promise.all(
+      categories.map(async (category) => {
+        const grantedScope = {
+          user: { realmId },
+          action: 'granted',
+          metadata: this.categoryKeyFilter(category.key),
+        } satisfies Prisma.UserConsentHistoryWhereInput;
 
-    const categoryCounts: CategoryConsentCount[] = [];
+        const [totalGrants, distinctUsers] = await Promise.all([
+          this.prisma.userConsentHistory.count({ where: grantedScope }),
+          this.countDistinctUsers(grantedScope),
+        ]);
 
-    for (const category of categories) {
-      // Count users who have granted consent covering this category
-      // This requires checking the metadata or scopes in history
-      const historyWithCategory = await this.prisma.userConsentHistory.findMany(
-        {
-          where: {
-            user: { realmId },
-            action: 'granted',
-            metadata: {
-              path: ['categoryKey'],
-              equals: category.key,
-            },
-          },
-          distinct: ['userId'],
-        },
-      );
-
-      // For now, count active consents and determine required vs optional
-      const isRequired = category.required;
-
-      categoryCounts.push({
-        categoryId: category.id,
-        categoryKey: category.key,
-        categoryDisplayName: category.displayName,
-        consentCount: historyWithCategory.length,
-        requiredConsentCount: isRequired ? historyWithCategory.length : 0,
-        optionalConsentCount: isRequired ? 0 : historyWithCategory.length,
-      });
-    }
-
-    return categoryCounts;
+        return {
+          categoryId: category.id,
+          categoryKey: category.key,
+          categoryName: category.displayName,
+          required: category.required,
+          totalGrants,
+          distinctUsers,
+        };
+      }),
+    );
   }
 
   /**
-   * Get detailed statistics for a specific consent category.
+   * Detailed statistics for a single consent category (by id, realm-scoped).
    */
   async getCategoryStats(
     realm: Realm,
-    categoryKey: string,
-  ): Promise<{
-    totalUsers: number;
-    consentedUsers24h: number;
-    consentedUsers7d: number;
-    consentedUsers30d: number;
-    revokedUsers24h: number;
-    updatedUsers24h: number;
-  }> {
-    const now = new Date();
-
-    const cutoff24h = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    const cutoff7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-    const cutoff30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-
-    const category = await this.prisma.consentCategory.findFirst({
-      where: { realmId: realm.id, key: categoryKey },
+    categoryId: string,
+  ): Promise<CategoryStats> {
+    const category = await this.prisma.consentCategory.findUnique({
+      where: { id: categoryId },
     });
-
-    if (!category) {
-      return {
-        totalUsers: 0,
-        consentedUsers24h: 0,
-        consentedUsers7d: 0,
-        consentedUsers30d: 0,
-        revokedUsers24h: 0,
-        updatedUsers24h: 0,
-      };
+    if (!category || category.realmId !== realm.id) {
+      throw new NotFoundException(`Consent category '${categoryId}' not found`);
     }
 
+    const { cutoff24h, cutoff7d, cutoff30d } = this.windows();
+    const keyFilter = this.categoryKeyFilter(category.key);
+    const base = {
+      user: { realmId: realm.id },
+      metadata: keyFilter,
+    } satisfies Prisma.UserConsentHistoryWhereInput;
+    const granted = { ...base, action: 'granted' };
+
     const [
-      historyWithCategory,
-      consentedUsers24h,
-      consentedUsers7d,
-      consentedUsers30d,
-      revokedUsers24h,
-      updatedUsers24h,
+      totalGrants,
+      totalRevokes,
+      grants24h,
+      grants7d,
+      grants30d,
+      activeUsers24h,
+      activeUsers7d,
+      activeUsers30d,
     ] = await Promise.all([
-      // All distinct users who ever consented to this category
-      this.prisma.userConsentHistory.findMany({
-        where: {
-          user: { realmId: realm.id },
-          action: 'granted',
-          metadata: {
-            path: ['categoryKey'],
-            equals: category.key,
-          },
-        },
-        distinct: ['userId'],
+      this.prisma.userConsentHistory.count({ where: granted }),
+      this.prisma.userConsentHistory.count({
+        where: { ...base, action: 'revoked' },
       }),
-
-      // Users who consented to this category in last 24h
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            action: 'granted',
-            createdAt: { gte: cutoff24h },
-            metadata: {
-              path: ['categoryKey'],
-              equals: category.key,
-            },
-          },
-        })
-        .then((rows) => rows.length),
-
-      // Users who consented to this category in last 7d
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            action: 'granted',
-            createdAt: { gte: cutoff7d },
-            metadata: {
-              path: ['categoryKey'],
-              equals: category.key,
-            },
-          },
-        })
-        .then((rows) => rows.length),
-
-      // Users who consented to this category in last 30d
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            action: 'granted',
-            createdAt: { gte: cutoff30d },
-            metadata: {
-              path: ['categoryKey'],
-              equals: category.key,
-            },
-          },
-        })
-        .then((rows) => rows.length),
-
-      // Users who revoked consent to this category in last 24h
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            action: 'revoked',
-            createdAt: { gte: cutoff24h },
-            metadata: {
-              path: ['categoryKey'],
-              equals: category.key,
-            },
-          },
-        })
-        .then((rows) => rows.length),
-
-      // Users who updated consent to this category in last 24h
-      this.prisma.userConsentHistory
-        .groupBy({
-          by: ['userId'],
-          where: {
-            user: { realmId: realm.id },
-            action: 'updated',
-            createdAt: { gte: cutoff24h },
-            metadata: {
-              path: ['categoryKey'],
-              equals: category.key,
-            },
-          },
-        })
-        .then((rows) => rows.length),
+      this.prisma.userConsentHistory.count({
+        where: { ...granted, createdAt: { gte: cutoff24h } },
+      }),
+      this.prisma.userConsentHistory.count({
+        where: { ...granted, createdAt: { gte: cutoff7d } },
+      }),
+      this.prisma.userConsentHistory.count({
+        where: { ...granted, createdAt: { gte: cutoff30d } },
+      }),
+      this.countDistinctUsers({ ...base, createdAt: { gte: cutoff24h } }),
+      this.countDistinctUsers({ ...base, createdAt: { gte: cutoff7d } }),
+      this.countDistinctUsers({ ...base, createdAt: { gte: cutoff30d } }),
     ]);
 
     return {
-      totalUsers: historyWithCategory.length,
-      consentedUsers24h,
-      consentedUsers7d,
-      consentedUsers30d,
-      revokedUsers24h,
-      updatedUsers24h,
+      categoryId: category.id,
+      categoryKey: category.key,
+      categoryName: category.displayName,
+      totalGrants,
+      totalRevokes,
+      grants24h,
+      grants7d,
+      grants30d,
+      activeUsers24h,
+      activeUsers7d,
+      activeUsers30d,
     };
   }
 }

--- a/src/prisma/prisma.mock.ts
+++ b/src/prisma/prisma.mock.ts
@@ -76,14 +76,18 @@ export function createMockPrismaService(): MockPrismaService {
     },
     userConsent: {
       findUnique: jest.fn(),
+      findMany: jest.fn(),
       create: jest.fn(),
       upsert: jest.fn(),
       deleteMany: jest.fn(),
+      count: jest.fn(),
     },
     userConsentHistory: {
       findUnique: jest.fn(),
       findMany: jest.fn(),
       create: jest.fn(),
+      count: jest.fn(),
+      groupBy: jest.fn(),
     },
     consentCategory: {
       findUnique: jest.fn(),
@@ -102,6 +106,7 @@ export function createMockPrismaService(): MockPrismaService {
       findMany: jest.fn(),
       create: jest.fn(),
       update: jest.fn(),
+      count: jest.fn(),
     },
     authenticationFlow: {
       findUnique: jest.fn(),

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -280,7 +280,12 @@ export class UsersController {
   getUserConsentHistory(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
   ) {
-    return this.usersService.getUserConsentHistory(realm, userId);
+    return this.usersService.getUserConsentHistory(realm, userId, {
+      page: page ? Number(page) : undefined,
+      limit: limit ? Number(limit) : undefined,
+    });
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -371,25 +371,28 @@ export class UsersService {
   async getUserConsentHistory(
     realm: Realm,
     userId: string,
-    options?: { limit?: number; offset?: number },
+    options?: { page?: number; limit?: number },
   ) {
     await this.findById(realm, userId);
-    const history = await this.prisma.userConsentHistory.findMany({
-      where: { userId },
-      include: {
-        client: {
-          select: {
-            id: true,
-            clientId: true,
-            name: true,
-          },
+
+    const limit = Math.min(Math.max(options?.limit ?? 20, 1), 100);
+    const page = Math.max(options?.page ?? 1, 1);
+    const skip = (page - 1) * limit;
+
+    const [rows, total] = await Promise.all([
+      this.prisma.userConsentHistory.findMany({
+        where: { userId },
+        include: {
+          client: { select: { id: true, clientId: true, name: true } },
         },
-      },
-      orderBy: { createdAt: 'desc' },
-      skip: options?.offset ?? 0,
-      take: options?.limit ?? 50,
-    });
-    return history.map((entry) => ({
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      this.prisma.userConsentHistory.count({ where: { userId } }),
+    ]);
+
+    const history = rows.map((entry) => ({
       id: entry.id,
       clientId: entry.clientId,
       clientName: entry.client?.name ?? entry.client?.clientId ?? 'Unknown',
@@ -401,5 +404,7 @@ export class UsersService {
       metadata: entry.metadata,
       createdAt: entry.createdAt,
     }));
+
+    return { history, total, page, pageSize: limit };
   }
 }

--- a/test/consent-stats.e2e-spec.ts
+++ b/test/consent-stats.e2e-spec.ts
@@ -1,0 +1,225 @@
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+import {
+  createTestApp,
+  TEST_ADMIN_API_KEY,
+  type SeededRealm,
+  type TestContext,
+} from './setup';
+
+/**
+ * E2E for the consent contract (F-16): category CRUD via key+displayName, the
+ * realm consent-statistics endpoint, and the per-category stats endpoint.
+ *
+ * Consent events are linked to a category only through
+ * `UserConsentHistory.metadata.categoryKey`, so the seed below tags history
+ * rows with a categoryKey and spreads them across the 24h/7d/30d windows; the
+ * assertions check the aggregation against those exact seeded counts.
+ */
+describe('Consent contract + statistics (e2e)', () => {
+  let app: INestApplication<App>;
+  let ctx: TestContext;
+  let seeded: SeededRealm;
+
+  const REALM_NAME = 'e2e-consent-realm';
+  const API_KEY_HEADER = 'x-admin-api-key';
+  const CATEGORY_KEY = 'marketing';
+
+  const adminRequest = () => request(app.getHttpServer());
+  const withKey = (req: request.Test) =>
+    req.set(API_KEY_HEADER, TEST_ADMIN_API_KEY);
+
+  const base = `/admin/realms/${REALM_NAME}`;
+
+  let categoryId: string;
+
+  // window offsets (ms): inside 24h, inside 7d (not 24h), inside 30d (not 7d)
+  const ago = (ms: number) => new Date(Date.now() - ms);
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    app = ctx.app;
+    seeded = await ctx.seedTestRealm(REALM_NAME);
+
+    // Two extra users so distinct-user counts differ from event counts.
+    const u2 = await ctx.prisma.user.create({
+      data: {
+        realmId: seeded.realm.id,
+        username: 'consent-u2',
+        email: 'consent-u2@example.com',
+        enabled: true,
+      },
+    });
+    const u3 = await ctx.prisma.user.create({
+      data: {
+        realmId: seeded.realm.id,
+        username: 'consent-u3',
+        email: 'consent-u3@example.com',
+        enabled: true,
+      },
+    });
+    const u1 = seeded.user.id;
+    const clientId = seeded.client.id;
+
+    // Category to aggregate against.
+    const category = await ctx.prisma.consentCategory.create({
+      data: {
+        realmId: seeded.realm.id,
+        key: CATEGORY_KEY,
+        displayName: 'Marketing',
+        required: false,
+        enabled: true,
+      },
+    });
+    categoryId = category.id;
+
+    // Active UserConsent rows (totalConsents).
+    await ctx.prisma.userConsent.createMany({
+      data: [
+        { userId: u1, clientId, scopes: ['openid'] },
+        { userId: u2.id, clientId, scopes: ['openid'] },
+      ],
+    });
+
+    const tagged = { categoryKey: CATEGORY_KEY };
+    const mkHistory = (
+      userId: string,
+      action: string,
+      when: Date,
+      withTag = true,
+    ) => ({
+      userId,
+      clientId,
+      action,
+      scopes: ['openid'],
+      metadata: withTag ? tagged : undefined,
+      createdAt: when,
+    });
+
+    // Granted, category-tagged:
+    //   24h: u1, u2  (2)   | 7d adds u3 (1) | 30d adds u1 again (1)
+    // Distinct users granted: u1,u2,u3 = 3.  totalGrants events = 4.
+    await ctx.prisma.userConsentHistory.createMany({
+      data: [
+        mkHistory(u1, 'granted', ago(2 * HOUR)),
+        mkHistory(u2.id, 'granted', ago(5 * HOUR)),
+        mkHistory(u3.id, 'granted', ago(3 * DAY)),
+        mkHistory(u1, 'granted', ago(20 * DAY)),
+        // One revoke (tagged), inside 24h
+        mkHistory(u2.id, 'revoked', ago(1 * HOUR)),
+        // One updated (tagged), inside 24h
+        mkHistory(u3.id, 'updated', ago(1 * HOUR)),
+        // An UNTAGGED action (counts toward realm action windows, not category)
+        mkHistory(u1, 'granted', ago(6 * HOUR), false),
+      ],
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    await ctx.prisma.realm
+      .delete({ where: { name: REALM_NAME } })
+      .catch(() => {});
+    await ctx.cleanup();
+  });
+
+  // ─── Category CRUD (key + displayName) ─────────────────────
+
+  it('POST consent-categories — creates with key + displayName', async () => {
+    const res = await withKey(
+      adminRequest()
+        .post(`${base}/consent-categories`)
+        .send({
+          key: 'analytics',
+          displayName: 'Analytics',
+          description: 'Usage analytics',
+          required: false,
+        }),
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.key).toBe('analytics');
+    expect(res.body.displayName).toBe('Analytics');
+    expect(res.body.enabled).toBe(true);
+  });
+
+  it('PUT consent-categories/:id — updates displayName', async () => {
+    const res = await withKey(
+      adminRequest()
+        .put(`${base}/consent-categories/${categoryId}`)
+        .send({ displayName: 'Marketing & Promotions' }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.displayName).toBe('Marketing & Promotions');
+    expect(res.body.key).toBe(CATEGORY_KEY);
+  });
+
+  // ─── Realm consent statistics ──────────────────────────────
+
+  it('GET stats/consents — returns the full canonical contract', async () => {
+    const res = await withKey(adminRequest().get(`${base}/stats/consents`));
+    expect(res.status).toBe(200);
+    const s = res.body;
+
+    expect(s.totalConsents).toBe(2);
+
+    // Action windows count ALL history rows (tagged + untagged):
+    // 24h: 2 granted + 1 revoked + 1 updated + 1 untagged granted = 5
+    expect(s.consentActionsLast24h).toBe(5);
+    // 7d: 24h(5) + u3 granted(3d) = 6
+    expect(s.consentActionsLast7d).toBe(6);
+    // 30d: 7d(6) + u1 granted(20d) = 7
+    expect(s.consentActionsLast30d).toBe(7);
+
+    // Per-type 24h: granted = 2 tagged + 1 untagged = 3; revoked 1; updated 1
+    expect(s.consentsGranted24h).toBe(3);
+    expect(s.consentsRevoked24h).toBe(1);
+    expect(s.consentsUpdated24h).toBe(1);
+
+    // Distinct active users by window (any tagged-or-untagged action):
+    // 24h: u1,u2,u3 = 3 ; 7d: +u3(already) = 3 ; 30d: 3
+    expect(s.activeUsersWithConsents24h).toBe(3);
+    expect(s.activeUsersWithConsents30d).toBe(3);
+
+    // Category breakdown (tagged 'granted' only): 4 events, 3 distinct users
+    const marketing = s.consentsByCategory.find(
+      (c: { categoryKey: string }) => c.categoryKey === CATEGORY_KEY,
+    );
+    expect(marketing).toMatchObject({
+      categoryName: 'Marketing & Promotions',
+      totalGrants: 4,
+      distinctUsers: 3,
+    });
+  });
+
+  // ─── Per-category statistics ───────────────────────────────
+
+  it('GET consent-categories/:id/stats — per-category windows', async () => {
+    const res = await withKey(
+      adminRequest().get(`${base}/consent-categories/${categoryId}/stats`),
+    );
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      categoryId,
+      categoryKey: CATEGORY_KEY,
+      totalGrants: 4, // tagged granted events
+      totalRevokes: 1, // tagged revoked events
+      grants24h: 2, // u1, u2 granted in 24h
+      grants7d: 3, // + u3 at 3d
+      grants30d: 4, // + u1 at 20d
+    });
+    // Active users (any tagged action) in 24h: u1(granted), u2(granted+revoked),
+    // u3(updated) = 3
+    expect(res.body.activeUsers24h).toBe(3);
+  });
+
+  it('GET consent-categories/:id/stats — 404 for unknown category', async () => {
+    const res = await withKey(
+      adminRequest().get(
+        `${base}/consent-categories/00000000-0000-0000-0000-000000000000/stats`,
+      ),
+    );
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Promotes the **F-16** consent fix from dev to main (PR #958, all checks green).

Backend-first reconciliation of the consent FE↔BE contract plus the full consent statistics metric set, then the frontend mirror.

- **Realm stats**: `totalConsents`, `activeUsersWithConsents{24h,7d,30d}`, `consentActionsLast{24h,7d,30d}`, per-type 24h breakdown, `consentsByCategory[]`, `pendingDeletions` (+grace).
- **New per-category stats endpoint** (`GET .../consent-categories/:id/stats`) — F-02's missing route: grant/revoke totals + grant & active-user windows.
- **Frontend**: `ConsentCategory` uses `key`+`displayName` (create no longer 400s, key immutable on edit); statistics page reachable via new nav entry + per-category usage panel; `UserConsentPanel` shows real per-client scope data.

**Category-linkage honesty:** the only event→category link is `UserConsentHistory.metadata.categoryKey`; the live OAuth grant path (`login.controller.ts:849`) doesn't tag it, so category-scoped metrics aggregate correctly but read zero on real data until a separate scope→category mapping feature is wired in. Out of scope here, by design.

Verified: backend unit + e2e (seeded windows), FE render tests, and a full real-browser walkthrough against live backend + Postgres (CRUD persisted; all stats matched the seed; no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)