### PR TITLE
fix(mfa): actionable error + rationale for static-key MFA-reset block (#6)

### DIFF
--- a/src/mfa/mfa.controller.spec.ts
+++ b/src/mfa/mfa.controller.spec.ts
@@ -140,7 +140,7 @@ describe('MfaController', () => {
 
       await expect(
         controller.resetMfa(realm, 'user-1', reqWithApiKey),
-      ).rejects.toThrow('API key authentication is not permitted');
+      ).rejects.toThrow('Static admin API keys cannot disable user MFA');
     });
 
     it('should throw UnauthorizedException when no session token is present', async () => {

--- a/src/mfa/mfa.controller.ts
+++ b/src/mfa/mfa.controller.ts
@@ -120,9 +120,18 @@ export class MfaController {
       throw new UnauthorizedException('Admin identity could not be determined');
     }
 
+    // Static admin API keys are intentionally rejected here. The key is a single
+    // shared secret that always carries super-admin, so if it ever leaks it must
+    // not be usable to bypass MFA on every account. Disabling a user's MFA
+    // therefore requires an interactively MFA-verified admin session (the Bearer
+    // path below). Users who lose their authenticator recover via their recovery
+    // codes; an MFA-verified admin reset is the fallback. (Deliberate: do not add
+    // an API-key break-glass path — it reintroduces the key-leak → mass-bypass risk.)
     if (adminUser.userId.startsWith('api-key:')) {
       throw new UnauthorizedException(
-        'MFA step-up is required to disable user MFA. API key authentication is not permitted for this operation.',
+        'Static admin API keys cannot disable user MFA — this is deliberate, so a leaked key cannot bypass MFA across every account. ' +
+          'Recovery paths: (1) the user redeems a recovery code; (2) an admin signs in interactively and completes MFA step-up ' +
+          '(POST /realms/:realmName/step-up/verify with acr=urn:idenplane:acr:mfa), then retries with that session.',
       );
     }
 


### PR DESCRIPTION
## Summary
Reading the code flipped the plan for finding #6. The static admin API key being unable to disable a user's MFA is **not a gap — it's a deliberate, correct security posture**:
- MFA reset already works via an **interactively MFA-verified admin session** (Bearer + step-up to `acr=mfa`).
- The static key always carries `super-admin`, so a "role gate" is meaningless; if the key leaks it must not be able to bypass MFA on every account.
- **Recovery codes exist** (`recoveryCode` model) — the user's primary self-recovery; admin reset is the fallback.

So instead of a break-glass endpoint (which would reintroduce the key-leak → mass-MFA-bypass risk), this just:
- rewrites the unhelpful 401 to point admins at the supported recovery paths, and
- adds a code comment documenting the deliberate design.

## Test plan
- [x] `npx jest src/mfa` → 68 passed (updated the message assertion) · eslint clean · `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)