### PR TITLE
ci(pr-hygiene): allow committed .env.example/.sample templates

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -28,8 +28,14 @@ jobs:
           set -e
           CHANGED=$(git diff --name-only origin/main...HEAD)
           echo "$CHANGED"
-          if echo "$CHANGED" | grep -E '^\.env|/\.env|(^|/)secrets/|(^|/)credentials/' ; then
-            echo "::error::PR touches env / secrets / credentials files"
+          # Block real env / secret / credential files, but allow committed
+          # templates such as .env.example / .env.sample (they carry no secrets).
+          OFFENDING=$(echo "$CHANGED" \
+            | grep -E '(^|/)\.env([._-][^/]*)?$|(^|/)secrets/|(^|/)credentials/' \
+            | grep -vE '\.(example|sample|template|dist)$' || true)
+          if [ -n "$OFFENDING" ]; then
+            echo "::error::PR touches env / secrets / credentials files:"
+            echo "$OFFENDING"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
The PR-hygiene guard's `^\.env` regex also matched `.env.example` (a safe, committed template), blocking any PR to `main` that edits it — which blocked the Batch-1 compose/webhook fix promotion (#982).

- Match real `.env` / `.env.local` / `secrets/` / `credentials/`, but allow `*.example` / `*.sample` / `*.template` / `*.dist`.
- Capture offending paths into a variable and test non-emptiness (no longer depends on pipeline exit-code behavior, which varies between grep flavors), and print the offending files.

## Test plan
- [x] `.env`, `.env.local`, `.env.production`, `admin-ui/.env`, `secrets/*`, `credentials/*` → still blocked
- [x] `.env.example`, `config/.env.sample` → allowed
- [x] `docker-compose.yml`, `src/app.ts` → allowed
- [x] Actual Batch-1 changeset (`.env.example`, `docker-compose.yml`, this file) → allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)