### PR TITLE
ci: publish multi-arch docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,6 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Enables building the linux/arm64 image on the amd64 runner via emulation.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -65,9 +69,9 @@ jobs:
         with:
           context: .
           push: true
-          # amd64 only for now (the demo/server is x86_64); add linux/arm64
-          # here once we want native Apple-silicon pulls.
-          platforms: linux/amd64
+          # Multi-arch: amd64 (servers/CI) + arm64 (Apple Silicon, Graviton).
+          # arm64 builds via QEMU emulation, so publishes take longer.
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
Adds linux/arm64 to the publish workflow (+ setup-qemu-action) so Apple Silicon / ARM users pull a native image instead of an emulated amd64 one. arm64 cross-builds via QEMU → publishes take ~2x longer.

After promotion: the docker-publish run builds both arches and the pushed manifest lists amd64 + arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)