### PR TITLE
fix(mfa+account+clients): ROPC continuation, account CSRF DiD, requiredAcr admin API (#23/#24/#25)

### DIFF
--- a/src/account/account.controller.spec.ts
+++ b/src/account/account.controller.spec.ts
@@ -66,6 +66,11 @@ describe('AccountController', () => {
     };
     themeRender = { render: jest.fn() };
     webAuthnService = { getUserCredentials: jest.fn().mockResolvedValue([]) };
+    const csrfService = {
+      validate: jest.fn().mockReturnValue(true),
+      generateToken: jest.fn().mockReturnValue('csrf-token-test'),
+      cookieName: jest.fn().mockReturnValue('XSRF-TOKEN-test'),
+    };
 
     controller = new AccountController(
       loginService as any,
@@ -75,9 +80,12 @@ describe('AccountController', () => {
       mfaService as any,
       themeRender as any,
       webAuthnService as any,
+      undefined as any, // dataExportService — not exercised in these tests
+      undefined as any, // accountDeletionService — not exercised in these tests
+      csrfService as any,
     );
 
-    mockRes = { redirect: jest.fn() };
+    mockRes = { redirect: jest.fn(), cookie: jest.fn() };
     mockReqWithSession = {
       cookies: { IDENPLANE_SESSION: 'valid-token' },
       query: {},

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -1,5 +1,6 @@
 import {
   Controller,
+  ForbiddenException,
   Get,
   Post,
   UseGuards,
@@ -26,6 +27,7 @@ import { ThemeRenderService } from '../theme/theme-render.service.js';
 import { WebAuthnService } from '../webauthn/webauthn.service.js';
 import { DataExportService } from './data-export.service.js';
 import { AccountDeletionService } from './account-deletion.service.js';
+import { CsrfService } from '../common/csrf/csrf.service.js';
 
 @ApiExcludeController()
 @Controller('realms/:realmName/account')
@@ -42,7 +44,33 @@ export class AccountController {
     private readonly webAuthnService: WebAuthnService,
     private readonly dataExportService: DataExportService,
     private readonly accountDeletionService: AccountDeletionService,
+    private readonly csrfService: CsrfService,
   ) {}
+
+  /** Set a fresh CSRF cookie and return the token for embedding in the form. */
+  private setCsrfCookie(realm: Realm, res: Response): string {
+    const token = this.csrfService.generateToken();
+    res.cookie(this.csrfService.cookieName(realm.name), token, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'strict',
+      path: `/realms/${realm.name}`,
+    });
+    return token;
+  }
+
+  /** Throw `ForbiddenException` when the double-submit CSRF token is invalid. */
+  private validateCsrf(realm: Realm, body: object, req: Request): void {
+    const bodyToken = (body as Record<string, unknown>)['_csrf'] as
+      | string
+      | undefined;
+    const cookieToken = (req.cookies as Record<string, string | undefined>)?.[
+      this.csrfService.cookieName(realm.name)
+    ];
+    if (!this.csrfService.validate(bodyToken, cookieToken)) {
+      throw new ForbiddenException('Invalid or missing CSRF token');
+    }
+  }
 
   private async getSessionUser(realm: Realm, req: Request) {
     const sessionToken = req.cookies?.['IDENPLANE_SESSION'] as
@@ -91,6 +119,7 @@ export class AccountController {
       }));
     }
 
+    const csrfToken = this.setCsrfCookie(realm, res);
     this.themeRender.render(
       res,
       realm,
@@ -109,6 +138,7 @@ export class AccountController {
           webAuthnCredentials.length > 0 ? webAuthnCredentials : null,
         success: query['success'] ?? '',
         error: query['error'] ?? '',
+        csrfToken,
       },
       req,
     );
@@ -121,6 +151,7 @@ export class AccountController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.validateCsrf(realm, body, req);
     const user = await this.getSessionUser(realm, req);
     if (!user) {
       return res.redirect(`/realms/${realm.name}/login`);
@@ -158,6 +189,7 @@ export class AccountController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.validateCsrf(realm, body, req);
     const user = await this.getSessionUser(realm, req);
     if (!user) {
       return res.redirect(`/realms/${realm.name}/login`);
@@ -265,6 +297,7 @@ export class AccountController {
       user.username,
     );
 
+    const csrfToken = this.setCsrfCookie(realm, res);
     this.themeRender.render(
       res,
       realm,
@@ -276,6 +309,7 @@ export class AccountController {
         secret: setup.secret,
         error: query['error'] ?? '',
         info: query['info'] ?? '',
+        csrfToken,
       },
       req,
     );
@@ -290,6 +324,7 @@ export class AccountController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.validateCsrf(realm, body, req);
     const user = await this.getSessionUser(realm, req);
     if (!user) {
       return res.redirect(`/realms/${realm.name}/login`);
@@ -335,6 +370,7 @@ export class AccountController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.validateCsrf(realm, body, req);
     const user = await this.getSessionUser(realm, req);
     if (!user) {
       return res.redirect(`/realms/${realm.name}/login`);
@@ -412,6 +448,7 @@ export class AccountController {
       user.id,
     );
 
+    const csrfToken = this.setCsrfCookie(realm, res);
     this.themeRender.render(
       res,
       realm,
@@ -422,6 +459,7 @@ export class AccountController {
         deletionStatus,
         error: query['error'] ?? '',
         success: query['success'] ?? '',
+        csrfToken,
       },
       req,
     );
@@ -436,6 +474,7 @@ export class AccountController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.validateCsrf(realm, body, req);
     const user = await this.getSessionUser(realm, req);
     if (!user) {
       return res.redirect(`/realms/${realm.name}/login`);
@@ -487,6 +526,7 @@ export class AccountController {
     @Req() req: Request,
     @Res() res: Response,
   ) {
+    this.validateCsrf(realm, body, req);
     const user = await this.getSessionUser(realm, req);
     if (!user) {
       return res.redirect(`/realms/${realm.name}/login`);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -975,7 +975,8 @@ export class AuthService {
     if (grantType) {
       // For the device_code grant (RFC 8628) accept both the full URN and the
       // shorthand alias so that clients stored with either value are permitted
-      // (issue #503).  All other grant types must match exactly.
+      // (issue #503).  All other grant types must match exactly — with one
+      // continuation exception below.
       const DEVICE_URN = 'urn:ietf:params:oauth:grant-type:device_code';
       const isDeviceGrant =
         grantType === DEVICE_URN || grantType === 'device_code';
@@ -983,9 +984,22 @@ export class AuthService {
         client.grantTypes.includes(DEVICE_URN) ||
         client.grantTypes.includes('device_code');
 
+      // A `password`-grant client that hands back `mfa_required` must be able
+      // to complete the challenge it issued; implicitly permit the
+      // `mfa_otp` continuation so admins don't have to grant both side-by-side
+      // (finding #23).
+      const MFA_OTP_URN = 'urn:ietf:params:oauth:grant-type:mfa-otp';
+      const isMfaOtpGrant =
+        grantType === MFA_OTP_URN || grantType === 'mfa_otp';
+      const clientAllowsMfaOtp =
+        client.grantTypes.includes(MFA_OTP_URN) ||
+        client.grantTypes.includes('password');
+
       const allowed = isDeviceGrant
         ? clientAllowsDevice
-        : client.grantTypes.includes(grantType);
+        : isMfaOtpGrant
+          ? clientAllowsMfaOtp
+          : client.grantTypes.includes(grantType);
       if (!allowed) {
         throw new OAuthTokenError(
           'unauthorized_client',

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -30,6 +30,8 @@ const CLIENT_SELECT = {
   backchannelLogoutUri: true,
   backchannelLogoutSessionRequired: true,
   serviceAccountUserId: true,
+  requiredAcr: true,
+  stepUpCacheDuration: true,
   createdAt: true,
   updatedAt: true,
 } as const;
@@ -105,6 +107,8 @@ export class ClientsService {
         backchannelLogoutUri: dto.backchannelLogoutUri,
         backchannelLogoutSessionRequired: dto.backchannelLogoutSessionRequired,
         serviceAccountUserId,
+        requiredAcr: dto.requiredAcr,
+        stepUpCacheDuration: dto.stepUpCacheDuration,
       },
       select: CLIENT_SELECT,
     });
@@ -202,6 +206,8 @@ export class ClientsService {
         requireConsent: dto.requireConsent,
         backchannelLogoutUri: dto.backchannelLogoutUri,
         backchannelLogoutSessionRequired: dto.backchannelLogoutSessionRequired,
+        requiredAcr: dto.requiredAcr,
+        stepUpCacheDuration: dto.stepUpCacheDuration,
       },
       select: CLIENT_SELECT,
     });

--- a/src/clients/dto/create-client.dto.ts
+++ b/src/clients/dto/create-client.dto.ts
@@ -3,6 +3,7 @@ import {
   IsOptional,
   IsBoolean,
   IsEnum,
+  IsInt,
   IsArray,
   MinLength,
   registerDecorator,
@@ -129,4 +130,22 @@ export class CreateClientDto {
   @IsOptional()
   @IsBoolean()
   backchannelLogoutSessionRequired?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Minimum Authentication Context Class Reference required before issuing a code for this client. When set, /authorize will redirect a session that does not satisfy it to the step-up challenge. Use `null` (or omit) for no enforcement.',
+    example: 'urn:idenplane:acr:mfa',
+  })
+  @IsOptional()
+  @IsString()
+  requiredAcr?: string | null;
+
+  @ApiPropertyOptional({
+    description:
+      'How long (seconds) a satisfied step-up ACR can be re-used before a fresh challenge is required.',
+    example: 300,
+  })
+  @IsOptional()
+  @IsInt()
+  stepUpCacheDuration?: number;
 }

--- a/src/login/login.module.ts
+++ b/src/login/login.module.ts
@@ -20,6 +20,6 @@ import { CsrfService } from '../common/csrf/csrf.service.js';
   ],
   controllers: [LoginController],
   providers: [LoginService, CsrfService],
-  exports: [LoginService],
+  exports: [LoginService, CsrfService],
 })
 export class LoginModule {}

--- a/src/theme/login-form-csrf.spec.ts
+++ b/src/theme/login-form-csrf.spec.ts
@@ -2,30 +2,44 @@ import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 /**
- * Every POST form rendered by a login theme must embed the `_csrf` hidden field
- * (the double-submit token validated by CsrfService). Regression guard for #22:
- * `device.hbs` omitted it, so every device approve/deny POST failed CSRF
- * validation (403) and the Device Authorization flow was unusable end-to-end.
+ * Every POST form rendered by a theme's `login` or `account` templates must
+ * embed the `_csrf` hidden field (the double-submit token validated by
+ * CsrfService). Regression guards for:
+ *   - #22: `login/device.hbs` omitted it, so device approve/deny → 403.
+ *   - #24: `account/totp-setup.hbs` (and the other account forms) omitted it,
+ *     and the corresponding controllers never called validateCsrf — every
+ *     account self-service POST (incl. password change & delete-account) was
+ *     missing its layered CSRF defense.
  */
-describe('login theme POST forms embed the CSRF field', () => {
+describe('theme POST forms embed the CSRF field', () => {
   const themesRoot = join(process.cwd(), 'themes');
   const themes = readdirSync(themesRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name);
 
-  const cases: Array<{ theme: string; file: string; content: string }> = [];
+  // Subtrees of each theme that render user-facing forms — both must embed _csrf.
+  const themeSubtrees = ['login', 'account'] as const;
+
+  const cases: Array<{
+    theme: string;
+    subtree: string;
+    file: string;
+    content: string;
+  }> = [];
   for (const theme of themes) {
-    const dir = join(themesRoot, theme, 'login', 'templates');
-    let files: string[];
-    try {
-      files = readdirSync(dir).filter((f) => f.endsWith('.hbs'));
-    } catch {
-      continue; // theme has no login templates
-    }
-    for (const file of files) {
-      const content = readFileSync(join(dir, file), 'utf8');
-      if (/<form[^>]*method=["']POST["']/i.test(content)) {
-        cases.push({ theme, file, content });
+    for (const subtree of themeSubtrees) {
+      const dir = join(themesRoot, theme, subtree, 'templates');
+      let files: string[];
+      try {
+        files = readdirSync(dir).filter((f) => f.endsWith('.hbs'));
+      } catch {
+        continue; // theme/subtree absent
+      }
+      for (const file of files) {
+        const content = readFileSync(join(dir, file), 'utf8');
+        if (/<form[^>]*method=["']POST["']/i.test(content)) {
+          cases.push({ theme, subtree, file, content });
+        }
       }
     }
   }
@@ -34,7 +48,10 @@ describe('login theme POST forms embed the CSRF field', () => {
     expect(cases.length).toBeGreaterThan(0);
   });
 
-  it.each(cases)('$theme/$file includes name="_csrf"', ({ content }) => {
-    expect(content).toContain('name="_csrf"');
-  });
+  it.each(cases)(
+    '$theme/$subtree/$file includes name="_csrf"',
+    ({ content }) => {
+      expect(content).toContain('name="_csrf"');
+    },
+  );
 });

--- a/themes/idenplane/account/templates/account.hbs
+++ b/themes/idenplane/account/templates/account.hbs
@@ -23,6 +23,7 @@
 <div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 0.5rem;">
   <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">{{msg "accountProfile"}}</h3>
   <form method="POST" action="/realms/{{realmName}}/account/profile" class="auth-form">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <div class="form-group">
       <label for="firstName">{{msg "accountFirstName"}}</label>
       <input type="text" id="firstName" name="firstName" value="{{firstName}}" autocomplete="given-name">
@@ -40,6 +41,7 @@
 <div style="border-top: 1px solid #e5e7eb; padding-top: 1.25rem; margin-top: 1.5rem;">
   <h3 style="font-size: 0.95rem; font-weight: 600; color: #374151; margin-bottom: 1rem;">{{msg "accountChangePassword"}}</h3>
   <form method="POST" action="/realms/{{realmName}}/account/password" class="auth-form">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <div class="form-group">
       <label for="currentPassword">{{msg "accountCurrentPassword"}}</label>
       <input type="password" id="currentPassword" name="currentPassword" required autocomplete="current-password">
@@ -69,6 +71,7 @@
   </div>
 
   <form method="POST" action="/realms/{{realmName}}/account/totp-disable" class="auth-form">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <div class="form-group">
       <label for="disablePassword">{{msg "accountCurrentPassword"}}</label>
       <input type="password" id="disablePassword" name="currentPassword" required autocomplete="current-password">

--- a/themes/idenplane/account/templates/totp-setup.hbs
+++ b/themes/idenplane/account/templates/totp-setup.hbs
@@ -36,6 +36,7 @@
 </div>
 
 <form method="POST" action="/realms/{{realmName}}/account/totp-setup" class="auth-form">
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="form-group">
     <label for="code">{{msg "totpSetupVerifyLabel"}}</label>
     <input type="text" id="code" name="code" pattern="[0-9]{6}" maxlength="6" inputmode="numeric" required autofocus

--- a/themes/midnight/account/templates/account.hbs
+++ b/themes/midnight/account/templates/account.hbs
@@ -23,6 +23,7 @@
 <div class="account-section">
   <h2>{{msg "accountProfile"}}</h2>
   <form method="POST" action="/realms/{{realmName}}/account/profile" class="auth-form">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <div class="auth-name-grid">
       <div class="form-group">
         <label for="firstName">{{msg "accountFirstName"}}</label>
@@ -42,6 +43,7 @@
 <div class="account-section">
   <h2>{{msg "accountChangePassword"}}</h2>
   <form method="POST" action="/realms/{{realmName}}/account/password" class="auth-form">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <div class="form-group">
       <label for="currentPassword">{{msg "accountCurrentPassword"}}</label>
       <input type="password" id="currentPassword" name="currentPassword" required autocomplete="current-password">
@@ -70,6 +72,7 @@
   </div>
 
   <form method="POST" action="/realms/{{realmName}}/account/totp-disable" class="auth-form">
+    <input type="hidden" name="_csrf" value="{{csrfToken}}">
     <div class="form-group">
       <label for="disablePassword">{{msg "accountCurrentPassword"}}</label>
       <input type="password" id="disablePassword" name="currentPassword" required autocomplete="current-password">

--- a/themes/midnight/account/templates/totp-setup.hbs
+++ b/themes/midnight/account/templates/totp-setup.hbs
@@ -36,6 +36,7 @@
 </div>
 
 <form method="POST" action="/realms/{{realmName}}/account/totp-setup" class="auth-form">
+  <input type="hidden" name="_csrf" value="{{csrfToken}}">
   <div class="form-group">
     <label for="code">{{msg "totpSetupVerifyLabel"}}</label>
     <input type="text" id="code" name="code" pattern="[0-9]{6}" maxlength="6" inputmode="numeric" required autofocus


### PR DESCRIPTION
Surfaced during the TeamDesk deep-test campaign (feature 03: MFA). Three independent gaps, all minor in isolation but worth closing together while the area is fresh.

## #23 — `mfa_otp` continuation rejected for plain password-grant clients
A client allowed `password` gets handed `mfa_required` + `mfa_token`, but cannot complete the challenge unless it is *also* granted `urn:ietf:params:oauth:grant-type:mfa-otp` (`unauthorized_client`). Implicitly permit the continuation in `validateClient` whenever the client already holds `password`. Mirrors the existing leniency for device_code (URN + shorthand both accepted).

## #24 — `/account/*` POSTs skipped CSRF validation entirely
None of `profile`, `password`, `totp-setup`, `totp-disable`, `delete-account`, `cancel-delete-account` called `validateCsrf`, and the account templates omitted the `_csrf` hidden field — confirmed by enrolling MFA end-to-end via a POST that carried **no** `_csrf` (HTTP 201 + recovery codes returned). `IDENPLANE_SESSION` is `SameSite=Strict` so the practical exposure is contained in modern browsers, but the gap removed a layered defense from two genuinely sensitive endpoints (password change, account delete) and broke consistency with every other form. Wire `CsrfService` through `AccountController` (LoginModule exports it for cross-module reuse now), embed `_csrf` in the account templates of both themes, and extend the form-CSRF unit spec to scan `themes/*/account/templates/` as well as `login`.

## #25 — `client.requiredAcr` was not exposable via the admin API
The DB column exists and `OAuthController` consults it to drive step-up — but `CreateClientDto` had no field for it (and `UpdateClientDto` inherits the same gap via `PartialType`), so admins could not configure step-up policy via the API; the only working path was a direct DB write (exactly what unblocked the step-up live test during MFA scenario coverage). Add `requiredAcr` and `stepUpCacheDuration` to the DTO, include both in `CLIENT_SELECT` so responses round-trip the configured value, and wire them into `clients.service.create`/`update`.

## Tests
- [x] `npx jest` — **113 suites, 1834 tests pass** (incl. new account-controller mocks for `csrfService` + extended form-CSRF spec)
- [x] Full e2e suite — **20 suites, 262 tests pass**
- [x] `tsc --noEmit -p tsconfig.build.json` clean · eslint clean
- [ ] Live re-verify after the next batched `dev→main` promotion

## Deferred (separate finding)
- `account/delete-account.hbs` template is missing from both themes (GET → 500). Not in this PR's scope; will track as a separate item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)