### PR TITLE
fix(device): add missing CSRF field to device verification form (#22)

### DIFF
--- a/src/theme/login-form-csrf.spec.ts
+++ b/src/theme/login-form-csrf.spec.ts
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Every POST form rendered by a login theme must embed the `_csrf` hidden field
+ * (the double-submit token validated by CsrfService). Regression guard for #22:
+ * `device.hbs` omitted it, so every device approve/deny POST failed CSRF
+ * validation (403) and the Device Authorization flow was unusable end-to-end.
+ */
+describe('login theme POST forms embed the CSRF field', () => {
+  const themesRoot = join(process.cwd(), 'themes');
+  const themes = readdirSync(themesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  const cases: Array<{ theme: string; file: string; content: string }> = [];
+  for (const theme of themes) {
+    const dir = join(themesRoot, theme, 'login', 'templates');
+    let files: string[];
+    try {
+      files = readdirSync(dir).filter((f) => f.endsWith('.hbs'));
+    } catch {
+      continue; // theme has no login templates
+    }
+    for (const file of files) {
+      const content = readFileSync(join(dir, file), 'utf8');
+      if (/<form[^>]*method=["']POST["']/i.test(content)) {
+        cases.push({ theme, file, content });
+      }
+    }
+  }
+
+  it('discovers POST-form templates to check', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)('$theme/$file includes name="_csrf"', ({ content }) => {
+    expect(content).toContain('name="_csrf"');
+  });
+});

--- a/themes/idenplane/login/templates/device.hbs
+++ b/themes/idenplane/login/templates/device.hbs
@@ -7,6 +7,7 @@
 {{/if}}
 
 <form method="POST" action="/realms/{{realmName}}/device" class="auth-form">
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="form-group">
     <label for="user_code">{{msg "deviceCode"}}</label>
     <input type="text" id="user_code" name="user_code" value="{{userCode}}" required

--- a/themes/midnight/login/templates/device.hbs
+++ b/themes/midnight/login/templates/device.hbs
@@ -7,6 +7,7 @@
 {{/if}}
 
 <form method="POST" action="/realms/{{realmName}}/device" class="auth-form">
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="form-group">
     <label for="user_code">{{msg "deviceCode"}}</label>
     <input type="text" id="user_code" name="user_code" value="{{userCode}}" required


### PR DESCRIPTION
## Summary
Found during the TeamDesk deep-test campaign (OAuth/OIDC core → Device Authorization Grant).

The device verification page (`device.hbs`, **both** `idenplane` and `midnight` themes) rendered its POST form **without the `_csrf` hidden field** — even though the controller sets the `XSRF-TOKEN-<realm>` cookie and validates a matching `_csrf` body field (double-submit pattern), and every *other* login-theme form (login, consent, register, totp, forgot/change/reset-password) includes it. As a result, **every device approve/deny submission failed CSRF validation with `403 "Invalid or missing CSRF token"`** — the Device Authorization Grant was unusable end-to-end.

The rest of the flow is correct: initiate ✅, `authorization_pending` ✅, approval + token issuance work the moment a valid `_csrf` is supplied (verified by manually completing the flow with the token present → `201` + tokens).

## Fix
- Add `<input type="hidden" name="_csrf" value="{{csrfToken}}">` to the device form in both themes (the controller already passes `csrfToken` to the template).
- Add a unit test that scans every login-theme template and asserts each POST form embeds `name="_csrf"` — guards #22 and any future form that forgets the token.

## Test plan
- [x] `npx jest src/theme/login-form-csrf.spec.ts` — 17 pass (every POST form across both themes has `_csrf`)
- [x] Manually confirmed live: with `_csrf` present the approve POST returns `201` and the subsequent device-code poll issues tokens
- [ ] Live re-verify via the hosted form after the next batched `dev→main` promotion (e2e harness doesn't configure the hbs view engine, so themed-page rendering can't be exercised there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)