### PR TITLE
feat(admin-ui): add all missing frontend features

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -40,6 +40,24 @@ import SetupWizardPage from './pages/setup-wizard/SetupWizardPage';
 import PendingRegistrationsPage from './pages/registration/PendingRegistrationsPage';
 import RegistrationFieldsPage from './pages/registration/RegistrationFieldsPage';
 import RegistrationSettingsPage from './pages/registration/RegistrationSettingsPage';
+import ContinuousRiskDashboard from './pages/continuous-verification/ContinuousRiskDashboard';
+import RiskPolicyListPage from './pages/continuous-verification/RiskPolicyListPage';
+import SessionRiskDetailPage from './pages/continuous-verification/SessionRiskDetailPage';
+import OrganizationListPage from './pages/organizations/OrganizationListPage';
+import OrganizationCreatePage from './pages/organizations/OrganizationCreatePage';
+import OrganizationDetailPage from './pages/organizations/OrganizationDetailPage';
+import WebhookListPage from './pages/webhooks/WebhookListPage';
+import WebhookCreatePage from './pages/webhooks/WebhookCreatePage';
+import WebhookDetailPage from './pages/webhooks/WebhookDetailPage';
+import ServiceAccountListPage from './pages/service-accounts/ServiceAccountListPage';
+import ServiceAccountCreatePage from './pages/service-accounts/ServiceAccountCreatePage';
+import ServiceAccountDetailPage from './pages/service-accounts/ServiceAccountDetailPage';
+import CustomAttributesPage from './pages/custom-attributes/CustomAttributesPage';
+import ScimConfigPage from './pages/scim/ScimConfigPage';
+import PolicyListPage from './pages/authorization/PolicyListPage';
+import PolicyCreatePage from './pages/authorization/PolicyCreatePage';
+import PolicyDetailPage from './pages/authorization/PolicyDetailPage';
+import PluginsPage from './pages/plugins/PluginsPage';
 import NotFoundPage from './pages/NotFoundPage';
 import { hasCredentials } from './api/client';
 
@@ -99,6 +117,24 @@ export default function App() {
           <Route path="/console/realms/:name/registration-approvals" element={<PendingRegistrationsPage />} />
           <Route path="/console/realms/:name/registration-fields" element={<RegistrationFieldsPage />} />
           <Route path="/console/realms/:name/registration-settings" element={<RegistrationSettingsPage />} />
+          <Route path="/console/realms/:name/risk-dashboard" element={<ContinuousRiskDashboard />} />
+          <Route path="/console/realms/:name/risk-policies" element={<RiskPolicyListPage />} />
+          <Route path="/console/realms/:name/risk-sessions/:sessionId" element={<SessionRiskDetailPage />} />
+          <Route path="/console/realms/:name/organizations" element={<OrganizationListPage />} />
+          <Route path="/console/realms/:name/organizations/new" element={<OrganizationCreatePage />} />
+          <Route path="/console/realms/:name/organizations/:slug" element={<OrganizationDetailPage />} />
+          <Route path="/console/realms/:name/webhooks" element={<WebhookListPage />} />
+          <Route path="/console/realms/:name/webhooks/new" element={<WebhookCreatePage />} />
+          <Route path="/console/realms/:name/webhooks/:webhookId" element={<WebhookDetailPage />} />
+          <Route path="/console/realms/:name/service-accounts" element={<ServiceAccountListPage />} />
+          <Route path="/console/realms/:name/service-accounts/new" element={<ServiceAccountCreatePage />} />
+          <Route path="/console/realms/:name/service-accounts/:accountId" element={<ServiceAccountDetailPage />} />
+          <Route path="/console/realms/:name/custom-attributes" element={<CustomAttributesPage />} />
+          <Route path="/console/realms/:name/scim" element={<ScimConfigPage />} />
+          <Route path="/console/realms/:name/authorization-policies" element={<PolicyListPage />} />
+          <Route path="/console/realms/:name/authorization-policies/new" element={<PolicyCreatePage />} />
+          <Route path="/console/realms/:name/authorization-policies/:policyId" element={<PolicyDetailPage />} />
+          <Route path="/console/plugins" element={<PluginsPage />} />
           {/* Catch-all for unknown /console/... paths — rendered inside the Layout shell */}
           <Route path="*" element={<NotFoundPage />} />
         </Route>

--- a/admin-ui/src/api/authorization.ts
+++ b/admin-ui/src/api/authorization.ts
@@ -1,0 +1,77 @@
+import apiClient from './client';
+
+export interface AuthPolicy {
+  id: string;
+  realmId: string;
+  name: string;
+  description: string | null;
+  effect: 'allow' | 'deny';
+  conditions: Record<string, unknown>;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function getPolicies(realmName: string): Promise<AuthPolicy[]> {
+  const { data } = await apiClient.get<AuthPolicy[]>(
+    `/realms/${realmName}/policies`,
+  );
+  return data;
+}
+
+export async function getPolicy(realmName: string, id: string): Promise<AuthPolicy> {
+  const { data } = await apiClient.get<AuthPolicy>(
+    `/realms/${realmName}/policies/${id}`,
+  );
+  return data;
+}
+
+export async function createPolicy(
+  realmName: string,
+  payload: Partial<AuthPolicy>,
+): Promise<AuthPolicy> {
+  const { data } = await apiClient.post<AuthPolicy>(
+    `/realms/${realmName}/policies`,
+    payload,
+  );
+  return data;
+}
+
+export async function updatePolicy(
+  realmName: string,
+  id: string,
+  payload: Partial<AuthPolicy>,
+): Promise<AuthPolicy> {
+  const { data } = await apiClient.put<AuthPolicy>(
+    `/realms/${realmName}/policies/${id}`,
+    payload,
+  );
+  return data;
+}
+
+export async function deletePolicy(realmName: string, id: string): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/policies/${id}`);
+}
+
+export async function evaluatePolicy(
+  realmName: string,
+  context: Record<string, unknown>,
+): Promise<unknown> {
+  const { data } = await apiClient.post<unknown>(
+    `/realms/${realmName}/policies/evaluate`,
+    context,
+  );
+  return data;
+}
+
+export async function testPolicy(
+  realmName: string,
+  id: string,
+  context: Record<string, unknown>,
+): Promise<unknown> {
+  const { data } = await apiClient.post<unknown>(
+    `/realms/${realmName}/policies/${id}/test`,
+    context,
+  );
+  return data;
+}

--- a/admin-ui/src/api/customAttributes.ts
+++ b/admin-ui/src/api/customAttributes.ts
@@ -1,0 +1,83 @@
+import apiClient from './client';
+
+export type AttributeType = 'text' | 'number' | 'boolean' | 'select' | 'multi-select';
+
+export interface CustomAttribute {
+  id: string;
+  realmId: string;
+  name: string;
+  displayName: string;
+  type: AttributeType;
+  required: boolean;
+  showOnRegistration: boolean;
+  showOnProfile: boolean;
+  options: string[];
+  order: number;
+  minLength: number | null;
+  maxLength: number | null;
+  min: number | null;
+  max: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function getCustomAttributes(realmName: string): Promise<CustomAttribute[]> {
+  const { data } = await apiClient.get<CustomAttribute[]>(
+    `/realms/${realmName}/custom-attributes`,
+  );
+  return data;
+}
+
+export async function getCustomAttribute(realmName: string, id: string): Promise<CustomAttribute> {
+  const { data } = await apiClient.get<CustomAttribute>(
+    `/realms/${realmName}/custom-attributes/${id}`,
+  );
+  return data;
+}
+
+export async function createCustomAttribute(
+  realmName: string,
+  payload: Partial<CustomAttribute>,
+): Promise<CustomAttribute> {
+  const { data } = await apiClient.post<CustomAttribute>(
+    `/realms/${realmName}/custom-attributes`,
+    payload,
+  );
+  return data;
+}
+
+export async function updateCustomAttribute(
+  realmName: string,
+  id: string,
+  payload: Partial<CustomAttribute>,
+): Promise<CustomAttribute> {
+  const { data } = await apiClient.put<CustomAttribute>(
+    `/realms/${realmName}/custom-attributes/${id}`,
+    payload,
+  );
+  return data;
+}
+
+export async function deleteCustomAttribute(realmName: string, id: string): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/custom-attributes/${id}`);
+}
+
+export async function getUserAttributes(
+  realmName: string,
+  userId: string,
+): Promise<Record<string, unknown>> {
+  const { data } = await apiClient.get<Record<string, unknown>>(
+    `/realms/${realmName}/users/${userId}/attributes`,
+  );
+  return data;
+}
+
+export async function updateUserAttributes(
+  realmName: string,
+  userId: string,
+  attrs: Record<string, unknown>,
+): Promise<void> {
+  await apiClient.put(`/realms/${realmName}/users/${userId}/attributes`, {
+    attributes: attrs,
+  });
+}

--- a/admin-ui/src/api/organizations.ts
+++ b/admin-ui/src/api/organizations.ts
@@ -1,0 +1,154 @@
+import apiClient from './client';
+
+export interface Organization {
+  id: string;
+  realmId: string;
+  slug: string;
+  name: string;
+  displayName: string | null;
+  description: string | null;
+  enabled: boolean;
+  logoUrl: string | null;
+  primaryColor: string | null;
+  requireMfa: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OrgMember {
+  id: string;
+  organizationId: string;
+  userId: string;
+  role: 'owner' | 'admin' | 'member';
+  user?: { id: string; username: string; email: string | null };
+  createdAt: string;
+}
+
+export interface OrgInvitation {
+  id: string;
+  organizationId: string;
+  email: string;
+  role: 'owner' | 'admin' | 'member';
+  token: string;
+  expiresAt: string | null;
+  acceptedAt: string | null;
+  createdAt: string;
+}
+
+export async function getOrganizations(realmName: string): Promise<Organization[]> {
+  const { data } = await apiClient.get<Organization[]>(`/realms/${realmName}/organizations`);
+  return data;
+}
+
+export async function getOrganization(realmName: string, slug: string): Promise<Organization> {
+  const { data } = await apiClient.get<Organization>(
+    `/realms/${realmName}/organizations/${slug}`,
+  );
+  return data;
+}
+
+export async function createOrganization(
+  realmName: string,
+  payload: {
+    slug: string;
+    name: string;
+    displayName?: string;
+    description?: string;
+    enabled?: boolean;
+    logoUrl?: string;
+    primaryColor?: string;
+    requireMfa?: boolean;
+  },
+): Promise<Organization> {
+  const { data } = await apiClient.post<Organization>(
+    `/realms/${realmName}/organizations`,
+    payload,
+  );
+  return data;
+}
+
+export async function updateOrganization(
+  realmName: string,
+  slug: string,
+  payload: {
+    name?: string;
+    displayName?: string;
+    description?: string;
+    enabled?: boolean;
+    logoUrl?: string;
+    primaryColor?: string;
+    requireMfa?: boolean;
+  },
+): Promise<Organization> {
+  const { data } = await apiClient.put<Organization>(
+    `/realms/${realmName}/organizations/${slug}`,
+    payload,
+  );
+  return data;
+}
+
+export async function deleteOrganization(realmName: string, slug: string): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/organizations/${slug}`);
+}
+
+export async function getOrgMembers(realmName: string, slug: string): Promise<OrgMember[]> {
+  const { data } = await apiClient.get<OrgMember[]>(
+    `/realms/${realmName}/organizations/${slug}/members`,
+  );
+  return data;
+}
+
+export async function addOrgMember(
+  realmName: string,
+  slug: string,
+  payload: { userId: string; role?: 'owner' | 'admin' | 'member' },
+): Promise<OrgMember> {
+  const { data } = await apiClient.post<OrgMember>(
+    `/realms/${realmName}/organizations/${slug}/members`,
+    payload,
+  );
+  return data;
+}
+
+export async function updateOrgMember(
+  realmName: string,
+  slug: string,
+  userId: string,
+  payload: { role: 'owner' | 'admin' | 'member' },
+): Promise<OrgMember> {
+  const { data } = await apiClient.put<OrgMember>(
+    `/realms/${realmName}/organizations/${slug}/members/${userId}`,
+    payload,
+  );
+  return data;
+}
+
+export async function removeOrgMember(
+  realmName: string,
+  slug: string,
+  userId: string,
+): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/organizations/${slug}/members/${userId}`);
+}
+
+export async function getOrgInvitations(
+  realmName: string,
+  slug: string,
+): Promise<OrgInvitation[]> {
+  const { data } = await apiClient.get<OrgInvitation[]>(
+    `/realms/${realmName}/organizations/${slug}/invitations`,
+  );
+  return data;
+}
+
+export async function createOrgInvitation(
+  realmName: string,
+  slug: string,
+  payload: { email: string; role?: 'owner' | 'admin' | 'member' },
+): Promise<OrgInvitation> {
+  const { data } = await apiClient.post<OrgInvitation>(
+    `/realms/${realmName}/organizations/${slug}/invitations`,
+    payload,
+  );
+  return data;
+}

--- a/admin-ui/src/api/plugins.ts
+++ b/admin-ui/src/api/plugins.ts
@@ -1,0 +1,34 @@
+import apiClient from './client';
+
+export interface Plugin {
+  name: string;
+  version: string;
+  description: string;
+  enabled: boolean;
+  author?: string;
+  homepage?: string;
+}
+
+export async function getPlugins(): Promise<Plugin[]> {
+  const { data } = await apiClient.get<Plugin[]>('/plugins');
+  return data;
+}
+
+export async function getPlugin(name: string): Promise<Plugin> {
+  const { data } = await apiClient.get<Plugin>(`/plugins/${name}`);
+  return data;
+}
+
+export async function enablePlugin(name: string): Promise<Plugin> {
+  const { data } = await apiClient.post<Plugin>(`/plugins/${name}/enable`);
+  return data;
+}
+
+export async function disablePlugin(name: string): Promise<Plugin> {
+  const { data } = await apiClient.post<Plugin>(`/plugins/${name}/disable`);
+  return data;
+}
+
+export async function deletePlugin(name: string): Promise<void> {
+  await apiClient.delete(`/plugins/${name}`);
+}

