### PR TITLE
Promote dev → main: social-login fixes (#15/#16/#17)

### DIFF
--- a/src/broker/broker.controller.spec.ts
+++ b/src/broker/broker.controller.spec.ts
@@ -31,6 +31,8 @@ describe('BrokerController', () => {
         scope: 'openid',
         state: 'abc',
         nonce: 'xyz',
+        code_challenge: 'challenge-abc',
+        code_challenge_method: 'S256',
       };
 
       await controller.login(
@@ -41,6 +43,8 @@ describe('BrokerController', () => {
         query.scope,
         query.state,
         query.nonce,
+        query.code_challenge,
+        query.code_challenge_method,
         res as any,
       );
 
@@ -53,6 +57,8 @@ describe('BrokerController', () => {
           scope: 'openid',
           state: 'abc',
           nonce: 'xyz',
+          code_challenge: 'challenge-abc',
+          code_challenge_method: 'S256',
         },
       );
       expect(res.redirect).toHaveBeenCalledWith(302, redirectUrl);

--- a/src/broker/broker.controller.ts
+++ b/src/broker/broker.controller.ts
@@ -33,6 +33,8 @@ export class BrokerController {
     @Query('scope') scope: string,
     @Query('state') state: string,
     @Query('nonce') nonce: string,
+    @Query('code_challenge') codeChallenge: string,
+    @Query('code_challenge_method') codeChallengeMethod: string,
     @Res() res: Response,
   ) {
     const redirectUrl = await this.brokerService.initiateLogin(realm, alias, {
@@ -41,6 +43,8 @@ export class BrokerController {
       scope,
       state,
       nonce,
+      code_challenge: codeChallenge,
+      code_challenge_method: codeChallengeMethod,
     });
 
     res.redirect(302, redirectUrl);

--- a/src/broker/broker.service.spec.ts
+++ b/src/broker/broker.service.spec.ts
@@ -232,6 +232,16 @@ describe('BrokerService', () => {
       scope: 'openid',
       state: 'client-state',
       nonce: 'client-nonce',
+      codeChallenge: 'challenge-abc',
+      codeChallengeMethod: 'S256',
+    };
+
+    const githubIdp = {
+      ...mockIdp,
+      alias: 'github',
+      displayName: 'GitHub',
+      userinfoUrl: 'https://api.github.com/user',
+      defaultScopes: 'read:user user:email',
     };
 
     const externalUserInfo = {
@@ -293,6 +303,10 @@ describe('BrokerService', () => {
           redirectUri: 'https://example.com/callback',
           scope: 'openid',
           nonce: 'client-nonce',
+          // Finding #15: PKCE carried through the broker so the code→token
+          // exchange can enforce it for public clients.
+          codeChallenge: 'challenge-abc',
+          codeChallengeMethod: 'S256',
         }),
       });
     });
@@ -656,6 +670,151 @@ describe('BrokerService', () => {
       await expect(
         service.handleCallback(mockRealm, 'google', 'auth-code', 'state-jwt'),
       ).rejects.toThrow(UnauthorizedException);
+    });
+
+    // Finding #16: GitHub returns email=null for private emails; fall back to
+    // /user/emails and pick the primary verified address.
+    it('should resolve a GitHub private email via /user/emails and send a User-Agent', async () => {
+      const githubState = { ...brokerState, alias: 'github' };
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue(githubState);
+      idpService.findByAlias.mockResolvedValue({ ...githubIdp, trustEmail: true });
+
+      (global.fetch as jest.Mock)
+        // 1. token exchange
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ access_token: 'gh-access-token' }),
+        })
+        // 2. /user (private email → null)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest
+            .fn()
+            .mockResolvedValue({ id: 4242, login: 'octocat', email: null }),
+        })
+        // 3. /user/emails
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue([
+            { email: 'public@x.com', primary: false, verified: true },
+            { email: 'x@y.com', primary: true, verified: true },
+          ]),
+        });
+
+      prisma.federatedIdentity.findUnique.mockResolvedValue(null);
+      prisma.user.findFirst.mockResolvedValue(null);
+      prisma.user.create.mockResolvedValue({ ...mockUser, id: 'gh-user-1' });
+      prisma.federatedIdentity.create.mockResolvedValue({});
+      prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.authorizationCode.create.mockResolvedValue({});
+
+      await service.handleCallback(
+        mockRealm,
+        'github',
+        'auth-code',
+        'state-jwt',
+      );
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          email: 'x@y.com',
+          emailVerified: true,
+        }),
+      });
+
+      // The userinfo request (2nd fetch) must carry a User-Agent header.
+      const userinfoCall = (global.fetch as jest.Mock).mock.calls[1];
+      expect(userinfoCall[0]).toBe('https://api.github.com/user');
+      expect(userinfoCall[1].headers['User-Agent']).toBe('Idenplane');
+
+      // The /user/emails request (3rd fetch) must be made with GitHub headers.
+      const emailsCall = (global.fetch as jest.Mock).mock.calls[2];
+      expect(emailsCall[0]).toBe('https://api.github.com/user/emails');
+      expect(emailsCall[1].headers['User-Agent']).toBe('Idenplane');
+      expect(emailsCall[1].headers.Accept).toBe('application/vnd.github+json');
+    });
+
+    it('should leave email empty when GitHub /user/emails fails', async () => {
+      const githubState = { ...brokerState, alias: 'github' };
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue(githubState);
+      idpService.findByAlias.mockResolvedValue(githubIdp);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ access_token: 'gh-access-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest
+            .fn()
+            .mockResolvedValue({ id: 4242, login: 'octocat', email: null }),
+        })
+        // /user/emails returns 403 (e.g. missing scope) — must not crash login
+        .mockResolvedValueOnce({ ok: false, status: 403 });
+
+      prisma.federatedIdentity.findUnique.mockResolvedValue(null);
+      prisma.user.create.mockResolvedValue({ ...mockUser, id: 'gh-user-2' });
+      prisma.federatedIdentity.create.mockResolvedValue({});
+      prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.authorizationCode.create.mockResolvedValue({});
+
+      await service.handleCallback(
+        mockRealm,
+        'github',
+        'auth-code',
+        'state-jwt',
+      );
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ email: undefined }),
+      });
+    });
+
+    // Finding #17: GitHub returns a single full `name`; split into first/last.
+    it('should split a full name into firstName/lastName when given/family absent', async () => {
+      const githubState = { ...brokerState, alias: 'github' };
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue(githubState);
+      idpService.findByAlias.mockResolvedValue(githubIdp);
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({ access_token: 'gh-access-token' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            id: 4242,
+            login: 'islam',
+            email: 'islam@x.com',
+            name: 'Islam Awad',
+          }),
+        });
+
+      prisma.federatedIdentity.findUnique.mockResolvedValue(null);
+      prisma.user.create.mockResolvedValue({ ...mockUser, id: 'gh-user-3' });
+      prisma.federatedIdentity.create.mockResolvedValue({});
+      prisma.client.findUnique.mockResolvedValue(mockClient);
+      prisma.authorizationCode.create.mockResolvedValue({});
+
+      await service.handleCallback(
+        mockRealm,
+        'github',
+        'auth-code',
+        'state-jwt',
+      );
+
+      expect(prisma.user.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          firstName: 'Islam',
+          lastName: 'Awad',
+          username: 'islam',
+        }),
+      });
     });
   });
 });

