### PR TITLE
fix(broker): themed error page on callback failure (instead of raw JSON) — #18

### DIFF
--- a/src/broker/broker.controller.spec.ts
+++ b/src/broker/broker.controller.spec.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { BrokerController } from './broker.controller.js';
 import type { Realm } from '@prisma/client';
 
@@ -7,6 +8,7 @@ describe('BrokerController', () => {
     initiateLogin: jest.Mock;
     handleCallback: jest.Mock;
   };
+  let themeRender: { render: jest.Mock };
 
   const realm = { id: 'realm-1', name: 'test-realm' } as Realm;
 
@@ -15,7 +17,11 @@ describe('BrokerController', () => {
       initiateLogin: jest.fn(),
       handleCallback: jest.fn(),
     };
-    controller = new BrokerController(brokerService as any);
+    themeRender = { render: jest.fn() };
+    controller = new BrokerController(
+      brokerService as any,
+      themeRender as any,
+    );
   });
 
   describe('login', () => {
@@ -65,13 +71,15 @@ describe('BrokerController', () => {
         redirectUrl: 'http://localhost/callback?code=authcode&state=abc',
       });
 
-      const res = { redirect: jest.fn() };
+      const req = {};
+      const res = { redirect: jest.fn(), status: jest.fn().mockReturnThis() };
 
       await controller.callback(
         realm,
         'google',
         'ext-code',
         'state-123',
+        req as any,
         res as any,
       );
 
@@ -84,6 +92,42 @@ describe('BrokerController', () => {
       expect(res.redirect).toHaveBeenCalledWith(
         302,
         'http://localhost/callback?code=authcode&state=abc',
+      );
+      expect(themeRender.render).not.toHaveBeenCalled();
+    });
+
+    it('should render a themed error page (not raw JSON) when federation fails', async () => {
+      brokerService.handleCallback.mockRejectedValue(
+        new UnauthorizedException(
+          'No matching user found and identity provider is configured as link-only',
+        ),
+      );
+
+      const req = {};
+      const res = { redirect: jest.fn(), status: jest.fn().mockReturnThis() };
+
+      await controller.callback(
+        realm,
+        'google',
+        'ext-code',
+        'state-123',
+        req as any,
+        res as any,
+      );
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(themeRender.render).toHaveBeenCalledWith(
+        res,
+        realm,
+        'login',
+        'error',
+        expect.objectContaining({
+          errorTitle: 'Sign-in failed',
+          errorMessage:
+            'No matching user found and identity provider is configured as link-only',
+        }),
+        req,
       );
     });
   });

--- a/src/broker/broker.controller.ts
+++ b/src/broker/broker.controller.ts
@@ -1,18 +1,31 @@
-import { Controller, Get, Param, Query, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  Param,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import type { Realm } from '@prisma/client';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
 import { BrokerService } from './broker.service.js';
+import { ThemeRenderService } from '../theme/theme-render.service.js';
 
 @ApiTags('Identity Broker')
 @Controller('realms/:realmName/broker')
 @UseGuards(RealmGuard)
 @Public()
 export class BrokerController {
-  constructor(private readonly brokerService: BrokerService) {}
+  constructor(
+    private readonly brokerService: BrokerService,
+    private readonly themeRender: ThemeRenderService,
+  ) {}
 
   @Get(':alias/login')
   @ApiOperation({ summary: 'Initiate social login with an external provider' })
@@ -63,14 +76,55 @@ export class BrokerController {
     @Param('alias') alias: string,
     @Query('code') code: string,
     @Query('state') state: string,
+    @Req() req: Request,
     @Res() res: Response,
   ) {
-    const result = await this.brokerService.handleCallback(
-      realm,
-      alias,
-      code,
-      state,
-    );
-    res.redirect(302, result.redirectUrl);
+    try {
+      const result = await this.brokerService.handleCallback(
+        realm,
+        alias,
+        code,
+        state,
+      );
+      res.redirect(302, result.redirectUrl);
+    } catch (err) {
+      // A broker callback is reached by the end-user's browser, so failures
+      // (link-only, token-exchange, invalid/expired state) must render a themed
+      // error page rather than leak a raw JSON exception to the user.
+      const status = err instanceof HttpException ? err.getStatus() : 400;
+      res.status(status);
+      this.themeRender.render(
+        res,
+        realm,
+        'login',
+        'error',
+        {
+          pageTitle: 'Sign-in failed',
+          errorTitle: 'Sign-in failed',
+          errorMessage: this.describeBrokerError(err),
+        },
+        req,
+      );
+    }
+  }
+
+  private describeBrokerError(err: unknown): string {
+    if (err instanceof HttpException) {
+      const response = err.getResponse();
+      if (typeof response === 'string') {
+        return response;
+      }
+      if (response && typeof response === 'object' && 'message' in response) {
+        const message = (response as { message: unknown }).message;
+        if (typeof message === 'string') {
+          return message;
+        }
+        if (Array.isArray(message)) {
+          return message.join(', ');
+        }
+      }
+      return err.message;
+    }
+    return 'Sign-in could not be completed. Please try again.';
   }
 }

--- a/src/broker/broker.module.ts
+++ b/src/broker/broker.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { BrokerController } from './broker.controller.js';
 import { BrokerService } from './broker.service.js';
 import { IdentityProvidersModule } from '../identity-providers/identity-providers.module.js';
+import { ThemeModule } from '../theme/theme.module.js';
 
 @Module({
-  imports: [IdentityProvidersModule],
+  imports: [IdentityProvidersModule, ThemeModule],
   controllers: [BrokerController],
   providers: [BrokerService],
 })


### PR DESCRIPTION
## Summary
- Broker callbacks (`/realms/:realm/broker/:alias/callback`) are hit by the end-user's browser, but any failure — link-only reject, token-exchange failure, invalid/expired state — bubbled to Nest's default exception filter and showed the user **raw JSON** (e.g. `{"statusCode":401,"message":"…link-only",…}`).
- The themed `error.hbs` template already existed in both themes but was wired to nothing. The callback now wraps `handleCallback` in try/catch and renders that page, with the HTTP status taken from the thrown `HttpException` (else 400).
- **Page-only, no auto-redirect** — avoids introducing an open-redirect surface, and matches how a real IdP (e.g. Keycloak) shows its own error page on federation failures. Scope kept to the callback; the `login`-endpoint throws are a separate surface, left untouched.
- `ThemeModule` added to `BrokerModule`; spec updated + a new test asserts the themed page renders (not JSON).

Found during the TeamDesk deep-test campaign (Identity Providers → `linkOnly` scenario). Tracked as finding **#18**.

## Test plan
- [x] `npx jest src/broker` — 25 tests pass (incl. new error-render test)
- [x] `tsc --noEmit -p tsconfig.build.json` — clean
- [ ] Live re-verify after the next batched `dev→main` promotion (trigger a `linkOnly` reject → see themed page, not JSON)

🤖 Generated with [Claude Code](https://claude.com/claude-code)