### PR TITLE
fix(cv): import CacheModule so RiskPolicyService can resolve CacheService

### DIFF
--- a/src/continuous-verification/continuous-verification.module.ts
+++ b/src/continuous-verification/continuous-verification.module.ts
@@ -16,9 +16,10 @@ import { EmailModule } from '../email/email.module.js';
 import { ImpossibleTravelService } from '../risk-assessment/impossible-travel.service.js';
 import { SessionsModule } from '../sessions/sessions.module.js';
 import { StepUpModule } from '../step-up/step-up.module.js';
+import { CacheModule } from '../cache/cache.module.js';
 
 @Module({
-  imports: [PrismaModule, EmailModule, SessionsModule, StepUpModule],
+  imports: [PrismaModule, EmailModule, SessionsModule, StepUpModule, CacheModule],
   providers: [
     ContinuousRiskAssessmentService,
     DevicePostureService,


### PR DESCRIPTION
## Summary

PR #1010 wired `ContinuousVerificationModule` into `AppModule` (#41 dead-code fix). That exposed a latent DI bug: `RiskPolicyService` depends on `CacheService` but the CV module never imported `CacheModule`.

Before #1010, the entire CV module was unimported, so the gap stayed dormant. Once `AppModule` resolved its providers, every E2E suite failed to compile with:

```
Nest can't resolve dependencies of the RiskPolicyService (PrismaService, ?).
Please make sure that the argument CacheService at index [1] is available
in the ContinuousVerificationModule module.
```

All 20 E2E suites cascaded on this; subsequent timer leakage from `AdminAuthService.cleanup()` then kept the runner alive past the normal 2-minute mark (we cancelled at 42 min).

## Fix

Add `CacheModule` to `ContinuousVerificationModule`'s `imports` list (textbook fix for that DI error).

## Test plan
- [x] `npm run build` clean
- [ ] CI: Lint & Unit Tests
- [ ] CI: **E2E Tests** must drop back to ~2-3 min (not 40+)
- [ ] CI: Build, Admin UI Tests