### PR TITLE
fix(oidc): include acr/amr in the access token (RFC 9068) (#12)

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -366,6 +366,24 @@ describe('AuthService', () => {
       expect(result.access_token).toBeDefined();
     });
 
+    it('includes acr in the access token (RFC 9068, finding #12)', async () => {
+      setupForTokenIssuance();
+      prisma.user.findUnique.mockResolvedValue(dbUser);
+
+      await service.handleTokenRequest(realm, {
+        grant_type: 'password',
+        client_id: 'my-client',
+        client_secret: 'correct-secret',
+        username: 'testuser',
+        password: 'pass',
+        scope: 'openid',
+      });
+
+      // signJwt is called for the access token first, then the id_token.
+      const accessTokenPayload = jwkService.signJwt.mock.calls[0][0];
+      expect(accessTokenPayload).toHaveProperty('acr');
+    });
+
     it('should not require client_secret for a public client', async () => {
       setupForTokenIssuance(publicClient as any);
       prisma.user.findUnique.mockResolvedValue(dbUser);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -955,6 +955,12 @@ export class AuthService {
       typ: 'Bearer',
       azp: clientId,
       sid: sessionId,
+      // RFC 9068 §2.2: surface the authentication context (acr) and methods
+      // (amr) in the access token too, so a resource server can make step-up /
+      // assurance decisions from the bearer token without needing the id_token.
+      // Mirror the id_token resolution (default acr = password).
+      acr: acr ?? ACR_PASSWORD,
+      ...(amr && amr.length > 0 ? { amr } : {}),
       ...userClaims,
       ...(includeRoles
         ? {


### PR DESCRIPTION
## Summary
The id_token carried `acr`/`amr` but the **access token did not**, so a resource server couldn't determine the authentication strength (e.g. whether MFA was used) from the bearer token — it would need the id_token (never sent to APIs) or an extra introspection round-trip. RFC 9068 §2.2 says these SHOULD be in the access token when present in the id_token.

Mirrors the id_token resolution: default `acr = urn:idenplane:acr:password`; include `amr` only when non-empty.

Finding #12 from the TeamDesk OIDC probe.

## Test plan
- [x] New unit test asserts the access-token payload includes `acr`
- [x] `npx jest src/auth` → 155 passed · `tsc --noEmit -p tsconfig.build.json` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)