### PR TITLE
fix(admin): clientId UUID/string routing (11 sites) + scope seed + admin consent revoke (#34b/#35/#36)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -83,6 +83,99 @@ async function main() {
 
   console.log(`  Realm: ${realm.name} (${realm.id})`);
 
+  // Seed the canonical OIDC client-scope catalog for the realm so that
+  // `GET /admin/realms/test/client-scopes` is populated (matches what
+  // RealmsService.create does for realms created at runtime via the API).
+  // The seed script is run with raw Prisma and can't easily import from the
+  // Nest service tree, so the catalog is duplicated here — keep it in sync
+  // with `src/scopes/scope-seed.service.ts`. Idempotent — skip-on-conflict.
+  const SEEDED_SCOPES = [
+    {
+      name: 'openid',
+      description: 'OpenID Connect scope',
+      mappers: [
+        {
+          name: 'sub',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'id', 'claim.name': 'sub' },
+        },
+      ],
+    },
+    {
+      name: 'profile',
+      description: 'User profile information',
+      mappers: [
+        {
+          name: 'username',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'username', 'claim.name': 'preferred_username' },
+        },
+        { name: 'full name', mapperType: 'oidc-full-name-mapper', config: {} },
+        {
+          name: 'given name',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'firstName', 'claim.name': 'given_name' },
+        },
+        {
+          name: 'family name',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'lastName', 'claim.name': 'family_name' },
+        },
+      ],
+    },
+    {
+      name: 'email',
+      description: 'Email address',
+      mappers: [
+        {
+          name: 'email',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'email', 'claim.name': 'email' },
+        },
+        {
+          name: 'email verified',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'emailVerified', 'claim.name': 'email_verified' },
+        },
+      ],
+    },
+    {
+      name: 'roles',
+      description: 'User roles',
+      mappers: [
+        {
+          name: 'realm roles',
+          mapperType: 'oidc-role-list-mapper',
+          config: { 'claim.name': 'realm_access' },
+        },
+      ],
+    },
+    { name: 'web-origins', description: 'Web origins for CORS', mappers: [] },
+    { name: 'offline_access', description: 'Offline access for long-lived tokens', mappers: [] },
+  ];
+  for (const scope of SEEDED_SCOPES) {
+    const existing = await prisma.clientScope.findUnique({
+      where: { realmId_name: { realmId: realm.id, name: scope.name } },
+    });
+    if (existing) continue;
+    await prisma.clientScope.create({
+      data: {
+        realmId: realm.id,
+        name: scope.name,
+        description: scope.description,
+        builtIn: true,
+        protocolMappers: {
+          create: scope.mappers.map((m) => ({
+            name: m.name,
+            mapperType: m.mapperType,
+            config: m.config,
+          })),
+        },
+      },
+    });
+  }
+  console.log(`  Seeded ${SEEDED_SCOPES.length} client scopes`);
+
   // Create test user
   const passwordHash = await argon2.hash('password123', {
     type: argon2.argon2id,

--- a/src/client-scopes/client-scopes.module.ts
+++ b/src/client-scopes/client-scopes.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ClientScopesController } from './client-scopes.controller.js';
 import { ClientScopesService } from './client-scopes.service.js';
+import { ClientsModule } from '../clients/clients.module.js';
 
 @Module({
+  imports: [ClientsModule],
   controllers: [ClientScopesController],
   providers: [ClientScopesService],
   exports: [ClientScopesService],

--- a/src/client-scopes/client-scopes.service.spec.ts
+++ b/src/client-scopes/client-scopes.service.spec.ts
@@ -47,9 +47,15 @@ describe('ClientScopesService', () => {
     clientId: 'my-app',
   };
 
+  const mockClientsService = {
+    findByClientId: jest.fn().mockResolvedValue(mockClient),
+  };
+
   beforeEach(() => {
     prisma = createMockPrismaService();
-    service = new ClientScopesService(prisma as any);
+    mockClientsService.findByClientId.mockReset();
+    mockClientsService.findByClientId.mockResolvedValue(mockClient);
+    service = new ClientScopesService(prisma as any, mockClientsService as any);
   });
 
   // ─── findAll ────────────────────────────────────────────
@@ -331,7 +337,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.getDefaultScopes(mockRealm, 'nonexistent'),
@@ -364,7 +370,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.assignDefaultScope(mockRealm, 'bad-client', 'scope-1'),
@@ -396,7 +402,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.removeDefaultScope(mockRealm, 'bad-client', 'scope-1'),
@@ -428,7 +434,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.getOptionalScopes(mockRealm, 'nonexistent'),
@@ -461,7 +467,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.assignOptionalScope(mockRealm, 'bad-client', 'scope-1'),
@@ -493,7 +499,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.removeOptionalScope(mockRealm, 'bad-client', 'scope-1'),

--- a/src/client-scopes/client-scopes.service.ts
+++ b/src/client-scopes/client-scopes.service.ts
@@ -6,12 +6,16 @@ import {
 import type { Realm } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { ClientsService } from '../clients/clients.service.js';
 import { CreateClientScopeDto } from './dto/create-client-scope.dto.js';
 import { UpdateClientScopeDto } from './dto/update-client-scope.dto.js';
 
 @Injectable()
 export class ClientScopesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clientsService: ClientsService,
+  ) {}
 
   async findAll(realm: Realm) {
     return this.prisma.clientScope.findMany({
@@ -132,13 +136,17 @@ export class ClientScopesService {
     await this.prisma.protocolMapper.delete({ where: { id: mapperId } });
   }
 
-  // Client scope assignments
-  async getDefaultScopes(realm: Realm, clientId: string) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
+  // ── Client scope assignments ────────────────────────────────
+  // The `:clientId` URL param accepts the human client_id string OR the row
+  // UUID — same shape as `/admin/realms/:r/clients/:id` CRUD. Resolve via
+  // ClientsService.findByClientId (which handles both) before any FK query,
+  // so a caller passing either form gets the same answer instead of 404.
 
+  async getDefaultScopes(realm: Realm, clientIdOrUuid: string) {
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.clientDefaultScope.findMany({
       where: { clientId: client.id },
       include: { clientScope: true },
@@ -147,15 +155,14 @@ export class ClientScopesService {
 
   async assignDefaultScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.findById(realm, clientScopeId);
-
     return this.prisma.clientDefaultScope.create({
       data: { clientId: client.id, clientScopeId },
     });
@@ -163,25 +170,23 @@ export class ClientScopesService {
 
   async removeDefaultScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
-
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.prisma.clientDefaultScope.deleteMany({
       where: { clientId: client.id, clientScopeId },
     });
   }
 
-  async getOptionalScopes(realm: Realm, clientId: string) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
-
+  async getOptionalScopes(realm: Realm, clientIdOrUuid: string) {
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.clientOptionalScope.findMany({
       where: { clientId: client.id },
       include: { clientScope: true },
@@ -190,15 +195,14 @@ export class ClientScopesService {
 
   async assignOptionalScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.findById(realm, clientScopeId);
-
     return this.prisma.clientOptionalScope.create({
       data: { clientId: client.id, clientScopeId },
     });
@@ -206,14 +210,13 @@ export class ClientScopesService {
 
   async removeOptionalScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
-
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.prisma.clientOptionalScope.deleteMany({
       where: { clientId: client.id, clientScopeId },
     });

--- a/src/roles/roles.module.ts
+++ b/src/roles/roles.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RolesController } from './roles.controller.js';
 import { RolesService } from './roles.service.js';
+import { ClientsModule } from '../clients/clients.module.js';
 
 @Module({
+  imports: [ClientsModule],
   controllers: [RolesController],
   providers: [RolesService],
   exports: [RolesService],

--- a/src/roles/roles.service.spec.ts
+++ b/src/roles/roles.service.spec.ts
@@ -36,9 +36,15 @@ describe('RolesService', () => {
     clientId: 'my-app',
   };
 
+  const mockClientsService = {
+    findByClientId: jest.fn().mockResolvedValue(mockClient),
+  };
+
   beforeEach(() => {
     prisma = createMockPrismaService();
-    service = new RolesService(prisma as any);
+    mockClientsService.findByClientId.mockReset();
+    mockClientsService.findByClientId.mockResolvedValue(mockClient);
+    service = new RolesService(prisma as any, mockClientsService as any);
   });
 
   // ─── Realm Roles ────────────────────────────────────────
@@ -169,7 +175,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.createClientRole(mockRealm, 'nonexistent', 'role'),
@@ -193,7 +199,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.findClientRoles(mockRealm, 'nonexistent'),
@@ -352,7 +358,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.assignClientRoles(mockRealm, 'user-1', 'nonexistent', [
@@ -390,7 +396,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.getUserClientRoles(mockRealm, 'user-1', 'nonexistent'),
@@ -426,7 +432,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.removeUserClientRoles(mockRealm, 'user-1', 'nonexistent', [

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -5,10 +5,14 @@ import {
 } from '@nestjs/common';
 import type { Realm } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { ClientsService } from '../clients/clients.service.js';
 
 @Injectable()
 export class RolesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clientsService: ClientsService,
+  ) {}
 
   // ─── Realm Roles ────────────────────────────────────────
 
@@ -86,32 +90,31 @@ export class RolesService {
 
   // ─── Client Roles ──────────────────────────────────────
 
+  // The `:clientId` URL param accepts either the human client_id string or
+  // the row UUID — same shape as `/admin/realms/:r/clients/:id` CRUD. Route
+  // through ClientsService.findByClientId so both forms work; previously the
+  // raw param went into `realmId_clientId` which only matched the string.
+
   async createClientRole(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     name: string,
     description?: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
-
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.role.create({
       data: { realmId: realm.id, clientId: client.id, name, description },
     });
   }
 
-  async findClientRoles(realm: Realm, clientId: string) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
-
+  async findClientRoles(realm: Realm, clientIdOrUuid: string) {
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.role.findMany({
       where: { realmId: realm.id, clientId: client.id },
       orderBy: { name: 'asc' },
@@ -188,7 +191,7 @@ export class RolesService {
   async assignClientRoles(
     realm: Realm,
     userId: string,
-    clientId: string,
+    clientIdOrUuid: string,
     roleNames: string[],
   ) {
     const user = await this.prisma.user.findFirst({
@@ -198,12 +201,10 @@ export class RolesService {
       throw new NotFoundException(`User '${userId}' not found`);
     }
 
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
 
     const roles = await this.prisma.role.findMany({
       where: {
@@ -224,15 +225,13 @@ export class RolesService {
   async removeUserClientRoles(
     realm: Realm,
     userId: string,
-    clientId: string,
+    clientIdOrUuid: string,
     roleNames: string[],
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
 
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
@@ -259,7 +258,11 @@ export class RolesService {
     return { removed: roleNames };
   }
 
-  async getUserClientRoles(realm: Realm, userId: string, clientId: string) {
+  async getUserClientRoles(
+    realm: Realm,
+    userId: string,
+    clientIdOrUuid: string,
+  ) {
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
     });
@@ -267,12 +270,10 @@ export class RolesService {
       throw new NotFoundException(`User '${userId}' not found`);
     }
 
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
 
     return this.prisma.role.findMany({
       where: {

--- a/src/scopes/scope-seed.service.ts
+++ b/src/scopes/scope-seed.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 
-const DEFAULT_SCOPES = [
+// Exported so non-Nest contexts (prisma/seed.ts, migration scripts) can seed
+// the same canonical OIDC scope catalog without rewriting it.
+export const DEFAULT_SCOPES = [
   {
     name: 'openid',
     description: 'OpenID Connect scope',
@@ -74,7 +76,7 @@ const DEFAULT_SCOPES = [
   },
 ];
 
-const OPTIONAL_SCOPES = [
+export const OPTIONAL_SCOPES = [
   {
     name: 'web-origins',
     description: 'Web origins for CORS',

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -290,4 +290,33 @@ export class UsersController {
       limit: limit ? Number(limit) : undefined,
     });
   }
+
+  @Delete(':userId/consents')
+  @RequireAdminRoles(['super-admin', 'admin'])
+  @ApiOperation({
+    summary: "Revoke all of a user's stored consents (after-compromise lockout)",
+  })
+  @ApiResponse({ status: 200, description: 'Revoked consents count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  revokeAllUserConsents(
+    @CurrentRealm() realm: Realm,
+    @Param('userId') userId: string,
+  ) {
+    return this.usersService.revokeUserConsents(realm, userId);
+  }
+
+  @Delete(':userId/consents/:clientId')
+  @RequireAdminRoles(['super-admin', 'admin'])
+  @ApiOperation({ summary: "Revoke a user's consent for a single client" })
+  @ApiResponse({ status: 200, description: 'Revoked consent count (0 or 1)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User or client not found' })
+  revokeUserConsentForClient(
+    @CurrentRealm() realm: Realm,
+    @Param('userId') userId: string,
+    @Param('clientId') clientIdOrUuid: string,
+  ) {
+    return this.usersService.revokeUserConsents(realm, userId, clientIdOrUuid);
+  }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller.js';
 import { UsersService } from './users.service.js';
 import { ThemeModule } from '../theme/theme.module.js';
+import { ConsentModule } from '../consent/consent.module.js';
 
 @Module({
-  imports: [ThemeModule],
+  imports: [ThemeModule, ConsentModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -14,6 +14,7 @@ import { EmailService } from '../email/email.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
 import { ThemeEmailService } from '../theme/theme-email.service.js';
 import { BruteForceService } from '../brute-force/brute-force.service.js';
+import { ConsentService } from '../consent/consent.service.js';
 import { CreateUserDto } from './dto/create-user.dto.js';
 import { UpdateUserDto } from './dto/update-user.dto.js';
 import type { Realm } from '@prisma/client';
@@ -44,6 +45,7 @@ export class UsersService {
     private readonly passwordPolicyService: PasswordPolicyService,
     private readonly themeEmail: ThemeEmailService,
     private readonly bruteForceService: BruteForceService,
+    private readonly consentService: ConsentService,
   ) {}
 
   async create(realm: Realm, dto: CreateUserDto) {
@@ -363,6 +365,49 @@ export class UsersService {
       createdAt: consent.createdAt,
       updatedAt: consent.updatedAt,
     }));
+  }
+
+  /**
+   * Revoke a user's stored consents. With no `clientIdOrUuid`, revokes every
+   * client the user has granted to (after-compromise lockout). With a
+   * `clientIdOrUuid`, revokes only that pairing. Each revocation is logged
+   * to `UserConsentHistory` by `ConsentService.revokeConsent`.
+   */
+  async revokeUserConsents(
+    realm: Realm,
+    userId: string,
+    clientIdOrUuid?: string,
+  ): Promise<{ revoked: number }> {
+    await this.findById(realm, userId);
+
+    if (clientIdOrUuid) {
+      const client = await this.prisma.client.findFirst({
+        where: {
+          realmId: realm.id,
+          OR: [{ id: clientIdOrUuid }, { clientId: clientIdOrUuid }],
+        },
+        select: { id: true },
+      });
+      if (!client) {
+        throw new NotFoundException(`Client '${clientIdOrUuid}' not found`);
+      }
+      const existing = await this.prisma.userConsent.findUnique({
+        where: { userId_clientId: { userId, clientId: client.id } },
+        select: { id: true },
+      });
+      if (!existing) return { revoked: 0 };
+      await this.consentService.revokeConsent(realm.id, userId, client.id);
+      return { revoked: 1 };
+    }
+
+    const all = await this.prisma.userConsent.findMany({
+      where: { userId },
+      select: { clientId: true },
+    });
+    for (const c of all) {
+      await this.consentService.revokeConsent(realm.id, userId, c.clientId);
+    }
+    return { revoked: all.length };
   }
 
   /**


### PR DESCRIPTION
## Summary

Three Feature 06 findings.

### #34b — 11-site `clientId` UUID/string routing inconsistency
Six handlers in `client-scopes.service.ts` (default + optional scope GET/POST/DELETE) and five in `roles.service.ts` (createClientRole, findClientRoles, assignClientRoles, removeUserClientRoles, getUserClientRoles) all looked the client up via `prisma.client.findUnique({where:{realmId_clientId:…}})` with the raw URL `:clientId` param — so only the client_id string worked. Row UUIDs returned 404 even though that's the form the `/admin/realms/:r/clients/:id` CRUD family accepts. Same antipattern as #34 (fixed in PR #1008 for `regenerateSecret`).

All 11 sites now route through `ClientsService.findByClientId` (which already accepts both forms). `ClientScopesModule` + `RolesModule` import `ClientsModule`.

### #35 — `prisma/seed.ts` doesn't seed the OIDC scope catalog
`RealmsService.create` already calls `ScopeSeedService.seedDefaultScopes` at the runtime API path — verified on a freshly POST-created realm (6 scopes seeded). The seeded `test` realm came up empty because `prisma/seed.ts` upserts the realm via raw Prisma and never invokes the Nest service. Adds the same scope-catalog seeding inline in `prisma/seed.ts` (skip-on-conflict via `realmId_name`). Also exports `DEFAULT_SCOPES` / `OPTIONAL_SCOPES` from `scope-seed.service.ts` for future script reuse.

### #36 — Admin consent revoke endpoints
Adds two endpoints (both `@RequireAdminRoles(['super-admin','admin'])`):
- `DELETE /admin/realms/:r/users/:u/consents` → revokes ALL stored consents for the user (after-compromise lockout)
- `DELETE /admin/realms/:r/users/:u/consents/:clientId` → revokes one (clientId accepts string or row UUID)

Routes through `ConsentService.revokeConsent`, which already writes a `user_consent_history` row per revocation — full audit trail.

## Test plan
- [x] `npm test` — 1842 tests pass (113 suites); client-scopes + roles specs extended to mock `ClientsService.findByClientId` and assert both happy + not-found paths
- [ ] CI E2E + Build — relying on workflow
- [ ] After merge + promotion, live-reverify on demo:
  - [ ] `GET /admin/clients/<row-uuid>/default-client-scopes` → 200 (was 404) (#34b)
  - [ ] `POST /admin/clients/<row-uuid>/roles {name}` → 201 (was 404) (#34b)
  - [ ] Fresh `test` realm via `npm run db:setup` → `GET /admin/realms/test/client-scopes` returns 6 scopes (#35)
  - [ ] `DELETE /admin/users/<id>/consents` → next `/authorize` re-prompts (#36)
  - [ ] `DELETE /admin/users/<id>/consents/<clientId>` → only that client re-prompts (#36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)