### PR TITLE
chore(deps): bump shell-quote from 1.8.3 to 1.8.4 in /docs (#1035)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -16783,9 +16783,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
Fixes Dependabot alert #165 (CVE-2026-9277 / GHSA-w7jw-789q-3m8p): shell-quote quote() does not escape newlines in object .op values, allowing shell command injection. Transitive dependency via launch-editor (webpack-dev-server) in the Docusaurus docs site.

<!--
  Thanks for contributing to Idenplane! Please fill out the sections below so reviewers
  can understand the change and verify it.

  For security fixes, please coordinate via SECURITY.md before opening a public PR.
-->

## Summary

<!-- One paragraph: what changed and why. -->

## Linked issues

<!-- e.g. Closes #123, Refs #456 -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to break)
- [ ] Documentation update
- [ ] Internal refactor / chore (no user-facing change)

## How was this tested?

<!--
  Describe how you verified the change works. For backend changes: unit tests, e2e tests,
  manual API calls. For admin-ui changes: screenshots or recordings, browser tested.
-->

- [ ] Unit tests added / updated
- [ ] E2E tests added / updated (where applicable)
- [ ] Manually tested

## Screenshots / recordings

<!-- For UI changes, before/after screenshots or a short recording. -->

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run build:all` succeeds
- [ ] If schema changed: a Prisma migration is included
- [ ] If user-facing: README / docs updated
- [ ] If breaking: documented in the description and in `DECISIONS.md`
