### PR TITLE
Promote: docker action bumps + dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,12 @@ updates:
     labels:
       - dependencies
       - ci
+    # One grouped PR for all action bumps instead of a separate PR per action
+    # (which previously opened 4 PRs touching the same workflow file).
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   # Docker base images
   - package-ecosystem: docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,17 +41,17 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Derive tags and labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: islamawad/idenplane
           tags: |
@@ -61,7 +61,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
Promotes #964 (docker/* action bumps v4/v4/v6/v7 + github-actions grouping). The push to main re-runs docker-publish with the new action versions = build validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)