### PR TITLE
promote: OAuth/OIDC core compliance + broker/device error UX (#18–#22)

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,6 +1,8 @@
 jest.mock('../crypto/jwk.service.js', () => ({ JwkService: jest.fn() }));
 
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { AuthController } from './auth.controller.js';
+import { OAuthTokenError } from './oauth-token-error.js';
 import type { Realm } from '@prisma/client';
 
 describe('AuthController', () => {
@@ -20,13 +22,21 @@ describe('AuthController', () => {
     connection: { remoteAddress: '127.0.0.1' },
   };
 
-  const res = {
-    set: jest.fn(),
+  let res: {
+    set: jest.Mock;
+    status: jest.Mock;
+    json: jest.Mock;
   };
 
   beforeEach(() => {
     mockAuthService = {
       handleTokenRequest: jest.fn(),
+    };
+
+    res = {
+      set: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
     };
 
     controller = new AuthController(mockAuthService as any);
@@ -73,6 +83,133 @@ describe('AuthController', () => {
         mockAuthService.handleTokenRequest.mock.calls[0];
       expect(passedRealm).toBe(realm);
       expect(passedBody).toBe(body);
+    });
+  });
+
+  describe('token - RFC 6749 §5.2 error serialization', () => {
+    it('serializes unsupported_grant_type as 400 { error } with no description', async () => {
+      mockAuthService.handleTokenRequest.mockRejectedValue(
+        new OAuthTokenError('unsupported_grant_type', undefined, 400),
+      );
+
+      await controller.token(
+        realm,
+        { grant_type: 'banana' },
+        req as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'unsupported_grant_type' });
+    });
+
+    it('serializes invalid_grant as 400 { error, error_description }', async () => {
+      mockAuthService.handleTokenRequest.mockRejectedValue(
+        new OAuthTokenError(
+          'invalid_grant',
+          'Invalid or expired refresh token',
+          400,
+        ),
+      );
+
+      await controller.token(
+        realm,
+        { grant_type: 'refresh_token', refresh_token: 'bad' },
+        req as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'invalid_grant',
+        error_description: 'Invalid or expired refresh token',
+      });
+    });
+
+    it('serializes invalid_client as 401 with a WWW-Authenticate header', async () => {
+      mockAuthService.handleTokenRequest.mockRejectedValue(
+        new OAuthTokenError('invalid_client', 'Invalid client credentials', 401),
+      );
+
+      await controller.token(
+        realm,
+        { grant_type: 'client_credentials', client_id: 'x', client_secret: 'y' },
+        req as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'invalid_client',
+        error_description: 'Invalid client credentials',
+      });
+      expect(res.set).toHaveBeenCalledWith(
+        'WWW-Authenticate',
+        'Basic realm="test-realm", error="invalid_client"',
+      );
+    });
+
+    it('passes through an mfa_required HttpException body with its status', async () => {
+      mockAuthService.handleTokenRequest.mockRejectedValue(
+        new HttpException(
+          {
+            error: 'mfa_required',
+            error_description: 'MFA verification is required',
+            mfa_token: 'mfa-tok-123',
+          },
+          HttpStatus.UNAUTHORIZED,
+        ),
+      );
+
+      await controller.token(
+        realm,
+        { grant_type: 'password', username: 'u', password: 'p' },
+        req as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'mfa_required',
+        error_description: 'MFA verification is required',
+        mfa_token: 'mfa-tok-123',
+      });
+      // mfa_required is not invalid_client — no WWW-Authenticate header.
+      expect(res.set).not.toHaveBeenCalledWith(
+        'WWW-Authenticate',
+        expect.anything(),
+      );
+    });
+
+    it('re-throws unexpected errors for the global filter to handle', async () => {
+      const unexpected = new Error('database is on fire');
+      mockAuthService.handleTokenRequest.mockRejectedValue(unexpected);
+
+      await expect(
+        controller.token(
+          realm,
+          { grant_type: 'password' },
+          req as any,
+          res as any,
+        ),
+      ).rejects.toThrow(unexpected);
+      expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('sets the no-store / no-cache headers on every token response', async () => {
+      mockAuthService.handleTokenRequest.mockResolvedValue({
+        access_token: 'tok',
+      });
+
+      await controller.token(
+        realm,
+        { grant_type: 'client_credentials' },
+        req as any,
+        res as any,
+      );
+
+      expect(res.set).toHaveBeenCalledWith('Cache-Control', 'no-store');
+      expect(res.set).toHaveBeenCalledWith('Pragma', 'no-cache');
     });
   });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,7 +7,7 @@ import {
   UseGuards,
   HttpCode,
   HttpStatus,
-  BadRequestException,
+  HttpException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -20,6 +20,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import type { Request, Response } from 'express';
 import type { Realm } from '@prisma/client';
 import { AuthService } from './auth.service.js';
+import { OAuthTokenError } from './oauth-token-error.js';
 import { TokenRequestDto } from './dto/token-request.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
@@ -82,15 +83,38 @@ export class AuthController {
         req.headers['user-agent'],
       );
     } catch (err) {
-      if (err instanceof BadRequestException) {
-        const msg =
-          typeof err.getResponse() === 'string'
-            ? err.getResponse()
-            : ((err.getResponse() as { message?: string }).message ??
-              'invalid_request');
-        res.status(400).json({ error: msg });
+      // RFC 6749 §5.2: serialize token-endpoint errors as
+      // `{ error: <code>, error_description? }` with the appropriate status.
+      if (err instanceof OAuthTokenError) {
+        if (err.code === 'invalid_client') {
+          // RFC 6749 §5.2: a 401 for failed client authentication must include
+          // a WWW-Authenticate header advertising the auth scheme.
+          res.set(
+            'WWW-Authenticate',
+            `Basic realm="${realm.name}", error="invalid_client"`,
+          );
+        }
+        res.status(err.httpStatus).json({
+          error: err.code,
+          ...(err.description ? { error_description: err.description } : {}),
+        });
         return;
       }
+      // Other HttpExceptions whose body already carries an `error` field — e.g.
+      // the `mfa_required` challenge response — are passed through verbatim so
+      // they keep their extra fields (such as `mfa_token`).
+      if (err instanceof HttpException) {
+        const responseBody = err.getResponse();
+        if (
+          typeof responseBody === 'object' &&
+          responseBody !== null &&
+          'error' in responseBody
+        ) {
+          res.status(err.getStatus()).json(responseBody);
+          return;
+        }
+      }
+      // Anything else is genuinely unexpected — let the global filter handle it.
       throw err;
     }
   }

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,17 +1,40 @@
-import { UnauthorizedException, BadRequestException } from '@nestjs/common';
-
 // Mock modules that transitively import jose (ESM-only) to avoid parse errors
 jest.mock('../crypto/jwk.service.js', () => ({
   JwkService: jest.fn(),
 }));
 
 import { AuthService } from './auth.service.js';
+import { OAuthTokenError } from './oauth-token-error.js';
 import {
   createMockPrismaService,
   type MockPrismaService,
 } from '../prisma/prisma.mock.js';
 import type { Realm } from '@prisma/client';
 import { ACR_PASSWORD, ACR_MFA } from '../step-up/step-up.service.js';
+
+/**
+ * Assert that the given promise rejects with an {@link OAuthTokenError}
+ * carrying the expected RFC 6749 §5.2 `error` code (and optional HTTP status).
+ */
+async function expectOAuthError(
+  promise: Promise<unknown>,
+  expectedCode: string,
+  expectedStatus?: number,
+): Promise<void> {
+  await expect(promise).rejects.toBeInstanceOf(OAuthTokenError);
+  try {
+    await promise;
+  } catch (err) {
+    const tokenError = err as OAuthTokenError;
+    expect(tokenError.code).toBe(expectedCode);
+    expect((tokenError.getResponse() as { error: string }).error).toBe(
+      expectedCode,
+    );
+    if (expectedStatus !== undefined) {
+      expect(tokenError.httpStatus).toBe(expectedStatus);
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers & fixtures
@@ -235,10 +258,20 @@ describe('AuthService', () => {
   // -----------------------------------------------------------------------
 
   describe('handleTokenRequest - unsupported grant type', () => {
-    it('should throw BadRequestException for an unknown grant_type', async () => {
-      await expect(
+    it('should throw unsupported_grant_type for an unknown grant_type', async () => {
+      await expectOAuthError(
         service.handleTokenRequest(realm, { grant_type: 'magic' }),
-      ).rejects.toThrow(BadRequestException);
+        'unsupported_grant_type',
+        400,
+      );
+    });
+
+    it('should throw invalid_request when grant_type is missing', async () => {
+      await expectOAuthError(
+        service.handleTokenRequest(realm, {}),
+        'invalid_request',
+        400,
+      );
     });
   });
 
@@ -247,37 +280,41 @@ describe('AuthService', () => {
   // -----------------------------------------------------------------------
 
   describe('validateClient (via password grant)', () => {
-    it('should throw BadRequestException when client_id is missing', async () => {
-      await expect(
+    it('should throw invalid_client when client_id is missing', async () => {
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: '',
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'invalid_client',
+        401,
+      );
     });
 
-    it('should throw UnauthorizedException when client does not exist', async () => {
+    it('should throw invalid_client when client does not exist', async () => {
       prisma.client.findUnique.mockResolvedValue(null);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'nonexistent',
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_client',
+        401,
+      );
     });
 
-    it('should throw UnauthorizedException when client is disabled', async () => {
+    it('should throw invalid_client when client is disabled', async () => {
       prisma.client.findUnique.mockResolvedValue({
         ...dbClient,
         enabled: false,
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -285,14 +322,16 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_client',
+        401,
+      );
     });
 
-    it('should throw UnauthorizedException when client_secret is wrong for a confidential client', async () => {
+    it('should throw invalid_client when client_secret is wrong for a confidential client', async () => {
       prisma.client.findUnique.mockResolvedValue(dbClient);
       crypto.verifyPassword.mockResolvedValue(false);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -300,16 +339,18 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_client',
+        401,
+      );
     });
 
-    it('should throw UnauthorizedException when confidential client has no secret configured', async () => {
+    it('should throw invalid_client when confidential client has no secret configured', async () => {
       prisma.client.findUnique.mockResolvedValue({
         ...dbClient,
         clientSecret: null,
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -317,30 +358,34 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_client',
+        401,
+      );
     });
 
-    it('should throw UnauthorizedException when confidential client receives no client_secret', async () => {
+    it('should throw invalid_client when confidential client receives no client_secret', async () => {
       prisma.client.findUnique.mockResolvedValue(dbClient);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_client',
+        401,
+      );
     });
 
-    it('should throw BadRequestException when grant type is not allowed for the client', async () => {
+    it('should throw unauthorized_client when grant type is not allowed for the client', async () => {
       prisma.client.findUnique.mockResolvedValue({
         ...dbClient,
         grantTypes: ['client_credentials'],
       });
       crypto.verifyPassword.mockResolvedValue(true);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -348,7 +393,9 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'unauthorized_client',
+        400,
+      );
     });
 
     it('should succeed for a valid confidential client', async () => {
@@ -460,37 +507,41 @@ describe('AuthService', () => {
       );
     });
 
-    it('should throw BadRequestException when username is missing', async () => {
+    it('should throw invalid_request when username is missing', async () => {
       setupValidClient();
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
           client_secret: 'correct-secret',
           password: 'pass',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'invalid_request',
+        400,
+      );
     });
 
-    it('should throw BadRequestException when password is missing', async () => {
+    it('should throw invalid_request when password is missing', async () => {
       setupValidClient();
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
           client_secret: 'correct-secret',
           username: 'testuser',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'invalid_request',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when user does not exist', async () => {
+    it('should throw invalid_grant when user does not exist', async () => {
       setupValidClient();
       prisma.user.findUnique.mockResolvedValue(null);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -498,14 +549,16 @@ describe('AuthService', () => {
           username: 'nonexistent',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when user is disabled', async () => {
+    it('should throw invalid_grant when user is disabled', async () => {
       setupValidClient();
       prisma.user.findUnique.mockResolvedValue({ ...dbUser, enabled: false });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -513,17 +566,19 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when user has no passwordHash', async () => {
+    it('should throw invalid_grant when user has no passwordHash', async () => {
       setupValidClient();
       prisma.user.findUnique.mockResolvedValue({
         ...dbUser,
         passwordHash: null,
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -531,10 +586,12 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'pass',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when password is incorrect', async () => {
+    it('should throw invalid_grant when password is incorrect', async () => {
       prisma.client.findUnique.mockResolvedValue(dbClient);
       prisma.user.findUnique.mockResolvedValue(dbUser);
       // First call: client secret check (true), second: password check (false)
@@ -542,7 +599,7 @@ describe('AuthService', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'password',
           client_id: 'my-client',
@@ -550,7 +607,9 @@ describe('AuthService', () => {
           username: 'testuser',
           password: 'wrong-password',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
   });
 
@@ -595,17 +654,19 @@ describe('AuthService', () => {
       expect(result.scope).toBe('openid');
     });
 
-    it('should throw UnauthorizedException when client_secret is wrong', async () => {
+    it('should throw invalid_client when client_secret is wrong', async () => {
       prisma.client.findUnique.mockResolvedValue(dbClient);
       crypto.verifyPassword.mockResolvedValue(false);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'client_credentials',
           client_id: 'my-client',
           client_secret: 'wrong-secret',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_client',
+        401,
+      );
     });
 
     it('should sign the JWT with the correct payload shape', async () => {
@@ -721,50 +782,56 @@ describe('AuthService', () => {
       expect(accessTokenPayload.amr).toEqual(['pwd', 'otp']);
     });
 
-    it('should throw BadRequestException when refresh_token is missing', async () => {
+    it('should throw invalid_request when refresh_token is missing', async () => {
       setupValidClient();
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'refresh_token',
           client_id: 'my-client',
           client_secret: 'correct-secret',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'invalid_request',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when refresh token does not exist', async () => {
+    it('should throw invalid_grant when refresh token does not exist', async () => {
       setupValidClient();
       prisma.refreshToken.findUnique.mockResolvedValue(null);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'refresh_token',
           refresh_token: 'nonexistent-token',
           client_id: 'my-client',
           client_secret: 'correct-secret',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when refresh token is expired', async () => {
+    it('should throw invalid_grant when refresh token is expired', async () => {
       setupValidClient();
       prisma.refreshToken.findUnique.mockResolvedValue({
         ...storedRefreshToken,
         expiresAt: new Date(Date.now() - 1000),
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'refresh_token',
           refresh_token: 'expired-token',
           client_id: 'my-client',
           client_secret: 'correct-secret',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException and revoke entire session when a revoked token is reused (reuse detection)', async () => {
+    it('should throw invalid_grant and revoke entire session when a revoked token is reused (reuse detection)', async () => {
       setupValidClient();
       prisma.refreshToken.findUnique.mockResolvedValue({
         ...storedRefreshToken,
@@ -772,14 +839,16 @@ describe('AuthService', () => {
       });
       prisma.refreshToken.updateMany.mockResolvedValue({ count: 3 });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'refresh_token',
           refresh_token: 'reused-token',
           client_id: 'my-client',
           client_secret: 'correct-secret',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
 
       // All tokens for the session should be revoked
       expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith({
@@ -796,14 +865,16 @@ describe('AuthService', () => {
         expiresAt: new Date(Date.now() - 1000),
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'refresh_token',
           refresh_token: 'expired-token',
           client_id: 'my-client',
           client_secret: 'correct-secret',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
 
       // updateMany should NOT be called because token was not revoked
       expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
@@ -813,14 +884,16 @@ describe('AuthService', () => {
       setupValidClient();
       prisma.refreshToken.findUnique.mockResolvedValue(null);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'refresh_token',
           refresh_token: 'some-opaque-token',
           client_id: 'my-client',
           client_secret: 'correct-secret',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
 
       expect(crypto.sha256).toHaveBeenCalledWith('some-opaque-token');
       expect(prisma.refreshToken.findUnique).toHaveBeenCalledWith({
@@ -971,23 +1044,25 @@ describe('AuthService', () => {
       expect(accessTokenPayload.amr).toEqual(['pwd']);
     });
 
-    it('should throw BadRequestException when code is missing', async () => {
-      await expect(
+    it('should throw invalid_request when code is missing', async () => {
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           client_id: 'my-client',
           client_secret: 'correct-secret',
           redirect_uri: 'https://app.example.com/callback',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'invalid_request',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when code does not exist', async () => {
+    it('should throw invalid_grant when code does not exist', async () => {
       setupValidClient();
       // update throws P2025 because no row matches (code doesn't exist)
       prisma.authorizationCode.update.mockRejectedValue(makePrismaP2025());
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           code: 'nonexistent-code',
@@ -995,15 +1070,17 @@ describe('AuthService', () => {
           client_secret: 'correct-secret',
           redirect_uri: 'https://app.example.com/callback',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when code is expired', async () => {
+    it('should throw invalid_grant when code is expired', async () => {
       setupValidClient();
       // update throws P2025 because the expiresAt filter excludes the expired row
       prisma.authorizationCode.update.mockRejectedValue(makePrismaP2025());
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           code: 'expired-code',
@@ -1011,15 +1088,17 @@ describe('AuthService', () => {
           client_secret: 'correct-secret',
           redirect_uri: 'https://app.example.com/callback',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when code was already used', async () => {
+    it('should throw invalid_grant when code was already used', async () => {
       setupValidClient();
       // update throws P2025 because used:false filter excludes the already-used row
       prisma.authorizationCode.update.mockRejectedValue(makePrismaP2025());
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           code: 'used-code',
@@ -1027,10 +1106,12 @@ describe('AuthService', () => {
           client_secret: 'correct-secret',
           redirect_uri: 'https://app.example.com/callback',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when code belongs to a different client', async () => {
+    it('should throw invalid_grant when code belongs to a different client', async () => {
       setupValidClient();
       prisma.authorizationCode.update.mockResolvedValue({
         ...authCode,
@@ -1038,7 +1119,7 @@ describe('AuthService', () => {
         used: true,
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           code: 'stolen-code',
@@ -1046,17 +1127,19 @@ describe('AuthService', () => {
           client_secret: 'correct-secret',
           redirect_uri: 'https://app.example.com/callback',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw BadRequestException when redirect_uri does not match', async () => {
+    it('should throw invalid_grant when redirect_uri does not match', async () => {
       setupValidClient();
       prisma.authorizationCode.update.mockResolvedValue({
         ...authCode,
         used: true,
       });
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           code: 'valid-auth-code',
@@ -1064,10 +1147,12 @@ describe('AuthService', () => {
           client_secret: 'correct-secret',
           redirect_uri: 'https://evil.example.com/callback',
         }),
-      ).rejects.toThrow(BadRequestException);
+        'invalid_grant',
+        400,
+      );
     });
 
-    it('should throw UnauthorizedException when user is not found for the code', async () => {
+    it('should throw invalid_grant when user is not found for the code', async () => {
       setupValidClient();
       setupSigningKey();
       setupSessionCreate();
@@ -1077,7 +1162,7 @@ describe('AuthService', () => {
       });
       prisma.user.findUnique.mockResolvedValue(null);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'authorization_code',
           code: 'valid-auth-code',
@@ -1085,7 +1170,9 @@ describe('AuthService', () => {
           client_secret: 'correct-secret',
           redirect_uri: 'https://app.example.com/callback',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        'invalid_grant',
+        400,
+      );
     });
 
     describe('PKCE', () => {
@@ -1095,7 +1182,7 @@ describe('AuthService', () => {
         codeChallengeMethod: 'S256',
       };
 
-      it('should throw BadRequestException when code has PKCE but code_verifier is missing', async () => {
+      it('should throw invalid_request when code has PKCE but code_verifier is missing', async () => {
         setupValidClient();
         // update succeeds (code exists, not used, not expired) and returns the pkce code
         prisma.authorizationCode.update.mockResolvedValue({
@@ -1103,7 +1190,7 @@ describe('AuthService', () => {
           used: true,
         });
 
-        await expect(
+        await expectOAuthError(
           service.handleTokenRequest(realm, {
             grant_type: 'authorization_code',
             code: 'valid-auth-code',
@@ -1111,10 +1198,12 @@ describe('AuthService', () => {
             client_secret: 'correct-secret',
             redirect_uri: 'https://app.example.com/callback',
           }),
-        ).rejects.toThrow(BadRequestException);
+          'invalid_request',
+          400,
+        );
       });
 
-      it('should throw UnauthorizedException when code_verifier does not match', async () => {
+      it('should throw invalid_grant when code_verifier does not match', async () => {
         setupValidClient();
         // update succeeds and returns the pkce code
         prisma.authorizationCode.update.mockResolvedValue({
@@ -1124,7 +1213,7 @@ describe('AuthService', () => {
         // sha256 returns a hex string; the base64url of its buffer will not match the stored challenge
         crypto.sha256.mockReturnValue('aabbccdd');
 
-        await expect(
+        await expectOAuthError(
           service.handleTokenRequest(realm, {
             grant_type: 'authorization_code',
             code: 'valid-auth-code',
@@ -1133,7 +1222,9 @@ describe('AuthService', () => {
             redirect_uri: 'https://app.example.com/callback',
             code_verifier: 'wrong-verifier',
           }),
-        ).rejects.toThrow(UnauthorizedException);
+          'invalid_grant',
+          400,
+        );
       });
 
       it('should succeed when code_verifier is valid', async () => {
@@ -1204,7 +1295,7 @@ describe('AuthService', () => {
       crypto.verifyPassword.mockResolvedValue(true);
     }
 
-    it('should throw BadRequestException with slow_down when polled before the interval elapses', async () => {
+    it('should throw slow_down when polled before the interval elapses', async () => {
       setupDeviceClient();
       prisma.deviceCode.findUnique.mockResolvedValue(
         makeDeviceCode({
@@ -1214,14 +1305,21 @@ describe('AuthService', () => {
       );
       prisma.deviceCode.update.mockResolvedValue({} as any);
 
-      await expect(
-        service.handleTokenRequest(realm, {
-          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-          device_code: 'test-device-code',
-          client_id: deviceClientId,
-          client_secret: deviceClientSecret,
-        }),
-      ).rejects.toThrow('slow_down');
+      const promise = service.handleTokenRequest(realm, {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'test-device-code',
+        client_id: deviceClientId,
+        client_secret: deviceClientSecret,
+      });
+      await expectOAuthError(promise, 'slow_down', 400);
+      // RFC 8628 §3.5 codes carry no error_description.
+      try {
+        await promise;
+      } catch (err) {
+        expect((err as OAuthTokenError).getResponse()).toEqual({
+          error: 'slow_down',
+        });
+      }
     });
 
     it('should increase the polling interval by 5 seconds when returning slow_down', async () => {
@@ -1312,64 +1410,76 @@ describe('AuthService', () => {
       );
     });
 
-    it('should throw BadRequestException with authorization_pending when not yet approved', async () => {
+    it('should throw authorization_pending when not yet approved', async () => {
       setupDeviceClient();
       prisma.deviceCode.findUnique.mockResolvedValue(
         makeDeviceCode({ approved: false, userId: null }) as any,
       );
       prisma.deviceCode.update.mockResolvedValue({} as any);
 
-      await expect(
-        service.handleTokenRequest(realm, {
-          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
-          device_code: 'test-device-code',
-          client_id: deviceClientId,
-          client_secret: deviceClientSecret,
-        }),
-      ).rejects.toThrow('authorization_pending');
+      const promise = service.handleTokenRequest(realm, {
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'test-device-code',
+        client_id: deviceClientId,
+        client_secret: deviceClientSecret,
+      });
+      await expectOAuthError(promise, 'authorization_pending', 400);
+      try {
+        await promise;
+      } catch (err) {
+        expect((err as OAuthTokenError).getResponse()).toEqual({
+          error: 'authorization_pending',
+        });
+      }
     });
 
-    it('should throw BadRequestException with access_denied when device is denied', async () => {
+    it('should throw access_denied when device is denied', async () => {
       setupDeviceClient();
       prisma.deviceCode.findUnique.mockResolvedValue(
         makeDeviceCode({ denied: true }) as any,
       );
       prisma.deviceCode.update.mockResolvedValue({} as any);
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
           device_code: 'test-device-code',
           client_id: deviceClientId,
           client_secret: deviceClientSecret,
         }),
-      ).rejects.toThrow('access_denied');
+        'access_denied',
+        400,
+      );
     });
 
-    it('should throw BadRequestException with expired_token when device code is expired', async () => {
+    it('should throw expired_token when device code is expired', async () => {
       setupDeviceClient();
       prisma.deviceCode.findUnique.mockResolvedValue(
         makeDeviceCode({ expiresAt: new Date(Date.now() - 1_000) }) as any,
       );
 
-      await expect(
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
           device_code: 'test-device-code',
           client_id: deviceClientId,
           client_secret: deviceClientSecret,
         }),
-      ).rejects.toThrow('expired_token');
+        'expired_token',
+        400,
+      );
     });
 
-    it('should throw BadRequestException when device_code parameter is missing', async () => {
-      await expect(
+    it('should throw invalid_request when device_code parameter is missing', async () => {
+      await expectOAuthError(
         service.handleTokenRequest(realm, {
           grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
           client_id: deviceClientId,
           client_secret: deviceClientSecret,
         }),
-      ).rejects.toThrow('device_code is required');
+        'invalid_request',
+        400,
+      );
     });
   });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -2,11 +2,10 @@ import {
   Injectable,
   Logger,
   Optional,
-  UnauthorizedException,
-  BadRequestException,
   HttpException,
   HttpStatus,
 } from '@nestjs/common';
+import { OAuthTokenError } from './oauth-token-error.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { JwkService } from '../crypto/jwk.service.js';
@@ -74,6 +73,14 @@ export class AuthService {
   ): Promise<TokenResponse> {
     const grantType = body['grant_type'];
 
+    if (!grantType) {
+      throw new OAuthTokenError(
+        'invalid_request',
+        'grant_type is required',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
     switch (grantType) {
       case 'password':
         return this.handlePasswordGrant(realm, body, ip, userAgent);
@@ -88,7 +95,11 @@ export class AuthService {
       case 'urn:ietf:params:oauth:grant-type:device_code':
         return this.handleDeviceCodeGrant(realm, body, ip, userAgent);
       default:
-        throw new BadRequestException(`Unsupported grant_type: ${grantType}`);
+        throw new OAuthTokenError(
+          'unsupported_grant_type',
+          `Unsupported grant_type: ${grantType}`,
+          HttpStatus.BAD_REQUEST,
+        );
     }
   }
 
@@ -109,21 +120,31 @@ export class AuthService {
     await this.validateClient(realm, client_id, client_secret, 'password');
 
     if (!username || !password) {
-      throw new BadRequestException('username and password are required');
+      throw new OAuthTokenError(
+        'invalid_request',
+        'username and password are required',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     const user = await this.prisma.user.findUnique({
       where: { realmId_username: { realmId: realm.id, username } },
     });
     if (!user || !user.enabled || !user.passwordHash) {
-      throw new UnauthorizedException('Invalid credentials');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'Invalid credentials',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Brute force check
     const lockStatus = this.bruteForceService.checkLocked(realm, user);
     if (lockStatus.locked) {
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Account is temporarily locked. Please try again later.',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -142,7 +163,11 @@ export class AuthService {
         realm: realm.name,
         status: 'failure',
       });
-      throw new UnauthorizedException('Invalid credentials');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'Invalid credentials',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Reset brute force failures on success
@@ -150,8 +175,10 @@ export class AuthService {
 
     // Check password expiry
     if (this.passwordPolicyService.isExpired(user, realm)) {
-      throw new BadRequestException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Password has expired. Please change your password.',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -178,8 +205,10 @@ export class AuthService {
     }
 
     if (mfaRequired && !mfaEnabled) {
-      throw new BadRequestException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'MFA setup required. Please set up two-factor authentication.',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -249,15 +278,21 @@ export class AuthService {
     );
 
     if (!mfa_token || !otp) {
-      throw new BadRequestException('mfa_token and otp are required');
+      throw new OAuthTokenError(
+        'invalid_request',
+        'mfa_token and otp are required',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Validate with attempt tracking (does not consume the challenge)
     const challenge =
       await this.mfaService.validateMfaChallengeWithAttemptCheck(mfa_token);
     if (!challenge) {
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Invalid or expired MFA token, or too many failed attempts',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -266,8 +301,10 @@ export class AuthService {
       this.logger.warn(
         `MFA cross-realm token use attempt: challenge realm ${challenge.realmId} used against realm ${realm.id}`,
       );
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Invalid or expired MFA token, or too many failed attempts',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -276,8 +313,10 @@ export class AuthService {
       this.logger.warn(
         `MFA cross-client token use attempt: challenge client ${challenge.clientId} used against client ${client_id}`,
       );
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Invalid or expired MFA token, or too many failed attempts',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -296,7 +335,11 @@ export class AuthService {
           ipAddress: ip,
           error: 'Invalid OTP code',
         });
-        throw new UnauthorizedException('Invalid OTP code');
+        throw new OAuthTokenError(
+          'invalid_grant',
+          'Invalid OTP code',
+          HttpStatus.BAD_REQUEST,
+        );
       }
     }
 
@@ -307,7 +350,11 @@ export class AuthService {
       where: { id: challenge.userId },
     });
     if (!user) {
-      throw new UnauthorizedException('User not found');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'User not found',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     await this.enforceSessionLimit(realm, user.id);
@@ -455,7 +502,11 @@ export class AuthService {
     const { refresh_token, client_id, client_secret, scope } = body;
 
     if (!refresh_token) {
-      throw new BadRequestException('refresh_token is required');
+      throw new OAuthTokenError(
+        'invalid_request',
+        'refresh_token is required',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     await this.validateClient(realm, client_id, client_secret, 'refresh_token');
@@ -489,7 +540,11 @@ export class AuthService {
         ipAddress: ip,
         error: 'Invalid or expired refresh token',
       });
-      throw new UnauthorizedException('Invalid or expired refresh token');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'Invalid or expired refresh token',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Enforce that the refresh token was issued to the requesting client.
@@ -501,13 +556,17 @@ export class AuthService {
         `Refresh token ${storedToken.id} has no clientId (legacy). ` +
           `Rejecting to prevent cross-client token reuse. User must re-authenticate.`,
       );
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'This refresh token predates client binding. Please log in again.',
+        HttpStatus.BAD_REQUEST,
       );
     }
     if (storedToken.clientId !== client_id) {
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Refresh token was not issued to this client',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -562,7 +621,11 @@ export class AuthService {
       body;
 
     if (!code) {
-      throw new BadRequestException('code is required');
+      throw new OAuthTokenError(
+        'invalid_request',
+        'code is required',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     const client = await this.validateClient(
@@ -596,32 +659,48 @@ export class AuthService {
         err !== null &&
         (err as { code?: string }).code === 'P2025';
       if (isPrismaNotFound) {
-        throw new UnauthorizedException(
+        throw new OAuthTokenError(
+          'invalid_grant',
           'Invalid or expired authorization code',
+          HttpStatus.BAD_REQUEST,
         );
       }
       throw err;
     }
 
     if (authCode.clientId !== client.id) {
-      throw new UnauthorizedException('Invalid or expired authorization code');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'Invalid or expired authorization code',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     if (authCode.redirectUri !== redirect_uri) {
-      throw new BadRequestException('redirect_uri mismatch');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'redirect_uri mismatch',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // PKCE enforcement: public clients must always use PKCE (OAuth 2.1 / RFC 7636)
     if (client.clientType === 'PUBLIC' && !authCode.codeChallenge) {
-      throw new BadRequestException(
+      throw new OAuthTokenError(
+        'invalid_request',
         'PKCE (code_challenge) is required for public clients',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
     // PKCE verification
     if (authCode.codeChallenge) {
       if (!code_verifier) {
-        throw new BadRequestException('code_verifier is required for PKCE');
+        throw new OAuthTokenError(
+          'invalid_request',
+          'code_verifier is required for PKCE',
+          HttpStatus.BAD_REQUEST,
+        );
       }
       const computedChallenge = Buffer.from(
         this.crypto.sha256(code_verifier),
@@ -629,7 +708,11 @@ export class AuthService {
       ).toString('base64url');
 
       if (computedChallenge !== authCode.codeChallenge) {
-        throw new UnauthorizedException('Invalid code_verifier');
+        throw new OAuthTokenError(
+          'invalid_grant',
+          'Invalid code_verifier',
+          HttpStatus.BAD_REQUEST,
+        );
       }
     }
 
@@ -637,13 +720,19 @@ export class AuthService {
       where: { id: authCode.userId },
     });
     if (!user) {
-      throw new UnauthorizedException('User not found');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'User not found',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     const lockStatus = this.bruteForceService.checkLocked(realm, user);
     if (lockStatus.locked) {
-      throw new UnauthorizedException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'Account is temporarily locked. Please try again later.',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -704,7 +793,11 @@ export class AuthService {
     const { device_code, client_id, client_secret } = body;
 
     if (!device_code) {
-      throw new BadRequestException('device_code is required');
+      throw new OAuthTokenError(
+        'invalid_request',
+        'device_code is required',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     await this.validateClient(
@@ -719,19 +812,35 @@ export class AuthService {
     });
 
     if (!deviceCode || deviceCode.realmId !== realm.id) {
-      throw new BadRequestException('authorization_pending');
+      throw new OAuthTokenError(
+        'authorization_pending',
+        undefined,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     if (deviceCode.expiresAt < new Date()) {
-      throw new BadRequestException('expired_token');
+      throw new OAuthTokenError(
+        'expired_token',
+        undefined,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     if (deviceCode.denied) {
-      throw new BadRequestException('access_denied');
+      throw new OAuthTokenError(
+        'access_denied',
+        undefined,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     if (!deviceCode.approved || !deviceCode.userId) {
-      throw new BadRequestException('authorization_pending');
+      throw new OAuthTokenError(
+        'authorization_pending',
+        undefined,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // RFC 8628 §3.5 — enforce minimum polling interval.
@@ -747,7 +856,11 @@ export class AuthService {
             interval: deviceCode.interval + 5,
           },
         });
-        throw new BadRequestException('slow_down');
+        throw new OAuthTokenError(
+          'slow_down',
+          undefined,
+          HttpStatus.BAD_REQUEST,
+        );
       }
     }
 
@@ -758,7 +871,11 @@ export class AuthService {
     });
 
     if (!deviceCode.approved || !deviceCode.userId) {
-      throw new BadRequestException('authorization_pending');
+      throw new OAuthTokenError(
+        'authorization_pending',
+        undefined,
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Device has been approved — issue tokens
@@ -766,20 +883,28 @@ export class AuthService {
       where: { id: deviceCode.userId },
     });
     if (!user) {
-      throw new UnauthorizedException('User not found');
+      throw new OAuthTokenError(
+        'invalid_grant',
+        'User not found',
+        HttpStatus.BAD_REQUEST,
+      );
     }
 
     // Check MFA — device code flow does not support interactive MFA
     const mfaEnabled = await this.mfaService.isMfaEnabled(user.id);
     if (mfaEnabled) {
-      throw new BadRequestException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'MFA verification required. Device code grant does not support MFA. Use authorization_code grant instead.',
+        HttpStatus.BAD_REQUEST,
       );
     }
     const mfaRequired = await this.mfaService.isMfaRequired(realm, user.id);
     if (mfaRequired) {
-      throw new BadRequestException(
+      throw new OAuthTokenError(
+        'invalid_grant',
         'MFA setup required. Use authorization_code grant to complete MFA setup.',
+        HttpStatus.BAD_REQUEST,
       );
     }
 
@@ -828,7 +953,11 @@ export class AuthService {
     grantType?: string,
   ) {
     if (!clientId) {
-      throw new BadRequestException('client_id is required');
+      throw new OAuthTokenError(
+        'invalid_client',
+        'client_id is required',
+        HttpStatus.UNAUTHORIZED,
+      );
     }
 
     const client = await this.prisma.client.findUnique({
@@ -836,7 +965,11 @@ export class AuthService {
     });
 
     if (!client || !client.enabled) {
-      throw new UnauthorizedException('Invalid client');
+      throw new OAuthTokenError(
+        'invalid_client',
+        'Invalid client',
+        HttpStatus.UNAUTHORIZED,
+      );
     }
 
     if (grantType) {
@@ -854,25 +987,39 @@ export class AuthService {
         ? clientAllowsDevice
         : client.grantTypes.includes(grantType);
       if (!allowed) {
-        throw new BadRequestException(
+        throw new OAuthTokenError(
+          'unauthorized_client',
           `Grant type '${grantType}' not allowed for this client`,
+          HttpStatus.BAD_REQUEST,
         );
       }
     }
 
     if (client.clientType === 'CONFIDENTIAL') {
       if (!clientSecret) {
-        throw new UnauthorizedException('client_secret is required');
+        throw new OAuthTokenError(
+          'invalid_client',
+          'client_secret is required',
+          HttpStatus.UNAUTHORIZED,
+        );
       }
       if (!client.clientSecret) {
-        throw new UnauthorizedException('Client has no secret configured');
+        throw new OAuthTokenError(
+          'invalid_client',
+          'Client has no secret configured',
+          HttpStatus.UNAUTHORIZED,
+        );
       }
       const valid = await this.crypto.verifyPassword(
         client.clientSecret,
         clientSecret,
       );
       if (!valid) {
-        throw new UnauthorizedException('Invalid client credentials');
+        throw new OAuthTokenError(
+          'invalid_client',
+          'Invalid client credentials',
+          HttpStatus.UNAUTHORIZED,
+        );
       }
     }
 

--- a/src/auth/oauth-token-error.ts
+++ b/src/auth/oauth-token-error.ts
@@ -1,0 +1,44 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+/**
+ * An RFC 6749 §5.2 compliant token-endpoint error.
+ *
+ * The JSON body produced by {@link getResponse} is `{ error, error_description? }`
+ * where `error` is a standard OAuth error CODE (e.g. `invalid_grant`,
+ * `invalid_client`, `unsupported_grant_type`) rather than a free-form message.
+ *
+ * The HTTP status is carried separately so the controller can branch — most
+ * errors are 400, but `invalid_client` is 401 and must additionally send a
+ * `WWW-Authenticate` header.
+ */
+export class OAuthTokenError extends HttpException {
+  /** The OAuth error code, e.g. `invalid_grant`. */
+  readonly code: string;
+  /** The human-readable `error_description`, when one is supplied. */
+  readonly description?: string;
+
+  constructor(
+    code: string,
+    description?: string,
+    status: HttpStatus = HttpStatus.BAD_REQUEST,
+  ) {
+    super(
+      {
+        error: code,
+        ...(description ? { error_description: description } : {}),
+      },
+      status,
+    );
+    this.code = code;
+    this.description = description;
+    // Preserve a meaningful `message` so string-based assertions (and the
+    // device-code RFC 8628 codes that double as messages) keep matching.
+    // Without this, NestJS derives `message` from the class name.
+    this.message = description ?? code;
+  }
+
+  /** The HTTP status code to respond with. */
+  get httpStatus(): number {
+    return this.getStatus();
+  }
+}

--- a/src/broker/broker.controller.spec.ts
+++ b/src/broker/broker.controller.spec.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { BrokerController } from './broker.controller.js';
 import type { Realm } from '@prisma/client';
 
@@ -7,6 +8,7 @@ describe('BrokerController', () => {
     initiateLogin: jest.Mock;
     handleCallback: jest.Mock;
   };
+  let themeRender: { render: jest.Mock };
 
   const realm = { id: 'realm-1', name: 'test-realm' } as Realm;
 
@@ -15,7 +17,11 @@ describe('BrokerController', () => {
       initiateLogin: jest.fn(),
       handleCallback: jest.fn(),
     };
-    controller = new BrokerController(brokerService as any);
+    themeRender = { render: jest.fn() };
+    controller = new BrokerController(
+      brokerService as any,
+      themeRender as any,
+    );
   });
 
   describe('login', () => {
@@ -65,13 +71,15 @@ describe('BrokerController', () => {
         redirectUrl: 'http://localhost/callback?code=authcode&state=abc',
       });
 
-      const res = { redirect: jest.fn() };
+      const req = {};
+      const res = { redirect: jest.fn(), status: jest.fn().mockReturnThis() };
 
       await controller.callback(
         realm,
         'google',
         'ext-code',
         'state-123',
+        req as any,
         res as any,
       );
 
@@ -84,6 +92,42 @@ describe('BrokerController', () => {
       expect(res.redirect).toHaveBeenCalledWith(
         302,
         'http://localhost/callback?code=authcode&state=abc',
+      );
+      expect(themeRender.render).not.toHaveBeenCalled();
+    });
+
+    it('should render a themed error page (not raw JSON) when federation fails', async () => {
+      brokerService.handleCallback.mockRejectedValue(
+        new UnauthorizedException(
+          'No matching user found and identity provider is configured as link-only',
+        ),
+      );
+
+      const req = {};
+      const res = { redirect: jest.fn(), status: jest.fn().mockReturnThis() };
+
+      await controller.callback(
+        realm,
+        'google',
+        'ext-code',
+        'state-123',
+        req as any,
+        res as any,
+      );
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(themeRender.render).toHaveBeenCalledWith(
+        res,
+        realm,
+        'login',
+        'error',
+        expect.objectContaining({
+          errorTitle: 'Sign-in failed',
+          errorMessage:
+            'No matching user found and identity provider is configured as link-only',
+        }),
+        req,
       );
     });
   });

--- a/src/broker/broker.controller.ts
+++ b/src/broker/broker.controller.ts
@@ -1,18 +1,31 @@
-import { Controller, Get, Param, Query, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  Param,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import type { Response } from 'express';
+import type { Request, Response } from 'express';
 import type { Realm } from '@prisma/client';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
 import { BrokerService } from './broker.service.js';
+import { ThemeRenderService } from '../theme/theme-render.service.js';
 
 @ApiTags('Identity Broker')
 @Controller('realms/:realmName/broker')
 @UseGuards(RealmGuard)
 @Public()
 export class BrokerController {
-  constructor(private readonly brokerService: BrokerService) {}
+  constructor(
+    private readonly brokerService: BrokerService,
+    private readonly themeRender: ThemeRenderService,
+  ) {}
 
   @Get(':alias/login')
   @ApiOperation({ summary: 'Initiate social login with an external provider' })
@@ -63,14 +76,55 @@ export class BrokerController {
     @Param('alias') alias: string,
     @Query('code') code: string,
     @Query('state') state: string,
+    @Req() req: Request,
     @Res() res: Response,
   ) {
-    const result = await this.brokerService.handleCallback(
-      realm,
-      alias,
-      code,
-      state,
-    );
-    res.redirect(302, result.redirectUrl);
+    try {
+      const result = await this.brokerService.handleCallback(
+        realm,
+        alias,
+        code,
+        state,
+      );
+      res.redirect(302, result.redirectUrl);
+    } catch (err) {
+      // A broker callback is reached by the end-user's browser, so failures
+      // (link-only, token-exchange, invalid/expired state) must render a themed
+      // error page rather than leak a raw JSON exception to the user.
+      const status = err instanceof HttpException ? err.getStatus() : 400;
+      res.status(status);
+      this.themeRender.render(
+        res,
+        realm,
+        'login',
+        'error',
+        {
+          pageTitle: 'Sign-in failed',
+          errorTitle: 'Sign-in failed',
+          errorMessage: this.describeBrokerError(err),
+        },
+        req,
+      );
+    }
+  }
+
+  private describeBrokerError(err: unknown): string {
+    if (err instanceof HttpException) {
+      const response = err.getResponse();
+      if (typeof response === 'string') {
+        return response;
+      }
+      if (response && typeof response === 'object' && 'message' in response) {
+        const message = (response as { message: unknown }).message;
+        if (typeof message === 'string') {
+          return message;
+        }
+        if (Array.isArray(message)) {
+          return message.join(', ');
+        }
+      }
+      return err.message;
+    }
+    return 'Sign-in could not be completed. Please try again.';
   }
 }

--- a/src/broker/broker.module.ts
+++ b/src/broker/broker.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { BrokerController } from './broker.controller.js';
 import { BrokerService } from './broker.service.js';
 import { IdentityProvidersModule } from '../identity-providers/identity-providers.module.js';
+import { ThemeModule } from '../theme/theme.module.js';
 
 @Module({
-  imports: [IdentityProvidersModule],
+  imports: [IdentityProvidersModule, ThemeModule],
   controllers: [BrokerController],
   providers: [BrokerService],
 })

--- a/src/oauth/oauth.controller.spec.ts
+++ b/src/oauth/oauth.controller.spec.ts
@@ -1,0 +1,82 @@
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { OAuthController } from './oauth.controller.js';
+import type { Realm } from '@prisma/client';
+
+describe('OAuthController', () => {
+  let controller: OAuthController;
+  let oauthService: { validateAuthRequest: jest.Mock };
+  let themeRender: { render: jest.Mock };
+
+  const realm = { id: 'realm-1', name: 'test-realm' } as Realm;
+
+  beforeEach(() => {
+    oauthService = { validateAuthRequest: jest.fn() };
+    themeRender = { render: jest.fn() };
+    controller = new OAuthController(
+      oauthService as any,
+      {} as any, // loginService
+      {} as any, // consentService
+      {} as any, // stepUpService
+      {} as any, // crypto
+      {} as any, // prisma
+      themeRender as any,
+    );
+  });
+
+  describe('authorize error rendering', () => {
+    it('renders a themed error page (not raw JSON) when the client is unknown', async () => {
+      oauthService.validateAuthRequest.mockRejectedValue(
+        new NotFoundException('Client not found'),
+      );
+      const req = {};
+      const res = { status: jest.fn().mockReturnThis(), redirect: jest.fn() };
+
+      await controller.authorize(
+        realm,
+        { client_id: 'ghost' },
+        req as any,
+        res as any,
+      );
+
+      expect(res.redirect).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(themeRender.render).toHaveBeenCalledWith(
+        res,
+        realm,
+        'login',
+        'error',
+        expect.objectContaining({ errorMessage: 'Client not found' }),
+        req,
+      );
+    });
+
+    it('renders a themed error page on an invalid redirect_uri (status from the exception)', async () => {
+      oauthService.validateAuthRequest.mockRejectedValue(
+        new BadRequestException('Invalid redirect_uri'),
+      );
+      const req = {};
+      const res = { status: jest.fn().mockReturnThis(), redirect: jest.fn() };
+
+      await controller.authorize(
+        realm,
+        {
+          client_id: 'test-client',
+          redirect_uri: 'http://evil.example/cb',
+          response_type: 'code',
+        },
+        req as any,
+        res as any,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(themeRender.render).toHaveBeenCalledWith(
+        res,
+        realm,
+        'login',
+        'error',
+        expect.objectContaining({ errorMessage: 'Invalid redirect_uri' }),
+        req,
+      );
+    });
+  });
+});

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -254,7 +254,7 @@ export class OAuthController {
         return response;
       }
       if (response && typeof response === 'object' && 'message' in response) {
-        const message = (response as { message: unknown }).message;
+        const message: unknown = response.message;
         if (typeof message === 'string') {
           return message;
         }

--- a/src/oauth/oauth.controller.ts
+++ b/src/oauth/oauth.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get, Query, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  HttpException,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
 import type { Realm } from '@prisma/client';
@@ -16,6 +24,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
+import { ThemeRenderService } from '../theme/theme-render.service.js';
 
 @ApiTags('OAuth')
 @Controller('realms/:realmName/protocol/openid-connect')
@@ -29,6 +38,7 @@ export class OAuthController {
     private readonly stepUpService: StepUpService,
     private readonly crypto: CryptoService,
     private readonly prisma: PrismaService,
+    private readonly themeRender: ThemeRenderService,
   ) {}
 
   @Get('auth')
@@ -47,6 +57,37 @@ export class OAuthController {
     @Query() query: Record<string, string>,
     @Req() req: Request,
     @Res() res: Response,
+  ) {
+    try {
+      await this.authorizeInternal(realm, query, req, res);
+    } catch (err) {
+      // The authorize endpoint is reached by the end-user's browser, so a
+      // validation failure (bad client_id / redirect_uri / response_type / PKCE)
+      // must render a themed error page rather than leak a raw JSON exception.
+      // These failures occur before a trusted redirect_uri is established, so a
+      // page (not a redirect) is the safe choice.
+      const status = err instanceof HttpException ? err.getStatus() : 400;
+      res.status(status);
+      this.themeRender.render(
+        res,
+        realm,
+        'login',
+        'error',
+        {
+          pageTitle: 'Request error',
+          errorTitle: 'We can’t complete this sign-in request',
+          errorMessage: this.describeAuthError(err),
+        },
+        req,
+      );
+    }
+  }
+
+  private async authorizeInternal(
+    realm: Realm,
+    query: Record<string, string>,
+    req: Request,
+    res: Response,
   ) {
     // Validate OAuth params (client_id, redirect_uri, etc.) early
     const client = await this.oauthService.validateAuthRequest(
@@ -205,6 +246,26 @@ export class OAuthController {
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────
+
+  private describeAuthError(err: unknown): string {
+    if (err instanceof HttpException) {
+      const response = err.getResponse();
+      if (typeof response === 'string') {
+        return response;
+      }
+      if (response && typeof response === 'object' && 'message' in response) {
+        const message = (response as { message: unknown }).message;
+        if (typeof message === 'string') {
+          return message;
+        }
+        if (Array.isArray(message)) {
+          return message.join(', ');
+        }
+      }
+      return err.message;
+    }
+    return 'The sign-in request could not be processed. Please try again.';
+  }
 
   /**
    * Given two optional ACR requirements, returns the one with higher

--- a/src/oauth/oauth.module.ts
+++ b/src/oauth/oauth.module.ts
@@ -3,9 +3,14 @@ import { OAuthController } from './oauth.controller.js';
 import { OAuthService } from './oauth.service.js';
 import { LoginModule } from '../login/login.module.js';
 import { StepUpModule } from '../step-up/step-up.module.js';
+import { ThemeModule } from '../theme/theme.module.js';
 
 @Module({
-  imports: [forwardRef(() => LoginModule), forwardRef(() => StepUpModule)],
+  imports: [
+    forwardRef(() => LoginModule),
+    forwardRef(() => StepUpModule),
+    ThemeModule,
+  ],
   controllers: [OAuthController],
   providers: [OAuthService],
   exports: [OAuthService],

--- a/src/theme/login-form-csrf.spec.ts
+++ b/src/theme/login-form-csrf.spec.ts
@@ -1,0 +1,40 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Every POST form rendered by a login theme must embed the `_csrf` hidden field
+ * (the double-submit token validated by CsrfService). Regression guard for #22:
+ * `device.hbs` omitted it, so every device approve/deny POST failed CSRF
+ * validation (403) and the Device Authorization flow was unusable end-to-end.
+ */
+describe('login theme POST forms embed the CSRF field', () => {
+  const themesRoot = join(process.cwd(), 'themes');
+  const themes = readdirSync(themesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+  const cases: Array<{ theme: string; file: string; content: string }> = [];
+  for (const theme of themes) {
+    const dir = join(themesRoot, theme, 'login', 'templates');
+    let files: string[];
+    try {
+      files = readdirSync(dir).filter((f) => f.endsWith('.hbs'));
+    } catch {
+      continue; // theme has no login templates
+    }
+    for (const file of files) {
+      const content = readFileSync(join(dir, file), 'utf8');
+      if (/<form[^>]*method=["']POST["']/i.test(content)) {
+        cases.push({ theme, file, content });
+      }
+    }
+  }
+
+  it('discovers POST-form templates to check', () => {
+    expect(cases.length).toBeGreaterThan(0);
+  });
+
+  it.each(cases)('$theme/$file includes name="_csrf"', ({ content }) => {
+    expect(content).toContain('name="_csrf"');
+  });
+});

--- a/src/tokens/tokens.service.spec.ts
+++ b/src/tokens/tokens.service.spec.ts
@@ -153,6 +153,69 @@ describe('TokensService', () => {
 
       expect(result).toEqual({ active: false });
     });
+
+    it('should return active=true for a valid opaque refresh token (RFC 7662)', async () => {
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockRejectedValue(new Error('not a JWT'));
+      cryptoService.sha256.mockReturnValue('rt-hash');
+      prisma.refreshToken.findUnique.mockResolvedValue({
+        tokenHash: 'rt-hash',
+        revoked: false,
+        expiresAt: new Date(Date.now() + 1_800_000),
+        createdAt: new Date(Date.now() - 1_000),
+        scope: 'openid profile',
+        clientId: 'my-app',
+        session: {
+          user: {
+            id: 'user-1',
+            username: 'testuser',
+            enabled: true,
+            realmId: 'realm-1',
+          },
+        },
+      });
+
+      const result = await service.introspect(
+        mockRealm,
+        'opaque-refresh-token',
+      );
+
+      expect(result.active).toBe(true);
+      expect((result as Record<string, unknown>).token_type).toBe(
+        'refresh_token',
+      );
+      expect(result.sub).toBe('user-1');
+      expect((result as Record<string, unknown>).client_id).toBe('my-app');
+      expect((result as Record<string, unknown>).azp).toBe('my-app');
+      expect(result.scope).toBe('openid profile');
+      expect(prisma.refreshToken.findUnique).toHaveBeenCalledWith({
+        where: { tokenHash: 'rt-hash' },
+        include: { session: { include: { user: true } } },
+      });
+    });
+
+    it('should return active=false for a revoked refresh token', async () => {
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockRejectedValue(new Error('not a JWT'));
+      cryptoService.sha256.mockReturnValue('rt-hash');
+      prisma.refreshToken.findUnique.mockResolvedValue({
+        revoked: true,
+        expiresAt: new Date(Date.now() + 1_800_000),
+        createdAt: new Date(),
+        session: {
+          user: {
+            id: 'user-1',
+            username: 'u',
+            enabled: true,
+            realmId: 'realm-1',
+          },
+        },
+      });
+
+      const result = await service.introspect(mockRealm, 'revoked-rt');
+
+      expect(result).toEqual({ active: false });
+    });
   });
 
   describe('validatePostLogoutRedirectUri', () => {

--- a/src/tokens/tokens.service.ts
+++ b/src/tokens/tokens.service.ts
@@ -112,8 +112,42 @@ export class TokensService {
         resource_access: payload['resource_access'],
       };
     } catch {
+      // Not a verifiable JWT (access/id token). Treat it as an opaque refresh
+      // token so introspection (RFC 7662) also covers refresh tokens — a valid
+      // refresh token must report active:true, not false.
+      return this.introspectRefreshToken(realm, token);
+    }
+  }
+
+  private async introspectRefreshToken(realm: Realm, token: string) {
+    const stored = await this.prisma.refreshToken.findUnique({
+      where: { tokenHash: this.crypto.sha256(token) },
+      include: { session: { include: { user: true } } },
+    });
+
+    if (!stored || stored.revoked || stored.expiresAt < new Date()) {
       return { active: false };
     }
+
+    const user = stored.session?.user;
+    if (!user || !user.enabled || user.realmId !== realm.id) {
+      return { active: false };
+    }
+
+    return {
+      active: true,
+      token_type: 'refresh_token',
+      sub: user.id,
+      username: user.username,
+      preferred_username: user.username,
+      // azp/client_id let the controller's ownership check confirm the caller
+      // is the client the token was issued to.
+      azp: stored.clientId ?? undefined,
+      client_id: stored.clientId ?? undefined,
+      scope: stored.scope ?? undefined,
+      exp: Math.floor(stored.expiresAt.getTime() / 1000),
+      iat: Math.floor(stored.createdAt.getTime() / 1000),
+    };
   }
 
   /**

--- a/test/brute-force.e2e-spec.ts
+++ b/test/brute-force.e2e-spec.ts
@@ -140,8 +140,8 @@ describe('Brute-Force Protection (e2e)', () => {
     it('should reject further login attempts when account is locked', async () => {
       // Even with correct credentials, the account is locked
       const res = await successfulLogin();
-      expect([401, 423]).toContain(res.status);
-      expect(res.body).toHaveProperty('message');
+      expect([400, 401, 423]).toContain(res.status);
+      expect(res.body).toHaveProperty('error');
     });
   });
 
@@ -296,7 +296,7 @@ describe('Brute-Force Protection (e2e)', () => {
       await new Promise<void>((resolve) => setTimeout(resolve, 2_500));
 
       const res = await successfulLogin();
-      expect([401, 423]).toContain(res.status);
+      expect([400, 401, 423]).toContain(res.status);
     });
   });
 });

--- a/test/mfa.e2e-spec.ts
+++ b/test/mfa.e2e-spec.ts
@@ -80,7 +80,7 @@ describe('MFA (TOTP) flows (e2e)', () => {
           username: 'testuser',
           password: 'WrongPassword!',
         })
-        .expect(401);
+        .expect(400);
     });
   });
 

--- a/test/oauth-flows.e2e-spec.ts
+++ b/test/oauth-flows.e2e-spec.ts
@@ -92,9 +92,9 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
           password: 'WrongPassword999!',
           scope: 'openid',
         })
-        .expect(401);
+        .expect(400);
 
-      expect(res.body).toHaveProperty('message');
+      expect(res.body).toHaveProperty('error');
     });
   });
 
@@ -294,7 +294,7 @@ describe('OAuth2 / OIDC Token Flows (e2e)', () => {
         })
         .expect(401);
 
-      expect(res.body).toHaveProperty('message');
+      expect(res.body).toHaveProperty('error');
     });
   });
 });

--- a/test/oauth-grant-types.e2e-spec.ts
+++ b/test/oauth-grant-types.e2e-spec.ts
@@ -158,7 +158,7 @@ describe('OAuth 2.0 Grant Types (e2e)', () => {
         });
 
       expect([400, 401]).toContain(replayRes.status);
-      expect(replayRes.body).toHaveProperty('message');
+      expect(replayRes.body).toHaveProperty('error');
     });
 
     it('should reject an invalid code_verifier (wrong PKCE)', async () => {
@@ -199,7 +199,7 @@ describe('OAuth 2.0 Grant Types (e2e)', () => {
         });
 
       expect([400, 401]).toContain(res.status);
-      expect(res.body).toHaveProperty('message');
+      expect(res.body).toHaveProperty('error');
     });
 
     it('should reject a missing code_verifier when code_challenge was set', async () => {
@@ -277,7 +277,7 @@ describe('OAuth 2.0 Grant Types (e2e)', () => {
         })
         .expect(401);
 
-      expect(res.body).toHaveProperty('message');
+      expect(res.body).toHaveProperty('error');
     });
 
     it('should reject a non-existent client_id', async () => {
@@ -291,7 +291,7 @@ describe('OAuth 2.0 Grant Types (e2e)', () => {
         });
 
       expect([400, 401, 404]).toContain(res.status);
-      expect(res.body).toHaveProperty('message');
+      expect(res.body).toHaveProperty('error');
     });
   });
 
@@ -488,7 +488,7 @@ describe('OAuth 2.0 Grant Types (e2e)', () => {
         });
 
       expect([400, 401]).toContain(res.status);
-      expect(res.body).toHaveProperty('message');
+      expect(res.body).toHaveProperty('error');
     });
 
     it('should reject reuse of a consumed refresh_token', async () => {

--- a/themes/idenplane/login/templates/device.hbs
+++ b/themes/idenplane/login/templates/device.hbs
@@ -7,6 +7,7 @@
 {{/if}}
 
 <form method="POST" action="/realms/{{realmName}}/device" class="auth-form">
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="form-group">
     <label for="user_code">{{msg "deviceCode"}}</label>
     <input type="text" id="user_code" name="user_code" value="{{userCode}}" required

--- a/themes/midnight/login/templates/device.hbs
+++ b/themes/midnight/login/templates/device.hbs
@@ -7,6 +7,7 @@
 {{/if}}
 
 <form method="POST" action="/realms/{{realmName}}/device" class="auth-form">
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="form-group">
     <label for="user_code">{{msg "deviceCode"}}</label>
     <input type="text" id="user_code" name="user_code" value="{{userCode}}" required


### PR DESCRIPTION
Batched **dev → main** promotion of the five fixes surfaced by the TeamDesk deep-test campaign (Identity Providers + OAuth/OIDC core features). All already merged to `dev` with green CI (1813 unit + 262 e2e).

| # | Sev | Fix | PR |
|---|---|---|---|
| 18 | minor/UX | Broker callback failures render a themed error page instead of raw JSON | #1000 |
| 19 | major | Token-endpoint errors are RFC 6749 §5.2-compliant (`invalid_grant`/`invalid_client`/… + correct status) — fixes OAuth client-lib refresh/re-auth handling | #1001 |
| 20 | minor | Introspection reports valid refresh tokens as active (RFC 7662) | #1001 |
| 21 | minor/UX | Authorization-endpoint validation errors render a themed page instead of raw JSON | #1001 |
| 22 | major (device) | Device verification form was missing its CSRF field → every approve/deny 403; Device Authorization Grant was unusable | #1002 |

## Post-merge plan
- Image rebuilds (`islamawad/idenplane:latest`) and deploys to demo.idenplane.cloud.
- Re-verify #18–#22 **live** via the TeamDesk OIDC client (clean-slate image pull) before continuing the campaign (MFA next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)