### PR TITLE
fix(rate-limit): stop admin-key double-count + counting rejected requests (#3,#7)

### DIFF
--- a/src/common/guards/admin-api-key.guard.spec.ts
+++ b/src/common/guards/admin-api-key.guard.spec.ts
@@ -100,6 +100,21 @@ describe('AdminApiKeyGuard', () => {
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 
+  it('counts the admin-key rate limit only once when run twice for one request (finding #3)', async () => {
+    reflector.getAllAndOverride.mockReturnValue(false);
+    configService.get.mockReturnValue('super-secret-key');
+    const ctx = createMockExecutionContext({
+      'x-admin-api-key': 'super-secret-key',
+    });
+
+    // The guard is registered both globally (APP_GUARD) and per-controller, so
+    // it runs twice for a single request — but must consume only one slot.
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+
+    expect(rateLimitService.checkAdminApiKeyLimit).toHaveBeenCalledTimes(1);
+  });
+
   it('should allow admin routes when a valid Bearer token is provided', async () => {
     reflector.getAllAndOverride.mockReturnValue(false);
     adminAuthService.validateAdminToken.mockResolvedValue({

--- a/src/common/guards/admin-api-key.guard.ts
+++ b/src/common/guards/admin-api-key.guard.ts
@@ -13,6 +13,7 @@ import { timingSafeEqual } from 'crypto';
 import { IS_PUBLIC_KEY } from '../decorators/public.decorator.js';
 import { AdminAuthService } from '../../admin-auth/admin-auth.service.js';
 import { RateLimitService } from '../../rate-limit/rate-limit.service.js';
+import type { RateLimitResult } from '../../rate-limit/rate-limit.dto.js';
 import { resolveClientIp } from '../utils/proxy-ip.util.js';
 
 @Injectable()
@@ -64,8 +65,18 @@ export class AdminApiKeyGuard implements CanActivate {
     const providedApiKey = request.headers['x-admin-api-key'];
     if (expectedKey && typeof providedApiKey === 'string') {
       const ip = resolveClientIp(request);
-      const rateLimitResult =
-        await this.rateLimitService.checkAdminApiKeyLimit(ip);
+      // This guard can run twice for a single request — it is registered both
+      // globally (APP_GUARD) and in per-controller @UseGuards. Compute the
+      // admin-key rate limit once per request and reuse it; otherwise one call
+      // increments the counter twice and halves the effective limit.
+      const rlReq = request as AdminRequest & {
+        __adminApiKeyRateLimit?: RateLimitResult;
+      };
+      let rateLimitResult = rlReq.__adminApiKeyRateLimit;
+      if (!rateLimitResult) {
+        rateLimitResult = await this.rateLimitService.checkAdminApiKeyLimit(ip);
+        rlReq.__adminApiKeyRateLimit = rateLimitResult;
+      }
       const headers = this.rateLimitService.computeHeaders(rateLimitResult);
       for (const [name, value] of Object.entries(headers)) {
         response.setHeader(name, value);

--- a/src/rate-limit/rate-limit.service.spec.ts
+++ b/src/rate-limit/rate-limit.service.spec.ts
@@ -97,6 +97,28 @@ describe('RateLimitService', () => {
     prisma = createMockPrismaService();
     upsertMock = createStatefulUpsertMock();
     prisma.rateLimitEntry.upsert = upsertMock;
+    // Stateful update mock sharing the upsert store so rejection-compensation
+    // (decrement) and window-reset writes are reflected in the same counters.
+    prisma.rateLimitEntry.update = jest
+      .fn()
+      .mockImplementation((args: { where: { key: string }; data: any }) => {
+        const store = (upsertMock as any).__store as Map<string, any>;
+        const entry = store.get(args.where.key);
+        if (entry) {
+          const d = args.data;
+          if (d.minuteCount?.decrement !== undefined)
+            entry.minuteCount -= d.minuteCount.decrement;
+          else if (typeof d.minuteCount === 'number')
+            entry.minuteCount = d.minuteCount;
+          if (d.hourCount?.decrement !== undefined)
+            entry.hourCount -= d.hourCount.decrement;
+          else if (typeof d.hourCount === 'number')
+            entry.hourCount = d.hourCount;
+          if (d.minuteWindowStart) entry.minuteWindowStart = d.minuteWindowStart;
+          if (d.hourWindowStart) entry.hourWindowStart = d.hourWindowStart;
+        }
+        return Promise.resolve(entry ? { ...entry } : { key: args.where.key });
+      });
     service = new RateLimitService(
       prisma as any,
       createMockRedisService() as any,
@@ -145,6 +167,28 @@ describe('RateLimitService', () => {
       expect(result.allowed).toBe(false);
       expect(result.remaining).toBe(0);
       expect(result.retryAfter).toBeGreaterThan(0);
+    });
+
+    it('does not inflate the counter when rejected requests retry (finding #7)', async () => {
+      prisma.realm.findUnique.mockResolvedValue({
+        ...rateLimitEnabledRealm,
+        clientRateLimitPerMinute: 2,
+      });
+
+      // Exhaust the 2 allowed requests
+      await service.checkClientLimit(clientId, realmId);
+      await service.checkClientLimit(clientId, realmId);
+
+      // Hammer with rejected retries — these must NOT keep incrementing
+      for (let i = 0; i < 5; i++) {
+        const r = await service.checkClientLimit(clientId, realmId);
+        expect(r.allowed).toBe(false);
+      }
+
+      const store = (upsertMock as any).__store as Map<string, any>;
+      const entry = [...store.values()][0];
+      // Counter stays capped at the limit (2), not 2 + 5 rejected retries.
+      expect(entry.minuteCount).toBe(2);
     });
 
     it('should track different clients independently', async () => {

--- a/src/rate-limit/rate-limit.service.ts
+++ b/src/rate-limit/rate-limit.service.ts
@@ -185,6 +185,13 @@ export class RateLimitService {
     const minuteResetAt = (minuteWindow + 1) * 60;
     const hourResetAt = (hourWindow + 1) * 3600;
 
+    // Don't count rejected requests: undo this request's increments so a retry
+    // storm cannot keep inflating the counter and extend the lockout window.
+    if (minuteCount > limitPerMinute || hourCount > limitPerHour) {
+      await this.redis.decr(minuteKey).catch(() => undefined);
+      await this.redis.decr(hourKey).catch(() => undefined);
+    }
+
     // Check minute limit
     if (minuteCount > limitPerMinute) {
       const retryAfter = minuteResetAt - now;
@@ -288,6 +295,19 @@ export class RateLimitService {
     const hourResetAt = Math.ceil(
       (Math.max(entryHourWindowStart, now) + hourWindowMs) / 1000,
     );
+
+    // Don't count rejected requests: undo this request's increment so a retry
+    // storm cannot keep inflating the counter and extend the lockout window.
+    if (minuteCount > limitPerMinute || hourCount > limitPerHour) {
+      await this.prisma.rateLimitEntry
+        .update({
+          where: { key },
+          data: { minuteCount: { decrement: 1 }, hourCount: { decrement: 1 } },
+        })
+        .catch(() => {
+          // Entry may have been cleaned up concurrently — nothing to undo.
+        });
+    }
 
     if (minuteCount > limitPerMinute) {
       const retryAfter = minuteResetAt - Math.floor(now / 1000);

--- a/src/redis/redis.service.ts
+++ b/src/redis/redis.service.ts
@@ -137,6 +137,15 @@ export class RedisService implements OnModuleInit, OnModuleDestroy {
     return count;
   }
 
+  /**
+   * Atomically decrement a key by 1. Used to undo a rejected request's INCR so
+   * throttled retries do not keep inflating the rate-limit counter.
+   */
+  async decr(key: string): Promise<number> {
+    if (!this.isAvailable()) return 0;
+    return this.client!.decr(key);
+  }
+
   /** Delete all keys matching a glob pattern (uses SCAN to avoid blocking). */
   async delPattern(pattern: string): Promise<void> {
     if (!this.isAvailable()) return;


### PR DESCRIPTION
## Summary
**#3 (major)** — `AdminApiKeyGuard` is registered **both** globally (`APP_GUARD`) and in every admin controller's `@UseGuards`, so it ran (and counted) **twice** per request → halved the effective admin-API-key limit. The guard enforces by **path** (`/admin/*`), so the global registration alone already protects every admin route. Rather than churn 27 controllers, the per-request rate-limit result is now **idempotent** (computed once, cached on the request) → one call consumes exactly one slot.

> Note: this revises plan-decision D1. After reading the guard I found it's path-based, so removing the global guard (the original D1) would be the *riskier* direction. Keeping both registrations + idempotent counting is the safe, minimal fix.

**#7 (minor)** — the limiter incremented **before** evaluating the limit, so rejected (429) requests kept inflating the counter and extending the lockout under retry storms. Now the increment is **undone when a request is rejected**, in both the Redis (new `RedisService.decr`) and database paths.

Combined with the source's `60/min` default, this restores the documented admin-key limit once the image is republished (**closes #4**).

## Test plan
- [x] New: guard counts the rate limit only once when run twice for one request (#3)
- [x] New: rejected retries don't inflate the counter — stays capped at the limit (#7)
- [x] `npx jest src/rate-limit src/common/guards` → 40 passed
- [x] `tsc --noEmit -p tsconfig.build.json` clean · eslint clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)