### PR TITLE
Promote dev → main: #13 (acr/amr reflect MFA) + #14 (account favicon)

### DIFF
--- a/prisma/migrations/20260528173747_add_satisfied_acr_amr/migration.sql
+++ b/prisma/migrations/20260528173747_add_satisfied_acr_amr/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable
+ALTER TABLE "authorization_codes" ADD COLUMN     "amr" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "satisfied_acr" TEXT;
+
+-- AlterTable
+ALTER TABLE "sessions" ADD COLUMN     "amr" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "satisfied_acr" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -399,12 +399,17 @@ model UserRole {
 // ─── SESSIONS & REFRESH TOKENS ────────────────────────────
 
 model Session {
-  id        String  @id @default(uuid())
-  userId    String  @map("user_id")
-  realmId   String  @default("") @map("realm_id")
-  clientId  String? @map("client_id")
-  ipAddress String? @map("ip_address")
-  userAgent String? @map("user_agent")
+  id           String   @id @default(uuid())
+  userId       String   @map("user_id")
+  realmId      String   @default("") @map("realm_id")
+  clientId     String?  @map("client_id")
+  ipAddress    String?  @map("ip_address")
+  userAgent    String?  @map("user_agent")
+  /// The ACR level actually satisfied when this session was established.
+  /// Lets the refresh_token grant preserve acr/amr across token rotation.
+  satisfiedAcr String?  @map("satisfied_acr")
+  /// The authentication methods (RFC 8176) actually performed for this session.
+  amr          String[] @default([]) @map("amr")
 
   createdAt DateTime @default(now()) @map("created_at")
   expiresAt DateTime @map("expires_at")
@@ -449,8 +454,15 @@ model AuthorizationCode {
   codeChallenge       String? @map("code_challenge")
   codeChallengeMethod String? @map("code_challenge_method")
   nonce               String?
-  acrValues           String? @map("acr_values")
-  used                Boolean @default(false)
+  /// The ACR value(s) *requested* by the client at authorization time.
+  acrValues           String?  @map("acr_values")
+  /// The ACR level actually *satisfied* by the authentication that produced
+  /// this code (password vs. password+MFA vs. WebAuthn). Read back at the
+  /// code→token exchange so the issued tokens reflect the real auth context.
+  satisfiedAcr        String?  @map("satisfied_acr")
+  /// The authentication methods (RFC 8176) actually performed.
+  amr                 String[] @default([]) @map("amr")
+  used                Boolean  @default(false)
 
   createdAt DateTime @default(now()) @map("created_at")
   expiresAt DateTime @map("expires_at")

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -668,7 +668,7 @@ describe('AuthService', () => {
 
       const result = await service.handleTokenRequest(realm, {
         grant_type: 'refresh_token',
-        refresh_token: 'original-opaque-token',
+        refresh_token: 'orig-opaque-rt',
         client_id: 'my-client',
         client_secret: 'correct-secret',
         scope: 'openid',
@@ -710,7 +710,7 @@ describe('AuthService', () => {
 
       await service.handleTokenRequest(realm, {
         grant_type: 'refresh_token',
-        refresh_token: 'original-opaque-token',
+        refresh_token: 'orig-opaque-rt',
         client_id: 'my-client',
         client_secret: 'correct-secret',
         scope: 'openid',

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -11,6 +11,7 @@ import {
   type MockPrismaService,
 } from '../prisma/prisma.mock.js';
 import type { Realm } from '@prisma/client';
+import { ACR_PASSWORD, ACR_MFA } from '../step-up/step-up.service.js';
 
 // ---------------------------------------------------------------------------
 // Helpers & fixtures
@@ -648,6 +649,8 @@ describe('AuthService', () => {
       session: {
         id: 'session-1',
         user: dbUser,
+        satisfiedAcr: null as string | null,
+        amr: [] as string[],
       },
     };
 
@@ -683,6 +686,39 @@ describe('AuthService', () => {
 
       // New refresh token should be created
       expect(prisma.refreshToken.create).toHaveBeenCalled();
+    });
+
+    it('preserves the session acr/amr across refresh (no downgrade to password)', async () => {
+      setupValidClient();
+      setupSigningKey();
+      setupEmptyRoles();
+      setupRefreshTokenCreate();
+
+      const mfaToken = {
+        ...storedRefreshToken,
+        session: {
+          ...storedRefreshToken.session,
+          satisfiedAcr: ACR_MFA,
+          amr: ['pwd', 'otp'],
+        },
+      };
+      prisma.refreshToken.findUnique.mockResolvedValue(mfaToken);
+      prisma.refreshToken.update.mockResolvedValue({
+        ...mfaToken,
+        revoked: true,
+      });
+
+      await service.handleTokenRequest(realm, {
+        grant_type: 'refresh_token',
+        refresh_token: 'original-opaque-token',
+        client_id: 'my-client',
+        client_secret: 'correct-secret',
+        scope: 'openid',
+      });
+
+      const accessTokenPayload = jwkService.signJwt.mock.calls[0][0];
+      expect(accessTokenPayload.acr).toBe(ACR_MFA);
+      expect(accessTokenPayload.amr).toEqual(['pwd', 'otp']);
     });
 
     it('should throw BadRequestException when refresh_token is missing', async () => {
@@ -811,6 +847,9 @@ describe('AuthService', () => {
       nonce: 'test-nonce',
       codeChallenge: null,
       codeChallengeMethod: null,
+      acrValues: null as string | null,
+      satisfiedAcr: null as string | null,
+      amr: [] as string[],
       used: false,
       expiresAt: futureDate,
       createdAt: new Date(),
@@ -859,6 +898,77 @@ describe('AuthService', () => {
           data: { used: true },
         }),
       );
+    });
+
+    it('reflects the satisfied MFA context (acr/amr) when the code carries it', async () => {
+      setupForTokenIssuance();
+      prisma.authorizationCode.update.mockResolvedValue({
+        ...authCode,
+        satisfiedAcr: ACR_MFA,
+        amr: ['pwd', 'otp'],
+        used: true,
+      });
+      prisma.user.findUnique.mockResolvedValue(dbUser);
+
+      await service.handleTokenRequest(
+        realm,
+        {
+          grant_type: 'authorization_code',
+          code: 'valid-auth-code',
+          client_id: 'my-client',
+          client_secret: 'correct-secret',
+          redirect_uri: 'https://app.example.com/callback',
+        },
+        '127.0.0.1',
+        'jest-agent',
+      );
+
+      // signJwt[0] = access token payload, signJwt[1] = id token payload
+      const accessTokenPayload = jwkService.signJwt.mock.calls[0][0];
+      const idTokenPayload = jwkService.signJwt.mock.calls[1][0];
+      expect(accessTokenPayload.acr).toBe(ACR_MFA);
+      expect(accessTokenPayload.amr).toEqual(['pwd', 'otp']);
+      expect(idTokenPayload.acr).toBe(ACR_MFA);
+      expect(idTokenPayload.amr).toContain('otp');
+
+      // The satisfied context is also persisted on the new session so refresh
+      // can preserve it.
+      expect(prisma.session.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            satisfiedAcr: ACR_MFA,
+            amr: ['pwd', 'otp'],
+          }),
+        }),
+      );
+    });
+
+    it('defaults to password-level acr/amr when the code carries no satisfied context', async () => {
+      setupForTokenIssuance();
+      prisma.authorizationCode.update.mockResolvedValue({
+        ...authCode,
+        satisfiedAcr: null,
+        amr: [],
+        used: true,
+      });
+      prisma.user.findUnique.mockResolvedValue(dbUser);
+
+      await service.handleTokenRequest(
+        realm,
+        {
+          grant_type: 'authorization_code',
+          code: 'valid-auth-code',
+          client_id: 'my-client',
+          client_secret: 'correct-secret',
+          redirect_uri: 'https://app.example.com/callback',
+        },
+        '127.0.0.1',
+        'jest-agent',
+      );
+
+      const accessTokenPayload = jwkService.signJwt.mock.calls[0][0];
+      expect(accessTokenPayload.acr).toBe(ACR_PASSWORD);
+      expect(accessTokenPayload.amr).toEqual(['pwd']);
     });
 
     it('should throw BadRequestException when code is missing', async () => {
@@ -1339,6 +1449,9 @@ describe('AuthService', () => {
         nonce: 'my-nonce-value',
         codeChallenge: null,
         codeChallengeMethod: null,
+        acrValues: null,
+        satisfiedAcr: null,
+        amr: [] as string[],
         used: false,
         expiresAt: new Date(Date.now() + 60_000),
         createdAt: new Date(),

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -190,6 +190,9 @@ export class AuthService {
         userId: user.id,
         ipAddress: ip,
         userAgent,
+        // Persist so a later refresh preserves the password-level context.
+        satisfiedAcr: ACR_PASSWORD,
+        amr: ['pwd'],
         expiresAt: new Date(Date.now() + realm.refreshTokenLifespan * 1000),
       },
     });
@@ -314,6 +317,9 @@ export class AuthService {
         userId: user.id,
         ipAddress: ip,
         userAgent,
+        // Persist so a later refresh preserves the MFA-level context.
+        satisfiedAcr: ACR_MFA,
+        amr: ['pwd', 'otp'],
         expiresAt: new Date(Date.now() + realm.refreshTokenLifespan * 1000),
       },
     });
@@ -526,12 +532,23 @@ export class AuthService {
       grant_type: 'refresh_token',
     });
 
+    // Preserve the session's satisfied auth context across refresh so the
+    // rotated tokens keep their acr/amr (and don't silently downgrade to
+    // password level). Legacy sessions with no stored context fall back.
+    const session = storedToken.session;
+    const acr = session.satisfiedAcr ?? ACR_PASSWORD;
+    const amr = session.amr.length > 0 ? session.amr : ['pwd'];
+
     return this.issueTokens(
       realm,
       user,
       client_id,
       storedToken.sessionId,
       scope || storedToken.scope || undefined,
+      undefined,
+      undefined,
+      acr,
+      amr,
     );
   }
 
@@ -632,11 +649,21 @@ export class AuthService {
 
     await this.enforceSessionLimit(realm, user.id);
 
+    // Reflect the auth context actually *satisfied* during login (persisted on
+    // the code at authorization time), not merely the client-*requested*
+    // `acrValues`. Falls back to password-level for legacy/null codes.
+    const acr = authCode.satisfiedAcr ?? ACR_PASSWORD;
+    const amr = authCode.amr.length > 0 ? authCode.amr : ['pwd'];
+
     const session = await this.prisma.session.create({
       data: {
         userId: user.id,
         ipAddress: ip,
         userAgent,
+        // Persist so the refresh_token grant can preserve acr/amr (see
+        // handleRefreshTokenGrant).
+        satisfiedAcr: acr,
+        amr,
         expiresAt: new Date(Date.now() + realm.refreshTokenLifespan * 1000),
       },
     });
@@ -654,12 +681,6 @@ export class AuthService {
       grant_type: 'authorization_code',
     });
 
-    // Resolve ACR from the auth code's stored acr_values (set at authorization time)
-    const storedAcrValues = authCode.acrValues;
-    const resolvedAcr = storedAcrValues
-      ? storedAcrValues.split(' ')[0]
-      : ACR_PASSWORD;
-
     return this.issueTokens(
       realm,
       user,
@@ -668,8 +689,8 @@ export class AuthService {
       authCode.scope ?? undefined,
       authCode.nonce ?? undefined,
       new Date(),
-      resolvedAcr,
-      ['pwd'],
+      acr,
+      amr,
       authCode.code,
     );
   }

--- a/src/consent/consent.service.ts
+++ b/src/consent/consent.service.ts
@@ -11,6 +11,14 @@ export interface ConsentRequest {
   realmName: string;
   scopes: string[];
   oauthParams: Record<string, string>;
+  /**
+   * The ACR level satisfied by the authentication that preceded the consent
+   * screen. Carried across the consent round-trip so the issued authorization
+   * code reflects the real auth context (RFC 8176 / RFC 9068).
+   */
+  satisfiedAcr?: string;
+  /** The authentication methods performed (e.g. `['pwd', 'otp']`). */
+  amr?: string[];
 }
 
 export type ConsentAction = 'granted' | 'revoked' | 'updated';

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -16,7 +16,11 @@ import { ConfigService } from '@nestjs/config';
 import { ApiExcludeController } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import { Prisma, type Realm, type User } from '@prisma/client';
-import type { AuthorizeParams } from '../oauth/oauth.service.js';
+import type {
+  AuthorizeParams,
+  SatisfiedAuthContext,
+} from '../oauth/oauth.service.js';
+import { ACR_PASSWORD, ACR_MFA } from '../step-up/step-up.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
@@ -390,8 +394,11 @@ export class LoginController {
         );
       }
 
-      // No MFA needed — proceed to create session
-      return await this.completeLogin(realm, user, b, oauthParams, req, res);
+      // No MFA needed — proceed to create session (password-only auth)
+      return await this.completeLogin(realm, user, b, oauthParams, req, res, {
+        acr: ACR_PASSWORD,
+        amr: ['pwd'],
+      });
     } catch (err: unknown) {
       const errMessage =
         err instanceof Error ? err.message : 'Invalid credentials';
@@ -428,6 +435,7 @@ export class LoginController {
     oauthParams: Record<string, string>,
     req: Request,
     res: Response,
+    authContext: SatisfiedAuthContext = {},
   ) {
     // Validate OAuth request (including redirect_uri) BEFORE creating session
     let client;
@@ -484,6 +492,10 @@ export class LoginController {
           realmName: realm.name,
           scopes,
           oauthParams,
+          // Carry the satisfied auth context across the consent round-trip so
+          // the code issued after consent reflects the real acr/amr.
+          satisfiedAcr: authContext.acr,
+          amr: authContext.amr,
         });
         return res.redirect(302, `/realms/${realm.name}/consent?req=${reqId}`);
       }
@@ -493,6 +505,7 @@ export class LoginController {
       realm,
       user,
       oauthParams as unknown as AuthorizeParams,
+      authContext,
     );
     res.redirect(302, result.redirectUrl);
   }
@@ -637,6 +650,7 @@ export class LoginController {
       );
     }
 
+    // Password + TOTP completed — second factor satisfied (RFC 8176).
     return await this.completeLogin(
       realm,
       user,
@@ -644,6 +658,7 @@ export class LoginController {
       challenge.oauthParams ?? {},
       req,
       res,
+      { acr: ACR_MFA, amr: ['pwd', 'otp'] },
     );
   }
 
@@ -884,6 +899,9 @@ export class LoginController {
       realm,
       user,
       consentReq.oauthParams as unknown as AuthorizeParams,
+      // Preserve the auth context established before the consent screen so the
+      // issued code carries the real acr/amr (not a defaulted password level).
+      { acr: consentReq.satisfiedAcr, amr: consentReq.amr },
     );
 
     res.redirect(302, result.redirectUrl);

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -5,7 +5,12 @@ import type { Realm } from '@prisma/client';
 import { OAuthService, type AuthorizeParams } from './oauth.service.js';
 import { LoginService } from '../login/login.service.js';
 import { ConsentService } from '../consent/consent.service.js';
-import { StepUpService } from '../step-up/step-up.service.js';
+import {
+  StepUpService,
+  ACR_PASSWORD,
+  ACR_MFA,
+  ACR_WEBAUTHN,
+} from '../step-up/step-up.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
@@ -73,6 +78,14 @@ export class OAuthController {
           return this.handlePromptLogin(res, realm.name, query);
         }
 
+        // Resolve the ACR actually satisfied by the existing SSO session so it
+        // can be reflected in any code issued silently below. Falls back to
+        // ACR_PASSWORD when there is no step-up record / login session.
+        const loginSession = await this.getLoginSessionByToken(sessionCookie);
+        const sessionAcr = loginSession
+          ? await this.stepUpService.getSessionAcr(loginSession.id)
+          : ACR_PASSWORD;
+
         // ── Step-up ACR check ────────────────────────────────────────────────
         //
         // Determine the highest required ACR from two sources:
@@ -90,12 +103,7 @@ export class OAuthController {
         );
 
         if (requiredAcr) {
-          // Look up the login session ID so we can check step-up records
-          const loginSession = await this.getLoginSessionByToken(sessionCookie);
           if (loginSession) {
-            const sessionAcr = await this.stepUpService.getSessionAcr(
-              loginSession.id,
-            );
             const stepUpNeeded = !this.stepUpService.satisfiesAcr(
               sessionAcr,
               requiredAcr,
@@ -124,6 +132,14 @@ export class OAuthController {
         }
         // ── End step-up check ────────────────────────────────────────────────
 
+        // Derive the satisfied auth context for any code issued via silent SSO.
+        // The session ACR is authoritative; the amr is derived from it: an
+        // MFA-or-stronger session implies the second factor was performed.
+        const ssoAuthContext = {
+          acr: sessionAcr,
+          amr: this.amrForSessionAcr(sessionAcr),
+        };
+
         // Check if client requires consent
         if (client.requireConsent) {
           const scopes = (query['scope'] ?? 'openid')
@@ -143,6 +159,8 @@ export class OAuthController {
               realmName: realm.name,
               scopes,
               oauthParams: query,
+              satisfiedAcr: ssoAuthContext.acr,
+              amr: ssoAuthContext.amr,
             });
             return res.redirect(
               302,
@@ -151,11 +169,13 @@ export class OAuthController {
           }
         }
 
-        // SSO: user already logged in and consent is granted, issue code directly
+        // SSO: user already logged in and consent is granted, issue code
+        // directly — carrying the session's satisfied acr/amr.
         const result = await this.oauthService.authorizeWithUser(
           realm,
           user,
           query as unknown as AuthorizeParams,
+          ssoAuthContext,
         );
         return res.redirect(302, result.redirectUrl);
       }
@@ -202,6 +222,26 @@ export class OAuthController {
     const reqStrength = this.stepUpService.getAcrStrength(requestedAcr);
     const clientStrength = this.stepUpService.getAcrStrength(clientAcr);
     return reqStrength >= clientStrength ? requestedAcr : clientAcr;
+  }
+
+  /**
+   * Derive RFC 8176 `amr` values from a session's satisfied ACR. We can only
+   * infer methods from the ACR level (we don't track per-method history on the
+   * SSO session), so each level maps to its canonical method set:
+   *   - WebAuthn  → ['hwk']        (hardware key; matches the passkey login path)
+   *   - MFA       → ['pwd', 'otp'] (password + second factor)
+   *   - otherwise → ['pwd']        (password only)
+   * Must be checked strongest-first so a WebAuthn session (which also satisfies
+   * MFA) is not mislabelled as password+otp.
+   */
+  private amrForSessionAcr(sessionAcr: string): string[] {
+    if (this.stepUpService.satisfiesAcr(sessionAcr, ACR_WEBAUTHN)) {
+      return ['hwk'];
+    }
+    if (this.stepUpService.satisfiesAcr(sessionAcr, ACR_MFA)) {
+      return ['pwd', 'otp'];
+    }
+    return ['pwd'];
   }
 
   private async getLoginSessionByToken(sessionToken: string) {

--- a/src/oauth/oauth.service.ts
+++ b/src/oauth/oauth.service.ts
@@ -11,6 +11,19 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { ScopesService } from '../scopes/scopes.service.js';
 import { matchesRedirectUri } from '../common/redirect-uri.utils.js';
 
+/**
+ * The authentication context actually *satisfied* by the flow that produced an
+ * authorization code (as opposed to the `acr_values` *requested* by the client).
+ * Persisted on the code so the code→token exchange can mint tokens whose
+ * `acr`/`amr` claims reflect the real authentication (RFC 8176 / RFC 9068).
+ */
+export interface SatisfiedAuthContext {
+  /** The ACR level satisfied (e.g. `urn:idenplane:acr:mfa`). */
+  acr?: string;
+  /** The authentication methods performed (e.g. `['pwd', 'otp']`). */
+  amr?: string[];
+}
+
 export interface AuthorizeParams {
   response_type: string;
   client_id: string;
@@ -105,6 +118,7 @@ export class OAuthService {
     realm: Realm,
     user: User,
     params: AuthorizeParams,
+    authContext: SatisfiedAuthContext = {},
   ): Promise<{ redirectUrl: string }> {
     const client = await this.validateAuthRequest(realm, params);
 
@@ -132,7 +146,11 @@ export class OAuthService {
         codeChallenge: params.code_challenge,
         codeChallengeMethod: params.code_challenge_method,
         nonce: params.nonce,
+        // `acrValues` is what the client *requested*; `satisfiedAcr`/`amr`
+        // record what the authentication flow actually *delivered*.
         acrValues: params.acr_values ?? null,
+        satisfiedAcr: authContext.acr ?? null,
+        amr: authContext.amr ?? [],
         expiresAt: new Date(Date.now() + 60 * 1000),
       },
     });

--- a/src/step-up/step-up.controller.ts
+++ b/src/step-up/step-up.controller.ts
@@ -338,7 +338,9 @@ export class StepUpController {
       return {
         status: 'success',
         acr: ACR_MFA,
-        amr: ['totp'],
+        // RFC 8176 vocabulary: 'otp' (matches the mfa-otp token grant). The
+        // session already proved 'pwd', so a completed TOTP step-up is pwd+otp.
+        amr: ['pwd', 'otp'],
       };
     }
 

--- a/src/webauthn/webauthn.controller.ts
+++ b/src/webauthn/webauthn.controller.ts
@@ -29,6 +29,7 @@ import {
   VerifyAuthenticationDto,
 } from './webauthn.dto.js';
 import type { AuthorizeParams } from '../oauth/oauth.service.js';
+import { ACR_WEBAUTHN } from '../step-up/step-up.service.js';
 import type {
   RegistrationResponseJSON,
   AuthenticationResponseJSON,
@@ -213,6 +214,10 @@ export class WebAuthnController {
       return res.json({ redirectUrl: `/realms/${realm.name}/account` });
     }
 
+    // Passwordless WebAuthn assertion: the hardware authenticator is the sole
+    // factor, so amr is `['hwk']` (RFC 8176). ACR reflects the WebAuthn level.
+    const authContext = { acr: ACR_WEBAUTHN, amr: ['hwk'] };
+
     try {
       const client = await this.oauthService.validateAuthRequest(
         realm,
@@ -237,6 +242,8 @@ export class WebAuthnController {
             realmName: realm.name,
             scopes,
             oauthParams,
+            satisfiedAcr: authContext.acr,
+            amr: authContext.amr,
           });
           return res.json({
             redirectUrl: `/realms/${realm.name}/consent?req=${reqId}`,
@@ -248,6 +255,7 @@ export class WebAuthnController {
         realm,
         user,
         oauthParams as unknown as AuthorizeParams,
+        authContext,
       );
       return res.json({ redirectUrl: result.redirectUrl });
     } catch (err: unknown) {

--- a/themes/idenplane/account/templates/layouts/main.hbs
+++ b/themes/idenplane/account/templates/layouts/main.hbs
@@ -6,6 +6,8 @@
   <title>{{pageTitle}} — {{appTitle}}</title>
   {{#if faviconUrl}}
   <link rel="icon" href="{{faviconUrl}}">
+  {{else}}
+  <link rel="icon" href="data:,">
   {{/if}}
   {{#each themeCssFiles}}
   <link rel="stylesheet" href="{{this}}">

--- a/themes/midnight/account/templates/layouts/main.hbs
+++ b/themes/midnight/account/templates/layouts/main.hbs
@@ -7,6 +7,8 @@
   <title>{{pageTitle}} &mdash; {{appTitle}}</title>
   {{#if faviconUrl}}
   <link rel="icon" href="{{faviconUrl}}">
+  {{else}}
+  <link rel="icon" href="data:,">
   {{/if}}
   {{#each themeCssFiles}}
   <link rel="stylesheet" href="{{this}}">


### PR DESCRIPTION
Round-2 promotion — the two follow-ups found by the TeamDesk re-verification pass.

- **#13 (major)** — tokens now reflect the *satisfied* auth context: after password+TOTP the access & id tokens carry `acr=mfa` and `amr=['pwd','otp']`; persisted on the AuthorizationCode and the Session (so refresh preserves them). Additive migration `add_satisfied_acr_amr`.
- **#14 (minor)** — favicon 404 suppressed on the hosted account-console layouts (the #9 fix only covered login).

Both CI-green on dev; #13 diff reviewed hunk-by-hunk. Migration auto-applies on deploy (`docker-entrypoint.sh` runs `prisma migrate deploy`).