### PR TITLE
feat(consent): tag grants with their category — per-category stats use real data (F-16)

### DIFF
--- a/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
@@ -22,6 +22,8 @@ interface CategoryForm {
   configurableByUser: boolean;
   showInAccountPortal: boolean;
   order: number;
+  /** Space-separated scope names while editing; parsed to string[] on submit. */
+  scopes: string;
 }
 
 const EMPTY_FORM: CategoryForm = {
@@ -32,7 +34,15 @@ const EMPTY_FORM: CategoryForm = {
   configurableByUser: true,
   showInAccountPortal: true,
   order: 0,
+  scopes: '',
 };
+
+/** Parse a space/comma-separated scope string into a clean string[]. */
+const parseScopes = (raw: string): string[] =>
+  raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
 
 export default function ConsentCategoryDetailPage() {
   const { name, categoryId } = useParams<{ name: string; categoryId?: string }>();
@@ -70,6 +80,7 @@ export default function ConsentCategoryDetailPage() {
       configurableByUser: category.configurableByUser,
       showInAccountPortal: category.showInAccountPortal,
       order: category.order,
+      scopes: category.scopes.join(' '),
     });
   }
 
@@ -82,6 +93,7 @@ export default function ConsentCategoryDetailPage() {
     configurableByUser: f.configurableByUser,
     showInAccountPortal: f.showInAccountPortal,
     order: f.order,
+    scopes: parseScopes(f.scopes),
   });
   const toUpdatePayload = (f: CategoryForm): Partial<ConsentCategory> => {
     const { key: _key, ...rest } = toCreatePayload(f);
@@ -257,6 +269,24 @@ export default function ConsentCategoryDetailPage() {
               }
               className="w-32 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
             />
+          </div>
+          <div>
+            <label htmlFor="scopes" className="block text-sm font-medium text-gray-700">
+              Governed Scopes
+            </label>
+            <input
+              type="text"
+              id="scopes"
+              value={form.scopes}
+              onChange={(e) => setForm({ ...form, scopes: e.target.value })}
+              placeholder="profile email"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 font-mono text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+            <p className="mt-1 text-xs text-gray-400">
+              Space-separated OIDC scopes this category governs (used to attribute
+              consent grants for statistics). Leave empty to govern the scope whose
+              name matches the key (<code className="font-mono">{form.key || 'key'}</code>).
+            </p>
           </div>
           <div className="flex flex-col gap-3">
             <label className="flex items-center gap-2">

--- a/admin-ui/src/pages/consent/__tests__/ConsentPages.test.tsx
+++ b/admin-ui/src/pages/consent/__tests__/ConsentPages.test.tsx
@@ -56,6 +56,8 @@ describe('ConsentCategoryDetailPage', () => {
     const key = screen.getByLabelText('Key') as HTMLInputElement;
     expect(key).toBeEnabled();
     expect(screen.getByLabelText('Display Name')).toBeInTheDocument();
+    // scope→category mapping input
+    expect(screen.getByLabelText('Governed Scopes')).toBeInTheDocument();
   });
 
   it('edit mode loads the category and shows usage statistics', async () => {

--- a/admin-ui/src/test/mocks/data.ts
+++ b/admin-ui/src/test/mocks/data.ts
@@ -259,6 +259,7 @@ export function makeConsentCategory(
     showInAccountPortal: true,
     order: 0,
     enabled: true,
+    scopes: [],
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
     ...overrides,

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -350,6 +350,11 @@ export interface ConsentCategory {
   showInAccountPortal: boolean;
   order: number;
   enabled: boolean;
+  /**
+   * OIDC scope names this category governs. Empty falls back to the convention
+   * that the category governs the scope whose name equals its `key`.
+   */
+  scopes: string[];
   createdAt: string;
   updatedAt: string;
 }

--- a/prisma/migrations/20260527111246_consent_category_scopes/migration.sql
+++ b/prisma/migrations/20260527111246_consent_category_scopes/migration.sql
@@ -1,0 +1,33 @@
+-- AlterTable
+ALTER TABLE "consent_categories" ADD COLUMN     "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[];
+
+-- Data backfill (F-16 follow-up): tag existing consent history with the
+-- categories it belongs to, so historical per-category statistics populate.
+--
+-- A category governs a granted scope when the scope is in its configured
+-- `scopes`, or — when `scopes` is empty (unconfigured) — when the category
+-- `key` equals one of the granted scopes (the convention default; explicit
+-- `scopes` config overrides it). Only rows not already tagged and matching at
+-- least one category are updated; everything else is left untouched.
+UPDATE "user_consent_history" uch
+SET "metadata" = jsonb_set(
+  COALESCE(uch."metadata", '{}'::jsonb),
+  '{categoryKeys}',
+  sub.keys
+)
+FROM (
+  SELECT h."id" AS id,
+         to_jsonb(array_agg(DISTINCT cc."key" ORDER BY cc."key")) AS keys
+  FROM "user_consent_history" h
+  JOIN "users" u ON u."id" = h."user_id"
+  JOIN "consent_categories" cc
+    ON cc."realm_id" = u."realm_id"
+   AND cc."enabled" = true
+   AND (
+     cc."scopes" && h."scopes"
+     OR (cardinality(cc."scopes") = 0 AND cc."key" = ANY(h."scopes"))
+   )
+  WHERE (h."metadata" -> 'categoryKeys') IS NULL
+  GROUP BY h."id"
+) sub
+WHERE uch."id" = sub."id";

--- a/prisma/schema.mysql.prisma
+++ b/prisma/schema.mysql.prisma
@@ -501,6 +501,9 @@ model ConsentCategory {
   showInAccountPortal Boolean @default(true) @map("show_in_account_portal")
   order               Int     @default(0)
   enabled             Boolean @default(true)
+  // JSON array of OIDC scope names this category governs (see the Postgres
+  // schema for semantics). Stored as JSON on MySQL.
+  scopes              Json    @default("[]")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2102,6 +2102,11 @@ model ConsentCategory {
   showInAccountPortal Boolean  @default(true) @map("show_in_account_portal")
   order               Int      @default(0)
   enabled             Boolean  @default(true)
+  // OIDC scope names this category governs. Used to tag consent grants with
+  // their category for per-category statistics. Empty = unconfigured: the
+  // category then governs the scope whose name equals its `key` (convention
+  // default). Setting any scope here disables that key fallback for this row.
+  scopes              String[] @default([])
   createdAt           DateTime @default(now()) @map("created_at")
   updatedAt           DateTime @updatedAt @map("updated_at")
 

--- a/prisma/schema.sqlite.prisma
+++ b/prisma/schema.sqlite.prisma
@@ -505,6 +505,9 @@ model ConsentCategory {
   showInAccountPortal Boolean @default(true) @map("show_in_account_portal")
   order               Int     @default(0)
   enabled             Boolean @default(true)
+  // JSON-encoded array of OIDC scope names this category governs (see the
+  // Postgres schema for semantics). Stored as a string on SQLite.
+  scopes              String  @default("[]")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/src/consent/consent-categories.controller.ts
+++ b/src/consent/consent-categories.controller.ts
@@ -64,10 +64,7 @@ export class ConsentCategoriesController {
   @ApiResponse({ status: 200, description: 'Consent category statistics' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
-  stats(
-    @CurrentRealm() realm: Realm,
-    @Param('categoryId') categoryId: string,
-  ) {
+  stats(@CurrentRealm() realm: Realm, @Param('categoryId') categoryId: string) {
     return this.statsService.getCategoryStats(realm, categoryId);
   }
 

--- a/src/consent/consent-category.service.ts
+++ b/src/consent/consent-category.service.ts
@@ -20,6 +20,7 @@ const CATEGORY_SELECT = {
   showInAccountPortal: true,
   order: true,
   enabled: true,
+  scopes: true,
   createdAt: true,
   updatedAt: true,
 } as const;
@@ -56,6 +57,7 @@ export class ConsentCategoryService {
         showInAccountPortal: dto.showInAccountPortal ?? true,
         order: dto.order ?? 0,
         enabled: dto.enabled ?? true,
+        scopes: dto.scopes ?? [],
       },
       select: CATEGORY_SELECT,
     });
@@ -127,6 +129,7 @@ export class ConsentCategoryService {
         }),
         ...(dto.order !== undefined && { order: dto.order }),
         ...(dto.enabled !== undefined && { enabled: dto.enabled }),
+        ...(dto.scopes !== undefined && { scopes: dto.scopes }),
       },
       select: CATEGORY_SELECT,
     });

--- a/src/consent/consent-stats.service.ts
+++ b/src/consent/consent-stats.service.ts
@@ -7,12 +7,11 @@
  *  - per-category stats (grant/revoke totals, grant and active-user windows) —
  *    for a single consent category's detail page.
  *
- * The only link between a consent event and a GDPR consent category is the
- * `categoryKey` stored in `UserConsentHistory.metadata`. Aggregations below
- * filter history on that JSON path. They are correct for any category-tagged
- * event; the live OAuth grant path does not yet tag events with a category, so
- * category-scoped numbers stay at zero until that tagging is wired in (a
- * separate feature — see F-16 notes). No metric is faked or hard-coded.
+ * The link between a consent event and its GDPR consent categories is the
+ * `categoryKeys` array stored in `UserConsentHistory.metadata` (the live grant
+ * path tags every grant via ConsentService.resolveCategoryKeys). Aggregations
+ * below filter history on that JSON path with `array_contains`. No metric is
+ * faked or hard-coded.
  */
 import { Injectable, NotFoundException } from '@nestjs/common';
 import type { Prisma, Realm } from '@prisma/client';
@@ -77,9 +76,12 @@ export class ConsentStatisticsService {
     };
   }
 
-  /** Prisma JSON-path filter matching history tagged with a category key. */
+  /**
+   * Prisma JSON-path filter matching history whose `metadata.categoryKeys`
+   * array contains the given category key.
+   */
   private categoryKeyFilter(key: string): Prisma.JsonFilter {
-    return { path: ['categoryKey'], equals: key };
+    return { path: ['categoryKeys'], array_contains: key };
   }
 
   /** Count distinct users in a history query. */
@@ -130,13 +132,25 @@ export class ConsentStatisticsService {
       }),
 
       this.prisma.userConsentHistory.count({
-        where: { ...realmScope, action: 'granted', createdAt: { gte: cutoff24h } },
+        where: {
+          ...realmScope,
+          action: 'granted',
+          createdAt: { gte: cutoff24h },
+        },
       }),
       this.prisma.userConsentHistory.count({
-        where: { ...realmScope, action: 'revoked', createdAt: { gte: cutoff24h } },
+        where: {
+          ...realmScope,
+          action: 'revoked',
+          createdAt: { gte: cutoff24h },
+        },
       }),
       this.prisma.userConsentHistory.count({
-        where: { ...realmScope, action: 'updated', createdAt: { gte: cutoff24h } },
+        where: {
+          ...realmScope,
+          action: 'updated',
+          createdAt: { gte: cutoff24h },
+        },
       }),
 
       this.getConsentsByCategory(realm.id),
@@ -148,7 +162,9 @@ export class ConsentStatisticsService {
         where: {
           user: { realmId: realm.id },
           status: 'pending',
-          scheduledAt: { lte: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000) },
+          scheduledAt: {
+            lte: new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000),
+          },
         },
       }),
     ]);

