### PR TITLE
docs(email): document per-realm SMTP + actionable unconfigured-email warning (#11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,19 @@ BASE_URL=http://localhost:3000
 # prevents direct public access to the app process, e.g. a managed cloud LB):
 #   TRUSTED_PROXIES=*
 # TRUSTED_PROXIES=
+
+# ─── Email / SMTP ──────────────────────────────────────────────────────────
+# Email (password reset, email verification, notifications) is configured
+# PER REALM — there are NO global SMTP environment variables. Set it via the
+# admin API:
+#   PATCH /admin/realms/<realm>
+#   {
+#     "smtpHost": "smtp.example.com", "smtpPort": 587, "smtpSecure": false,
+#     "smtpUser": "apikey", "smtpPassword": "...",
+#     "smtpFrom": "noreply@example.com"
+#   }
+# Until a realm has smtpHost set, that realm's emails are silently skipped (a
+# warning is logged). Note: the forgot-password page still shows a generic
+# "if an account exists, we sent a link" message even when SMTP is unset — this
+# is intentional, to avoid account enumeration. Configure SMTP per realm before
+# relying on email-based flows (reset / verification).

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -94,7 +94,10 @@ export class EmailService {
 
     if (!realm?.smtpHost) {
       this.logger.warn(
-        `SMTP not configured for realm "${realmName}", skipping email to ${to}`,
+        `SMTP is not configured for realm "${realmName}" — skipping email to ${to}. ` +
+          `Email is configured per realm: PATCH /admin/realms/${realmName} with ` +
+          `smtpHost/smtpPort/smtpUser/smtpPassword/smtpFrom/smtpSecure. Until then, ` +
+          `password-reset / verification emails are silently dropped.`,
       );
       return;
     }


### PR DESCRIPTION
## Summary
Email is configured **per realm** (no global SMTP env vars), which was undocumented; when a realm has no `smtpHost`, emails are silently dropped with only a terse warn while the forgot-password page still shows a generic "we sent a link" (intentional anti-enumeration).

- Documents per-realm SMTP setup (`PATCH /admin/realms/<realm>` with `smtpHost/...`) in `.env.example`.
- Makes the skip-warning actionable (points to the exact admin API call).

The ambiguous end-user message is **kept by design** (account-enumeration defense). Finding #11 (minor) from the TeamDesk OIDC probe.

## Test plan
- [x] `npx jest src/email` → 13 passed · `tsc` clean · eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)