--- a/admin-ui/src/api/scim.ts
+++ b/admin-ui/src/api/scim.ts
@@ -1,0 +1,115 @@
+import apiClient from './client';
+
+export interface ScimToken {
+  id: string;
+  realmId: string;
+  name: string;
+  tokenPrefix: string;
+  enabled: boolean;
+  revoked: boolean;
+  expiresAt: string | null;
+  scopes: string[];
+  description: string | null;
+  createdAt: string;
+}
+
+export interface ScimTokenCreateResult extends ScimToken {
+  plainToken: string;
+}
+
+export interface ScimAttributeMapping {
+  id: string;
+  realmId: string;
+  resourceType: string;
+  scimAttribute: string;
+  idenplaneAttribute: string;
+  enabled: boolean;
+  direction: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ScimStatus {
+  enabled: boolean;
+  userAutocreate: boolean;
+  groupSyncEnabled: boolean;
+  activeTokens: number;
+  totalUsers: number;
+  totalGroups: number;
+}
+
+export async function getScimTokens(realmName: string): Promise<ScimToken[]> {
+  const { data } = await apiClient.get<ScimToken[]>(
+    `/realms/${realmName}/scim/tokens`,
+  );
+  return data;
+}
+
+export async function createScimToken(
+  realmName: string,
+  payload: {
+    name: string;
+    description?: string;
+    expiresAt?: string;
+    scopes?: string[];
+  },
+): Promise<ScimTokenCreateResult> {
+  const { data } = await apiClient.post<ScimTokenCreateResult>(
+    `/realms/${realmName}/scim/tokens`,
+    payload,
+  );
+  return data;
+}
+
+export async function deleteScimToken(realmName: string, tokenId: string): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/scim/tokens/${tokenId}`);
+}
+
+export async function revokeScimToken(realmName: string, tokenId: string): Promise<void> {
+  await apiClient.put(`/realms/${realmName}/scim/tokens/${tokenId}/revoke`);
+}
+
+export async function enableScimToken(realmName: string, tokenId: string): Promise<void> {
+  await apiClient.put(`/realms/${realmName}/scim/tokens/${tokenId}/enable`);
+}
+
+export async function disableScimToken(realmName: string, tokenId: string): Promise<void> {
+  await apiClient.put(`/realms/${realmName}/scim/tokens/${tokenId}/disable`);
+}
+
+export async function getScimAttributeMappings(realmName: string): Promise<ScimAttributeMapping[]> {
+  const { data } = await apiClient.get<ScimAttributeMapping[]>(
+    `/realms/${realmName}/scim/attribute-mappings`,
+  );
+  return data;
+}
+
+export async function createScimAttributeMapping(
+  realmName: string,
+  payload: {
+    resourceType: string;
+    scimAttribute: string;
+    idenplaneAttribute: string;
+    direction?: string;
+  },
+): Promise<ScimAttributeMapping> {
+  const { data } = await apiClient.post<ScimAttributeMapping>(
+    `/realms/${realmName}/scim/attribute-mappings`,
+    payload,
+  );
+  return data;
+}
+
+export async function deleteScimAttributeMapping(
+  realmName: string,
+  mappingId: string,
+): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/scim/attribute-mappings/${mappingId}`);
+}
+
+export async function getScimStatus(realmName: string): Promise<ScimStatus> {
+  const { data } = await apiClient.get<ScimStatus>(
+    `/realms/${realmName}/scim/status`,
+  );
+  return data;
+}