--- a/src/broker/broker.service.ts
+++ b/src/broker/broker.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  Logger,
   BadRequestException,
   UnauthorizedException,
 } from '@nestjs/common';
@@ -19,6 +20,35 @@ interface BrokerState {
   scope?: string;
   state?: string;
   nonce?: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+}
+
+/** A single entry returned by GitHub's `GET /user/emails` endpoint. */
+interface GithubEmail {
+  email: string;
+  primary: boolean;
+  verified: boolean;
+  visibility: string | null;
+}
+
+const GITHUB_API_HOST = 'api.github.com';
+/** Sent on every userinfo request — required by GitHub's API, harmless elsewhere. */
+const USER_AGENT = 'Idenplane';
+
+/**
+ * Coerce a userinfo claim to a non-empty string. Userinfo payloads are
+ * untrusted JSON, so only primitive scalars are accepted — objects/arrays/null
+ * (and empty strings) collapse to `undefined` rather than `'[object Object]'`.
+ */
+function toStr(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.length > 0 ? value : undefined;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return undefined;
 }
 
 interface ExternalUserInfo {
@@ -33,6 +63,8 @@ interface ExternalUserInfo {
 
 @Injectable()
 export class BrokerService {
+  private readonly logger = new Logger(BrokerService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwkService: JwkService,
@@ -51,6 +83,8 @@ export class BrokerService {
       scope?: string;
       state?: string;
       nonce?: string;
+      code_challenge?: string;
+      code_challenge_method?: string;
     },
   ): Promise<string> {
     if (!params.client_id) {
@@ -89,6 +123,8 @@ export class BrokerService {
       scope: params.scope,
       state: params.state,
       nonce: params.nonce,
+      codeChallenge: params.code_challenge,
+      codeChallengeMethod: params.code_challenge_method,
     };
 
     const stateJwt = await this.jwkService.signJwt(
@@ -175,6 +211,10 @@ export class BrokerService {
         redirectUri: brokerState.redirectUri,
         scope: brokerState.scope,
         nonce: brokerState.nonce,
+        // Carry PKCE from the original client request through the broker so the
+        // subsequent code→token exchange enforces it for public clients.
+        codeChallenge: brokerState.codeChallenge,
+        codeChallengeMethod: brokerState.codeChallengeMethod,
         expiresAt: new Date(Date.now() + 60 * 1000),
       },
     });
@@ -229,7 +269,12 @@ export class BrokerService {
     const url = idp.userinfoUrl ?? idp.tokenUrl.replace('/token', '/userinfo');
 
     const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${accessToken}` },
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        // GitHub's REST API rejects requests without a User-Agent; harmless for
+        // every other provider.
+        'User-Agent': USER_AGENT,
+      },
     });
 
     if (!response.ok) {
@@ -238,35 +283,116 @@ export class BrokerService {
       );
     }
 
-    const data = (await response.json()) as Record<string, string | undefined>;
+    const data = (await response.json()) as Record<string, unknown>;
 
-    const subject = String(data['sub'] ?? data['id'] ?? '');
-    const rawGivenName = data['given_name'] ?? data['first_name'];
-    const rawFamilyName = data['family_name'] ?? data['last_name'];
-    const rawPreferredUsername = data['preferred_username'] ?? data['login'];
-    const givenName =
-      rawGivenName !== undefined ? String(rawGivenName) : undefined;
-    const familyName =
-      rawFamilyName !== undefined ? String(rawFamilyName) : undefined;
-    const preferredUsername =
-      rawPreferredUsername !== undefined
-        ? String(rawPreferredUsername)
-        : undefined;
+    const subject = toStr(data['sub'] ?? data['id']) ?? '';
+    const name = toStr(data['name']);
+    let givenName = toStr(data['given_name'] ?? data['first_name']);
+    let familyName = toStr(data['family_name'] ?? data['last_name']);
+    const preferredUsername = toStr(
+      data['preferred_username'] ?? data['login'],
+    );
+
+    // Finding #17: providers like GitHub return a single full `name` (e.g.
+    // "Islam Awad") rather than OIDC-style given/family names. Derive them by
+    // splitting on the first whitespace so the user record gets a name.
+    if (givenName === undefined && familyName === undefined && name) {
+      const trimmed = name.trim();
+      const firstSpace = trimmed.search(/\s/);
+      if (firstSpace === -1) {
+        givenName = trimmed || undefined;
+      } else {
+        givenName = trimmed.slice(0, firstSpace);
+        familyName = trimmed.slice(firstSpace + 1).trim() || undefined;
+      }
+    }
+
+    let email = toStr(data['email']);
+    let emailVerified =
+      data['email_verified'] === true || data['email_verified'] === 'true'
+        ? true
+        : data['email_verified'] === false || data['email_verified'] === 'false'
+          ? false
+          : undefined;
+
+    // Finding #16: GitHub's /user endpoint returns email=null for users whose
+    // email is private, even when the user:email scope is granted. Fall back to
+    // the /user/emails endpoint to resolve their primary (or first verified)
+    // address. Scoped to GitHub — the well-known non-OIDC provider.
+    if (!email && this.isGithub(idp)) {
+      const githubEmail = await this.fetchGithubPrimaryEmail(accessToken);
+      if (githubEmail) {
+        email = githubEmail.email;
+        emailVerified = githubEmail.verified;
+      }
+    }
 
     return {
       sub: subject,
-      email: data['email'],
-      emailVerified:
-        data['email_verified'] === 'true'
-          ? true
-          : data['email_verified'] === 'false'
-            ? false
-            : undefined,
-      name: data['name'],
-      givenName: givenName,
-      familyName: familyName,
-      preferredUsername: preferredUsername,
+      email,
+      emailVerified,
+      name,
+      givenName,
+      familyName,
+      preferredUsername,
     };
+  }
+
+  /** Detect GitHub by its userinfo host so the email fallback stays targeted. */
+  private isGithub(idp: IdentityProvider): boolean {
+    if (!idp.userinfoUrl) {
+      return false;
+    }
+    try {
+      return new URL(idp.userinfoUrl).hostname === GITHUB_API_HOST;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolve a GitHub user's email via `GET /user/emails`, picking the primary
+   * address (falling back to the first verified one, else the first). Returns
+   * `undefined` and logs a warning if the request fails — never throws, so a
+   * private-email user can still log in (just without an email).
+   */
+  private async fetchGithubPrimaryEmail(
+    accessToken: string,
+  ): Promise<GithubEmail | undefined> {
+    try {
+      const response = await fetch('https://api.github.com/user/emails', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'User-Agent': USER_AGENT,
+          Accept: 'application/vnd.github+json',
+        },
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `GitHub /user/emails returned ${response.status}; federated user will have no email`,
+        );
+        return undefined;
+      }
+
+      const emails = (await response.json()) as GithubEmail[];
+      if (!Array.isArray(emails) || emails.length === 0) {
+        return undefined;
+      }
+
+      return (
+        emails.find((e) => e.primary) ??
+        emails.find((e) => e.verified) ??
+        emails[0]
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to fetch GitHub /user/emails: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return undefined;
+    }
   }
 
   private async linkOrCreateUser(

--- a/src/login/login.controller.ts
+++ b/src/login/login.controller.ts
@@ -118,7 +118,7 @@ export class LoginController {
   // ─── LOGIN ──────────────────────────────────────────────
 
   @Get('login')
-  showLoginForm(
+  async showLoginForm(
     @CurrentRealm() realm: Realm,
     @Query() query: Record<string, string>,
     @Req() req: Request,
@@ -128,8 +128,7 @@ export class LoginController {
     // Build a properly percent-encoded register link so the hosted page does
     // not emit a URL with literal spaces (scope) or an unencoded redirect_uri,
     // and so empty params are dropped rather than rendered as `nonce=`.
-    const registerParams = new URLSearchParams();
-    for (const k of [
+    const oauthParamKeys = [
       'client_id',
       'redirect_uri',
       'response_type',
@@ -138,7 +137,9 @@ export class LoginController {
       'nonce',
       'code_challenge',
       'code_challenge_method',
-    ]) {
+    ];
+    const registerParams = new URLSearchParams();
+    for (const k of oauthParamKeys) {
       const v = query[k];
       if (v) registerParams.set(k, v);
     }
@@ -146,6 +147,27 @@ export class LoginController {
     const registerUrl = `/realms/${realm.name}/register${
       registerQs ? `?${registerQs}` : ''
     }`;
+
+    // Surface enabled identity providers as "Sign in with …" buttons. Each
+    // broker login URL carries the same OAuth/PKCE params (percent-encoded,
+    // empty params dropped) as the register link so social login stays secure
+    // for public PKCE clients.
+    const enabledIdps = await this.prisma.identityProvider.findMany({
+      where: { realmId: realm.id, enabled: true },
+      select: { alias: true, displayName: true },
+      orderBy: { alias: 'asc' },
+    });
+    const identityProviders = enabledIdps.map((idp) => {
+      const brokerQs = registerParams.toString();
+      return {
+        alias: idp.alias,
+        displayName: idp.displayName ?? idp.alias,
+        loginUrl: `/realms/${realm.name}/broker/${idp.alias}/login${
+          brokerQs ? `?${brokerQs}` : ''
+        }`,
+      };
+    });
+
     this.themeRender.render(
       res,
       realm,
@@ -167,6 +189,7 @@ export class LoginController {
         info: query['info'] ?? '',
         login_hint: query['login_hint'] ?? '',
         registerUrl,
+        identityProviders,
         csrfToken,
       },
       req,

--- a/themes/idenplane/login/templates/login.hbs
+++ b/themes/idenplane/login/templates/login.hbs
@@ -178,6 +178,19 @@
 </script>
 {{/if}}
 
+{{#if identityProviders.length}}
+<div style="margin-top: 1rem;">
+  <div style="display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.75rem;">
+    <div style="flex: 1; height: 1px; background: #e5e7eb;"></div>
+    <span style="color: #9ca3af; font-size: 0.8rem;">or</span>
+    <div style="flex: 1; height: 1px; background: #e5e7eb;"></div>
+  </div>
+  {{#each identityProviders}}
+  <a href="{{this.loginUrl}}" style="width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 0.5rem; background: #ffffff; color: #374151; border: 1px solid #d1d5db; border-radius: 6px; padding: 0.65rem 1.25rem; font-size: 0.95rem; text-decoration: none; font-weight: 500; margin-bottom: 0.5rem; box-sizing: border-box;">Sign in with {{this.displayName}}</a>
+  {{/each}}
+</div>
+{{/if}}
+
 {{#if registrationAllowed}}
 <div style="text-align: center; margin-top: 1rem;">
   <a href="{{registerUrl}}" style="color: var(--primary-color); text-decoration: none; font-size: 0.85rem;">{{msg "loginNoAccount"}}</a>

--- a/themes/midnight/login/templates/login.hbs
+++ b/themes/midnight/login/templates/login.hbs
@@ -38,6 +38,15 @@
   <button type="submit" class="btn-primary">{{msg "loginSignIn"}}</button>
 </form>
 
+{{#if identityProviders.length}}
+<div class="auth-divider" style="margin-top: 1rem;"><span>or</span></div>
+<div style="display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.75rem;">
+  {{#each identityProviders}}
+  <a href="{{this.loginUrl}}" class="btn-secondary">Sign in with {{this.displayName}}</a>
+  {{/each}}
+</div>
+{{/if}}
+
 {{#if registrationAllowed}}
 <div class="auth-footer-link">
   <a href="{{registerUrl}}">{{msg "loginNoAccount"}}</a>


### PR DESCRIPTION
Promotes the Identity-Providers / social-login fixes found via TeamDesk:
- #15 hosted login page now renders "Sign in with <provider>" buttons + PKCE carried through the broker
- #16 GitHub federation resolves private emails via /user/emails (+ User-Agent)
- #17 federated user's name populated from GitHub's single `name`

CI-green on dev; diff reviewed. No migration. Triggers an image rebuild.