### PR TITLE
promote(dev→main): batch fixes #31-#41 (PRs #1007/#1008/#1009/#1010)

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -83,6 +83,99 @@ async function main() {
 
   console.log(`  Realm: ${realm.name} (${realm.id})`);
 
+  // Seed the canonical OIDC client-scope catalog for the realm so that
+  // `GET /admin/realms/test/client-scopes` is populated (matches what
+  // RealmsService.create does for realms created at runtime via the API).
+  // The seed script is run with raw Prisma and can't easily import from the
+  // Nest service tree, so the catalog is duplicated here — keep it in sync
+  // with `src/scopes/scope-seed.service.ts`. Idempotent — skip-on-conflict.
+  const SEEDED_SCOPES = [
+    {
+      name: 'openid',
+      description: 'OpenID Connect scope',
+      mappers: [
+        {
+          name: 'sub',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'id', 'claim.name': 'sub' },
+        },
+      ],
+    },
+    {
+      name: 'profile',
+      description: 'User profile information',
+      mappers: [
+        {
+          name: 'username',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'username', 'claim.name': 'preferred_username' },
+        },
+        { name: 'full name', mapperType: 'oidc-full-name-mapper', config: {} },
+        {
+          name: 'given name',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'firstName', 'claim.name': 'given_name' },
+        },
+        {
+          name: 'family name',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'lastName', 'claim.name': 'family_name' },
+        },
+      ],
+    },
+    {
+      name: 'email',
+      description: 'Email address',
+      mappers: [
+        {
+          name: 'email',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'email', 'claim.name': 'email' },
+        },
+        {
+          name: 'email verified',
+          mapperType: 'oidc-usermodel-attribute-mapper',
+          config: { 'user.attribute': 'emailVerified', 'claim.name': 'email_verified' },
+        },
+      ],
+    },
+    {
+      name: 'roles',
+      description: 'User roles',
+      mappers: [
+        {
+          name: 'realm roles',
+          mapperType: 'oidc-role-list-mapper',
+          config: { 'claim.name': 'realm_access' },
+        },
+      ],
+    },
+    { name: 'web-origins', description: 'Web origins for CORS', mappers: [] },
+    { name: 'offline_access', description: 'Offline access for long-lived tokens', mappers: [] },
+  ];
+  for (const scope of SEEDED_SCOPES) {
+    const existing = await prisma.clientScope.findUnique({
+      where: { realmId_name: { realmId: realm.id, name: scope.name } },
+    });
+    if (existing) continue;
+    await prisma.clientScope.create({
+      data: {
+        realmId: realm.id,
+        name: scope.name,
+        description: scope.description,
+        builtIn: true,
+        protocolMappers: {
+          create: scope.mappers.map((m) => ({
+            name: m.name,
+            mapperType: m.mapperType,
+            config: m.config,
+          })),
+        },
+      },
+    });
+  }
+  console.log(`  Seeded ${SEEDED_SCOPES.length} client scopes`);
+
   // Create test user
   const passwordHash = await argon2.hash('password123', {
     type: argon2.argon2id,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -63,6 +63,7 @@ import { ServiceAccountsModule } from './service-accounts/service-accounts.modul
 import { RegistrationModule } from './registration/registration.module.js';
 import { ScimModule } from './scim/scim.module.js';
 import { NhiModule } from './nhi/nhi.module.js';
+import { ContinuousVerificationModule } from './continuous-verification/continuous-verification.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -138,6 +139,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     RegistrationModule,
     ScimModule,
     NhiModule,
+    ContinuousVerificationModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,9 +3,10 @@ import { AuthController } from './auth.controller.js';
 import { AuthService } from './auth.service.js';
 import { CustomAttributesModule } from '../custom-attributes/custom-attributes.module.js';
 import { StepUpModule } from '../step-up/step-up.module.js';
+import { UserFederationModule } from '../user-federation/user-federation.module.js';
 
 @Module({
-  imports: [CustomAttributesModule, StepUpModule],
+  imports: [CustomAttributesModule, StepUpModule, UserFederationModule],
   controllers: [AuthController],
   providers: [AuthService],
   exports: [AuthService],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -198,6 +198,12 @@ describe('AuthService', () => {
       getOidcClaimsForUser: jest.fn().mockResolvedValue({}),
     };
 
+    const userFederationService = {
+      authenticateViaFederation: jest
+        .fn()
+        .mockResolvedValue({ authenticated: false }),
+    };
+
     service = new AuthService(
       prisma as any,
       crypto as any,
@@ -210,6 +216,7 @@ describe('AuthService', () => {
       eventsService as any,
       metricsService as any,
       customAttributesService as any,
+      userFederationService as any,
     );
   });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -25,6 +25,7 @@ import {
   type UserClaimSource,
 } from '../scopes/claims.resolver.js';
 import { CustomAttributesService } from '../custom-attributes/custom-attributes.service.js';
+import { UserFederationService } from '../user-federation/user-federation.service.js';
 import {
   StepUpService,
   ACR_PASSWORD,
@@ -61,6 +62,7 @@ export class AuthService {
     private readonly eventsService: EventsService,
     private readonly metricsService: MetricsService,
     private readonly customAttributesService: CustomAttributesService,
+    private readonly userFederationService: UserFederationService,
     @Optional() private readonly stepUpService?: StepUpService,
     @Optional() private readonly pluginManager?: PluginManagerService,
   ) {}
@@ -127,15 +129,64 @@ export class AuthService {
       );
     }
 
-    const user = await this.prisma.user.findUnique({
+    let user = await this.prisma.user.findUnique({
       where: { realmId_username: { realmId: realm.id, username } },
     });
+
+    // Federated users have empty passwordHash — route to LDAP bind instead of
+    // rejecting outright. UserFederationService.authenticateViaFederation does
+    // the bind-as-service / find-DN / bind-as-user dance against the configured
+    // LDAP server, and find-or-imports the user. Realm-scoping is enforced
+    // inside that call.
+    if (
+      user &&
+      user.enabled &&
+      !user.passwordHash &&
+      user.federationLink
+    ) {
+      const federationResult =
+        await this.userFederationService.authenticateViaFederation(
+          realm.id,
+          username,
+          password,
+        );
+      if (!federationResult.authenticated) {
+        throw new OAuthTokenError(
+          'invalid_grant',
+          'Invalid credentials',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      // refresh the user row in case the federation flow updated attributes
+      user = await this.prisma.user.findUnique({
+        where: { id: federationResult.userId ?? user.id },
+      });
+    }
+
     if (!user || !user.enabled || !user.passwordHash) {
-      throw new OAuthTokenError(
-        'invalid_grant',
-        'Invalid credentials',
-        HttpStatus.BAD_REQUEST,
-      );
+      // Last-resort federation attempt for the "user doesn't exist locally"
+      // case — `authenticateViaFederation` will import-on-first-login when
+      // the federation has `importEnabled=true`.
+      if (!user || (!user.passwordHash && !user.federationLink)) {
+        const federationResult =
+          await this.userFederationService.authenticateViaFederation(
+            realm.id,
+            username,
+            password,
+          );
+        if (federationResult.authenticated && federationResult.userId) {
+          user = await this.prisma.user.findUnique({
+            where: { id: federationResult.userId },
+          });
+        }
+      }
+      if (!user || !user.enabled) {
+        throw new OAuthTokenError(
+          'invalid_grant',
+          'Invalid credentials',
+          HttpStatus.BAD_REQUEST,
+        );
+      }
     }
 
     // Brute force check
@@ -148,7 +199,13 @@ export class AuthService {
       );
     }
 
-    const valid = await this.crypto.verifyPassword(user.passwordHash, password);
+    // Skip local password check for federated users — already authenticated
+    // via LDAP above; no `passwordHash` to compare against.
+    const skipLocalPwdCheck = !user.passwordHash && !!user.federationLink;
+    const valid =
+      skipLocalPwdCheck ||
+      (user.passwordHash &&
+        (await this.crypto.verifyPassword(user.passwordHash, password)));
     if (!valid) {
       await this.bruteForceService.recordFailure(realm, user.id, ip);
       void this.eventsService.recordLoginEvent({

--- a/src/client-scopes/client-scopes.module.ts
+++ b/src/client-scopes/client-scopes.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ClientScopesController } from './client-scopes.controller.js';
 import { ClientScopesService } from './client-scopes.service.js';
+import { ClientsModule } from '../clients/clients.module.js';
 
 @Module({
+  imports: [ClientsModule],
   controllers: [ClientScopesController],
   providers: [ClientScopesService],
   exports: [ClientScopesService],

--- a/src/client-scopes/client-scopes.service.spec.ts
+++ b/src/client-scopes/client-scopes.service.spec.ts
@@ -47,9 +47,15 @@ describe('ClientScopesService', () => {
     clientId: 'my-app',
   };
 
+  const mockClientsService = {
+    findByClientId: jest.fn().mockResolvedValue(mockClient),
+  };
+
   beforeEach(() => {
     prisma = createMockPrismaService();
-    service = new ClientScopesService(prisma as any);
+    mockClientsService.findByClientId.mockReset();
+    mockClientsService.findByClientId.mockResolvedValue(mockClient);
+    service = new ClientScopesService(prisma as any, mockClientsService as any);
   });
 
   // ─── findAll ────────────────────────────────────────────
@@ -331,7 +337,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.getDefaultScopes(mockRealm, 'nonexistent'),
@@ -364,7 +370,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.assignDefaultScope(mockRealm, 'bad-client', 'scope-1'),
@@ -396,7 +402,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.removeDefaultScope(mockRealm, 'bad-client', 'scope-1'),
@@ -428,7 +434,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.getOptionalScopes(mockRealm, 'nonexistent'),
@@ -461,7 +467,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.assignOptionalScope(mockRealm, 'bad-client', 'scope-1'),
@@ -493,7 +499,7 @@ describe('ClientScopesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.removeOptionalScope(mockRealm, 'bad-client', 'scope-1'),

--- a/src/client-scopes/client-scopes.service.ts
+++ b/src/client-scopes/client-scopes.service.ts
@@ -6,12 +6,16 @@ import {
 import type { Realm } from '@prisma/client';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { ClientsService } from '../clients/clients.service.js';
 import { CreateClientScopeDto } from './dto/create-client-scope.dto.js';
 import { UpdateClientScopeDto } from './dto/update-client-scope.dto.js';
 
 @Injectable()
 export class ClientScopesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clientsService: ClientsService,
+  ) {}
 
   async findAll(realm: Realm) {
     return this.prisma.clientScope.findMany({
@@ -132,13 +136,17 @@ export class ClientScopesService {
     await this.prisma.protocolMapper.delete({ where: { id: mapperId } });
   }
 
-  // Client scope assignments
-  async getDefaultScopes(realm: Realm, clientId: string) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
+  // ── Client scope assignments ────────────────────────────────
+  // The `:clientId` URL param accepts the human client_id string OR the row
+  // UUID — same shape as `/admin/realms/:r/clients/:id` CRUD. Resolve via
+  // ClientsService.findByClientId (which handles both) before any FK query,
+  // so a caller passing either form gets the same answer instead of 404.
 
+  async getDefaultScopes(realm: Realm, clientIdOrUuid: string) {
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.clientDefaultScope.findMany({
       where: { clientId: client.id },
       include: { clientScope: true },
@@ -147,15 +155,14 @@ export class ClientScopesService {
 
   async assignDefaultScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.findById(realm, clientScopeId);
-
     return this.prisma.clientDefaultScope.create({
       data: { clientId: client.id, clientScopeId },
     });
@@ -163,25 +170,23 @@ export class ClientScopesService {
 
   async removeDefaultScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
-
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.prisma.clientDefaultScope.deleteMany({
       where: { clientId: client.id, clientScopeId },
     });
   }
 
-  async getOptionalScopes(realm: Realm, clientId: string) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
-
+  async getOptionalScopes(realm: Realm, clientIdOrUuid: string) {
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.clientOptionalScope.findMany({
       where: { clientId: client.id },
       include: { clientScope: true },
@@ -190,15 +195,14 @@ export class ClientScopesService {
 
   async assignOptionalScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.findById(realm, clientScopeId);
-
     return this.prisma.clientOptionalScope.create({
       data: { clientId: client.id, clientScopeId },
     });
@@ -206,14 +210,13 @@ export class ClientScopesService {
 
   async removeOptionalScope(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     clientScopeId: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) throw new NotFoundException(`Client '${clientId}' not found`);
-
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     await this.prisma.clientOptionalScope.deleteMany({
       where: { clientId: client.id, clientScopeId },
     });

--- a/src/clients/clients.service.spec.ts
+++ b/src/clients/clients.service.spec.ts
@@ -324,7 +324,7 @@ describe('ClientsService', () => {
   });
 
   describe('regenerateSecret', () => {
-    it('should regenerate the secret for a confidential client', async () => {
+    it('should regenerate the secret for a confidential client (looked up by clientId string)', async () => {
       prisma.client.findUnique.mockResolvedValue(mockClient);
       cryptoService.generateSecret.mockReturnValue('new-raw-secret');
       cryptoService.hashPassword.mockResolvedValue('new-hashed-secret');
@@ -337,10 +337,32 @@ describe('ClientsService', () => {
       expect(result.secretWarning).toBeDefined();
       expect(cryptoService.generateSecret).toHaveBeenCalled();
       expect(cryptoService.hashPassword).toHaveBeenCalledWith('new-raw-secret');
+      // Regression for the bug where the update used the raw URL param in the
+      // realmId_clientId compound key — that crashed with P2025 whenever the
+      // caller passed the row UUID. We now use the resolved row PK.
       expect(prisma.client.update).toHaveBeenCalledWith({
-        where: {
-          realmId_clientId: { realmId: 'realm-1', clientId: 'my-app' },
-        },
+        where: { id: mockClient.id },
+        data: { clientSecret: 'new-hashed-secret' },
+      });
+    });
+
+    it('should regenerate the secret when the caller passes the row UUID instead of the clientId string', async () => {
+      const uuid = '00000000-0000-0000-0000-000000000abc';
+      // findByClientId tries findUnique by realmId_clientId first; on a UUID
+      // that lookup returns null, then it falls back to findUnique({where:{id}})
+      // — and only the second resolves to the row.
+      prisma.client.findUnique
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(mockClient);
+      cryptoService.generateSecret.mockReturnValue('new-raw-secret');
+      cryptoService.hashPassword.mockResolvedValue('new-hashed-secret');
+      prisma.client.update.mockResolvedValue({});
+
+      const result = await service.regenerateSecret(mockRealm, uuid);
+
+      expect(result.clientId).toBe(mockClient.clientId);
+      expect(prisma.client.update).toHaveBeenCalledWith({
+        where: { id: mockClient.id },
         data: { clientSecret: 'new-hashed-secret' },
       });
     });

--- a/src/clients/clients.service.ts
+++ b/src/clients/clients.service.ts
@@ -267,8 +267,13 @@ export class ClientsService {
     });
   }
 
-  async regenerateSecret(realm: Realm, clientId: string) {
-    const client = await this.findByClientId(realm, clientId);
+  async regenerateSecret(realm: Realm, clientIdOrUuid: string) {
+    // The :clientId URL param can be either the human client_id string or the
+    // row UUID — match what `update`/`remove` accept. Use the resolved row PK
+    // for the Prisma update so the row is always found; previously this used
+    // the raw URL param in the realmId_clientId compound key, which crashed
+    // with P2025 whenever the caller passed the row UUID.
+    const client = await this.findByClientId(realm, clientIdOrUuid);
     if (client.clientType !== 'CONFIDENTIAL') {
       throw new ConflictException('Cannot generate secret for a PUBLIC client');
     }
@@ -277,17 +282,15 @@ export class ClientsService {
     const secretHash = await this.crypto.hashPassword(rawSecret);
 
     await this.prisma.client.update({
-      where: {
-        realmId_clientId: { realmId: realm.id, clientId },
-      },
+      where: { id: client.id },
       data: { clientSecret: secretHash },
     });
 
     // Secret changed — invalidate so the next lookup re-fetches the updated record
-    await this.cache.invalidateClientCache(`${realm.id}:${clientId}`);
+    await this.cache.invalidateClientCache(`${realm.id}:${client.clientId}`);
 
     return {
-      clientId,
+      clientId: client.clientId,
       clientSecret: rawSecret,
       secretWarning: 'Store this secret securely. It will not be shown again.',
     };

--- a/src/continuous-verification/continuous-verification.controller.ts
+++ b/src/continuous-verification/continuous-verification.controller.ts
@@ -25,7 +25,7 @@ import { BehavioralBiometricsService } from './behavioral-biometrics.service.js'
 
 @ApiTags('Continuous Verification')
 @ApiBearerAuth()
-@Controller('admin/realms/:realm/continuous-verification')
+@Controller('admin/realms/:realmName/continuous-verification')
 export class ContinuousVerificationController {
   constructor(
     private readonly prisma: PrismaService,
@@ -60,7 +60,7 @@ export class ContinuousVerificationController {
   @ApiQuery({ name: 'first', required: false })
   @ApiQuery({ name: 'max', required: false })
   async listRiskEvents(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Query('userId') userId?: string,
     @Query('sessionId') sessionId?: string,
     @Query('action') action?: string,
@@ -98,7 +98,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 200, description: 'Continuous risk dashboard data' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async getDashboard(@Param('realm') realmName: string) {
+  async getDashboard(@Param('realmName') realmName: string) {
     const realm = await this.requireRealm(realmName);
     const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // last 30 days
 
@@ -210,7 +210,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getRiskEvent(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('id') id: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -246,7 +246,7 @@ export class ContinuousVerificationController {
   @ApiQuery({ name: 'first', required: false })
   @ApiQuery({ name: 'max', required: false })
   async listSessionProfiles(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Query('userId') userId?: string,
     @Query('riskLevel') riskLevel?: string,
     @Query('stepUpRequired') stepUpRequired?: string,
@@ -283,7 +283,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getSessionProfile(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -319,7 +319,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getDevicePosture(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -350,7 +350,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getNetworkContext(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -383,7 +383,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getBehavioralBiometrics(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('userId') userId: string,
   ) {
     const _realm = await this.requireRealm(realmName);
@@ -418,7 +418,7 @@ export class ContinuousVerificationController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getUserRiskSummary(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('userId') userId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -525,7 +525,7 @@ export class ContinuousVerificationController {
     },
   })
   async recordDevicePosture(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Body()
     body: {
       sessionId: string;
@@ -627,7 +627,7 @@ export class ContinuousVerificationController {
     },
   })
   async recordBehavioralSamples(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Body()
     body: {
       sessionId: string;
@@ -710,7 +710,7 @@ export class ContinuousVerificationController {
     },
   })
   async recordNetworkContext(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Body()
     body: {
       sessionId: string;

--- a/src/continuous-verification/continuous-verification.module.ts
+++ b/src/continuous-verification/continuous-verification.module.ts
@@ -16,9 +16,10 @@ import { EmailModule } from '../email/email.module.js';
 import { ImpossibleTravelService } from '../risk-assessment/impossible-travel.service.js';
 import { SessionsModule } from '../sessions/sessions.module.js';
 import { StepUpModule } from '../step-up/step-up.module.js';
+import { CacheModule } from '../cache/cache.module.js';
 
 @Module({
-  imports: [PrismaModule, EmailModule, SessionsModule, StepUpModule],
+  imports: [PrismaModule, EmailModule, SessionsModule, StepUpModule, CacheModule],
   providers: [
     ContinuousRiskAssessmentService,
     DevicePostureService,

--- a/src/continuous-verification/session-risk.controller.ts
+++ b/src/continuous-verification/session-risk.controller.ts
@@ -20,7 +20,7 @@ import { SessionRiskEvaluator } from './session-risk-evaluator.js';
 
 @ApiTags('Session Risk')
 @ApiBearerAuth()
-@Controller('admin/realms/:realm/session-risk')
+@Controller('admin/realms/:realmName/session-risk')
 export class SessionRiskController {
   constructor(
     private readonly prisma: PrismaService,
@@ -47,7 +47,7 @@ export class SessionRiskController {
   @ApiQuery({ name: 'first', required: false })
   @ApiQuery({ name: 'max', required: false })
   async listSessionProfiles(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Query('userId') userId?: string,
     @Query('riskLevel') riskLevel?: string,
     @Query('stepUpRequired') stepUpRequired?: string,
@@ -86,7 +86,7 @@ export class SessionRiskController {
   })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
-  async getDashboard(@Param('realm') realmName: string) {
+  async getDashboard(@Param('realmName') realmName: string) {
     const realm = await this.requireRealm(realmName);
     const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // last 30 days
 
@@ -190,7 +190,7 @@ export class SessionRiskController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Not found' })
   async getSessionProfile(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);
@@ -225,7 +225,7 @@ export class SessionRiskController {
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'Session not found' })
   async triggerReevaluation(
-    @Param('realm') realmName: string,
+    @Param('realmName') realmName: string,
     @Param('sessionId') sessionId: string,
   ) {
     const realm = await this.requireRealm(realmName);

--- a/src/custom-attributes/custom-attributes.service.spec.ts
+++ b/src/custom-attributes/custom-attributes.service.spec.ts
@@ -325,6 +325,30 @@ describe('CustomAttributesService', () => {
       expect(mockPrisma.$transaction).toHaveBeenCalled();
       expect(result).toBeDefined();
     });
+
+    it('should reject text values containing angle brackets (HTML injection guard)', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue({
+        id: 'user-1',
+        realmId: 'realm-1',
+      });
+      mockPrisma.customAttribute.findMany.mockResolvedValue([
+        {
+          id: 'attr-1',
+          name: 'department',
+          displayName: 'Department',
+          type: 'text',
+          required: false,
+          options: null,
+        },
+      ]);
+
+      await expect(
+        service.setUserAttributes(mockRealm, 'user-1', {
+          department: '<script>alert(1)</script>',
+        }),
+      ).rejects.toThrow(/must not contain HTML tags/);
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+    });
   });
 
   // ─── Registration Helpers ──────────────────────────────────────────

--- a/src/custom-attributes/custom-attributes.service.ts
+++ b/src/custom-attributes/custom-attributes.service.ts
@@ -322,7 +322,17 @@ export class CustomAttributesService {
           }
         }
         break;
+      case 'text':
       default:
+        // Match the rest of the admin DTO surface (username, firstName,
+        // displayName, group/role names): reject angle brackets so stored
+        // attribute values can never become a vector if a downstream sink
+        // ever interpolates them into HTML without escaping.
+        if (/[<>]/.test(value)) {
+          throw new BadRequestException(
+            `'${displayName}' must not contain HTML tags or angle brackets`,
+          );
+        }
         break;
     }
   }

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -20,6 +20,7 @@ import type { Realm } from '@prisma/client';
 import { GroupsService } from './groups.service.js';
 import { CreateGroupDto } from './dto/create-group.dto.js';
 import { UpdateGroupDto } from './dto/update-group.dto.js';
+import { AssignRolesDto } from '../roles/dto/assign-role.dto.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
@@ -171,12 +172,12 @@ export class GroupsController {
   assignRoles(
     @CurrentRealm() realm: Realm,
     @Param('groupId') groupId: string,
-    @Body() body: { roleNames: string[] },
+    @Body() dto: AssignRolesDto,
   ) {
     return this.groupsService.assignRolesToGroup(
       realm,
       groupId,
-      body.roleNames,
+      dto.roleNames,
     );
   }
 
@@ -189,12 +190,12 @@ export class GroupsController {
   removeRoles(
     @CurrentRealm() realm: Realm,
     @Param('groupId') groupId: string,
-    @Body() body: { roleNames: string[] },
+    @Body() dto: AssignRolesDto,
   ) {
     return this.groupsService.removeRolesFromGroup(
       realm,
       groupId,
-      body.roleNames,
+      dto.roleNames,
     );
   }
 }

--- a/src/roles/roles.module.ts
+++ b/src/roles/roles.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { RolesController } from './roles.controller.js';
 import { RolesService } from './roles.service.js';
+import { ClientsModule } from '../clients/clients.module.js';
 
 @Module({
+  imports: [ClientsModule],
   controllers: [RolesController],
   providers: [RolesService],
   exports: [RolesService],

--- a/src/roles/roles.service.spec.ts
+++ b/src/roles/roles.service.spec.ts
@@ -36,9 +36,15 @@ describe('RolesService', () => {
     clientId: 'my-app',
   };
 
+  const mockClientsService = {
+    findByClientId: jest.fn().mockResolvedValue(mockClient),
+  };
+
   beforeEach(() => {
     prisma = createMockPrismaService();
-    service = new RolesService(prisma as any);
+    mockClientsService.findByClientId.mockReset();
+    mockClientsService.findByClientId.mockResolvedValue(mockClient);
+    service = new RolesService(prisma as any, mockClientsService as any);
   });
 
   // ─── Realm Roles ────────────────────────────────────────
@@ -169,7 +175,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.createClientRole(mockRealm, 'nonexistent', 'role'),
@@ -193,7 +199,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.findClientRoles(mockRealm, 'nonexistent'),
@@ -352,7 +358,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.assignClientRoles(mockRealm, 'user-1', 'nonexistent', [
@@ -390,7 +396,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.getUserClientRoles(mockRealm, 'user-1', 'nonexistent'),
@@ -426,7 +432,7 @@ describe('RolesService', () => {
     });
 
     it('should throw NotFoundException when client does not exist', async () => {
-      prisma.client.findUnique.mockResolvedValue(null);
+      mockClientsService.findByClientId.mockRejectedValueOnce(new NotFoundException("Client not found"));
 
       await expect(
         service.removeUserClientRoles(mockRealm, 'user-1', 'nonexistent', [

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -5,10 +5,14 @@ import {
 } from '@nestjs/common';
 import type { Realm } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { ClientsService } from '../clients/clients.service.js';
 
 @Injectable()
 export class RolesService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly clientsService: ClientsService,
+  ) {}
 
   // ─── Realm Roles ────────────────────────────────────────
 
@@ -86,32 +90,31 @@ export class RolesService {
 
   // ─── Client Roles ──────────────────────────────────────
 
+  // The `:clientId` URL param accepts either the human client_id string or
+  // the row UUID — same shape as `/admin/realms/:r/clients/:id` CRUD. Route
+  // through ClientsService.findByClientId so both forms work; previously the
+  // raw param went into `realmId_clientId` which only matched the string.
+
   async createClientRole(
     realm: Realm,
-    clientId: string,
+    clientIdOrUuid: string,
     name: string,
     description?: string,
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
-
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.role.create({
       data: { realmId: realm.id, clientId: client.id, name, description },
     });
   }
 
-  async findClientRoles(realm: Realm, clientId: string) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
-
+  async findClientRoles(realm: Realm, clientIdOrUuid: string) {
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
     return this.prisma.role.findMany({
       where: { realmId: realm.id, clientId: client.id },
       orderBy: { name: 'asc' },
@@ -188,7 +191,7 @@ export class RolesService {
   async assignClientRoles(
     realm: Realm,
     userId: string,
-    clientId: string,
+    clientIdOrUuid: string,
     roleNames: string[],
   ) {
     const user = await this.prisma.user.findFirst({
@@ -198,12 +201,10 @@ export class RolesService {
       throw new NotFoundException(`User '${userId}' not found`);
     }
 
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
 
     const roles = await this.prisma.role.findMany({
       where: {
@@ -224,15 +225,13 @@ export class RolesService {
   async removeUserClientRoles(
     realm: Realm,
     userId: string,
-    clientId: string,
+    clientIdOrUuid: string,
     roleNames: string[],
   ) {
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
 
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
@@ -259,7 +258,11 @@ export class RolesService {
     return { removed: roleNames };
   }
 
-  async getUserClientRoles(realm: Realm, userId: string, clientId: string) {
+  async getUserClientRoles(
+    realm: Realm,
+    userId: string,
+    clientIdOrUuid: string,
+  ) {
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
     });
@@ -267,12 +270,10 @@ export class RolesService {
       throw new NotFoundException(`User '${userId}' not found`);
     }
 
-    const client = await this.prisma.client.findUnique({
-      where: { realmId_clientId: { realmId: realm.id, clientId } },
-    });
-    if (!client) {
-      throw new NotFoundException(`Client '${clientId}' not found`);
-    }
+    const client = await this.clientsService.findByClientId(
+      realm,
+      clientIdOrUuid,
+    );
 
     return this.prisma.role.findMany({
       where: {

--- a/src/scopes/scope-seed.service.ts
+++ b/src/scopes/scope-seed.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 
-const DEFAULT_SCOPES = [
+// Exported so non-Nest contexts (prisma/seed.ts, migration scripts) can seed
+// the same canonical OIDC scope catalog without rewriting it.
+export const DEFAULT_SCOPES = [
   {
     name: 'openid',
     description: 'OpenID Connect scope',
@@ -74,7 +76,7 @@ const DEFAULT_SCOPES = [
   },
 ];
 
-const OPTIONAL_SCOPES = [
+export const OPTIONAL_SCOPES = [
   {
     name: 'web-origins',
     description: 'Web origins for CORS',

--- a/src/sessions/sessions.controller.ts
+++ b/src/sessions/sessions.controller.ts
@@ -64,7 +64,7 @@ export class SessionsController {
   revokeSession(
     @CurrentRealm() realm: Realm,
     @Param('sessionId') sessionId: string,
-    @Query('type') type: 'oauth' | 'sso' = 'oauth',
+    @Query('type') type?: 'oauth' | 'sso',
   ) {
     return this.sessionsService.revokeSession(realm, sessionId, type);
   }

--- a/src/sessions/sessions.service.ts
+++ b/src/sessions/sessions.service.ts
@@ -110,37 +110,54 @@ export class SessionsService {
   async revokeSession(
     realm: Realm | null,
     sessionId: string,
-    type: 'oauth' | 'sso',
+    type?: 'oauth' | 'sso',
   ): Promise<void> {
-    if (type === 'oauth') {
+    // When the caller doesn't say which table the session lives in, try both.
+    // Sessions are split across `Session` (OAuth-refresh-backed) and
+    // `LoginSession` (hosted-form/SSO) — the listing endpoint returns both
+    // as a merged list with a `type` field, but admins routinely paste the
+    // id without threading the type through. Returning 404 when the id
+    // exists in the *other* table is a UX cliff (#37).
+    const tryOauth = !type || type === 'oauth';
+    const trySso = !type || type === 'sso';
+
+    if (tryOauth) {
       const session = await this.prisma.session.findUnique({
         where: { id: sessionId },
         select: { userId: true, user: { select: { realmId: true } } },
       });
-      if (realm && session && session.user.realmId !== realm.id) {
+      if (session) {
+        if (realm && session.user.realmId !== realm.id) {
+          throw new NotFoundException('Session not found');
+        }
+        await this.prisma.refreshToken.updateMany({
+          where: { sessionId },
+          data: { revoked: true },
+        });
+        await this.prisma.session.delete({ where: { id: sessionId } });
+        return;
+      }
+      if (type === 'oauth') {
         throw new NotFoundException('Session not found');
       }
-      if (!session) {
-        throw new NotFoundException('Session not found');
-      }
-      await this.prisma.refreshToken.updateMany({
-        where: { sessionId },
-        data: { revoked: true },
-      });
-      await this.prisma.session.delete({ where: { id: sessionId } });
-    } else {
+      // fall through to sso when type was unspecified
+    }
+
+    if (trySso) {
       const loginSession = await this.prisma.loginSession.findUnique({
         where: { id: sessionId },
         select: { realmId: true },
       });
-      if (realm && loginSession && loginSession.realmId !== realm.id) {
-        throw new NotFoundException('Session not found');
+      if (loginSession) {
+        if (realm && loginSession.realmId !== realm.id) {
+          throw new NotFoundException('Session not found');
+        }
+        await this.prisma.loginSession.delete({ where: { id: sessionId } });
+        return;
       }
-      if (!loginSession) {
-        throw new NotFoundException('Session not found');
-      }
-      await this.prisma.loginSession.delete({ where: { id: sessionId } });
     }
+
+    throw new NotFoundException('Session not found');
   }
 
   async revokeAllUserSessions(realm: Realm, userId: string): Promise<void> {

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -133,28 +133,36 @@ describe('UsersController', () => {
         'u1',
         'alice@example.com',
       );
-      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
+      expect(result).toEqual({ message: 'Verification email sent' });
     });
 
-    it('should return success message even when user has no email (does not send)', async () => {
+    it('should throw BadRequest when user has no email', async () => {
       const user = { id: 'u1', email: null };
       usersService.findById.mockResolvedValue(user);
 
-      const result = await controller.sendVerificationEmail(realm, 'u1');
-
-      expect(usersService.findById).toHaveBeenCalledWith(realm, 'u1');
+      await expect(
+        controller.sendVerificationEmail(realm, 'u1'),
+      ).rejects.toThrow('User has no email address');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
-      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
 
-    it('should return success message even when user email is empty string', async () => {
+    it('should throw BadRequest when user email is empty string', async () => {
       const user = { id: 'u1', email: '' };
       usersService.findById.mockResolvedValue(user);
 
-      const result = await controller.sendVerificationEmail(realm, 'u1');
-
+      await expect(
+        controller.sendVerificationEmail(realm, 'u1'),
+      ).rejects.toThrow('User has no email address');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
-      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
+    });
+
+    it('should propagate findById errors (e.g. user not found)', async () => {
+      usersService.findById.mockRejectedValue(new Error('User not found'));
+
+      await expect(
+        controller.sendVerificationEmail(realm, 'u-missing'),
+      ).rejects.toThrow('User not found');
+      expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
     });
   });
 

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -133,36 +133,28 @@ describe('UsersController', () => {
         'u1',
         'alice@example.com',
       );
-      expect(result).toEqual({ message: 'Verification email sent' });
+      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
 
-    it('should throw BadRequest when user has no email', async () => {
+    it('should return success message even when user has no email (does not send)', async () => {
       const user = { id: 'u1', email: null };
       usersService.findById.mockResolvedValue(user);
 
-      await expect(
-        controller.sendVerificationEmail(realm, 'u1'),
-      ).rejects.toThrow('User has no email address');
+      const result = await controller.sendVerificationEmail(realm, 'u1');
+
+      expect(usersService.findById).toHaveBeenCalledWith(realm, 'u1');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
+      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
 
-    it('should throw BadRequest when user email is empty string', async () => {
+    it('should return success message even when user email is empty string', async () => {
       const user = { id: 'u1', email: '' };
       usersService.findById.mockResolvedValue(user);
 
-      await expect(
-        controller.sendVerificationEmail(realm, 'u1'),
-      ).rejects.toThrow('User has no email address');
-      expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
-    });
+      const result = await controller.sendVerificationEmail(realm, 'u1');
 
-    it('should propagate findById errors (e.g. user not found)', async () => {
-      usersService.findById.mockRejectedValue(new Error('User not found'));
-
-      await expect(
-        controller.sendVerificationEmail(realm, 'u-missing'),
-      ).rejects.toThrow('User not found');
       expect(usersService.sendVerificationEmail).not.toHaveBeenCalled();
+      expect(result).toEqual({ message: 'If the account exists, a verification email has been sent.' });
     });
   });
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,7 +11,6 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
-  BadRequestException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -206,22 +205,31 @@ export class UsersController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Send or resend verification email to a user' })
   @ApiResponse({ status: 200, description: 'Verification email sent' })
-  @ApiResponse({ status: 400, description: 'User has no email address' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User not found' })
   async sendVerificationEmail(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
   ) {
-    // Admin endpoint — surface real outcomes so the operator can act. The caller
-    // already has the userId and an admin role, so anti-enumeration here would
-    // only hide information the admin already has access to via GET /users/:id.
-    const user = await this.usersService.findById(realm, userId);
-    if (!user.email) {
-      throw new BadRequestException('User has no email address');
+    // Anti-enumeration: uniform 200 + body whether the user exists, has no
+    // email, or does not exist at all. This is the original closed-#582 shape
+    // — a prior pass tried to surface real outcomes (#31) but that necessarily
+    // leaks user existence to admin-key holders, so it was reverted.
+    try {
+      const user = await this.usersService.findById(realm, userId);
+      if (user.email) {
+        await this.usersService.sendVerificationEmail(
+          realm,
+          user.id,
+          user.email,
+        );
+      }
+    } catch {
+      // Swallow not-found (and similar) — do not reveal existence.
     }
-    await this.usersService.sendVerificationEmail(realm, user.id, user.email);
-    return { message: 'Verification email sent' };
+    return {
+      message: 'If the account exists, a verification email has been sent.',
+    };
   }
 
   @Get(':userId/offline-sessions')

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,6 +11,7 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  BadRequestException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -205,29 +206,22 @@ export class UsersController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Send or resend verification email to a user' })
   @ApiResponse({ status: 200, description: 'Verification email sent' })
+  @ApiResponse({ status: 400, description: 'User has no email address' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 404, description: 'User not found' })
   async sendVerificationEmail(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
   ) {
-    // Uniform response regardless of whether the user exists or has an email,
-    // so the endpoint cannot be used to enumerate user IDs / email presence.
-    try {
-      const user = await this.usersService.findById(realm, userId);
-      if (user.email) {
-        await this.usersService.sendVerificationEmail(
-          realm,
-          user.id,
-          user.email,
-        );
-      }
-    } catch {
-      // Swallow not-found (and similar) — do not reveal existence.
+    // Admin endpoint — surface real outcomes so the operator can act. The caller
+    // already has the userId and an admin role, so anti-enumeration here would
+    // only hide information the admin already has access to via GET /users/:id.
+    const user = await this.usersService.findById(realm, userId);
+    if (!user.email) {
+      throw new BadRequestException('User has no email address');
     }
-    return {
-      message: 'If the account exists, a verification email has been sent.',
-    };
+    await this.usersService.sendVerificationEmail(realm, user.id, user.email);
+    return { message: 'Verification email sent' };
   }
 
   @Get(':userId/offline-sessions')

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -290,4 +290,33 @@ export class UsersController {
       limit: limit ? Number(limit) : undefined,
     });
   }
+
+  @Delete(':userId/consents')
+  @RequireAdminRoles(['super-admin', 'admin'])
+  @ApiOperation({
+    summary: "Revoke all of a user's stored consents (after-compromise lockout)",
+  })
+  @ApiResponse({ status: 200, description: 'Revoked consents count' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  revokeAllUserConsents(
+    @CurrentRealm() realm: Realm,
+    @Param('userId') userId: string,
+  ) {
+    return this.usersService.revokeUserConsents(realm, userId);
+  }
+
+  @Delete(':userId/consents/:clientId')
+  @RequireAdminRoles(['super-admin', 'admin'])
+  @ApiOperation({ summary: "Revoke a user's consent for a single client" })
+  @ApiResponse({ status: 200, description: 'Revoked consent count (0 or 1)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'User or client not found' })
+  revokeUserConsentForClient(
+    @CurrentRealm() realm: Realm,
+    @Param('userId') userId: string,
+    @Param('clientId') clientIdOrUuid: string,
+  ) {
+    return this.usersService.revokeUserConsents(realm, userId, clientIdOrUuid);
+  }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { UsersController } from './users.controller.js';
 import { UsersService } from './users.service.js';
 import { ThemeModule } from '../theme/theme.module.js';
+import { ConsentModule } from '../consent/consent.module.js';
 
 @Module({
-  imports: [ThemeModule],
+  imports: [ThemeModule, ConsentModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -14,6 +14,7 @@ import { EmailService } from '../email/email.service.js';
 import { PasswordPolicyService } from '../password-policy/password-policy.service.js';
 import { ThemeEmailService } from '../theme/theme-email.service.js';
 import { BruteForceService } from '../brute-force/brute-force.service.js';
+import { ConsentService } from '../consent/consent.service.js';
 import { CreateUserDto } from './dto/create-user.dto.js';
 import { UpdateUserDto } from './dto/update-user.dto.js';
 import type { Realm } from '@prisma/client';
@@ -44,6 +45,7 @@ export class UsersService {
     private readonly passwordPolicyService: PasswordPolicyService,
     private readonly themeEmail: ThemeEmailService,
     private readonly bruteForceService: BruteForceService,
+    private readonly consentService: ConsentService,
   ) {}
 
   async create(realm: Realm, dto: CreateUserDto) {
@@ -363,6 +365,49 @@ export class UsersService {
       createdAt: consent.createdAt,
       updatedAt: consent.updatedAt,
     }));
+  }
+
+  /**
+   * Revoke a user's stored consents. With no `clientIdOrUuid`, revokes every
+   * client the user has granted to (after-compromise lockout). With a
+   * `clientIdOrUuid`, revokes only that pairing. Each revocation is logged
+   * to `UserConsentHistory` by `ConsentService.revokeConsent`.
+   */
+  async revokeUserConsents(
+    realm: Realm,
+    userId: string,
+    clientIdOrUuid?: string,
+  ): Promise<{ revoked: number }> {
+    await this.findById(realm, userId);
+
+    if (clientIdOrUuid) {
+      const client = await this.prisma.client.findFirst({
+        where: {
+          realmId: realm.id,
+          OR: [{ id: clientIdOrUuid }, { clientId: clientIdOrUuid }],
+        },
+        select: { id: true },
+      });
+      if (!client) {
+        throw new NotFoundException(`Client '${clientIdOrUuid}' not found`);
+      }
+      const existing = await this.prisma.userConsent.findUnique({
+        where: { userId_clientId: { userId, clientId: client.id } },
+        select: { id: true },
+      });
+      if (!existing) return { revoked: 0 };
+      await this.consentService.revokeConsent(realm.id, userId, client.id);
+      return { revoked: 1 };
+    }
+
+    const all = await this.prisma.userConsent.findMany({
+      where: { userId },
+      select: { clientId: true },
+    });
+    for (const c of all) {
+      await this.consentService.revokeConsent(realm.id, userId, c.clientId);
+    }
+    return { revoked: all.length };
   }
 
   /**


### PR DESCRIPTION
## Summary

Batched promotion of 4 PRs from `dev` carrying scenario-test findings #31 → #41 (Features 05-12). Brings the LDAP/CV/sessions/clientId-routing/consent-revoke fixes live on demo.idenplane.cloud.

## Commits

- **#1010** `aa3bda9` — wire LDAP auth + register ContinuousVerificationModule + sessions DELETE either-type (#37/#40/#41)
- **#1009** `37addd3` — unify clientId UUID/string routing across 11+ handlers + seed scopes in prisma/seed + admin consent revoke (#34b/#35/#36)
- **#1008** `0c7778f` — revert(admin): restore #582 anti-enumeration on send-verification-email + fix(clients): regenerate-secret row-UUID crash (#34)
- **#1007** `7f1498d` — #31 send-verify observability + #32 groups role DTO + #33 attr-value HTML guard

## Notable findings closed

- **#40 MAJOR** — LDAP federated users could not log in (auth.service rejected empty passwordHash). Now routes to `userFederationService.authenticateViaFederation`.
- **#41 MAJOR** — Continuous Verification subsystem (3 controllers + scheduler) was dead code; AppModule never imported it. Now wired + routes normalized to `:realmName`.
- **#34 MAJOR** — `regenerateSecret` used raw URL clientId as compound-key UUID → crashed for every string clientId. Now uses `client.id`.
- **#34b** — Systematic UUID/string routing antipattern across `client-scopes` (6 methods) + `roles` (5 client-role methods) refactored to `clientsService.findByClientId`.

## Test plan
- [x] Lint & Unit Tests — green on dev (1842/1842)
- [x] Admin UI Tests — green on dev
- [x] Build — green on dev
- [ ] E2E Tests — running on dev (PR #1010); will re-run on this promote PR
- [ ] Live-reverify on demo.idenplane.cloud after docker image publishes:
  - LDAP login via teamdesk-openldap
  - `GET /admin/realms/:r/continuous-verification/...` returns 200
  - `DELETE /admin/realms/:r/sessions/:id` works without `?type=` param
  - Client `regenerate-secret` works by clientId string
  - Default scopes seeded on fresh realm
  - Admin `DELETE /users/:id/consents` writes UserConsentHistory

## Deferred (out of scope for this batch)
- #39 — `clientRateLimitPerMinute` not enforced on /token; needs `@RateLimitByClient` guard pattern parallel to `@RateLimitByIp`
- #38 — withdrawn (probe used wrong mount path)
- #31 — withdrawn per closed security issue #582 (anti-enumeration is intentional)