### PR TITLE
revert #31 (closed #582) + fix(clients): regenerate-secret row-UUID crash (#34)

### DIFF
--- a/src/clients/clients.service.spec.ts
+++ b/src/clients/clients.service.spec.ts
@@ -324,7 +324,7 @@ describe('ClientsService', () => {
   });
 
   describe('regenerateSecret', () => {
-    it('should regenerate the secret for a confidential client', async () => {
+    it('should regenerate the secret for a confidential client (looked up by clientId string)', async () => {
       prisma.client.findUnique.mockResolvedValue(mockClient);
       cryptoService.generateSecret.mockReturnValue('new-raw-secret');
       cryptoService.hashPassword.mockResolvedValue('new-hashed-secret');
@@ -337,10 +337,32 @@ describe('ClientsService', () => {
       expect(result.secretWarning).toBeDefined();
       expect(cryptoService.generateSecret).toHaveBeenCalled();
       expect(cryptoService.hashPassword).toHaveBeenCalledWith('new-raw-secret');
+      // Regression for the bug where the update used the raw URL param in the
+      // realmId_clientId compound key — that crashed with P2025 whenever the
+      // caller passed the row UUID. We now use the resolved row PK.
       expect(prisma.client.update).toHaveBeenCalledWith({
-        where: {
-          realmId_clientId: { realmId: 'realm-1', clientId: 'my-app' },
-        },
+        where: { id: mockClient.id },
+        data: { clientSecret: 'new-hashed-secret' },
+      });
+    });
+
+    it('should regenerate the secret when the caller passes the row UUID instead of the clientId string', async () => {
+      const uuid = '00000000-0000-0000-0000-000000000abc';
+      // findByClientId tries findUnique by realmId_clientId first; on a UUID
+      // that lookup returns null, then it falls back to findUnique({where:{id}})
+      // — and only the second resolves to the row.
+      prisma.client.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockClient);
+      cryptoService.generateSecret.mockReturnValue('new-raw-secret');
+      cryptoService.hashPassword.mockResolvedValue('new-hashed-secret');
+      prisma.client.update.mockResolvedValue({});
+
+      const result = await service.regenerateSecret(mockRealm, uuid);
+
+      expect(result.clientId).toBe(mockClient.clientId);
+      expect(prisma.client.update).toHaveBeenCalledWith({
+        where: { id: mockClient.id },
         data: { clientSecret: 'new-hashed-secret' },
       });
     });

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -267,8 +267,13 @@ export class ClientsService {
     });
   }
 
-  async regenerateSecret(realm: Realm, clientId: string) {
-    const client = await this.findByClientId(realm, clientId);
+  async regenerateSecret(realm: Realm, clientIdOrUuid: string) {
+    // The :clientId URL param can be either the human client_id string or the
+    // row UUID — match what `update`/`remove` accept. Use the resolved row PK
+    // for the Prisma update so the row is always found; previously this used
+    // the raw URL param in the realmId_clientId compound key, which crashed
+    // with P2025 whenever the caller passed the row UUID.
+    const client = await this.findByClientId(realm, clientIdOrUuid);
     if (client.clientType !== 'CONFIDENTIAL') {
       throw new ConflictException('Cannot generate secret for a PUBLIC client');
     }
@@ -277,17 +282,15 @@ export class ClientsService {
     const secretHash = await this.crypto.hashPassword(rawSecret);
 
     await this.prisma.client.update({
-      where: {
-        realmId_clientId: { realmId: realm.id, clientId },
-      },
+      where: { id: client.id },
       data: { clientSecret: secretHash },
     });
 
     // Secret changed — invalidate so the next lookup re-fetches the updated record
-    await this.cache.invalidateClientCache(`${realm.id}:${clientId}`);
+    await this.cache.invalidateClientCache(`${realm.id}:${client.clientId}`);
 
     return {
-      clientId,
+      clientId: client.clientId,
       clientSecret: rawSecret,
       secretWarning: 'Store this secret securely. It will not be shown again.',
     };

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -133,36 +133,28 @@ describe('UsersController', () => {
         'u1',
         'alice@example.com',
       );
-      expect(result).toEqual({ message: 'Verification email sent' });
+      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
 
-    it('should throw BadRequest when user has no email', async () => {
+    it('should return success message even when user has no email (does not send)', async () => {
       const user = { id: 'u1', email: null };
       usersService.findById.mockResolvedValue(user);
 
-      await expect(
-        controller.sendVerificationEmail(realm, 'u1'),
-      ).rejects.toThrow('User has no email address');
+      const result = await controller.sendVerificationEmail(realm, 'u1');
+
+      expect(usersService.findById).toHaveBeenCalledWith(realm, 'u1');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
+      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
 
-    it('should throw BadRequest when user email is empty string', async () => {
+    it('should return success message even when user email is empty string', async () => {
       const user = { id: 'u1', email: '' };
       usersService.findById.mockResolvedValue(user);
 
-      await expect(
-        controller.sendVerificationEmail(realm, 'u1'),
-      ).rejects.toThrow('User has no email address');
-      expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
-    });
+      const result = await controller.sendVerificationEmail(realm, 'u1');
 
-    it('should propagate findById errors (e.g. user not found)', async () => {
-      usersService.findById.mockRejectedValue(new Error('User not found'));
-
-      await expect(
-        controller.sendVerificationEmail(realm, 'u-missing'),
-      ).rejects.toThrow('User not found');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
+      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
   });
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,7 +11,6 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  BadRequestException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -206,22 +205,31 @@ export class UsersController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Send or resend verification email to a user' })
   @ApiResponse({ status: 200, description: 'Verification email sent' })
-  @ApiResponse({ status: 400, description: 'User has no email address' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User not found' })
   async sendVerificationEmail(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
   ) {
-    // Admin endpoint — surface real outcomes so the operator can act. The caller
-    // already has the userId and an admin role, so anti-enumeration here would
-    // only hide information the admin already has access to via GET /users/:id.
-    const user = await this.usersService.findById(realm, userId);
-    if (!user.email) {
-      throw new BadRequestException('User has no email address');
+    // Anti-enumeration: uniform 200 + body whether the user exists, has no
+    // email, or does not exist at all. This is the original closed-#582 shape
+    // — a prior pass tried to surface real outcomes (#31) but that necessarily
+    // leaks user existence to admin-key holders, so it was reverted.
+    try {
+      const user = await this.usersService.findById(realm, userId);
+      if (user.email) {
+        await this.usersService.sendVerificationEmail(
+          realm,
+          user.id,
+          user.email,
+        );
+      }
+    } catch {
+      // Swallow not-found (and similar) — do not reveal existence.
     }
-    await this.usersService.sendVerificationEmail(realm, user.id, user.email);
-    return { message: 'Verification email sent' };
+    return {
+      message: 'If the account exists, a verification email has been sent.',
+    };
   }
 
   @Get(':userId/offline-sessions')


### PR DESCRIPTION
## Summary

Two-part follow-up to PR #1007:

### Revert #31 — restore #582 anti-enumeration on `send-verification-email`
PR #1007 surfaced "real outcomes" (200/400/404) on `POST /admin/users/:id/send-verification-email`. I missed that the uniform-response shape is the deliberate fix for closed security issue **[#582](https://github.com/idenplane/idenplane/issues/582)** ([MEDIUM] User enumeration via sendVerificationEmail endpoint) — and that `test/bug-reproduction.e2e-spec.ts` BUG #6 was a regression guard for exactly that decision. CI caught it (E2E failure on PR #1007), advisor confirmed by reading the issue body. Restores the original handler verbatim plus a comment pointing back at #582 so the next reviewer doesn't fall into the same trap.

### Fix #34 — `regenerate-secret` row-UUID crash
`POST /admin/realms/:r/clients/:id/regenerate-secret` crashed with HTTP 500 (Prisma P2025 — "No record was found for an update") whenever the caller passed the **row UUID** instead of the human `client_id` string. Root cause: `regenerateSecret` was passing the raw `:clientId` URL param into the `realmId_clientId` compound key, which expects the client_id *string*. The same antipattern exists nowhere else — `update`/`remove` already resolve `existing.clientId` first. Switches to the resolved row PK (`where: {id}`) so both forms of the URL param work; operators can finally rotate leaked secrets via the API.

Trap-of-the-trap: the existing unit test passed because the mocked `prisma.client.update` ignored the `where` clause. New unit tests assert the exact `where` shape and add a row-UUID path, so this can't silently regress.

## Test plan
- [x] `npm test` — 1842 tests pass (113 suites), including the previously-failing `bug-reproduction.e2e-spec.ts` BUG #6 (when run via e2e) and 2 new `clients.service.spec` regressions for #34
- [ ] CI E2E + Build — relying on workflow
- [ ] After merge + promotion, live-reverify on demo:
  - [ ] `POST /admin/users/<no-email-id>/send-verification-email` → 200 `If the account exists…` (back to anti-enumeration shape, #582 honored)
  - [ ] `POST /admin/clients/<row-uuid>/regenerate-secret` → 200 with new secret (was 500) (#34)
  - [ ] `POST /admin/clients/<client_id-string>/regenerate-secret` → 200 with new secret (#34)
  - [ ] Old secret rejected, new secret accepted for client_credentials grant (#34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)