### PR TITLE
fix(oidc): friendly redirect on invalid RP-initiated logout, not JSON (#10)

### DIFF
--- a/src/tokens/tokens.controller.spec.ts
+++ b/src/tokens/tokens.controller.spec.ts
@@ -1,6 +1,6 @@
 jest.mock('../crypto/jwk.service.js', () => ({ JwkService: jest.fn() }));
 
-import { UnauthorizedException } from '@nestjs/common';
+import { UnauthorizedException, BadRequestException } from '@nestjs/common';
 import { TokensController } from './tokens.controller.js';
 import type { Realm } from '@prisma/client';
 
@@ -238,6 +238,34 @@ describe('TokensController', () => {
       expect(res.redirect).toHaveBeenCalledWith(
         'https://app.example.com/after-logout?state=xyz',
       );
+    });
+
+    it('redirects to the login page instead of raw JSON when the logout request is invalid (#10)', async () => {
+      mockTokensService.validatePostLogoutRedirectUri.mockRejectedValue(
+        new BadRequestException(
+          'post_logout_redirect_uri is not valid for this client',
+        ),
+      );
+      const req = mockReq({ cookies: { IDENPLANE_SESSION: 'sso-token-abc' } });
+      const res = mockRes();
+
+      await controller.logoutGet(
+        realm,
+        'id-token-hint',
+        'https://evil.example.com/steal',
+        undefined,
+        req,
+        res,
+      );
+
+      // Best-effort sign-out still happens, and the browser is redirected to
+      // the login page with the reason rather than shown a raw JSON 400.
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        'IDENPLANE_SESSION',
+        expect.objectContaining({ path: `/realms/${realm.name}` }),
+      );
+      const redirectArg = res.redirect.mock.calls[0][0];
+      expect(redirectArg).toContain(`/realms/${realm.name}/login?error=`);
     });
 
     it('skips SSO invalidation when no session cookie is present', async () => {

--- a/src/tokens/tokens.controller.ts
+++ b/src/tokens/tokens.controller.ts
@@ -270,14 +270,30 @@ export class TokensController {
     @Res() res: Response,
   ) {
     if (postLogoutRedirectUri) {
-      // Validate post_logout_redirect_uri against the client's registered
-      // redirect URIs *before* performing any session teardown so that an
-      // attacker cannot abuse the endpoint as an open redirector.
-      await this.tokensService.validatePostLogoutRedirectUri(
-        realm,
-        postLogoutRedirectUri,
-        idTokenHint,
-      );
+      // Validate post_logout_redirect_uri against the client's registered URIs
+      // *before* any teardown so the endpoint can't be abused as an open
+      // redirector. This endpoint is reached by top-level browser navigation,
+      // so on failure send the user to the login page (signed out) with the
+      // reason rather than dumping a raw JSON error to the browser.
+      try {
+        await this.tokensService.validatePostLogoutRedirectUri(
+          realm,
+          postLogoutRedirectUri,
+          idTokenHint,
+        );
+      } catch (err) {
+        await this.tokensService
+          .logoutByIdToken(realm, resolveClientIp(req), idTokenHint)
+          .catch(() => undefined);
+        await this.clearBrowserSsoSession(realm, req, res);
+        const message =
+          err instanceof BadRequestException
+            ? this.extractErrorMessage(err)
+            : 'Invalid logout request';
+        return res.redirect(
+          `/realms/${realm.name}/login?error=${encodeURIComponent(message)}`,
+        );
+      }
     }
 
     await this.tokensService.logoutByIdToken(
@@ -285,10 +301,30 @@ export class TokensController {
       resolveClientIp(req),
       idTokenHint,
     );
+    await this.clearBrowserSsoSession(realm, req, res);
 
-    // End the browser SSO session as well. Without this the IDENPLANE_SESSION
-    // cookie survives logout and /authorize silently re-authenticates the user
-    // on the next sign-in, so "Sign out" would not actually end the session.
+    if (postLogoutRedirectUri) {
+      const redirectUrl = new URL(postLogoutRedirectUri);
+      if (state) {
+        redirectUrl.searchParams.set('state', state);
+      }
+      res.redirect(redirectUrl.toString());
+    } else {
+      res.status(HttpStatus.NO_CONTENT).send();
+    }
+  }
+
+  /**
+   * Invalidate the browser SSO (login) session and clear the IDENPLANE_SESSION
+   * cookie (matching the path it was set with) so RP-initiated logout actually
+   * ends the IdP session — otherwise /authorize silently re-authenticates from
+   * the surviving cookie on the next sign-in.
+   */
+  private async clearBrowserSsoSession(
+    realm: Realm,
+    req: Request,
+    res: Response,
+  ): Promise<void> {
     const ssoToken = (req.cookies as Record<string, string> | undefined)?.[
       'IDENPLANE_SESSION'
     ];
@@ -301,16 +337,14 @@ export class TokensController {
       sameSite: 'strict',
       path: `/realms/${realm.name}`,
     });
+  }
 
-    if (postLogoutRedirectUri) {
-      const redirectUrl = new URL(postLogoutRedirectUri);
-      if (state) {
-        redirectUrl.searchParams.set('state', state);
-      }
-      res.redirect(redirectUrl.toString());
-    } else {
-      res.status(HttpStatus.NO_CONTENT).send();
-    }
+  private extractErrorMessage(err: BadRequestException): string {
+    const resp = err.getResponse();
+    if (typeof resp === 'string') return resp;
+    const m = (resp as { message?: string | string[] }).message;
+    if (Array.isArray(m)) return m.join(', ');
+    return m ?? 'Invalid logout request';
   }
 
   @Get('userinfo')


### PR DESCRIPTION
## Summary
`end_session_endpoint` is reached by top-level browser navigation, but an invalid logout request returned a **raw JSON 400** to the browser. Now the validation error is caught, the user is **signed out best-effort** (open-redirect protection preserved — we never redirect to the unvalidated URI), and redirected to the login page with the reason. The SSO-session teardown (from #2) is refactored into a shared `clearBrowserSsoSession` helper.

Finding #10 (minor) from the TeamDesk OIDC probe.

## Test plan
- [x] New unit test: invalid logout → redirect to `/realms/<realm>/login?error=...` (not JSON), cookie still cleared
- [x] Existing #2 tests still pass (cookie cleared + session invalidated on the 204 and redirect paths) — `npx jest src/tokens/tokens.controller.spec.ts` 14 passed
- [x] `tsc` + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)