### PR TITLE
fix(oidc): end the browser SSO session on RP-initiated logout

### DIFF
--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -10,6 +10,9 @@ describe('TokensController', () => {
     introspect: jest.Mock;
     revoke: jest.Mock;
     logout: jest.Mock;
+    logoutByIdToken: jest.Mock;
+    validatePostLogoutRedirectUri: jest.Mock;
+    invalidateLoginSession: jest.Mock;
     userinfo: jest.Mock;
     assertTokenBelongsToClient: jest.Mock;
   };
@@ -47,6 +50,9 @@ describe('TokensController', () => {
       introspect: jest.fn(),
       revoke: jest.fn(),
       logout: jest.fn(),
+      logoutByIdToken: jest.fn().mockResolvedValue(undefined),
+      validatePostLogoutRedirectUri: jest.fn().mockResolvedValue(undefined),
+      invalidateLoginSession: jest.fn().mockResolvedValue(undefined),
       userinfo: jest.fn(),
       assertTokenBelongsToClient: jest.fn().mockResolvedValue(undefined),
     };
@@ -172,6 +178,82 @@ describe('TokensController', () => {
         '127.0.0.1',
         'rt-123',
       );
+    });
+  });
+
+  describe('logoutGet (RP-initiated logout)', () => {
+    const mockRes = () =>
+      ({
+        redirect: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        send: jest.fn(),
+        clearCookie: jest.fn(),
+      }) as any;
+
+    it('invalidates the SSO session and clears IDENPLANE_SESSION with the matching path', async () => {
+      const req = mockReq({ cookies: { IDENPLANE_SESSION: 'sso-token-abc' } });
+      const res = mockRes();
+
+      await controller.logoutGet(
+        realm,
+        'id-token-hint',
+        undefined,
+        undefined,
+        req,
+        res,
+      );
+
+      expect(mockTokensService.invalidateLoginSession).toHaveBeenCalledWith(
+        'sso-token-abc',
+      );
+      // The cookie was set with path `/realms/<name>`; clearing with any other
+      // path silently no-ops in the browser, so assert the path explicitly.
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        'IDENPLANE_SESSION',
+        expect.objectContaining({ path: `/realms/${realm.name}` }),
+      );
+      expect(res.status).toHaveBeenCalledWith(204);
+    });
+
+    it('still clears the cookie when redirecting to a post_logout_redirect_uri', async () => {
+      const req = mockReq({ cookies: { IDENPLANE_SESSION: 'sso-token-abc' } });
+      const res = mockRes();
+
+      await controller.logoutGet(
+        realm,
+        'id-token-hint',
+        'https://app.example.com/after-logout',
+        'xyz',
+        req,
+        res,
+      );
+
+      expect(
+        mockTokensService.validatePostLogoutRedirectUri,
+      ).toHaveBeenCalled();
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        'IDENPLANE_SESSION',
+        expect.objectContaining({ path: `/realms/${realm.name}` }),
+      );
+      expect(res.redirect).toHaveBeenCalledWith(
+        'https://app.example.com/after-logout?state=xyz',
+      );
+    });
+
+    it('skips SSO invalidation when no session cookie is present', async () => {
+      const req = mockReq();
+      const res = mockRes();
+
+      await controller.logoutGet(
+        realm,
+        'id-token-hint',
+        undefined,
+        undefined,
+        req,
+        res,
+      );
+
+      expect(mockTokensService.invalidateLoginSession).not.toHaveBeenCalled();
     });
   });
 

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -286,6 +286,22 @@ export class TokensController {
       idTokenHint,
     );
 
+    // End the browser SSO session as well. Without this the IDENPLANE_SESSION
+    // cookie survives logout and /authorize silently re-authenticates the user
+    // on the next sign-in, so "Sign out" would not actually end the session.
+    const ssoToken = (req.cookies as Record<string, string> | undefined)?.[
+      'IDENPLANE_SESSION'
+    ];
+    if (ssoToken) {
+      await this.tokensService.invalidateLoginSession(ssoToken);
+    }
+    res.clearCookie('IDENPLANE_SESSION', {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      path: `/realms/${realm.name}`,
+    });
+
     if (postLogoutRedirectUri) {
       const redirectUrl = new URL(postLogoutRedirectUri);
       if (state) {

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -400,6 +400,20 @@ export class TokensService {
       });
   }
 
+  /**
+   * Invalidate the browser SSO (login) session behind an IDENPLANE_SESSION
+   * cookie. RP-initiated logout must call this so a still-valid cookie cannot
+   * be replayed to silently re-authenticate at /authorize after sign-out.
+   */
+  async invalidateLoginSession(sessionToken: string): Promise<void> {
+    const tokenHash = this.crypto.sha256(sessionToken);
+    await this.prisma.loginSession
+      .delete({ where: { tokenHash } })
+      .catch(() => {
+        // Login session may already be absent/expired — nothing to do.
+      });
+  }
+
   async userinfo(realm: Realm, accessToken: string) {
     const signingKey = await this.prisma.realmSigningKey.findFirst({
       where: { realmId: realm.id, active: true },


### PR DESCRIPTION
## Summary
RP-initiated logout (`GET .../protocol/openid-connect/logout`) deleted the OAuth `Session` for the `id_token`'s `sid` and revoked its refresh tokens, but **never cleared the browser SSO cookie `IDENPLANE_SESSION`**. Because `/authorize` reads that cookie for silent SSO, clicking **Sign in** again after **Sign out** re-authenticated the user with no credential prompt — "Sign out" didn't actually end the session (a real risk on shared/kiosk devices).

- `logoutGet` now **invalidates the login session server-side** (deletes the `loginSession` row by token hash) so a copied cookie can't be replayed, and
- **clears `IDENPLANE_SESSION`** with the same `path` it was set with (`/realms/<name>`) — a mismatched path makes `clearCookie` a silent no-op.

This is **finding #2 (blocker)** from the TeamDesk OIDC integration probe.

## Test plan
- [x] New unit tests: cookie cleared with `path: /realms/<name>` + `invalidateLoginSession` called, on both the **204** and **redirect** branches; skipped when no cookie present
- [x] `npx jest src/tokens` → 28 passed
- [x] `tsc --noEmit -p tsconfig.build.json` clean
- [ ] (post-merge, manual) re-verify in TeamDesk: Sign out → Sign in now prompts for credentials

> Note: touches `src/**` → merging to `main` will trigger an image republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)