--- a/src/consent/consent.service.spec.ts
+++ b/src/consent/consent.service.spec.ts
@@ -14,6 +14,7 @@ describe('ConsentService', () => {
     hashPassword: jest.Mock;
   };
 
+  const realmId = 'realm-1';
   const userId = 'user-1';
   const clientId = 'client-1';
 
@@ -34,6 +35,8 @@ describe('ConsentService', () => {
       verifyPassword: jest.fn(),
       hashPassword: jest.fn(),
     };
+    // No categories configured by default → recordConsentHistory tags nothing.
+    prisma.consentCategory.findMany.mockResolvedValue([]);
     service = new ConsentService(prisma as any, crypto as any);
   });
 
@@ -120,7 +123,12 @@ describe('ConsentService', () => {
       const expected = { userId, clientId, scopes };
       prisma.userConsent.upsert.mockResolvedValue(expected);
 
-      const result = await service.grantConsent(userId, clientId, scopes);
+      const result = await service.grantConsent(
+        realmId,
+        userId,
+        clientId,
+        scopes,
+      );
 
       expect(result).toEqual(expected);
       expect(prisma.userConsent.upsert).toHaveBeenCalledWith({
@@ -137,7 +145,7 @@ describe('ConsentService', () => {
         scopes: [],
       });
 
-      await service.grantConsent(userId, clientId, []);
+      await service.grantConsent(realmId, userId, clientId, []);
 
       expect(prisma.userConsent.upsert).toHaveBeenCalledWith({
         where: { userId_clientId: { userId, clientId } },
@@ -147,13 +155,85 @@ describe('ConsentService', () => {
     });
   });
 
+  // ─── resolveCategoryKeys + tagging ──────────────────────────
+
+  describe('category tagging', () => {
+    it('resolveCategoryKeys queries enabled categories by scope/key fallback', async () => {
+      prisma.consentCategory.findMany.mockResolvedValue([
+        { key: 'marketing' },
+        { key: 'profile' },
+      ]);
+
+      const keys = await service.resolveCategoryKeys(realmId, [
+        'openid',
+        'profile',
+      ]);
+
+      expect(keys).toEqual(['marketing', 'profile']);
+      expect(prisma.consentCategory.findMany).toHaveBeenCalledWith({
+        where: {
+          realmId,
+          enabled: true,
+          OR: [
+            { scopes: { hasSome: ['openid', 'profile'] } },
+            {
+              AND: [
+                { scopes: { isEmpty: true } },
+                { key: { in: ['openid', 'profile'] } },
+              ],
+            },
+          ],
+        },
+        select: { key: true },
+        orderBy: { key: 'asc' },
+      });
+    });
+
+    it('returns no keys for an empty scope list (no query)', async () => {
+      const keys = await service.resolveCategoryKeys(realmId, []);
+      expect(keys).toEqual([]);
+      expect(prisma.consentCategory.findMany).not.toHaveBeenCalled();
+    });
+
+    it('grantConsent tags history with the resolved categoryKeys', async () => {
+      prisma.userConsent.findUnique.mockResolvedValue(null);
+      prisma.userConsent.upsert.mockResolvedValue({ userId, clientId, scopes: ['profile'] });
+      prisma.consentCategory.findMany.mockResolvedValue([{ key: 'profile' }]);
+
+      await service.grantConsent(realmId, userId, clientId, ['profile']);
+
+      expect(prisma.userConsentHistory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            action: 'granted',
+            metadata: { categoryKeys: ['profile'] },
+          }),
+        }),
+      );
+    });
+
+    it('grantConsent records JsonNull metadata when no category matches', async () => {
+      prisma.userConsent.findUnique.mockResolvedValue(null);
+      prisma.userConsent.upsert.mockResolvedValue({ userId, clientId, scopes: ['openid'] });
+      prisma.consentCategory.findMany.mockResolvedValue([]);
+
+      await service.grantConsent(realmId, userId, clientId, ['openid']);
+
+      const arg = prisma.userConsentHistory.create.mock.calls[0][0];
+      expect(arg.data.metadata).toBeDefined();
+      expect(arg.data.metadata).not.toEqual(
+        expect.objectContaining({ categoryKeys: expect.anything() }),
+      );
+    });
+  });
+
   // ─── revokeConsent ──────────────────────────────────────────
 
   describe('revokeConsent', () => {
     it('should deleteMany for the user-client pair', async () => {
       prisma.userConsent.deleteMany.mockResolvedValue({ count: 1 });
 
-      await service.revokeConsent(userId, clientId);
+      await service.revokeConsent(realmId, userId, clientId);
 
       expect(prisma.userConsent.deleteMany).toHaveBeenCalledWith({
         where: { userId, clientId },
@@ -164,7 +244,7 @@ describe('ConsentService', () => {
       prisma.userConsent.deleteMany.mockResolvedValue({ count: 0 });
 
       await expect(
-        service.revokeConsent(userId, clientId),
+        service.revokeConsent(realmId, userId, clientId),
       ).resolves.toBeUndefined();
     });
   });

--- a/src/consent/consent.service.ts
+++ b/src/consent/consent.service.ts
@@ -113,9 +113,45 @@ export class ConsentService {
   }
 
   /**
+   * Resolve which consent categories a set of granted scopes belongs to, in a
+   * realm. A category governs a scope when the scope is in its configured
+   * `scopes`, or — when `scopes` is empty (unconfigured) — when the category
+   * `key` equals one of the scopes (the convention default). Setting any
+   * explicit scope on a category therefore overrides the key fallback for it.
+   *
+   * The returned keys are what per-category statistics group by
+   * (`UserConsentHistory.metadata.categoryKeys`).
+   */
+  async resolveCategoryKeys(
+    realmId: string,
+    scopes: string[],
+  ): Promise<string[]> {
+    if (scopes.length === 0) return [];
+    const categories = await this.prisma.consentCategory.findMany({
+      where: {
+        realmId,
+        enabled: true,
+        OR: [
+          { scopes: { hasSome: scopes } },
+          { AND: [{ scopes: { isEmpty: true } }, { key: { in: scopes } }] },
+        ],
+      },
+      select: { key: true },
+      orderBy: { key: 'asc' },
+    });
+    return categories.map((c) => c.key);
+  }
+
+  /**
    * Record a consent action in the history table.
+   *
+   * The granted scopes are resolved to their consent categories and stored as
+   * `metadata.categoryKeys` so per-category statistics populate from real
+   * grants. Runs for every action (grant/update/revoke) since both write paths
+   * funnel through here.
    */
   private async recordConsentHistory(
+    realmId: string,
     userId: string,
     clientId: string,
     action: ConsentAction,
@@ -124,6 +160,13 @@ export class ConsentService {
     context?: ConsentContext,
   ): Promise<void> {
     try {
+      const categoryKeys = await this.resolveCategoryKeys(realmId, scopes);
+      const baseMeta = context?.metadata;
+      const metadata =
+        categoryKeys.length > 0
+          ? { ...(baseMeta ?? {}), categoryKeys }
+          : baseMeta;
+
       await this.prisma.userConsentHistory.create({
         data: {
           userId,
@@ -133,8 +176,8 @@ export class ConsentService {
           policyVersion: policyVersion ?? null,
           ipAddress: context?.ipAddress ?? null,
           userAgent: context?.userAgent ?? null,
-          metadata: context?.metadata
-            ? (context.metadata as unknown as Prisma.InputJsonValue)
+          metadata: metadata
+            ? (metadata as unknown as Prisma.InputJsonValue)
             : Prisma.JsonNull,
         },
       });
@@ -149,6 +192,7 @@ export class ConsentService {
    * Grant consent with history tracking and versioning support.
    */
   async grantConsent(
+    realmId: string,
     userId: string,
     clientId: string,
     scopes: string[],
@@ -168,6 +212,7 @@ export class ConsentService {
     });
 
     await this.recordConsentHistory(
+      realmId,
       userId,
       clientId,
       action,
@@ -183,6 +228,7 @@ export class ConsentService {
    * Revoke consent for a user-client pair with history tracking.
    */
   async revokeConsent(
+    realmId: string,
     userId: string,
     clientId: string,
     context?: ConsentContext,
@@ -197,6 +243,7 @@ export class ConsentService {
 
     if (existing) {
       await this.recordConsentHistory(
+        realmId,
         userId,
         clientId,
         'revoked',
@@ -284,15 +331,16 @@ export class ConsentService {
       orderBy: { createdAt: 'desc' },
     });
 
-    // Build a map of category key -> last accepted version
+    // Build a map of category key -> last accepted version. A history entry
+    // may belong to several categories (metadata.categoryKeys); the entries are
+    // newest-first, so the first version seen per category is the latest.
     const lastAcceptedByCategory = new Map<string, string>();
     for (const entry of historyEntries) {
-      const metadata = entry.metadata as { categoryKey?: string } | null;
-      if (
-        metadata?.categoryKey &&
-        !lastAcceptedByCategory.has(metadata.categoryKey)
-      ) {
-        lastAcceptedByCategory.set(metadata.categoryKey, entry.policyVersion!);
+      const metadata = entry.metadata as { categoryKeys?: string[] } | null;
+      for (const key of metadata?.categoryKeys ?? []) {
+        if (!lastAcceptedByCategory.has(key)) {
+          lastAcceptedByCategory.set(key, entry.policyVersion!);
+        }
       }
     }
 

--- a/src/consent/dto/create-consent-category.dto.ts
+++ b/src/consent/dto/create-consent-category.dto.ts
@@ -1,4 +1,11 @@
-import { IsString, IsOptional, IsBoolean, IsInt, Min } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsInt,
+  Min,
+  IsArray,
+} from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateConsentCategoryDto {
@@ -51,4 +58,18 @@ export class CreateConsentCategoryDto {
   @IsOptional()
   @IsBoolean()
   enabled?: boolean;
+
+  @ApiPropertyOptional({
+    type: [String],
+    example: ['profile', 'email'],
+    description:
+      'OIDC scope names this category governs (used to tag consent grants ' +
+      'for per-category statistics). Leave empty to fall back to the ' +
+      'convention that a category governs the scope whose name equals its ' +
+      '`key`; setting any scope here overrides that fallback.',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  scopes?: string[];
 }

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -847,6 +847,7 @@ export class LoginController {
     }
 
     await this.consentService.grantConsent(
+      realm.id,
       consentReq.userId,
       consentReq.clientId,
       consentReq.scopes,

--- a/test/consent-grant-tagging.e2e-spec.ts
+++ b/test/consent-grant-tagging.e2e-spec.ts
@@ -1,0 +1,117 @@
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import type { App } from 'supertest/types';
+import {
+  createTestApp,
+  TEST_ADMIN_API_KEY,
+  type SeededRealm,
+  type TestContext,
+} from './setup';
+import { ConsentService } from '../src/consent/consent.service';
+
+/**
+ * F-16 follow-up: a real consent grant (through ConsentService.grantConsent —
+ * the single entry point every HTTP consent path funnels to) must tag history
+ * with its consent categories, so the per-category stats endpoint increments
+ * for the right category only. Not a direct stats seed.
+ */
+describe('Consent grant category tagging (e2e)', () => {
+  let app: INestApplication<App>;
+  let ctx: TestContext;
+  let seeded: SeededRealm;
+  let consentService: ConsentService;
+
+  const REALM_NAME = 'e2e-grant-tag-realm';
+  const API_KEY_HEADER = 'x-admin-api-key';
+  const base = `/admin/realms/${REALM_NAME}`;
+
+  const withKey = (req: request.Test) =>
+    req.set(API_KEY_HEADER, TEST_ADMIN_API_KEY);
+  const totalGrants = async (categoryId: string): Promise<number> => {
+    const res = await withKey(
+      request(app.getHttpServer()).get(
+        `${base}/consent-categories/${categoryId}/stats`,
+      ),
+    );
+    expect(res.status).toBe(200);
+    return res.body.totalGrants as number;
+  };
+
+  let profileCatId: string; // explicit scopes:['profile']
+  let analyticsCatId: string; // explicit scopes:['analytics']
+  let emailCatId: string; // empty scopes → key fallback ('email')
+  let secondUserId: string; // a fresh user so the email grant is `granted`
+
+  beforeAll(async () => {
+    ctx = await createTestApp();
+    app = ctx.app;
+    seeded = await ctx.seedTestRealm(REALM_NAME);
+    consentService = app.get(ConsentService);
+
+    const mk = (key: string, scopes: string[]) =>
+      ctx.prisma.consentCategory.create({
+        data: {
+          realmId: seeded.realm.id,
+          key,
+          displayName: key,
+          enabled: true,
+          scopes,
+        },
+        select: { id: true },
+      });
+
+    profileCatId = (await mk('profile', ['profile'])).id;
+    analyticsCatId = (await mk('analytics', ['analytics'])).id;
+    emailCatId = (await mk('email', [])).id; // empty → key fallback
+
+    const u2 = await ctx.prisma.user.create({
+      data: {
+        realmId: seeded.realm.id,
+        username: 'grant-tag-u2',
+        email: 'grant-tag-u2@example.com',
+        enabled: true,
+      },
+      select: { id: true },
+    });
+    secondUserId = u2.id;
+  }, 30_000);
+
+  afterAll(async () => {
+    await ctx.prisma.realm
+      .delete({ where: { name: REALM_NAME } })
+      .catch(() => {});
+    await ctx.cleanup();
+  });
+
+  it('tags a real grant by explicit scope mapping (profile only)', async () => {
+    expect(await totalGrants(profileCatId)).toBe(0);
+    expect(await totalGrants(analyticsCatId)).toBe(0);
+
+    // Real grant for `openid profile` — profile category governs `profile`.
+    await consentService.grantConsent(
+      seeded.realm.id,
+      seeded.user.id,
+      seeded.client.id,
+      ['openid', 'profile'],
+    );
+
+    expect(await totalGrants(profileCatId)).toBe(1); // incremented
+    expect(await totalGrants(analyticsCatId)).toBe(0); // untouched
+  });
+
+  it('tags a real grant by key fallback when scopes are unconfigured', async () => {
+    expect(await totalGrants(emailCatId)).toBe(0);
+
+    // `email` category has empty scopes, so it governs the `email` scope via
+    // the key==scope convention. Fresh user → a `granted` action.
+    await consentService.grantConsent(
+      seeded.realm.id,
+      secondUserId,
+      seeded.client.id,
+      ['openid', 'email'],
+    );
+
+    expect(await totalGrants(emailCatId)).toBe(1); // key fallback tagged it
+    expect(await totalGrants(profileCatId)).toBe(1); // unchanged from test 1
+  });
+});

--- a/test/consent-stats.e2e-spec.ts
+++ b/test/consent-stats.e2e-spec.ts
@@ -84,7 +84,7 @@ describe('Consent contract + statistics (e2e)', () => {
       ],
     });
 
-    const tagged = { categoryKey: CATEGORY_KEY };
+    const tagged = { categoryKeys: [CATEGORY_KEY] };
     const mkHistory = (
       userId: string,
       action: string,


### PR DESCRIPTION
Promotes the F-16 follow-up from dev to main (PR #960, all checks green).

Makes per-category consent statistics populate from **real grants** by tagging consent history with its category at the live grant path — resolving the known limitation #958 documented.

- **Mapping**: new `ConsentCategory.scopes` (String[]); a category governs a scope when it's in `scopes`, or — if `scopes` is empty — when the category `key` equals the scope (convention default, overridable).
- **Backend**: `resolveCategoryKeys` runs inside `recordConsentHistory` so every grant/revoke persists `metadata.categoryKeys[]`; stats group-by uses `array_contains`. One row per grant → action counts stay exact. Migration backfills existing history where unambiguous.
- **Frontend**: "Governed Scopes" input on the category form.

Verified with unit + e2e (real grant increments the right category only) and a full real-browser OAuth consent grant (profile 0→1, analytics 0, no console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)