--- a/admin-ui/src/api/serviceAccounts.ts
+++ b/admin-ui/src/api/serviceAccounts.ts
@@ -1,0 +1,102 @@
+import apiClient from './client';
+
+export interface ServiceAccount {
+  id: string;
+  realmId: string;
+  name: string;
+  description: string | null;
+  enabled: boolean;
+  allowedIps: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ApiKey {
+  id: string;
+  serviceAccountId: string;
+  name: string | null;
+  keyPrefix: string | null;
+  scopes: string[];
+  enabled: boolean;
+  revoked: boolean;
+  expiresAt: string | null;
+  maxRequestsPerDay: number | null;
+  maxRequestsPerMonth: number | null;
+  rateLimitPerMinute: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ApiKeyCreateResult extends ApiKey {
+  plainKey: string;
+}
+
+export interface CreateServiceAccountDto {
+  name: string;
+  description?: string;
+  allowedIps?: string[];
+}
+
+export interface UpdateServiceAccountDto {
+  name?: string;
+  description?: string;
+  allowedIps?: string[];
+  enabled?: boolean;
+}
+
+export interface CreateApiKeyDto {
+  name?: string;
+  scopes?: string[];
+  expiresAt?: string;
+  maxRequestsPerDay?: number;
+  maxRequestsPerMonth?: number;
+  rateLimitPerMinute?: number;
+}
+
+export async function getServiceAccounts(realmName: string): Promise<ServiceAccount[]> {
+  const { data } = await apiClient.get<ServiceAccount[]>(`/realms/${realmName}/service-accounts`);
+  return data;
+}
+
+export async function getServiceAccount(realmName: string, accountId: string): Promise<ServiceAccount> {
+  const { data } = await apiClient.get<ServiceAccount>(`/realms/${realmName}/service-accounts/${accountId}`);
+  return data;
+}
+
+export async function createServiceAccount(realmName: string, dto: CreateServiceAccountDto): Promise<ServiceAccount> {
+  const { data } = await apiClient.post<ServiceAccount>(`/realms/${realmName}/service-accounts`, dto);
+  return data;
+}
+
+export async function updateServiceAccount(realmName: string, accountId: string, dto: UpdateServiceAccountDto): Promise<ServiceAccount> {
+  const { data } = await apiClient.put<ServiceAccount>(`/realms/${realmName}/service-accounts/${accountId}`, dto);
+  return data;
+}
+
+export async function deleteServiceAccount(realmName: string, accountId: string): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/service-accounts/${accountId}`);
+}
+
+export async function getApiKeys(realmName: string, accountId: string): Promise<ApiKey[]> {
+  const { data } = await apiClient.get<ApiKey[]>(`/realms/${realmName}/service-accounts/${accountId}/api-keys`);
+  return data;
+}
+
+export async function createApiKey(realmName: string, accountId: string, dto: CreateApiKeyDto): Promise<ApiKeyCreateResult> {
+  const { data } = await apiClient.post<ApiKeyCreateResult>(
+    `/realms/${realmName}/service-accounts/${accountId}/api-keys`,
+    dto,
+  );
+  return data;
+}
+
+export async function revokeApiKey(realmName: string, accountId: string, keyId: string): Promise<void> {
+  await apiClient.post(`/realms/${realmName}/service-accounts/${accountId}/api-keys/${keyId}/revoke`);
+}
+
+export async function rotateApiKey(realmName: string, accountId: string, keyId: string): Promise<ApiKeyCreateResult> {
+  const { data } = await apiClient.post<ApiKeyCreateResult>(
+    `/realms/${realmName}/service-accounts/${accountId}/api-keys/${keyId}/rotate`,
+  );
+  return data;
+}

--- a/admin-ui/src/api/users.ts
+++ b/admin-ui/src/api/users.ts
@@ -111,3 +111,20 @@ export async function revokeOfflineSession(
     `/realms/${realmName}/users/${userId}/offline-sessions/${tokenId}`,
   );
 }
+
+export interface ImpersonationResult {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  expiresIn: number;
+}
+
+export async function impersonateUser(
+  realmName: string,
+  userId: string,
+): Promise<ImpersonationResult> {
+  const { data } = await apiClient.post<ImpersonationResult>(
+    `/realms/${realmName}/users/${userId}/impersonate`,
+  );
+  return data;
+}

--- a/admin-ui/src/api/webhooks.ts
+++ b/admin-ui/src/api/webhooks.ts
@@ -1,0 +1,74 @@
+import apiClient from './client';
+
+export interface Webhook {
+  id: string;
+  realmId: string;
+  url: string;
+  description: string | null;
+  enabled: boolean;
+  eventTypes: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WebhookDelivery {
+  id: string;
+  webhookId: string;
+  eventType: string;
+  statusCode: number | null;
+  success: boolean;
+  requestBody: unknown;
+  responseBody: string | null;
+  duration: number | null;
+  attempt: number;
+  createdAt: string;
+}
+
+export interface CreateWebhookDto {
+  url: string;
+  secret: string;
+  eventTypes: string[];
+  description?: string;
+  enabled?: boolean;
+}
+
+export interface UpdateWebhookDto {
+  url?: string;
+  secret?: string;
+  eventTypes?: string[];
+  description?: string;
+  enabled?: boolean;
+}
+
+export async function getWebhooks(realmName: string): Promise<Webhook[]> {
+  const { data } = await apiClient.get<Webhook[]>(`/realms/${realmName}/webhooks`);
+  return data;
+}
+
+export async function getWebhook(realmName: string, id: string): Promise<Webhook> {
+  const { data } = await apiClient.get<Webhook>(`/realms/${realmName}/webhooks/${id}`);
+  return data;
+}
+
+export async function createWebhook(realmName: string, dto: CreateWebhookDto): Promise<Webhook> {
+  const { data } = await apiClient.post<Webhook>(`/realms/${realmName}/webhooks`, dto);
+  return data;
+}
+
+export async function updateWebhook(realmName: string, id: string, dto: UpdateWebhookDto): Promise<Webhook> {
+  const { data } = await apiClient.put<Webhook>(`/realms/${realmName}/webhooks/${id}`, dto);
+  return data;
+}
+
+export async function deleteWebhook(realmName: string, id: string): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/webhooks/${id}`);
+}
+
+export async function testWebhook(realmName: string, id: string): Promise<void> {
+  await apiClient.post(`/realms/${realmName}/webhooks/${id}/test`);
+}
+
+export async function getWebhookDeliveries(realmName: string, id: string): Promise<WebhookDelivery[]> {
+  const { data } = await apiClient.get<WebhookDelivery[]>(`/realms/${realmName}/webhooks/${id}/deliveries`);
+  return data;
+}

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -56,12 +56,21 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/identity-providers`, label: 'Identity Providers', icon: Icons.Idp },
         { to: `/console/realms/${currentRealm}/saml-providers`, label: 'SAML Providers', icon: Icons.Globe },
         { to: `/console/realms/${currentRealm}/auth-flows`, label: 'Auth Flows', icon: Icons.Build },
+        { to: `/console/realms/${currentRealm}/risk-dashboard`, label: 'Risk Dashboard', icon: Icons.ShieldCheck },
+        { to: `/console/realms/${currentRealm}/risk-policies`, label: 'Risk Policies', icon: Icons.Roles },
+        { to: `/console/realms/${currentRealm}/webhooks`, label: 'Webhooks', icon: Icons.Globe },
+        { to: `/console/realms/${currentRealm}/service-accounts`, label: 'Service Accounts', icon: Icons.Clients },
+        { to: `/console/realms/${currentRealm}/organizations`, label: 'Organizations', icon: Icons.Groups },
+        { to: `/console/realms/${currentRealm}/custom-attributes`, label: 'Custom Attributes', icon: Icons.Code },
+        { to: `/console/realms/${currentRealm}/scim`, label: 'SCIM', icon: Icons.Database },
+        { to: `/console/realms/${currentRealm}/authorization-policies`, label: 'Authorization', icon: Icons.Roles },
       ]
     : [];
 
   const globalNav: NavItem[] = [
     { to: '/console', label: 'Dashboard', icon: Icons.Dashboard, end: true },
     { to: '/console/realms', label: 'Realms', icon: Icons.Realms, end: false },
+    { to: '/console/plugins', label: 'Plugins', icon: Icons.Zap, end: false },
   ];
 
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>

--- a/admin-ui/src/pages/authorization/PolicyCreatePage.tsx
+++ b/admin-ui/src/pages/authorization/PolicyCreatePage.tsx
@@ -1,0 +1,173 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createPolicy } from '../../api/authorization';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+export default function PolicyCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    effect: 'allow' as 'allow' | 'deny',
+    conditions: '{}',
+    enabled: true,
+  });
+  const [conditionsError, setConditionsError] = useState('');
+
+  const createMutation = useMutation({
+    mutationFn: () => {
+      const parsed = JSON.parse(form.conditions);
+      return createPolicy(name!, {
+        name: form.name,
+        description: form.description || undefined,
+        effect: form.effect,
+        conditions: parsed,
+        enabled: form.enabled,
+      });
+    },
+    onSuccess: (policy) => {
+      queryClient.invalidateQueries({ queryKey: ['policies', name] });
+      navigate(`/console/realms/${name}/authorization-policies/${policy.id}`);
+    },
+  });
+
+  function validateConditions(value: string): boolean {
+    try {
+      JSON.parse(value);
+      setConditionsError('');
+      return true;
+    } catch {
+      setConditionsError('Invalid JSON — please fix before saving.');
+      return false;
+    }
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!validateConditions(form.conditions)) return;
+    createMutation.mutate();
+  }
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Create Policy</h1>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+      >
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="policy-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name</label>
+            <input
+              id="policy-name"
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="e.g. require-mfa-for-admin"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="policy-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="policy-description"
+              type="text"
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-2 text-sm font-medium text-gray-700">Effect</p>
+          <div className="flex gap-6">
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="effect"
+                value="allow"
+                checked={form.effect === 'allow'}
+                onChange={() => setForm({ ...form, effect: 'allow' })}
+                className="text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Allow</span>
+            </label>
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="effect"
+                value="deny"
+                checked={form.effect === 'deny'}
+                onChange={() => setForm({ ...form, effect: 'deny' })}
+                className="text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">Deny</span>
+            </label>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="policy-conditions" className="mb-1.5 block text-sm font-medium text-gray-700">
+            Conditions (JSON)
+          </label>
+          <textarea
+            id="policy-conditions"
+            rows={8}
+            value={form.conditions}
+            onChange={(e) => {
+              setForm({ ...form, conditions: e.target.value });
+              if (conditionsError) validateConditions(e.target.value);
+            }}
+            onBlur={(e) => validateConditions(e.target.value)}
+            className={`w-full rounded-md border px-3 py-2 font-mono text-sm shadow-sm focus:ring-1 focus:outline-none ${conditionsError ? 'border-red-400 focus:border-red-400 focus:ring-red-400' : 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500'}`}
+          />
+          {conditionsError && (
+            <p className="mt-1 text-xs text-red-600">{conditionsError}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={form.enabled}
+              onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            Enabled
+          </label>
+        </div>
+
+        {createMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {getErrorMessage(createMutation.error, 'Failed to create policy.')}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(`/console/realms/${name}/authorization-policies`)}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={createMutation.isPending || !!conditionsError}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {createMutation.isPending ? 'Creating...' : 'Create Policy'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/authorization/PolicyDetailPage.tsx
+++ b/admin-ui/src/pages/authorization/PolicyDetailPage.tsx
@@ -1,0 +1,310 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getPolicy, updatePolicy, deletePolicy, testPolicy } from '../../api/authorization';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+export default function PolicyDetailPage() {
+  const { name, policyId } = useParams<{ name: string; policyId: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [showDelete, setShowDelete] = useState(false);
+  const [conditionsError, setConditionsError] = useState('');
+  const [testInput, setTestInput] = useState('{}');
+  const [testInputError, setTestInputError] = useState('');
+  const [testResult, setTestResult] = useState<unknown>(null);
+
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    effect: 'allow' as 'allow' | 'deny',
+    conditions: '{}',
+    enabled: true,
+  });
+
+  const { data: policy, isLoading } = useQuery({
+    queryKey: ['policy', name, policyId],
+    queryFn: () => getPolicy(name!, policyId!),
+    enabled: !!name && !!policyId,
+  });
+
+  const [seededPolicy, setSeededPolicy] = useState(policy);
+  if (policy && policy !== seededPolicy) {
+    setSeededPolicy(policy);
+    setForm({
+      name: policy.name,
+      description: policy.description ?? '',
+      effect: policy.effect,
+      conditions: JSON.stringify(policy.conditions, null, 2),
+      enabled: policy.enabled,
+    });
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: () => {
+      const parsed = JSON.parse(form.conditions);
+      return updatePolicy(name!, policyId!, {
+        name: form.name,
+        description: form.description || undefined,
+        effect: form.effect,
+        conditions: parsed,
+        enabled: form.enabled,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['policy', name, policyId] });
+      queryClient.invalidateQueries({ queryKey: ['policies', name] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deletePolicy(name!, policyId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['policies', name] });
+      navigate(`/console/realms/${name}/authorization-policies`);
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationFn: () => {
+      const ctx = JSON.parse(testInput);
+      return testPolicy(name!, policyId!, ctx);
+    },
+    onSuccess: (result) => setTestResult(result),
+  });
+
+  function validateConditions(value: string): boolean {
+    try {
+      JSON.parse(value);
+      setConditionsError('');
+      return true;
+    } catch {
+      setConditionsError('Invalid JSON — please fix before saving.');
+      return false;
+    }
+  }
+
+  function validateTestInput(value: string): boolean {
+    try {
+      JSON.parse(value);
+      setTestInputError('');
+      return true;
+    } catch {
+      setTestInputError('Invalid JSON context.');
+      return false;
+    }
+  }
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!validateConditions(form.conditions)) return;
+    updateMutation.mutate();
+  }
+
+  function handleRunTest(e: FormEvent) {
+    e.preventDefault();
+    if (!validateTestInput(testInput)) return;
+    testMutation.mutate();
+  }
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading policy...</div>;
+  }
+
+  if (!policy) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">Policy not found.</div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">{policy.name}</h1>
+        <button
+          onClick={() => setShowDelete(true)}
+          className="rounded-md border border-red-300 bg-white px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50"
+        >
+          Delete Policy
+        </button>
+      </div>
+
+      {/* Edit form */}
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+      >
+        <h2 className="text-lg font-semibold text-gray-900">Policy Settings</h2>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="policy-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name</label>
+            <input
+              id="policy-name"
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="policy-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="policy-description"
+              type="text"
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <div>
+          <p className="mb-2 text-sm font-medium text-gray-700">Effect</p>
+          <div className="flex gap-6">
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="effect"
+                value="allow"
+                checked={form.effect === 'allow'}
+                onChange={() => setForm({ ...form, effect: 'allow' })}
+                className="text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Allow</span>
+            </label>
+            <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+              <input
+                type="radio"
+                name="effect"
+                value="deny"
+                checked={form.effect === 'deny'}
+                onChange={() => setForm({ ...form, effect: 'deny' })}
+                className="text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">Deny</span>
+            </label>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="policy-conditions" className="mb-1.5 block text-sm font-medium text-gray-700">
+            Conditions (JSON)
+          </label>
+          <textarea
+            id="policy-conditions"
+            rows={8}
+            value={form.conditions}
+            onChange={(e) => {
+              setForm({ ...form, conditions: e.target.value });
+              if (conditionsError) validateConditions(e.target.value);
+            }}
+            onBlur={(e) => validateConditions(e.target.value)}
+            className={`w-full rounded-md border px-3 py-2 font-mono text-sm shadow-sm focus:ring-1 focus:outline-none ${conditionsError ? 'border-red-400 focus:border-red-400 focus:ring-red-400' : 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500'}`}
+          />
+          {conditionsError && (
+            <p className="mt-1 text-xs text-red-600">{conditionsError}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={form.enabled}
+              onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            Enabled
+          </label>
+        </div>
+
+        {updateMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {getErrorMessage(updateMutation.error, 'Failed to update policy.')}
+          </div>
+        )}
+
+        {updateMutation.isSuccess && (
+          <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
+            Policy updated successfully.
+          </div>
+        )}
+
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={updateMutation.isPending || !!conditionsError}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+
+      {/* Test Policy section */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm space-y-4">
+        <h2 className="text-lg font-semibold text-gray-900">Test Policy</h2>
+        <p className="text-sm text-gray-500">
+          Provide an evaluation context as JSON to test how this policy responds.
+        </p>
+
+        <form onSubmit={handleRunTest} className="space-y-4">
+          <div>
+            <label htmlFor="test-context" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Context (JSON)
+            </label>
+            <textarea
+              id="test-context"
+              rows={6}
+              value={testInput}
+              onChange={(e) => {
+                setTestInput(e.target.value);
+                if (testInputError) validateTestInput(e.target.value);
+              }}
+              onBlur={(e) => validateTestInput(e.target.value)}
+              className={`w-full rounded-md border px-3 py-2 font-mono text-sm shadow-sm focus:ring-1 focus:outline-none ${testInputError ? 'border-red-400 focus:border-red-400 focus:ring-red-400' : 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500'}`}
+            />
+            {testInputError && (
+              <p className="mt-1 text-xs text-red-600">{testInputError}</p>
+            )}
+          </div>
+
+          {testMutation.isError && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+              {getErrorMessage(testMutation.error, 'Test evaluation failed.')}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={testMutation.isPending || !!testInputError}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {testMutation.isPending ? 'Running...' : 'Run Test'}
+          </button>
+        </form>
+
+        {testResult !== null && (
+          <div className="rounded-md bg-gray-50 border border-gray-200 p-4">
+            <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-500">Result</p>
+            <pre className="overflow-auto font-mono text-sm text-gray-800">
+              {JSON.stringify(testResult, null, 2)}
+            </pre>
+          </div>
+        )}
+      </section>
+
+      <ConfirmDialog
+        isOpen={showDelete}
+        title="Delete Policy"
+        message={`Are you sure you want to delete the policy "${policy.name}"? This action cannot be undone.`}
+        onConfirm={() => deleteMutation.mutate()}
+        onCancel={() => setShowDelete(false)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/authorization/PolicyListPage.tsx
+++ b/admin-ui/src/pages/authorization/PolicyListPage.tsx
@@ -1,0 +1,104 @@
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getPolicies } from '../../api/authorization';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+export default function PolicyListPage() {
+  const { name } = useParams<{ name: string }>();
+
+  const { data: policies, isLoading, error } = useQuery({
+    queryKey: ['policies', name],
+    queryFn: () => getPolicies(name!),
+    enabled: !!name,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Authorization Policies</h1>
+        <Link
+          to={`/console/realms/${name}/authorization-policies/new`}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Create Policy
+        </Link>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          {getErrorMessage(error, 'Failed to load policies.')}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-gray-500">Loading policies...</div>
+      ) : !policies || policies.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No authorization policies defined for this realm.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Effect</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Conditions</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {policies.map((policy) => {
+                const conditionsSnippet = JSON.stringify(policy.conditions);
+                return (
+                  <tr key={policy.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <Link
+                        to={`/console/realms/${name}/authorization-policies/${policy.id}`}
+                        className="font-medium text-indigo-600 hover:text-indigo-900"
+                      >
+                        {policy.name}
+                      </Link>
+                      {policy.description && (
+                        <p className="mt-0.5 text-xs text-gray-500">{policy.description}</p>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          policy.effect === 'allow'
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-red-100 text-red-700'
+                        }`}
+                      >
+                        {policy.effect}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500">
+                      <code className="block max-w-xs truncate font-mono text-xs">
+                        {conditionsSnippet.length > 80
+                          ? conditionsSnippet.slice(0, 80) + '…'
+                          : conditionsSnippet}
+                      </code>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          policy.enabled
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {policy.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/custom-attributes/CustomAttributesPage.tsx
+++ b/admin-ui/src/pages/custom-attributes/CustomAttributesPage.tsx
@@ -1,0 +1,499 @@
+import { useState, type FormEvent } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getCustomAttributes,
+  createCustomAttribute,
+  updateCustomAttribute,
+  deleteCustomAttribute,
+} from '../../api/customAttributes';
+import type { CustomAttribute, AttributeType } from '../../api/customAttributes';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+const ATTRIBUTE_TYPES: AttributeType[] = ['text', 'number', 'boolean', 'select', 'multi-select'];
+
+const NEEDS_OPTIONS: AttributeType[] = ['select', 'multi-select'];
+const NEEDS_LENGTH: AttributeType[] = ['text'];
+const NEEDS_RANGE: AttributeType[] = ['number'];
+
+interface FormState {
+  name: string;
+  displayName: string;
+  type: AttributeType;
+  required: boolean;
+  showOnRegistration: boolean;
+  showOnProfile: boolean;
+  options: string;
+  minLength: string;
+  maxLength: string;
+  min: string;
+  max: string;
+}
+
+const emptyForm: FormState = {
+  name: '',
+  displayName: '',
+  type: 'text',
+  required: false,
+  showOnRegistration: false,
+  showOnProfile: false,
+  options: '',
+  minLength: '',
+  maxLength: '',
+  min: '',
+  max: '',
+};
+
+function attributeToForm(attr: CustomAttribute): FormState {
+  return {
+    name: attr.name,
+    displayName: attr.displayName,
+    type: attr.type,
+    required: attr.required,
+    showOnRegistration: attr.showOnRegistration,
+    showOnProfile: attr.showOnProfile,
+    options: attr.options.join(', '),
+    minLength: attr.minLength !== null ? String(attr.minLength) : '',
+    maxLength: attr.maxLength !== null ? String(attr.maxLength) : '',
+    min: attr.min !== null ? String(attr.min) : '',
+    max: attr.max !== null ? String(attr.max) : '',
+  };
+}
+
+function formToPayload(form: FormState): Partial<CustomAttribute> {
+  return {
+    name: form.name,
+    displayName: form.displayName,
+    type: form.type,
+    required: form.required,
+    showOnRegistration: form.showOnRegistration,
+    showOnProfile: form.showOnProfile,
+    options: NEEDS_OPTIONS.includes(form.type)
+      ? form.options.split(',').map((s) => s.trim()).filter(Boolean)
+      : [],
+    minLength:
+      NEEDS_LENGTH.includes(form.type) && form.minLength !== ''
+        ? Number(form.minLength)
+        : null,
+    maxLength:
+      NEEDS_LENGTH.includes(form.type) && form.maxLength !== ''
+        ? Number(form.maxLength)
+        : null,
+    min:
+      NEEDS_RANGE.includes(form.type) && form.min !== ''
+        ? Number(form.min)
+        : null,
+    max:
+      NEEDS_RANGE.includes(form.type) && form.max !== ''
+        ? Number(form.max)
+        : null,
+  };
+}
+
+function AttributeForm({
+  form,
+  onChange,
+  editingName,
+  onSubmit,
+  onCancel,
+  isPending,
+  error,
+}: {
+  form: FormState;
+  onChange: (f: FormState) => void;
+  editingName: boolean;
+  onSubmit: (e: FormEvent) => void;
+  onCancel: () => void;
+  isPending: boolean;
+  error: unknown;
+}) {
+  const set = (patch: Partial<FormState>) => onChange({ ...form, ...patch });
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="mb-6 space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      <h2 className="text-lg font-semibold text-gray-900">
+        {editingName ? 'Edit Attribute' : 'New Attribute'}
+      </h2>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <label htmlFor="attr-name" className="mb-1.5 block text-sm font-medium text-gray-700">
+            Name
+          </label>
+          <input
+            id="attr-name"
+            type="text"
+            required
+            readOnly={editingName}
+            value={form.name}
+            onChange={(e) => set({ name: e.target.value })}
+            placeholder="e.g. department"
+            className={`w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none ${editingName ? 'bg-gray-50 text-gray-500' : ''}`}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="attr-display-name" className="mb-1.5 block text-sm font-medium text-gray-700">
+            Display Name
+          </label>
+          <input
+            id="attr-display-name"
+            type="text"
+            required
+            value={form.displayName}
+            onChange={(e) => set({ displayName: e.target.value })}
+            placeholder="e.g. Department"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+          />
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="attr-type" className="mb-1.5 block text-sm font-medium text-gray-700">
+          Type
+        </label>
+        <select
+          id="attr-type"
+          value={form.type}
+          onChange={(e) => set({ type: e.target.value as AttributeType })}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+        >
+          {ATTRIBUTE_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {NEEDS_OPTIONS.includes(form.type) && (
+        <div>
+          <label htmlFor="attr-options" className="mb-1.5 block text-sm font-medium text-gray-700">
+            Options (comma-separated)
+          </label>
+          <textarea
+            id="attr-options"
+            rows={2}
+            value={form.options}
+            onChange={(e) => set({ options: e.target.value })}
+            placeholder="e.g. Engineering, Marketing, Sales"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+          />
+        </div>
+      )}
+
+      {NEEDS_LENGTH.includes(form.type) && (
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="attr-min-length" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Min Length
+            </label>
+            <input
+              id="attr-min-length"
+              type="number"
+              min={0}
+              value={form.minLength}
+              onChange={(e) => set({ minLength: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="attr-max-length" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Max Length
+            </label>
+            <input
+              id="attr-max-length"
+              type="number"
+              min={0}
+              value={form.maxLength}
+              onChange={(e) => set({ maxLength: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+      )}
+
+      {NEEDS_RANGE.includes(form.type) && (
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="attr-min" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Min
+            </label>
+            <input
+              id="attr-min"
+              type="number"
+              value={form.min}
+              onChange={(e) => set({ min: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="attr-max" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Max
+            </label>
+            <input
+              id="attr-max"
+              type="number"
+              value={form.max}
+              onChange={(e) => set({ max: e.target.value })}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-6">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={form.required}
+            onChange={(e) => set({ required: e.target.checked })}
+            className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+          />
+          Required
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={form.showOnRegistration}
+            onChange={(e) => set({ showOnRegistration: e.target.checked })}
+            className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+          />
+          Show on Registration
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={form.showOnProfile}
+            onChange={(e) => set({ showOnProfile: e.target.checked })}
+            className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+          />
+          Show on Profile
+        </label>
+      </div>
+
+      {error && (
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {getErrorMessage(error, 'Failed to save attribute.')}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+        >
+          {isPending ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default function CustomAttributesPage() {
+  const { name } = useParams<{ name: string }>();
+  const queryClient = useQueryClient();
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createForm, setCreateForm] = useState<FormState>(emptyForm);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState<FormState>(emptyForm);
+
+  const [deleteTarget, setDeleteTarget] = useState<CustomAttribute | null>(null);
+
+  const { data: attributes, isLoading, error } = useQuery({
+    queryKey: ['custom-attributes', name],
+    queryFn: () => getCustomAttributes(name!),
+    enabled: !!name,
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => createCustomAttribute(name!, formToPayload(createForm)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['custom-attributes', name] });
+      setCreateForm(emptyForm);
+      setShowCreate(false);
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: () => updateCustomAttribute(name!, editingId!, formToPayload(editForm)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['custom-attributes', name] });
+      setEditingId(null);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteCustomAttribute(name!, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['custom-attributes', name] });
+      setDeleteTarget(null);
+    },
+  });
+
+  function startEdit(attr: CustomAttribute) {
+    setShowCreate(false);
+    setEditingId(attr.id);
+    setEditForm(attributeToForm(attr));
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+  }
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading custom attributes...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        {getErrorMessage(error, 'Failed to load custom attributes.')}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Custom Attributes</h1>
+        <button
+          onClick={() => {
+            setEditingId(null);
+            setCreateForm(emptyForm);
+            setShowCreate(true);
+          }}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Add Attribute
+        </button>
+      </div>
+
+      {showCreate && (
+        <AttributeForm
+          form={createForm}
+          onChange={setCreateForm}
+          editingName={false}
+          onSubmit={(e) => { e.preventDefault(); createMutation.mutate(); }}
+          onCancel={() => { setShowCreate(false); setCreateForm(emptyForm); }}
+          isPending={createMutation.isPending}
+          error={createMutation.isError ? createMutation.error : null}
+        />
+      )}
+
+      {editingId && (
+        <AttributeForm
+          form={editForm}
+          onChange={setEditForm}
+          editingName={true}
+          onSubmit={(e) => { e.preventDefault(); updateMutation.mutate(); }}
+          onCancel={cancelEdit}
+          isPending={updateMutation.isPending}
+          error={updateMutation.isError ? updateMutation.error : null}
+        />
+      )}
+
+      {!attributes || attributes.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No custom attributes defined for this realm.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Display Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Required</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Registration</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Profile</th>
+                <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {attributes.map((attr) => (
+                <tr key={attr.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-800">
+                      {attr.name}
+                    </code>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-700">{attr.displayName}</td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                      {attr.type}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    {attr.required ? (
+                      <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Yes</span>
+                    ) : (
+                      <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">No</span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    {attr.showOnRegistration ? (
+                      <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Yes</span>
+                    ) : (
+                      <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">No</span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    {attr.showOnProfile ? (
+                      <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">Yes</span>
+                    ) : (
+                      <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">No</span>
+                    )}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right">
+                    <button
+                      onClick={() => startEdit(attr)}
+                      className="mr-4 text-sm font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => setDeleteTarget(attr)}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {deleteMutation.isError && (
+        <div className="mt-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {getErrorMessage(deleteMutation.error, 'Failed to delete attribute.')}
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Delete Custom Attribute"
+        message={`Are you sure you want to delete "${deleteTarget?.displayName}"? This will remove the attribute definition from the realm.`}
+        onConfirm={() => deleteTarget && deleteMutation.mutate(deleteTarget.id)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/organizations/OrganizationCreatePage.tsx
+++ b/admin-ui/src/pages/organizations/OrganizationCreatePage.tsx
@@ -1,0 +1,191 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createOrganization } from '../../api/organizations';
+
+export default function OrganizationCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    slug: '',
+    name: '',
+    displayName: '',
+    description: '',
+    logoUrl: '',
+    primaryColor: '#6366f1',
+    requireMfa: false,
+    enabled: true,
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createOrganization(name!, {
+        slug: form.slug,
+        name: form.name,
+        displayName: form.displayName || undefined,
+        description: form.description || undefined,
+        logoUrl: form.logoUrl || undefined,
+        primaryColor: form.primaryColor || undefined,
+        requireMfa: form.requireMfa,
+        enabled: form.enabled,
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['organizations', name] });
+      navigate(`/console/realms/${name}/organizations/${result.slug}`);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    mutation.mutate();
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Create Organization</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-gray-900">General</h2>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="field-org-slug" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Slug *
+              </label>
+              <input
+                id="field-org-slug"
+                type="text"
+                required
+                pattern="^[a-z0-9-]+$"
+                title="Lowercase letters, numbers, hyphens"
+                placeholder="my-org"
+                value={form.slug}
+                onChange={(e) => set('slug', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+              <p className="mt-1 text-xs text-gray-500">Lowercase letters, numbers, hyphens</p>
+            </div>
+            <div>
+              <label htmlFor="field-org-name" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Name *
+              </label>
+              <input
+                id="field-org-name"
+                type="text"
+                required
+                value={form.name}
+                onChange={(e) => set('name', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="field-org-displayName" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Display Name
+              </label>
+              <input
+                id="field-org-displayName"
+                type="text"
+                value={form.displayName}
+                onChange={(e) => set('displayName', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="field-org-logoUrl" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Logo URL
+              </label>
+              <input
+                id="field-org-logoUrl"
+                type="url"
+                value={form.logoUrl}
+                onChange={(e) => set('logoUrl', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="field-org-description" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Description
+            </label>
+            <textarea
+              id="field-org-description"
+              rows={3}
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="field-org-primaryColor" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Primary Color
+              </label>
+              <input
+                id="field-org-primaryColor"
+                type="color"
+                value={form.primaryColor}
+                onChange={(e) => set('primaryColor', e.target.value)}
+                className="h-10 w-full cursor-pointer rounded-md border border-gray-300 px-1 py-1"
+              />
+            </div>
+            <div className="space-y-3 pt-6">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="field-org-requireMfa"
+                  checked={form.requireMfa}
+                  onChange={(e) => set('requireMfa', e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="text-sm font-medium text-gray-700">Require MFA</span>
+              </label>
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="field-org-enabled"
+                  checked={form.enabled}
+                  onChange={(e) => set('enabled', e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="text-sm font-medium text-gray-700">Enabled</span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        {mutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {(mutation.error as Error)?.message || 'Failed to create organization.'}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+          <Link
+            to={`/console/realms/${name}/organizations`}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating...' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/organizations/OrganizationDetailPage.tsx
+++ b/admin-ui/src/pages/organizations/OrganizationDetailPage.tsx
@@ -1,0 +1,565 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getOrganization,
+  updateOrganization,
+  deleteOrganization,
+  getOrgMembers,
+  addOrgMember,
+  updateOrgMember,
+  removeOrgMember,
+  getOrgInvitations,
+  createOrgInvitation,
+} from '../../api/organizations';
+import type { OrgMember } from '../../api/organizations';
+import ConfirmDialog from '../../components/ConfirmDialog';
+
+type OrgRole = 'owner' | 'admin' | 'member';
+
+function RoleBadge({ role }: { role: OrgRole }) {
+  const classes: Record<OrgRole, string> = {
+    owner: 'bg-purple-100 text-purple-700',
+    admin: 'bg-blue-100 text-blue-700',
+    member: 'bg-gray-100 text-gray-700',
+  };
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${classes[role]}`}>
+      {role.charAt(0).toUpperCase() + role.slice(1)}
+    </span>
+  );
+}
+
+const INPUT_CLS =
+  'w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none';
+
+const ROLE_SELECT_CLS =
+  'rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none';
+
+export default function OrganizationDetailPage() {
+  const { name, slug } = useParams<{ name: string; slug: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [showDelete, setShowDelete] = useState(false);
+  const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
+  const [pendingRoles, setPendingRoles] = useState<Record<string, OrgRole>>({});
+  const [addForm, setAddForm] = useState({ userId: '', role: 'member' as OrgRole });
+  const [inviteForm, setInviteForm] = useState({ email: '', role: 'member' as OrgRole });
+
+  const { data: org, isLoading } = useQuery({
+    queryKey: ['organization', name, slug],
+    queryFn: () => getOrganization(name!, slug!),
+    enabled: !!name && !!slug,
+  });
+
+  const { data: members } = useQuery({
+    queryKey: ['org-members', name, slug],
+    queryFn: () => getOrgMembers(name!, slug!),
+    enabled: !!name && !!slug,
+  });
+
+  const { data: invitations } = useQuery({
+    queryKey: ['org-invitations', name, slug],
+    queryFn: () => getOrgInvitations(name!, slug!),
+    enabled: !!name && !!slug,
+  });
+
+  const [form, setForm] = useState({
+    name: '',
+    displayName: '',
+    description: '',
+    logoUrl: '',
+    primaryColor: '#6366f1',
+    requireMfa: false,
+    enabled: true,
+  });
+
+  const [seededOrg, setSeededOrg] = useState(org);
+  if (org && org !== seededOrg) {
+    setSeededOrg(org);
+    setForm({
+      name: org.name,
+      displayName: org.displayName ?? '',
+      description: org.description ?? '',
+      logoUrl: org.logoUrl ?? '',
+      primaryColor: org.primaryColor ?? '#6366f1',
+      requireMfa: org.requireMfa,
+      enabled: org.enabled,
+    });
+  }
+
+  const [seededMembers, setSeededMembers] = useState<OrgMember[] | undefined>(members);
+  if (members && members !== seededMembers) {
+    setSeededMembers(members);
+    const roles: Record<string, OrgRole> = {};
+    for (const m of members) {
+      roles[m.userId] = m.role;
+    }
+    setPendingRoles(roles);
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      updateOrganization(name!, slug!, {
+        name: form.name,
+        displayName: form.displayName || undefined,
+        description: form.description || undefined,
+        logoUrl: form.logoUrl || undefined,
+        primaryColor: form.primaryColor || undefined,
+        requireMfa: form.requireMfa,
+        enabled: form.enabled,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['organization', name, slug] });
+      queryClient.invalidateQueries({ queryKey: ['organizations', name] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteOrganization(name!, slug!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['organizations', name] });
+      navigate(`/console/realms/${name}/organizations`);
+    },
+  });
+
+  const addMemberMutation = useMutation({
+    mutationFn: () =>
+      addOrgMember(name!, slug!, { userId: addForm.userId, role: addForm.role }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-members', name, slug] });
+      setAddForm({ userId: '', role: 'member' });
+    },
+  });
+
+  const updateMemberMutation = useMutation({
+    mutationFn: ({ userId, role }: { userId: string; role: OrgRole }) =>
+      updateOrgMember(name!, slug!, userId, { role }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-members', name, slug] });
+    },
+  });
+
+  const removeMemberMutation = useMutation({
+    mutationFn: (userId: string) => removeOrgMember(name!, slug!, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-members', name, slug] });
+      setRemovingMemberId(null);
+    },
+  });
+
+  const inviteMutation = useMutation({
+    mutationFn: () =>
+      createOrgInvitation(name!, slug!, { email: inviteForm.email, role: inviteForm.role }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['org-invitations', name, slug] });
+      setInviteForm({ email: '', role: 'member' });
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    updateMutation.mutate();
+  }
+
+  function handleAddMember(e: FormEvent) {
+    e.preventDefault();
+    addMemberMutation.mutate();
+  }
+
+  function handleInvite(e: FormEvent) {
+    e.preventDefault();
+    inviteMutation.mutate();
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading organization...</div>;
+  }
+
+  if (!org) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        Organization not found.
+      </div>
+    );
+  }
+
+  const memberToRemove = members?.find((m) => m.userId === removingMemberId);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{org.name}</h1>
+          {org.displayName && (
+            <p className="mt-1 text-sm text-gray-500">{org.displayName}</p>
+          )}
+        </div>
+        <button
+          onClick={() => setShowDelete(true)}
+          className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+        >
+          Delete
+        </button>
+      </div>
+
+      {/* Settings */}
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-900">Settings</h2>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="field-org-slug" className="mb-1.5 block text-sm font-medium text-gray-700">Slug</label>
+            <input
+              id="field-org-slug"
+              type="text"
+              value={org.slug}
+              disabled
+              className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="field-org-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name *</label>
+            <input
+              id="field-org-name"
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              className={INPUT_CLS}
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="field-org-displayName" className="mb-1.5 block text-sm font-medium text-gray-700">Display Name</label>
+            <input
+              id="field-org-displayName"
+              type="text"
+              value={form.displayName}
+              onChange={(e) => set('displayName', e.target.value)}
+              className={INPUT_CLS}
+            />
+          </div>
+          <div>
+            <label htmlFor="field-org-logoUrl" className="mb-1.5 block text-sm font-medium text-gray-700">Logo URL</label>
+            <input
+              id="field-org-logoUrl"
+              type="url"
+              value={form.logoUrl}
+              onChange={(e) => set('logoUrl', e.target.value)}
+              className={INPUT_CLS}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="field-org-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+          <textarea
+            id="field-org-description"
+            rows={3}
+            value={form.description}
+            onChange={(e) => set('description', e.target.value)}
+            className={INPUT_CLS}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="field-org-primaryColor" className="mb-1.5 block text-sm font-medium text-gray-700">Primary Color</label>
+            <input
+              id="field-org-primaryColor"
+              type="color"
+              value={form.primaryColor}
+              onChange={(e) => set('primaryColor', e.target.value)}
+              className="h-10 w-full cursor-pointer rounded-md border border-gray-300 px-1 py-1"
+            />
+          </div>
+          <div className="space-y-3 pt-6">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="field-org-requireMfa"
+                checked={form.requireMfa}
+                onChange={(e) => set('requireMfa', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm font-medium text-gray-700">Require MFA</span>
+            </label>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="field-org-enabled"
+                checked={form.enabled}
+                onChange={(e) => set('enabled', e.target.checked)}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <span className="text-sm font-medium text-gray-700">Enabled</span>
+            </label>
+          </div>
+        </div>
+
+        {updateMutation.isSuccess && (
+          <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
+            Organization updated successfully.
+          </div>
+        )}
+        {updateMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            Failed to update organization.
+          </div>
+        )}
+
+        <div className="flex justify-end border-t border-gray-200 pt-4">
+          <button
+            type="submit"
+            disabled={updateMutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+
+      {/* Members */}
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900">Members</h2>
+        </div>
+
+        {members && members.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Username</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Email</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Role</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {members.map((member) => (
+                  <tr key={member.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                      {member.user?.username ?? member.userId}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {member.user?.email ?? '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <RoleBadge role={member.role} />
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <div className="flex items-center gap-2">
+                        <select
+                          value={pendingRoles[member.userId] ?? member.role}
+                          onChange={(e) =>
+                            setPendingRoles((r) => ({
+                              ...r,
+                              [member.userId]: e.target.value as OrgRole,
+                            }))
+                          }
+                          className={ROLE_SELECT_CLS}
+                        >
+                          <option value="member">Member</option>
+                          <option value="admin">Admin</option>
+                          <option value="owner">Owner</option>
+                        </select>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            updateMemberMutation.mutate({
+                              userId: member.userId,
+                              role: pendingRoles[member.userId] ?? member.role,
+                            })
+                          }
+                          disabled={updateMemberMutation.isPending}
+                          className="rounded-md bg-indigo-600 px-2 py-1 text-xs font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+                        >
+                          Update
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setRemovingMemberId(member.userId)}
+                          className="rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="px-6 py-8 text-center text-sm text-gray-500">No members yet.</div>
+        )}
+
+        <div className="border-t border-gray-200 px-6 py-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">Add Member</h3>
+          <form onSubmit={handleAddMember} className="flex items-end gap-3">
+            <div className="flex-1">
+              <label htmlFor="field-add-userId" className="mb-1 block text-xs font-medium text-gray-600">
+                User ID
+              </label>
+              <input
+                id="field-add-userId"
+                type="text"
+                required
+                value={addForm.userId}
+                onChange={(e) => setAddForm((f) => ({ ...f, userId: e.target.value }))}
+                className={INPUT_CLS}
+              />
+            </div>
+            <div>
+              <label htmlFor="field-add-role" className="mb-1 block text-xs font-medium text-gray-600">
+                Role
+              </label>
+              <select
+                id="field-add-role"
+                value={addForm.role}
+                onChange={(e) => setAddForm((f) => ({ ...f, role: e.target.value as OrgRole }))}
+                className={ROLE_SELECT_CLS}
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+                <option value="owner">Owner</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              disabled={addMemberMutation.isPending}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {addMemberMutation.isPending ? 'Adding...' : 'Add'}
+            </button>
+          </form>
+          {addMemberMutation.isError && (
+            <div className="mt-2 rounded-md bg-red-50 p-2 text-xs text-red-700">
+              Failed to add member.
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Invitations */}
+      <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
+        <div className="border-b border-gray-200 px-6 py-4">
+          <h2 className="text-lg font-semibold text-gray-900">Invitations</h2>
+        </div>
+
+        {invitations && invitations.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Email</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Role</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Created</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {invitations.map((inv) => (
+                  <tr key={inv.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-900">{inv.email}</td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <RoleBadge role={inv.role} />
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      {inv.acceptedAt ? (
+                        <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                          Accepted
+                        </span>
+                      ) : (
+                        <span className="inline-flex rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-700">
+                          Pending
+                        </span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {new Date(inv.createdAt).toLocaleDateString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="px-6 py-8 text-center text-sm text-gray-500">No invitations yet.</div>
+        )}
+
+        <div className="border-t border-gray-200 px-6 py-4">
+          <h3 className="mb-3 text-sm font-semibold text-gray-700">Invite User</h3>
+          <form onSubmit={handleInvite} className="flex items-end gap-3">
+            <div className="flex-1">
+              <label htmlFor="field-invite-email" className="mb-1 block text-xs font-medium text-gray-600">
+                Email
+              </label>
+              <input
+                id="field-invite-email"
+                type="email"
+                required
+                value={inviteForm.email}
+                onChange={(e) => setInviteForm((f) => ({ ...f, email: e.target.value }))}
+                className={INPUT_CLS}
+              />
+            </div>
+            <div>
+              <label htmlFor="field-invite-role" className="mb-1 block text-xs font-medium text-gray-600">
+                Role
+              </label>
+              <select
+                id="field-invite-role"
+                value={inviteForm.role}
+                onChange={(e) => setInviteForm((f) => ({ ...f, role: e.target.value as OrgRole }))}
+                className={ROLE_SELECT_CLS}
+              >
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+                <option value="owner">Owner</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              disabled={inviteMutation.isPending}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {inviteMutation.isPending ? 'Sending...' : 'Send'}
+            </button>
+          </form>
+          {inviteMutation.isError && (
+            <div className="mt-2 rounded-md bg-red-50 p-2 text-xs text-red-700">
+              Failed to send invitation.
+            </div>
+          )}
+        </div>
+      </div>
+
+      <ConfirmDialog
+        isOpen={showDelete}
+        title="Delete Organization"
+        message={`Are you sure you want to delete organization "${org.name}"? This action cannot be undone.`}
+        onConfirm={() => deleteMutation.mutate()}
+        onCancel={() => setShowDelete(false)}
+      />
+
+      <ConfirmDialog
+        isOpen={!!removingMemberId}
+        title="Remove Member"
+        message={`Are you sure you want to remove ${memberToRemove?.user?.username ?? removingMemberId} from this organization?`}
+        onConfirm={() => {
+          if (removingMemberId) removeMemberMutation.mutate(removingMemberId);
+        }}
+        onCancel={() => setRemovingMemberId(null)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/organizations/OrganizationListPage.tsx
+++ b/admin-ui/src/pages/organizations/OrganizationListPage.tsx
@@ -1,0 +1,89 @@
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getOrganizations } from '../../api/organizations';
+
+export default function OrganizationListPage() {
+  const { name } = useParams<{ name: string }>();
+
+  const { data: organizations, isLoading, error } = useQuery({
+    queryKey: ['organizations', name],
+    queryFn: () => getOrganizations(name!),
+    enabled: !!name,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Organizations</h1>
+        <Link
+          to={`/console/realms/${name}/organizations/new`}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Create Organization
+        </Link>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          Failed to load data: {error.message}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-gray-500">Loading organizations...</div>
+      ) : !organizations || organizations.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No organizations configured.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Display Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Members</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {organizations.map((org) => (
+                <tr key={org.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <Link
+                      to={`/console/realms/${name}/organizations/${org.slug}`}
+                      className="font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {org.name}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {org.displayName || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    -
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                        org.enabled
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-red-100 text-red-700'
+                      }`}
+                    >
+                      {org.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    {new Date(org.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/plugins/PluginsPage.tsx
+++ b/admin-ui/src/pages/plugins/PluginsPage.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getPlugins, enablePlugin, disablePlugin, deletePlugin } from '../../api/plugins';
+import type { Plugin } from '../../api/plugins';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+function PluginCard({
+  plugin,
+  onToggle,
+  onDelete,
+  isToggling,
+}: {
+  plugin: Plugin;
+  onToggle: (plugin: Plugin) => void;
+  onDelete: (plugin: Plugin) => void;
+  isToggling: boolean;
+}) {
+  return (
+    <div className="flex flex-col rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-gray-900">{plugin.name}</h3>
+            <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
+              v{plugin.version}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-gray-500">{plugin.description}</p>
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-400">
+            {plugin.author && <span>by {plugin.author}</span>}
+            {plugin.homepage && (
+              <a
+                href={plugin.homepage}
+                target="_blank"
+                rel="noreferrer"
+                className="text-indigo-500 hover:text-indigo-700"
+              >
+                Homepage
+              </a>
+            )}
+          </div>
+        </div>
+
+        {/* Toggle */}
+        <button
+          type="button"
+          role="switch"
+          aria-checked={plugin.enabled}
+          disabled={isToggling}
+          onClick={() => onToggle(plugin)}
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 ${plugin.enabled ? 'bg-indigo-600' : 'bg-gray-200'}`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${plugin.enabled ? 'translate-x-5' : 'translate-x-0'}`}
+          />
+        </button>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between">
+        <span
+          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${plugin.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}
+        >
+          {plugin.enabled ? 'Enabled' : 'Disabled'}
+        </span>
+        <button
+          onClick={() => onDelete(plugin)}
+          className="text-sm font-medium text-red-600 hover:text-red-800"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function PluginsPage() {
+  const queryClient = useQueryClient();
+  const [deleteTarget, setDeleteTarget] = useState<Plugin | null>(null);
+
+  const { data: plugins, isLoading, error } = useQuery({
+    queryKey: ['plugins'],
+    queryFn: getPlugins,
+  });
+
+  const enableMutation = useMutation({
+    mutationFn: (name: string) => enablePlugin(name),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['plugins'] }),
+  });
+
+  const disableMutation = useMutation({
+    mutationFn: (name: string) => disablePlugin(name),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['plugins'] }),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (name: string) => deletePlugin(name),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['plugins'] });
+      setDeleteTarget(null);
+    },
+  });
+
+  function handleToggle(plugin: Plugin) {
+    if (plugin.enabled) {
+      disableMutation.mutate(plugin.name);
+    } else {
+      enableMutation.mutate(plugin.name);
+    }
+  }
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading plugins...</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+        {getErrorMessage(error, 'Failed to load plugins.')}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Plugins</h1>
+          <p className="mt-1 text-sm text-gray-500">Manage installed plugins across all realms.</p>
+        </div>
+      </div>
+
+      {(enableMutation.isError || disableMutation.isError || deleteMutation.isError) && (
+        <div className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-700">
+          {getErrorMessage(
+            enableMutation.error ?? disableMutation.error ?? deleteMutation.error,
+            'Operation failed.',
+          )}
+        </div>
+      )}
+
+      {!plugins || plugins.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No plugins installed.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {plugins.map((plugin) => (
+            <PluginCard
+              key={plugin.name}
+              plugin={plugin}
+              onToggle={handleToggle}
+              onDelete={setDeleteTarget}
+              isToggling={
+                (enableMutation.isPending || disableMutation.isPending) &&
+                (enableMutation.variables === plugin.name || disableMutation.variables === plugin.name)
+              }
+            />
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={!!deleteTarget}
+        title="Delete Plugin"
+        message={`Are you sure you want to uninstall "${deleteTarget?.name}"? This action cannot be undone.`}
+        onConfirm={() => deleteTarget && deleteMutation.mutate(deleteTarget.name)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/scim/ScimConfigPage.tsx
+++ b/admin-ui/src/pages/scim/ScimConfigPage.tsx
@@ -1,0 +1,536 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getScimStatus,
+  getScimTokens,
+  createScimToken,
+  deleteScimToken,
+  revokeScimToken,
+  enableScimToken,
+  disableScimToken,
+  getScimAttributeMappings,
+  createScimAttributeMapping,
+  deleteScimAttributeMapping,
+} from '../../api/scim';
+import type { ScimTokenCreateResult } from '../../api/scim';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+const SCIM_SCOPES = ['users:read', 'users:write', 'groups:read', 'groups:write'];
+
+export default function ScimConfigPage() {
+  const { name } = useParams<{ name: string }>();
+  const queryClient = useQueryClient();
+
+  const [showCreateToken, setShowCreateToken] = useState(false);
+  const [tokenForm, setTokenForm] = useState({
+    name: '',
+    description: '',
+    expiresAt: '',
+    scopes: [] as string[],
+  });
+  const [newPlainToken, setNewPlainToken] = useState<string | null>(null);
+  const [tokenCopied, setTokenCopied] = useState(false);
+  const [deleteTokenTarget, setDeleteTokenTarget] = useState<string | null>(null);
+
+  const [mappingForm, setMappingForm] = useState({
+    resourceType: 'User',
+    scimAttribute: '',
+    idenplaneAttribute: '',
+    direction: 'inbound',
+  });
+  const [deleteMappingTarget, setDeleteMappingTarget] = useState<string | null>(null);
+
+  const { data: status, isLoading: statusLoading } = useQuery({
+    queryKey: ['scim-status', name],
+    queryFn: () => getScimStatus(name!),
+    enabled: !!name,
+  });
+
+  const { data: tokens, isLoading: tokensLoading, error: tokensError } = useQuery({
+    queryKey: ['scim-tokens', name],
+    queryFn: () => getScimTokens(name!),
+    enabled: !!name,
+  });
+
+  const { data: mappings, isLoading: mappingsLoading, error: mappingsError } = useQuery({
+    queryKey: ['scim-mappings', name],
+    queryFn: () => getScimAttributeMappings(name!),
+    enabled: !!name,
+  });
+
+  const createTokenMutation = useMutation({
+    mutationFn: () =>
+      createScimToken(name!, {
+        name: tokenForm.name,
+        description: tokenForm.description || undefined,
+        expiresAt: tokenForm.expiresAt || undefined,
+        scopes: tokenForm.scopes.length > 0 ? tokenForm.scopes : undefined,
+      }),
+    onSuccess: (result: ScimTokenCreateResult) => {
+      queryClient.invalidateQueries({ queryKey: ['scim-tokens', name] });
+      queryClient.invalidateQueries({ queryKey: ['scim-status', name] });
+      setNewPlainToken(result.plainToken);
+      setTokenForm({ name: '', description: '', expiresAt: '', scopes: [] });
+      setShowCreateToken(false);
+    },
+  });
+
+  const deleteTokenMutation = useMutation({
+    mutationFn: (tokenId: string) => deleteScimToken(name!, tokenId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scim-tokens', name] });
+      queryClient.invalidateQueries({ queryKey: ['scim-status', name] });
+      setDeleteTokenTarget(null);
+    },
+  });
+
+  const revokeTokenMutation = useMutation({
+    mutationFn: (tokenId: string) => revokeScimToken(name!, tokenId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scim-tokens', name] }),
+  });
+
+  const enableTokenMutation = useMutation({
+    mutationFn: (tokenId: string) => enableScimToken(name!, tokenId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scim-tokens', name] }),
+  });
+
+  const disableTokenMutation = useMutation({
+    mutationFn: (tokenId: string) => disableScimToken(name!, tokenId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['scim-tokens', name] }),
+  });
+
+  const createMappingMutation = useMutation({
+    mutationFn: () =>
+      createScimAttributeMapping(name!, {
+        resourceType: mappingForm.resourceType,
+        scimAttribute: mappingForm.scimAttribute,
+        idenplaneAttribute: mappingForm.idenplaneAttribute,
+        direction: mappingForm.direction,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scim-mappings', name] });
+      setMappingForm({ resourceType: 'User', scimAttribute: '', idenplaneAttribute: '', direction: 'inbound' });
+    },
+  });
+
+  const deleteMappingMutation = useMutation({
+    mutationFn: (mappingId: string) => deleteScimAttributeMapping(name!, mappingId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['scim-mappings', name] });
+      setDeleteMappingTarget(null);
+    },
+  });
+
+  function toggleScope(scope: string) {
+    setTokenForm((prev) => ({
+      ...prev,
+      scopes: prev.scopes.includes(scope)
+        ? prev.scopes.filter((s) => s !== scope)
+        : [...prev.scopes, scope],
+    }));
+  }
+
+  async function copyToken(token: string) {
+    try {
+      await navigator.clipboard.writeText(token);
+      setTokenCopied(true);
+      setTimeout(() => setTokenCopied(false), 2000);
+    } catch {
+      // clipboard may not be available in non-secure contexts
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold text-gray-900">SCIM Configuration</h1>
+
+      {/* Status card */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900">Status</h2>
+        {statusLoading ? (
+          <div className="text-sm text-gray-500">Loading status...</div>
+        ) : status ? (
+          <dl className="grid grid-cols-2 gap-x-8 gap-y-3 sm:grid-cols-3">
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">SCIM Enabled</dt>
+              <dd className="mt-1">
+                <span
+                  className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${status.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}
+                >
+                  {status.enabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">Active Tokens</dt>
+              <dd className="mt-1 text-sm font-medium text-gray-900">{status.activeTokens}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">User Autocreate</dt>
+              <dd className="mt-1">
+                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${status.userAutocreate ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
+                  {status.userAutocreate ? 'On' : 'Off'}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">Group Sync</dt>
+              <dd className="mt-1">
+                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${status.groupSyncEnabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
+                  {status.groupSyncEnabled ? 'Enabled' : 'Disabled'}
+                </span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">Total Users</dt>
+              <dd className="mt-1 text-sm font-medium text-gray-900">{status.totalUsers}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">Total Groups</dt>
+              <dd className="mt-1 text-sm font-medium text-gray-900">{status.totalGroups}</dd>
+            </div>
+          </dl>
+        ) : null}
+      </section>
+
+      {/* Tokens section */}
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">Tokens</h2>
+          <button
+            onClick={() => setShowCreateToken(true)}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+          >
+            Create Token
+          </button>
+        </div>
+
+        {newPlainToken && (
+          <div className="rounded-md bg-yellow-50 border border-yellow-200 p-4">
+            <p className="mb-2 text-sm font-medium text-yellow-800">
+              Token created — copy it now. It will not be shown again.
+            </p>
+            <div className="flex items-center gap-3">
+              <code className="flex-1 rounded bg-yellow-100 px-3 py-2 font-mono text-sm text-yellow-900 break-all">
+                {newPlainToken}
+              </code>
+              <button
+                onClick={() => copyToken(newPlainToken)}
+                className="shrink-0 rounded-md border border-yellow-300 bg-yellow-100 px-3 py-2 text-sm font-medium text-yellow-800 hover:bg-yellow-200"
+              >
+                {tokenCopied ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+            <button
+              onClick={() => setNewPlainToken(null)}
+              className="mt-3 text-xs text-yellow-600 hover:text-yellow-800"
+            >
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        {showCreateToken && (
+          <form
+            onSubmit={(e) => { e.preventDefault(); createTokenMutation.mutate(); }}
+            className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm space-y-4"
+          >
+            <h3 className="text-base font-semibold text-gray-900">New Token</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="token-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name</label>
+                <input
+                  id="token-name"
+                  type="text"
+                  required
+                  value={tokenForm.name}
+                  onChange={(e) => setTokenForm({ ...tokenForm, name: e.target.value })}
+                  placeholder="e.g. Okta SCIM"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="token-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+                <input
+                  id="token-description"
+                  type="text"
+                  value={tokenForm.description}
+                  onChange={(e) => setTokenForm({ ...tokenForm, description: e.target.value })}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+            </div>
+            <div>
+              <label htmlFor="token-expires" className="mb-1.5 block text-sm font-medium text-gray-700">Expires At (optional)</label>
+              <input
+                id="token-expires"
+                type="date"
+                value={tokenForm.expiresAt}
+                onChange={(e) => setTokenForm({ ...tokenForm, expiresAt: e.target.value })}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <p className="mb-2 text-sm font-medium text-gray-700">Scopes</p>
+              <div className="flex flex-wrap gap-4">
+                {SCIM_SCOPES.map((scope) => (
+                  <label key={scope} className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+                    <input
+                      type="checkbox"
+                      checked={tokenForm.scopes.includes(scope)}
+                      onChange={() => toggleScope(scope)}
+                      className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    {scope}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {createTokenMutation.isError && (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+                {getErrorMessage(createTokenMutation.error, 'Failed to create token.')}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setShowCreateToken(false)}
+                className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={createTokenMutation.isPending}
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {createTokenMutation.isPending ? 'Creating...' : 'Create'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {tokensError && (
+          <div role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+            {getErrorMessage(tokensError, 'Failed to load tokens.')}
+          </div>
+        )}
+
+        {tokensLoading ? (
+          <div className="text-sm text-gray-500">Loading tokens...</div>
+        ) : !tokens || tokens.length === 0 ? (
+          <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-sm text-gray-500">
+            No SCIM tokens created.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Prefix</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Enabled</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Expires</th>
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {tokens.map((token) => (
+                  <tr key={token.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                      {token.name}
+                      {token.revoked && (
+                        <span className="ml-2 inline-flex rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">Revoked</span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <code className="font-mono text-xs text-gray-600">{token.tokenPrefix}…</code>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${token.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
+                        {token.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {token.expiresAt ? new Date(token.expiresAt).toLocaleDateString() : 'Never'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-right text-sm">
+                      {token.enabled ? (
+                        <button
+                          onClick={() => disableTokenMutation.mutate(token.id)}
+                          className="mr-3 font-medium text-gray-600 hover:text-gray-900"
+                        >
+                          Disable
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => enableTokenMutation.mutate(token.id)}
+                          className="mr-3 font-medium text-indigo-600 hover:text-indigo-900"
+                        >
+                          Enable
+                        </button>
+                      )}
+                      {!token.revoked && (
+                        <button
+                          onClick={() => revokeTokenMutation.mutate(token.id)}
+                          className="mr-3 font-medium text-yellow-600 hover:text-yellow-800"
+                        >
+                          Revoke
+                        </button>
+                      )}
+                      <button
+                        onClick={() => setDeleteTokenTarget(token.id)}
+                        className="font-medium text-red-600 hover:text-red-800"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Attribute Mappings section */}
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold text-gray-900">Attribute Mappings</h2>
+
+        <form
+          onSubmit={(e) => { e.preventDefault(); createMappingMutation.mutate(); }}
+          className="flex flex-wrap items-end gap-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+        >
+          <div>
+            <label htmlFor="mapping-resource-type" className="mb-1.5 block text-sm font-medium text-gray-700">Resource Type</label>
+            <select
+              id="mapping-resource-type"
+              value={mappingForm.resourceType}
+              onChange={(e) => setMappingForm({ ...mappingForm, resourceType: e.target.value })}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="User">User</option>
+              <option value="Group">Group</option>
+            </select>
+          </div>
+          <div>
+            <label htmlFor="mapping-scim-attr" className="mb-1.5 block text-sm font-medium text-gray-700">SCIM Attribute</label>
+            <input
+              id="mapping-scim-attr"
+              type="text"
+              required
+              value={mappingForm.scimAttribute}
+              onChange={(e) => setMappingForm({ ...mappingForm, scimAttribute: e.target.value })}
+              placeholder="e.g. userName"
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="mapping-user-attr" className="mb-1.5 block text-sm font-medium text-gray-700">Idenplane Attribute</label>
+            <input
+              id="mapping-user-attr"
+              type="text"
+              required
+              value={mappingForm.idenplaneAttribute}
+              onChange={(e) => setMappingForm({ ...mappingForm, idenplaneAttribute: e.target.value })}
+              placeholder="e.g. username"
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="mapping-direction" className="mb-1.5 block text-sm font-medium text-gray-700">Direction</label>
+            <select
+              id="mapping-direction"
+              value={mappingForm.direction}
+              onChange={(e) => setMappingForm({ ...mappingForm, direction: e.target.value })}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            >
+              <option value="inbound">Inbound</option>
+              <option value="outbound">Outbound</option>
+              <option value="bidirectional">Bidirectional</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            disabled={createMappingMutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            Add
+          </button>
+        </form>
+
+        {createMappingMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {getErrorMessage(createMappingMutation.error, 'Failed to add mapping.')}
+          </div>
+        )}
+
+        {mappingsError && (
+          <div role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+            {getErrorMessage(mappingsError, 'Failed to load attribute mappings.')}
+          </div>
+        )}
+
+        {mappingsLoading ? (
+          <div className="text-sm text-gray-500">Loading mappings...</div>
+        ) : !mappings || mappings.length === 0 ? (
+          <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-sm text-gray-500">
+            No custom attribute mappings.
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Resource Type</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">SCIM Attribute</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Idenplane Attribute</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Direction</th>
+                  <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {mappings.map((mapping) => (
+                  <tr key={mapping.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-700">{mapping.resourceType}</td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">{mapping.scimAttribute}</td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-700">{mapping.idenplaneAttribute}</td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">{mapping.direction}</td>
+                    <td className="whitespace-nowrap px-6 py-4 text-right">
+                      <button
+                        onClick={() => setDeleteMappingTarget(mapping.id)}
+                        className="text-sm font-medium text-red-600 hover:text-red-800"
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <ConfirmDialog
+        isOpen={!!deleteTokenTarget}
+        title="Delete SCIM Token"
+        message="Are you sure you want to delete this token? Any clients using it will lose access immediately."
+        onConfirm={() => deleteTokenTarget && deleteTokenMutation.mutate(deleteTokenTarget)}
+        onCancel={() => setDeleteTokenTarget(null)}
+      />
+
+      <ConfirmDialog
+        isOpen={!!deleteMappingTarget}
+        title="Delete Attribute Mapping"
+        message="Are you sure you want to remove this attribute mapping?"
+        onConfirm={() => deleteMappingTarget && deleteMappingMutation.mutate(deleteMappingTarget)}
+        onCancel={() => setDeleteMappingTarget(null)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/service-accounts/ServiceAccountCreatePage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountCreatePage.tsx
@@ -1,0 +1,107 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createServiceAccount } from '../../api/serviceAccounts';
+
+export default function ServiceAccountCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    allowedIps: '',
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createServiceAccount(name!, {
+        name: form.name,
+        description: form.description || undefined,
+        allowedIps: form.allowedIps
+          ? form.allowedIps.split('\n').map((s) => s.trim()).filter(Boolean)
+          : undefined,
+      }),
+    onSuccess: (account) => {
+      queryClient.invalidateQueries({ queryKey: ['service-accounts', name] });
+      navigate(`/console/realms/${name}/service-accounts/${account.id}`);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    mutation.mutate();
+  }
+
+  const set = (field: string, value: string) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Create Service Account</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="field-sa-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name *</label>
+            <input
+              id="field-sa-name"
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-sa-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="field-sa-description"
+              type="text"
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-sa-allowedIps" className="mb-1.5 block text-sm font-medium text-gray-700">Allowed IPs</label>
+            <textarea
+              id="field-sa-allowedIps"
+              rows={4}
+              value={form.allowedIps}
+              onChange={(e) => set('allowedIps', e.target.value)}
+              placeholder="One IP or CIDR per line"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        {mutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {(mutation.error as Error)?.message || 'Failed to create service account.'}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={() => navigate(`/console/realms/${name}/service-accounts`)}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating...' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/service-accounts/ServiceAccountDetailPage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountDetailPage.tsx
@@ -1,0 +1,474 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getServiceAccount,
+  updateServiceAccount,
+  deleteServiceAccount,
+  getApiKeys,
+  createApiKey,
+  revokeApiKey,
+  rotateApiKey,
+  type ApiKeyCreateResult,
+} from '../../api/serviceAccounts';
+import ConfirmDialog from '../../components/ConfirmDialog';
+
+export default function ServiceAccountDetailPage() {
+  const { name, id } = useParams<{ name: string; id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [showDelete, setShowDelete] = useState(false);
+  const [showKeyForm, setShowKeyForm] = useState(false);
+  const [newKey, setNewKey] = useState<ApiKeyCreateResult | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const { data: account, isLoading } = useQuery({
+    queryKey: ['service-account', name, id],
+    queryFn: () => getServiceAccount(name!, id!),
+    enabled: !!name && !!id,
+  });
+
+  const { data: apiKeys } = useQuery({
+    queryKey: ['api-keys', name, id],
+    queryFn: () => getApiKeys(name!, id!),
+    enabled: !!name && !!id,
+  });
+
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    allowedIps: '',
+    enabled: true,
+  });
+
+  const [seededAccount, setSeededAccount] = useState(account);
+  if (account && account !== seededAccount) {
+    setSeededAccount(account);
+    setForm({
+      name: account.name,
+      description: account.description ?? '',
+      allowedIps: account.allowedIps.join('\n'),
+      enabled: account.enabled,
+    });
+  }
+
+  const [keyForm, setKeyForm] = useState({
+    name: '',
+    scopes: '',
+    expiresAt: '',
+    maxRequestsPerDay: '',
+    maxRequestsPerMonth: '',
+    rateLimitPerMinute: '',
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      updateServiceAccount(name!, id!, {
+        name: form.name,
+        description: form.description || undefined,
+        allowedIps: form.allowedIps
+          ? form.allowedIps.split('\n').map((s) => s.trim()).filter(Boolean)
+          : [],
+        enabled: form.enabled,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['service-account', name, id] });
+      queryClient.invalidateQueries({ queryKey: ['service-accounts', name] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteServiceAccount(name!, id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['service-accounts', name] });
+      navigate(`/console/realms/${name}/service-accounts`);
+    },
+  });
+
+  const createKeyMutation = useMutation({
+    mutationFn: () =>
+      createApiKey(name!, id!, {
+        name: keyForm.name || undefined,
+        scopes: keyForm.scopes ? keyForm.scopes.split(',').map((s) => s.trim()).filter(Boolean) : undefined,
+        expiresAt: keyForm.expiresAt || undefined,
+        maxRequestsPerDay: keyForm.maxRequestsPerDay ? Number(keyForm.maxRequestsPerDay) : undefined,
+        maxRequestsPerMonth: keyForm.maxRequestsPerMonth ? Number(keyForm.maxRequestsPerMonth) : undefined,
+        rateLimitPerMinute: keyForm.rateLimitPerMinute ? Number(keyForm.rateLimitPerMinute) : undefined,
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['api-keys', name, id] });
+      setNewKey(result);
+      setShowKeyForm(false);
+      setKeyForm({ name: '', scopes: '', expiresAt: '', maxRequestsPerDay: '', maxRequestsPerMonth: '', rateLimitPerMinute: '' });
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (keyId: string) => revokeApiKey(name!, id!, keyId),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['api-keys', name, id] }),
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: (keyId: string) => rotateApiKey(name!, id!, keyId),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['api-keys', name, id] });
+      setNewKey(result);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    updateMutation.mutate();
+  }
+
+  function handleKeyFormSubmit(e: FormEvent) {
+    e.preventDefault();
+    createKeyMutation.mutate();
+  }
+
+  function handleCopy() {
+    if (newKey) {
+      navigator.clipboard.writeText(newKey.plainKey).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    }
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  const setKey = (field: string, value: string) =>
+    setKeyForm((f) => ({ ...f, [field]: value }));
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading service account...</div>;
+  }
+
+  if (!account) {
+    return <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">Service account not found.</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">{account.name}</h1>
+          {account.description && (
+            <p className="mt-1 text-sm text-gray-500">{account.description}</p>
+          )}
+        </div>
+        <button
+          onClick={() => setShowDelete(true)}
+          className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+        >
+          Delete
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="field-sa-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name *</label>
+            <input
+              id="field-sa-name"
+              type="text"
+              required
+              value={form.name}
+              onChange={(e) => set('name', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-sa-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="field-sa-description"
+              type="text"
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-sa-allowedIps" className="mb-1.5 block text-sm font-medium text-gray-700">Allowed IPs</label>
+            <textarea
+              id="field-sa-allowedIps"
+              rows={4}
+              value={form.allowedIps}
+              onChange={(e) => set('allowedIps', e.target.value)}
+              placeholder="One IP or CIDR per line"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="field-sa-enabled"
+              checked={form.enabled}
+              onChange={(e) => set('enabled', e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            <label htmlFor="field-sa-enabled" className="text-sm font-medium text-gray-700">Enabled</label>
+          </div>
+        </div>
+
+        {updateMutation.isSuccess && (
+          <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
+            Service account updated successfully.
+          </div>
+        )}
+        {updateMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            Failed to update service account.
+          </div>
+        )}
+
+        <div className="flex justify-end border-t border-gray-200 pt-4">
+          <button
+            type="submit"
+            disabled={updateMutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+
+      {newKey && (
+        <div className="rounded-lg border border-yellow-200 bg-yellow-50 p-4 space-y-2">
+          <p className="text-sm font-semibold text-yellow-800">
+            Copy your API key now — it will not be shown again.
+          </p>
+          <div className="flex items-center gap-2">
+            <input
+              readOnly
+              value={newKey.plainKey}
+              className="flex-1 rounded-md border border-yellow-300 bg-white px-3 py-2 font-mono text-sm text-gray-800 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="rounded-md border border-yellow-300 bg-white px-3 py-2 text-sm font-medium text-yellow-800 hover:bg-yellow-100"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => setNewKey(null)}
+            className="text-xs text-yellow-700 underline"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900">API Keys</h2>
+          {!showKeyForm && (
+            <button
+              type="button"
+              onClick={() => setShowKeyForm(true)}
+              className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+            >
+              Generate API Key
+            </button>
+          )}
+        </div>
+
+        {showKeyForm && (
+          <form
+            onSubmit={handleKeyFormSubmit}
+            className="space-y-4 rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+          >
+            <h3 className="text-base font-semibold text-gray-900">New API Key</h3>
+
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="field-key-name" className="mb-1.5 block text-sm font-medium text-gray-700">Name</label>
+                <input
+                  id="field-key-name"
+                  type="text"
+                  value={keyForm.name}
+                  onChange={(e) => setKey('name', e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="field-key-scopes" className="mb-1.5 block text-sm font-medium text-gray-700">Scopes</label>
+                <input
+                  id="field-key-scopes"
+                  type="text"
+                  value={keyForm.scopes}
+                  onChange={(e) => setKey('scopes', e.target.value)}
+                  placeholder="Comma-separated"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="field-key-expiresAt" className="mb-1.5 block text-sm font-medium text-gray-700">Expires At</label>
+              <input
+                id="field-key-expiresAt"
+                type="date"
+                value={keyForm.expiresAt}
+                onChange={(e) => setKey('expiresAt', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label htmlFor="field-key-rpm" className="mb-1.5 block text-sm font-medium text-gray-700">Rate limit / min</label>
+                <input
+                  id="field-key-rpm"
+                  type="number"
+                  min={1}
+                  value={keyForm.rateLimitPerMinute}
+                  onChange={(e) => setKey('rateLimitPerMinute', e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="field-key-rpd" className="mb-1.5 block text-sm font-medium text-gray-700">Max req / day</label>
+                <input
+                  id="field-key-rpd"
+                  type="number"
+                  min={1}
+                  value={keyForm.maxRequestsPerDay}
+                  onChange={(e) => setKey('maxRequestsPerDay', e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <label htmlFor="field-key-rpm2" className="mb-1.5 block text-sm font-medium text-gray-700">Max req / month</label>
+                <input
+                  id="field-key-rpm2"
+                  type="number"
+                  min={1}
+                  value={keyForm.maxRequestsPerMonth}
+                  onChange={(e) => setKey('maxRequestsPerMonth', e.target.value)}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+                />
+              </div>
+            </div>
+
+            {createKeyMutation.isError && (
+              <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+                {(createKeyMutation.error as Error)?.message || 'Failed to generate API key.'}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+              <button
+                type="button"
+                onClick={() => setShowKeyForm(false)}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={createKeyMutation.isPending}
+                className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+              >
+                {createKeyMutation.isPending ? 'Generating...' : 'Generate'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {apiKeys && apiKeys.length > 0 && (
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Prefix</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Scopes</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Expires</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {apiKeys.map((key) => (
+                  <tr key={key.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 font-mono text-sm text-gray-700">
+                      {key.keyPrefix ?? '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-700">
+                      {key.name ?? '-'}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500">
+                      {key.scopes.length > 0 ? key.scopes.join(', ') : '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {key.expiresAt ? new Date(key.expiresAt).toLocaleDateString() : 'Never'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          key.revoked
+                            ? 'bg-red-100 text-red-700'
+                            : key.enabled
+                            ? 'bg-green-100 text-green-700'
+                            : 'bg-gray-100 text-gray-700'
+                        }`}
+                      >
+                        {key.revoked ? 'Revoked' : key.enabled ? 'Active' : 'Disabled'}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <div className="flex items-center gap-2">
+                        {!key.revoked && (
+                          <button
+                            type="button"
+                            onClick={() => revokeMutation.mutate(key.id)}
+                            disabled={revokeMutation.isPending}
+                            className="text-red-600 hover:text-red-800 disabled:opacity-50"
+                          >
+                            Revoke
+                          </button>
+                        )}
+                        {!key.revoked && (
+                          <button
+                            type="button"
+                            onClick={() => rotateMutation.mutate(key.id)}
+                            disabled={rotateMutation.isPending}
+                            className="text-indigo-600 hover:text-indigo-800 disabled:opacity-50"
+                          >
+                            Rotate
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {apiKeys && apiKeys.length === 0 && (
+          <div className="rounded-md border border-gray-200 bg-white p-6 text-center text-sm text-gray-500">
+            No API keys yet.
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        isOpen={showDelete}
+        title="Delete Service Account"
+        message={`Are you sure you want to delete service account "${account.name}"?`}
+        onConfirm={() => deleteMutation.mutate()}
+        onCancel={() => setShowDelete(false)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/service-accounts/ServiceAccountListPage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountListPage.tsx
@@ -1,0 +1,85 @@
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getServiceAccounts } from '../../api/serviceAccounts';
+
+export default function ServiceAccountListPage() {
+  const { name } = useParams<{ name: string }>();
+
+  const { data: accounts, isLoading, error } = useQuery({
+    queryKey: ['service-accounts', name],
+    queryFn: () => getServiceAccounts(name!),
+    enabled: !!name,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Service Accounts</h1>
+        <Link
+          to={`/console/realms/${name}/service-accounts/new`}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Create Service Account
+        </Link>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          Failed to load data: {error.message}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-gray-500">Loading service accounts...</div>
+      ) : !accounts || accounts.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No service accounts configured.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Description</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {accounts.map((account) => (
+                <tr key={account.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <Link
+                      to={`/console/realms/${name}/service-accounts/${account.id}`}
+                      className="font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {account.name}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {account.description || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                        account.enabled
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-red-100 text-red-700'
+                      }`}
+                    >
+                      {account.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    {new Date(account.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/users/UserDetailPage.tsx
+++ b/admin-ui/src/pages/users/UserDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getUserById, updateUser, deleteUser, resetPassword, getMfaStatus, resetMfa, getOfflineSessions, revokeOfflineSession } from '../../api/users';
+import { getUserById, updateUser, deleteUser, resetPassword, getMfaStatus, resetMfa, getOfflineSessions, revokeOfflineSession, impersonateUser, type ImpersonationResult } from '../../api/users';
 import {
   getRealmRoles,
   getUserRealmRoles,
@@ -25,6 +25,7 @@ export default function UserDetailPage() {
   const queryClient = useQueryClient();
   const [showDelete, setShowDelete] = useState(false);
   const [showResetMfa, setShowResetMfa] = useState(false);
+  const [impersonationResult, setImpersonationResult] = useState<ImpersonationResult | null>(null);
   const [newPassword, setNewPassword] = useState('');
   const [passwordMsg, setPasswordMsg] = useState('');
   const [selectedRole, setSelectedRole] = useState('');
@@ -217,6 +218,11 @@ export default function UserDetailPage() {
     onSuccess: () => refetchOffline(),
   });
 
+  const impersonateMutation = useMutation({
+    mutationFn: () => impersonateUser(name!, id!),
+    onSuccess: (result) => setImpersonationResult(result),
+  });
+
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
     updateMutation.mutate();
@@ -257,13 +263,68 @@ export default function UserDetailPage() {
           <h1 className="text-2xl font-bold text-gray-900">{user.username}</h1>
           <p className="mt-1 text-sm text-gray-500">{user.email}</p>
         </div>
-        <button
-          onClick={() => setShowDelete(true)}
-          className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
-        >
-          Delete User
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => impersonateMutation.mutate()}
+            disabled={impersonateMutation.isPending}
+            className="rounded-md border border-amber-300 bg-amber-50 px-4 py-2 text-sm font-medium text-amber-700 hover:bg-amber-100 disabled:opacity-50"
+          >
+            {impersonateMutation.isPending ? 'Generating...' : 'Impersonate'}
+          </button>
+          <button
+            onClick={() => setShowDelete(true)}
+            className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+          >
+            Delete User
+          </button>
+        </div>
       </div>
+
+      {impersonationResult && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+          <div className="flex items-start justify-between">
+            <div>
+              <h3 className="text-sm font-semibold text-amber-800">Impersonation Tokens</h3>
+              <p className="mt-0.5 text-xs text-amber-600">
+                These tokens allow you to act as <span className="font-medium">{user.username}</span>. They expire in {impersonationResult.expiresIn}s. Copy and store securely.
+              </p>
+            </div>
+            <button onClick={() => setImpersonationResult(null)} className="text-amber-400 hover:text-amber-600">
+              <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+            </button>
+          </div>
+          <div className="mt-3 space-y-2">
+            <div>
+              <span className="text-xs font-medium text-amber-700">Access Token</span>
+              <div className="mt-1 flex items-center gap-2">
+                <code className="flex-1 truncate rounded bg-amber-100 px-2 py-1 text-xs text-amber-900">{impersonationResult.accessToken}</code>
+                <button
+                  onClick={() => navigator.clipboard.writeText(impersonationResult.accessToken)}
+                  className="shrink-0 rounded border border-amber-300 px-2 py-1 text-xs text-amber-700 hover:bg-amber-100"
+                >Copy</button>
+              </div>
+            </div>
+            {impersonationResult.refreshToken && (
+              <div>
+                <span className="text-xs font-medium text-amber-700">Refresh Token</span>
+                <div className="mt-1 flex items-center gap-2">
+                  <code className="flex-1 truncate rounded bg-amber-100 px-2 py-1 text-xs text-amber-900">{impersonationResult.refreshToken}</code>
+                  <button
+                    onClick={() => navigator.clipboard.writeText(impersonationResult.refreshToken)}
+                    className="shrink-0 rounded border border-amber-300 px-2 py-1 text-xs text-amber-700 hover:bg-amber-100"
+                  >Copy</button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {impersonateMutation.isError && (
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          Failed to impersonate user. Ensure impersonation is enabled for this realm.
+        </div>
+      )}
 
       {/* Profile form */}
       <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">

--- a/admin-ui/src/pages/webhooks/WebhookCreatePage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookCreatePage.tsx
@@ -1,0 +1,163 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createWebhook } from '../../api/webhooks';
+import PasswordInput from '../../components/PasswordInput';
+
+const EVENT_TYPES = [
+  'user.created',
+  'user.updated',
+  'user.deleted',
+  'user.login',
+  'user.login.failed',
+  'user.password.reset',
+  'realm.updated',
+  'client.created',
+  'client.deleted',
+  'role.assigned',
+  'role.removed',
+];
+
+export default function WebhookCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    url: '',
+    secret: '',
+    description: '',
+    eventTypes: [] as string[],
+    enabled: true,
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createWebhook(name!, {
+        url: form.url,
+        secret: form.secret,
+        eventTypes: form.eventTypes,
+        description: form.description || undefined,
+        enabled: form.enabled,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['webhooks', name] });
+      navigate(`/console/realms/${name}/webhooks`);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    mutation.mutate();
+  }
+
+  function toggleEventType(eventType: string) {
+    setForm((f) => ({
+      ...f,
+      eventTypes: f.eventTypes.includes(eventType)
+        ? f.eventTypes.filter((t) => t !== eventType)
+        : [...f.eventTypes, eventType],
+    }));
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">Add Webhook</h1>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="field-wh-url" className="mb-1.5 block text-sm font-medium text-gray-700">URL *</label>
+            <input
+              id="field-wh-url"
+              type="url"
+              required
+              value={form.url}
+              onChange={(e) => set('url', e.target.value)}
+              placeholder="https://example.com/webhook"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-wh-secret" className="mb-1.5 block text-sm font-medium text-gray-700">Secret *</label>
+            <PasswordInput
+              id="field-wh-secret"
+              required
+              minLength={8}
+              value={form.secret}
+              onChange={(e) => set('secret', e.target.value)}
+              placeholder="Min. 8 characters"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-wh-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="field-wh-description"
+              type="text"
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="field-wh-enabled"
+              checked={form.enabled}
+              onChange={(e) => set('enabled', e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            <label htmlFor="field-wh-enabled" className="text-sm font-medium text-gray-700">Enabled</label>
+          </div>
+        </div>
+
+        <div className="space-y-3 border-t border-gray-200 pt-4">
+          <h2 className="text-lg font-semibold text-gray-900">Event Types *</h2>
+          <div className="grid grid-cols-2 gap-2">
+            {EVENT_TYPES.map((et) => (
+              <label key={et} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={form.eventTypes.includes(et)}
+                  onChange={() => toggleEventType(et)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="text-sm text-gray-700">{et}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {mutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {(mutation.error as Error)?.message || 'Failed to create webhook.'}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+          <button
+            type="button"
+            onClick={() => navigate(`/console/realms/${name}/webhooks`)}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={mutation.isPending || form.eventTypes.length === 0}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating...' : 'Create'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/webhooks/WebhookDetailPage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookDetailPage.tsx
@@ -1,0 +1,305 @@
+import { useState, type FormEvent } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  getWebhook,
+  updateWebhook,
+  deleteWebhook,
+  testWebhook,
+  getWebhookDeliveries,
+} from '../../api/webhooks';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import PasswordInput from '../../components/PasswordInput';
+
+const EVENT_TYPES = [
+  'user.created',
+  'user.updated',
+  'user.deleted',
+  'user.login',
+  'user.login.failed',
+  'user.password.reset',
+  'realm.updated',
+  'client.created',
+  'client.deleted',
+  'role.assigned',
+  'role.removed',
+];
+
+export default function WebhookDetailPage() {
+  const { name, id } = useParams<{ name: string; id: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [showDelete, setShowDelete] = useState(false);
+  const [testResult, setTestResult] = useState<'success' | 'error' | null>(null);
+
+  const { data: webhook, isLoading } = useQuery({
+    queryKey: ['webhook', name, id],
+    queryFn: () => getWebhook(name!, id!),
+    enabled: !!name && !!id,
+  });
+
+  const { data: deliveries } = useQuery({
+    queryKey: ['webhook-deliveries', name, id],
+    queryFn: () => getWebhookDeliveries(name!, id!),
+    enabled: !!name && !!id,
+  });
+
+  const [form, setForm] = useState({
+    url: '',
+    secret: '',
+    description: '',
+    eventTypes: [] as string[],
+    enabled: true,
+  });
+
+  const [seededWebhook, setSeededWebhook] = useState(webhook);
+  if (webhook && webhook !== seededWebhook) {
+    setSeededWebhook(webhook);
+    setForm({
+      url: webhook.url,
+      secret: '',
+      description: webhook.description ?? '',
+      eventTypes: webhook.eventTypes,
+      enabled: webhook.enabled,
+    });
+  }
+
+  const updateMutation = useMutation({
+    mutationFn: () =>
+      updateWebhook(name!, id!, {
+        url: form.url,
+        secret: form.secret || undefined,
+        description: form.description || undefined,
+        eventTypes: form.eventTypes,
+        enabled: form.enabled,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['webhook', name, id] });
+      queryClient.invalidateQueries({ queryKey: ['webhooks', name] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteWebhook(name!, id!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['webhooks', name] });
+      navigate(`/console/realms/${name}/webhooks`);
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationFn: () => testWebhook(name!, id!),
+    onSuccess: () => {
+      setTestResult('success');
+      queryClient.invalidateQueries({ queryKey: ['webhook-deliveries', name, id] });
+    },
+    onError: () => setTestResult('error'),
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    updateMutation.mutate();
+  }
+
+  function toggleEventType(eventType: string) {
+    setForm((f) => ({
+      ...f,
+      eventTypes: f.eventTypes.includes(eventType)
+        ? f.eventTypes.filter((t) => t !== eventType)
+        : [...f.eventTypes, eventType],
+    }));
+  }
+
+  const set = (field: string, value: string | boolean) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  if (isLoading) {
+    return <div className="text-gray-500">Loading webhook...</div>;
+  }
+
+  if (!webhook) {
+    return <div className="rounded-md bg-red-50 p-4 text-sm text-red-700">Webhook not found.</div>;
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900 break-all">{webhook.url}</h1>
+          {webhook.description && (
+            <p className="mt-1 text-sm text-gray-500">{webhook.description}</p>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => {
+              setTestResult(null);
+              testMutation.mutate();
+            }}
+            disabled={testMutation.isPending}
+            className="rounded-md border border-indigo-300 px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 disabled:opacity-50"
+          >
+            {testMutation.isPending ? 'Testing...' : 'Test Webhook'}
+          </button>
+          <button
+            onClick={() => setShowDelete(true)}
+            className="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {testResult === 'success' && (
+        <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
+          Test delivery sent successfully.
+        </div>
+      )}
+      {testResult === 'error' && (
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+          Test delivery failed. Check deliveries below for details.
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="field-wh-url" className="mb-1.5 block text-sm font-medium text-gray-700">URL *</label>
+            <input
+              id="field-wh-url"
+              type="url"
+              required
+              value={form.url}
+              onChange={(e) => set('url', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-wh-secret" className="mb-1.5 block text-sm font-medium text-gray-700">Secret</label>
+            <PasswordInput
+              id="field-wh-secret"
+              value={form.secret}
+              onChange={(e) => set('secret', e.target.value)}
+              placeholder="Leave blank to keep current"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="field-wh-description" className="mb-1.5 block text-sm font-medium text-gray-700">Description</label>
+            <input
+              id="field-wh-description"
+              type="text"
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="field-wh-enabled"
+              checked={form.enabled}
+              onChange={(e) => set('enabled', e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            <label htmlFor="field-wh-enabled" className="text-sm font-medium text-gray-700">Enabled</label>
+          </div>
+        </div>
+
+        <div className="space-y-3 border-t border-gray-200 pt-4">
+          <h2 className="text-lg font-semibold text-gray-900">Event Types</h2>
+          <div className="grid grid-cols-2 gap-2">
+            {EVENT_TYPES.map((et) => (
+              <label key={et} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={form.eventTypes.includes(et)}
+                  onChange={() => toggleEventType(et)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <span className="text-sm text-gray-700">{et}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {updateMutation.isSuccess && (
+          <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
+            Webhook updated successfully.
+          </div>
+        )}
+        {updateMutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            Failed to update webhook.
+          </div>
+        )}
+
+        <div className="flex justify-end border-t border-gray-200 pt-4">
+          <button
+            type="submit"
+            disabled={updateMutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </form>
+
+      {deliveries && deliveries.length > 0 && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold text-gray-900">Recent Deliveries</h2>
+          <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Event</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Result</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Duration</th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Time</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {deliveries.map((d) => (
+                  <tr key={d.id} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-700">{d.eventType}</td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {d.statusCode ?? '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          d.success ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'
+                        }`}
+                      >
+                        {d.success ? 'Success' : 'Failed'}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {d.duration != null ? `${d.duration}ms` : '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {new Date(d.createdAt).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={showDelete}
+        title="Delete Webhook"
+        message={`Are you sure you want to delete this webhook?`}
+        onConfirm={() => deleteMutation.mutate()}
+        onCancel={() => setShowDelete(false)}
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/webhooks/WebhookListPage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookListPage.tsx
@@ -1,0 +1,91 @@
+import { Link, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { getWebhooks } from '../../api/webhooks';
+
+export default function WebhookListPage() {
+  const { name } = useParams<{ name: string }>();
+
+  const { data: webhooks, isLoading, error } = useQuery({
+    queryKey: ['webhooks', name],
+    queryFn: () => getWebhooks(name!),
+    enabled: !!name,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold text-gray-900">Webhooks</h1>
+        <Link
+          to={`/console/realms/${name}/webhooks/new`}
+          className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+        >
+          Add Webhook
+        </Link>
+      </div>
+
+      {error && (
+        <div role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-700">
+          Failed to load data: {error.message}
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-gray-500">Loading webhooks...</div>
+      ) : !webhooks || webhooks.length === 0 ? (
+        <div className="rounded-md border border-gray-200 bg-white p-8 text-center text-gray-500">
+          No webhooks configured.
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">URL</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Description</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Events</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Status</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {webhooks.map((webhook) => (
+                <tr key={webhook.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <Link
+                      to={`/console/realms/${name}/webhooks/${webhook.id}`}
+                      className="font-medium text-indigo-600 hover:text-indigo-900"
+                    >
+                      {webhook.url}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4 text-sm text-gray-500">
+                    {webhook.description || '-'}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                      {webhook.eventTypes.length} event{webhook.eventTypes.length !== 1 ? 's' : ''}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                        webhook.enabled
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-red-100 text-red-700'
+                      }`}
+                    >
+                      {webhook.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                    {new Date(webhook.createdAt).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Webhooks** - list/create/detail pages with event-type checkboxes, delivery history table, and Test Webhook action
- **Service Accounts** - list/create/detail pages with full API key lifecycle (generate, revoke, rotate) and one-time plain-key reveal banner
- **Organizations** - list/create/detail pages with member management (role select + update/remove) and invitation sending
- **Custom Attributes** - single-page CRUD with inline edit, type-conditional controls, and registration/profile visibility toggles
- **SCIM Config** - token management (create/enable/disable/revoke/delete) with one-time plain-token reveal, custom attribute mapping table
- **Authorization Policies** - list/create/detail pages with JSON conditions editor and per-policy test runner
- **Plugins** - global card grid with enable/disable toggle and delete per plugin
- **Impersonation** - Impersonate button on UserDetailPage showing amber access/refresh token reveal with copy buttons
- **Risk Assessment routing** - wires up the three existing continuous-verification pages (dashboard, policy list, session detail) that were unregistered in App.tsx
- **Layout** - nav entries for all new realm-scoped sections plus global Plugins link
- **7 new API modules** - organizations, webhooks, serviceAccounts, customAttributes, scim, authorization, plugins; impersonateUser added to users.ts

## Test plan
- [x] npm run lint - clean
- [x] npm test - 336 passed, 2 skipped

Generated with Claude Code