### PR TITLE
fix(features-07-12): LDAP auth wiring (#40 major) + CV module register (#41 major) + sessions either-type (#37)

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -63,6 +63,7 @@ import { ServiceAccountsModule } from './service-accounts/service-accounts.modul
 import { RegistrationModule } from './registration/registration.module.js';
 import { ScimModule } from './scim/scim.module.js';
 import { NhiModule } from './nhi/nhi.module.js';
+import { ContinuousVerificationModule } from './continuous-verification/continuous-verification.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -138,6 +139,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     RegistrationModule,
     ScimModule,
     NhiModule,
+    ContinuousVerificationModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,10 @@ import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
 import { CustomAttributesModule } from '../custom-attributes/custom-attributes.module.js';
 import { StepUpModule } from '../step-up/step-up.module.js';
+import { UserFederationModule } from '../user-federation/user-federation.module.js';
 
 @Module({
-  imports: [CustomAttributesModule, StepUpModule],
+  imports: [CustomAttributesModule, StepUpModule, UserFederationModule],
   controllers: [AuthController],
   providers: [AuthService],
   exports: [AuthService],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -198,6 +198,12 @@ describe('AuthService', () => {
       getOidcClaimsForUser: jest.fn().mockResolvedValue({}),
     };
 
+    const userFederationService = {
+      authenticateViaFederation: jest
+        .fn()
+        .mockResolvedValue({ authenticated: false }),
+    };
+
     service = new AuthService(
       prisma as any,
       crypto as any,
@@ -210,6 +216,7 @@ describe('AuthService', () => {
       eventsService as any,
       metricsService as any,
       customAttributesService as any,
+      userFederationService as any,
     );
   });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -25,6 +25,7 @@ import {
   type UserClaimSource,
 } from '../scopes/claims.resolver.js';
 import { CustomAttributesService } from '../custom-attributes/custom-attributes.service.js';
+import { UserFederationService } from '../user-federation/user-federation.service.js';
 import {
   StepUpService,
   ACR_PASSWORD,
@@ -61,6 +62,7 @@ export class AuthService {
     private readonly eventsService: EventsService,
     private readonly metricsService: MetricsService,
     private readonly customAttributesService: CustomAttributesService,
+    private readonly userFederationService: UserFederationService,
     @Optional() private readonly stepUpService?: StepUpService,
     @Optional() private readonly pluginManager?: PluginManagerService,
   ) {}
@@ -127,15 +129,64 @@ export class AuthService {
       );
     }
 
-    const user = await this.prisma.user.findUnique({
+    let user = await this.prisma.user.findUnique({
       where: { realmId_username: { realmId: realm.id, username } },
     });
+
+    // Federated users have empty passwordHash — route to LDAP bind instead of
+    // rejecting outright. UserFederationService.authenticateViaFederation does
+    // the bind-as-service / find-DN / bind-as-user dance against the configured
+    // LDAP server, and find-or-imports the user. Realm-scoping is enforced
+    // inside that call.
+    if (
+      user &&
+      user.enabled &&
+      !user.passwordHash &&
+      user.federationLink
+    ) {
+      const federationResult =
+        await this.userFederationService.authenticateViaFederation(
+          realm.id,
+          username,
+          password,
+        );
+      if (!federationResult.authenticated) {
+        throw new OAuthTokenError(
+          'invalid_grant',
+          'Invalid credentials',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      // refresh the user row in case the federation flow updated attributes
+      user = await this.prisma.user.findUnique({
+        where: { id: federationResult.userId ?? user.id },
+      });
+    }
+
     if (!user || !user.enabled || !user.passwordHash) {
-      throw new OAuthTokenError(
-        'invalid_grant',
-        'Invalid credentials',
-        HttpStatus.BAD_REQUEST,
-      );
+      // Last-resort federation attempt for the "user doesn't exist locally"
+      // case — `authenticateViaFederation` will import-on-first-login when
+      // the federation has `importEnabled=true`.
+      if (!user || (!user.passwordHash && !user.federationLink)) {
+        const federationResult =
+          await this.userFederationService.authenticateViaFederation(
+            realm.id,
+            username,
+            password,
+          );
+        if (federationResult.authenticated && federationResult.userId) {
+          user = await this.prisma.user.findUnique({
+            where: { id: federationResult.userId },
+          });
+        }
+      }
+      if (!user || !user.enabled) {
+        throw new OAuthTokenError(
+          'invalid_grant',
+          'Invalid credentials',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
     }
 
     // Brute force check
@@ -148,7 +199,13 @@ export class AuthService {
       );
     }
 
-    const valid = await this.crypto.verifyPassword(user.passwordHash, password);
+    // Skip local password check for federated users — already authenticated
+    // via LDAP above; no `passwordHash` to compare against.
+    const skipLocalPwdCheck = !user.passwordHash && !!user.federationLink;
+    const valid =
+      skipLocalPwdCheck ||
+      (user.passwordHash &&
+        (await this.crypto.verifyPassword(user.passwordHash, password)));
     if (!valid) {
       await this.bruteForceService.recordFailure(realm, user.id, ip);
       void this.eventsService.recordLoginEvent({

--- a/src/continuous-verification/continuous-verification.controller.ts
+++ b/src/continuous-verification/continuous-verification.controller.ts
@@ -25,7 +25,7 @@ import { BehavioralBiometricsService } from './behavioral-biometrics.service.js'
 
 @ApiTags('Continuous Verification')
 @ApiBearerAuth()
-@Controller('admin/realms/:realm/continuous-verification')
+@Controller('admin/realms/:realmName/continuous-verification')
 export class ContinuousVerificationController {
   constructor(
     private readonly prisma: PrismaService,
@@ -60,7 +60,7 @@ export class ContinuousVerificationController {
   @ApiQuery({ name: 'first', required: false })
   @ApiQuery({ name: 'max', required: false })
   async listRiskEvents(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Query('userId') userId?: string,
     @Query('sessionId') sessionId?: string,
     @Query('action') action?: string,
@@ -98,7 +98,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 200, description: 'Continuous risk dashboard data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async getDashboard(@Param('realm') realmName: string) {
+  async getDashboard(@Param('realmName') realmName: string) {
     const realm = await this.requireRealm(realmName);
     const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // last 30 days
 
@@ -210,7 +210,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getRiskEvent(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('id') id: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -246,7 +246,7 @@ export class ContinuousVerificationController {
   @ApiQuery({ name: 'first', required: false })
   @ApiQuery({ name: 'max', required: false })
   async listSessionProfiles(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Query('userId') userId?: string,
     @Query('riskLevel') riskLevel?: string,
     @Query('stepUpRequired') stepUpRequired?: string,
@@ -283,7 +283,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getSessionProfile(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -319,7 +319,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getDevicePosture(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -350,7 +350,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getNetworkContext(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -383,7 +383,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getBehavioralBiometrics(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('userId') userId: string,
   ) {
     const _realm = await this.requireRealm(realmName);
@@ -418,7 +418,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getUserRiskSummary(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('userId') userId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -525,7 +525,7 @@ export class ContinuousVerificationController {
     },
   })
   async recordDevicePosture(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Body()
     body: {
       sessionId: string;
@@ -627,7 +627,7 @@ export class ContinuousVerificationController {
     },
   })
   async recordBehavioralSamples(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Body()
     body: {
       sessionId: string;
@@ -710,7 +710,7 @@ export class ContinuousVerificationController {
     },
   })
   async recordNetworkContext(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Body()
     body: {
       sessionId: string;

--- a/src/continuous-verification/session-risk.controller.ts
+++ b/src/continuous-verification/session-risk.controller.ts
@@ -20,7 +20,7 @@ import { SessionRiskEvaluator } from './session-risk-evaluator.js';
 
 @ApiTags('Session Risk')
 @ApiBearerAuth()
-@Controller('admin/realms/:realm/session-risk')
+@Controller('admin/realms/:realmName/session-risk')
 export class SessionRiskController {
   constructor(
     private readonly prisma: PrismaService,
@@ -47,7 +47,7 @@ export class SessionRiskController {
   @ApiQuery({ name: 'first', required: false })
   @ApiQuery({ name: 'max', required: false })
   async listSessionProfiles(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Query('userId') userId?: string,
     @Query('riskLevel') riskLevel?: string,
     @Query('stepUpRequired') stepUpRequired?: string,
@@ -86,7 +86,7 @@ export class SessionRiskController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async getDashboard(@Param('realm') realmName: string) {
+  async getDashboard(@Param('realmName') realmName: string) {
     const realm = await this.requireRealm(realmName);
     const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // last 30 days
 
@@ -190,7 +190,7 @@ export class SessionRiskController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getSessionProfile(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -225,7 +225,7 @@ export class SessionRiskController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Session not found' })
   async triggerReevaluation(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);

--- a/src/sessions/sessions.controller.ts
+++ b/src/sessions/sessions.controller.ts
@@ -64,7 +64,7 @@ export class SessionsController {
   revokeSession(
     @CurrentRealm() realm: Realm,
     @Param('sessionId') sessionId: string,
-    @Query('type') type: 'oauth' | 'sso' = 'oauth',
+    @Query('type') type?: 'oauth' | 'sso',
   ) {
     return this.sessionsService.revokeSession(realm, sessionId, type);
   }

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -110,37 +110,54 @@ export class SessionsService {
   async revokeSession(
     realm: Realm | null,
     sessionId: string,
-    type: 'oauth' | 'sso',
+    type?: 'oauth' | 'sso',
   ): Promise<void> {
-    if (type === 'oauth') {
+    // When the caller doesn't say which table the session lives in, try both.
+    // Sessions are split across `Session` (OAuth-refresh-backed) and
+    // `LoginSession` (hosted-form/SSO) — the listing endpoint returns both
+    // as a merged list with a `type` field, but admins routinely paste the
+    // id without threading the type through. Returning 404 when the id
+    // exists in the *other* table is a UX cliff (#37).
+    const tryOauth = !type || type === 'oauth';
+    const trySso = !type || type === 'sso';
+
+    if (tryOauth) {
       const session = await this.prisma.session.findUnique({
         where: { id: sessionId },
         select: { userId: true, user: { select: { realmId: true } } },
       });
-      if (realm && session && session.user.realmId !== realm.id) {
+      if (session) {
+        if (realm && session.user.realmId !== realm.id) {
+          throw new NotFoundException('Session not found');
+        }
+        await this.prisma.refreshToken.updateMany({
+          where: { sessionId },
+          data: { revoked: true },
+        });
+        await this.prisma.session.delete({ where: { id: sessionId } });
+        return;
+      }
+      if (type === 'oauth') {
         throw new NotFoundException('Session not found');
       }
-      if (!session) {
-        throw new NotFoundException('Session not found');
-      }
-      await this.prisma.refreshToken.updateMany({
-        where: { sessionId },
-        data: { revoked: true },
-      });
-      await this.prisma.session.delete({ where: { id: sessionId } });
-    } else {
+      // fall through to sso when type was unspecified
+    }
+
+    if (trySso) {
       const loginSession = await this.prisma.loginSession.findUnique({
         where: { id: sessionId },
         select: { realmId: true },
       });
-      if (realm && loginSession && loginSession.realmId !== realm.id) {
-        throw new NotFoundException('Session not found');
+      if (loginSession) {
+        if (realm && loginSession.realmId !== realm.id) {
+          throw new NotFoundException('Session not found');
+        }
+        await this.prisma.loginSession.delete({ where: { id: sessionId } });
+        return;
       }
-      if (!loginSession) {
-        throw new NotFoundException('Session not found');
-      }
-      await this.prisma.loginSession.delete({ where: { id: sessionId } });
     }
+
+    throw new NotFoundException('Session not found');
   }
 
   async revokeAllUserSessions(realm: Realm, userId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Three findings from the closing pass of the campaign (features 07-12). Two are major dead-code/unwired-feature fixes; one is a UX nit.

### #40 (major) — LDAP federated users can finally log in
`auth.service` was rejecting any user with empty `password_hash` outright, even when `users.federation_link` was set — and `UserFederationService.authenticateViaFederation` already had the full bind-as-service/find-DN/bind-as-user dance implemented. Now AuthService routes federated users through that service before failing; also handles import-on-first-login.

### #41 (major) — Continuous Verification module imported in AppModule
The entire `ContinuousVerificationModule` (3 controllers + scheduler) was implemented but never imported in `AppModule`, so every endpoint 404'd. Added the import. Also aligned `:realm` → `:realmName` path-param naming in the two controllers that diverged.

### #37 (UX) — `DELETE /sessions/:id` either-type
Defaulted to `type=oauth` and 404'd for SSO sessions. Now tries both `Session` and `LoginSession` tables when `type` is omitted.

### Withdrawn / deferred
- **#38 withdrawn** — my probe used the wrong path (`/attack-detection/brute-force/locked-users` doesn't exist; correct mount is `/brute-force/locked-users` and works correctly).
- **#39 deferred** — `clientRateLimitPerMinute` not enforced on `/token`. Needs a parallel guard to `@RateLimitByIp()`, scope larger than this batch.

Scenarios + findings in `TeamDesk/test-plan/07-12-*.md`.

## Test plan
- [x] `npm test` — 1842 tests pass (113 suites); auth.service.spec extended with UserFederationService mock
- [ ] CI E2E + Build — relying on workflow
- [ ] After promote dev → main, live-reverify on demo:
  - [ ] LDAP federated user ROPC → access_token (#40)
  - [ ] `GET /admin/realms/test/continuous-verification` → 200 (#41)
  - [ ] `DELETE /admin/realms/test/sessions/<sso-id>` without `?type` → 204 (#37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)