### PR TITLE
fix(account): suppress favicon 404 on hosted account pages (#14)

### DIFF
--- a/themes/idenplane/account/templates/layouts/main.hbs
+++ b/themes/idenplane/account/templates/layouts/main.hbs
@@ -6,6 +6,8 @@
   <title>{{pageTitle}} — {{appTitle}}</title>
   {{#if faviconUrl}}
   <link rel="icon" href="{{faviconUrl}}">
+  {{else}}
+  <link rel="icon" href="data:,">
   {{/if}}
   {{#each themeCssFiles}}
   <link rel="stylesheet" href="{{this}}">

--- a/themes/midnight/account/templates/layouts/main.hbs
+++ b/themes/midnight/account/templates/layouts/main.hbs
@@ -7,6 +7,8 @@
   <title>{{pageTitle}} &mdash; {{appTitle}}</title>
   {{#if faviconUrl}}
   <link rel="icon" href="{{faviconUrl}}">
+  {{else}}
+  <link rel="icon" href="data:,">
   {{/if}}
   {{#each themeCssFiles}}
   <link rel="stylesheet" href="{{this}}">


### PR DESCRIPTION
## Summary
The #9 fix only covered the login layout; the account layouts still 404'd on `/favicon.ico` (e.g. `/account/totp-setup`). Applies the same empty-`data:` icon fallback to both account layouts (idenplane, midnight).

Finding #14 (minor) from the TeamDesk re-verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)