### PR TITLE
test(auth): shorten refresh-token fixture to not trip the secret scanner

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -668,7 +668,7 @@ describe('AuthService', () => {
 
       const result = await service.handleTokenRequest(realm, {
         grant_type: 'refresh_token',
-        refresh_token: 'original-opaque-token',
+        refresh_token: 'orig-opaque-rt',
         client_id: 'my-client',
         client_secret: 'correct-secret',
         scope: 'openid',
@@ -710,7 +710,7 @@ describe('AuthService', () => {
 
       await service.handleTokenRequest(realm, {
         grant_type: 'refresh_token',
-        refresh_token: 'original-opaque-token',
+        refresh_token: 'orig-opaque-rt',
         client_id: 'my-client',
         client_secret: 'correct-secret',
         scope: 'openid',


### PR DESCRIPTION
The #13 refresh tests used `refresh_token: 'original-opaque-token'` (21 chars), which matches the pr-hygiene inline-secret pattern and flagged a fake test value as a possible leak on the dev→main promotion. The value is opaque (the lookup is mocked), so it's renamed to a short literal — keeping the secret scanner strict instead of weakening it or merging past a red "possible secret" check.

- [x] `npx jest src/auth/auth.service.spec.ts` → 65 passed