### PR TITLE
fix(admin-ui): fix TS build error in CustomAttributesPage

### DIFF
--- a/admin-ui/src/pages/custom-attributes/CustomAttributesPage.tsx
+++ b/admin-ui/src/pages/custom-attributes/CustomAttributesPage.tsx
@@ -276,7 +276,7 @@ function AttributeForm({
         </label>
       </div>
 
-      {error && (
+      {error != null && (
         <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
           {getErrorMessage(error, 'Failed to save attribute.')}
         </div>


### PR DESCRIPTION
The \error\ prop typed as \unknown\ causes \{error && <div>}\ to fail TypeScript compilation with 'Type unknown is not assignable to type ReactNode'. Changed to \{error != null && ...}\ to properly narrow the type. Fixes Docker image build (CI run 28191604782).