### PR TITLE
fix(docker): wire WEBHOOK secrets into compose so the quickstart boots

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,17 +27,18 @@ ADMIN_API_KEY=REPLACE_ME_WITH_A_STRONG_RANDOM_SECRET
 # REQUIRED: Password for the admin user.
 ADMIN_PASSWORD=REPLACE_ME_WITH_A_STRONG_PASSWORD
 
-# REQUIRED: 32-byte (or longer) key used to encrypt webhook secrets at rest
-# (AES-256-GCM).  Generate one with: openssl rand -hex 32
-# If this key changes, all stored webhook secrets become unreadable; rotate
-# with care.  Defaults to an insecure dev value when unset — always override
-# in production.
+# REQUIRED in production: 32-byte (or longer) key used to encrypt webhook
+# secrets at rest (AES-256-GCM).  Generate one with: openssl rand -hex 32
+# When NODE_ENV=production the server refuses to boot (fatal exit) if this is
+# unset or left at the built-in default; in development it falls back to an
+# insecure dev key with a warning.  If this key changes, all stored webhook
+# secrets become unreadable; rotate with care.
 WEBHOOK_SECRET_KEY=REPLACE_ME_WITH_A_STRONG_RANDOM_SECRET
 #
-# REQUIRED: Salt used when deriving the AES key from WEBHOOK_SECRET_KEY via
-# scrypt.  Generate one with: openssl rand -hex 16
+# REQUIRED in production: salt used when deriving the AES key from
+# WEBHOOK_SECRET_KEY via scrypt.  Generate one with: openssl rand -hex 16
+# Same boot rule as above: production refuses to start if unset or default.
 # Changing this value invalidates all previously encrypted webhook secrets.
-# Must be changed from the default before running in production.
 WEBHOOK_ENCRYPTION_SALT=REPLACE_ME_WITH_A_UNIQUE_RANDOM_SALT
 THROTTLE_TTL=60000
 THROTTLE_LIMIT=100

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,10 @@ services:
       ADMIN_API_KEY: ${ADMIN_API_KEY:?Set ADMIN_API_KEY}
       ADMIN_USER: ${ADMIN_USER}
       ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+      # Required: the server hard-exits in production when these are unset, so
+      # fail fast here with a clear message instead of an opaque restart loop.
+      WEBHOOK_SECRET_KEY: ${WEBHOOK_SECRET_KEY:?Set WEBHOOK_SECRET_KEY (openssl rand -hex 32)}
+      WEBHOOK_ENCRYPTION_SALT: ${WEBHOOK_ENCRYPTION_SALT:?Set WEBHOOK_ENCRYPTION_SALT (openssl rand -hex 16)}
       THROTTLE_TTL: ${THROTTLE_TTL:-60000}
       THROTTLE_LIMIT: ${THROTTLE_LIMIT:-100}
       BASE_URL: ${BASE_URL:-http://localhost:3000}


### PR DESCRIPTION
## Summary
- The shipped `docker-compose.yml` never passed `WEBHOOK_SECRET_KEY` / `WEBHOOK_ENCRYPTION_SALT` to the `app` service, so the documented `docker compose up` **crash-looped** in production (`CryptoService.onModuleInit` hard-exits when either is unset under `NODE_ENV=production`).
- Now passed via the fail-fast `${VAR:?...}` pattern (matching the existing `ADMIN_API_KEY`), so a missing value errors immediately with an actionable message instead of an opaque restart loop.
- Corrected `.env.example`, which claimed an "insecure dev value when unset" fallback that does **not** apply in production (there it is a fatal exit).

Found while battle-testing Idenplane as an OIDC provider from a real client app (TeamDesk). This was finding #1 (blocker).

## Test plan
- [x] `ADMIN_API_KEY=dummy docker compose config` → fails fast: `required variable WEBHOOK_SECRET_KEY is missing a value: Set WEBHOOK_SECRET_KEY (openssl rand -hex 32)`
- [x] With `WEBHOOK_SECRET_KEY` + `WEBHOOK_ENCRYPTION_SALT` set → `docker compose config` validates cleanly
- [x] No source/app code touched (not in the docker-publish trigger paths → no image rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)