### PR TITLE
chore(deps): bump shell-quote from 1.8.3 to 1.8.4 in /docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16783,9 +16783,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
## Summary

Resolves **Dependabot alert #165** — [CVE-2026-9277](https://nvd.nist.gov/vuln/detail/CVE-2026-9277) / [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) (Critical, CVSS 8.1).

`shell-quote`'s `quote()` did not escape line terminators in object-token `.op` values, so a newline in `.op` passed through unescaped — POSIX shells treat it as a command separator, enabling shell command injection. Fixed upstream in `1.8.4` via allowlist validation of object tokens.

## Where it lives here

Transitive dependency of the **Docusaurus docs site only** (not the Idenplane server):

```
docs → @docusaurus (webpack-dev-server) → launch-editor → shell-quote
```

Practical exposure is low — it's local dev tooling for the docs site and nothing ships to production — but bumping clears the alert.

## Changes

- `docs/package-lock.json`: `shell-quote` 1.8.3 → 1.8.4 (3-line lockfile bump, already within the `^1.8.3` range)

🤖 Generated with [Claude Code](https://claude.com/claude-code)