### PR TITLE
fix(admin-ui): always apply ProgressEvent polyfill for MSW post-jsdom callbacks

### DIFF
--- a/admin-ui/src/test/setupTests.ts
+++ b/admin-ui/src/test/setupTests.ts
@@ -2,25 +2,23 @@ import '@testing-library/jest-dom';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { server } from './mocks/server';
 
-// jsdom defines ProgressEvent on `window`, but a late XHR progress/load callback
-// from MSW can fire after the jsdom realm is torn down, where the lookup resolves
-// against the bare Node global instead — there `ProgressEvent` is undefined,
-// surfacing as an intermittent "ProgressEvent is not defined" unhandled error
-// that flakes the suite under CI parallelism. Pin a minimal global polyfill.
-if (typeof (globalThis as { ProgressEvent?: unknown }).ProgressEvent === 'undefined') {
-  class ProgressEventPolyfill extends Event {
-    readonly lengthComputable: boolean;
-    readonly loaded: number;
-    readonly total: number;
-    constructor(type: string, init?: ProgressEventInit) {
-      super(type, init);
-      this.lengthComputable = init?.lengthComputable ?? false;
-      this.loaded = init?.loaded ?? 0;
-      this.total = init?.total ?? 0;
-    }
+// MSW's XHR interceptor can fire a progress/load callback after jsdom tears down.
+// At that point the lookup resolves against the bare Node global where ProgressEvent
+// is not defined. The fix: always pin the polyfill unconditionally — jsdom may
+// provide its own during tests, but the polyfill persists on the underlying worker
+// global after jsdom cleanup. The previous conditional form never ran because jsdom
+// always has ProgressEvent, leaving the Node global unpatched.
+(globalThis as { ProgressEvent: unknown }).ProgressEvent = class ProgressEvent extends Event {
+  readonly lengthComputable: boolean;
+  readonly loaded: number;
+  readonly total: number;
+  constructor(type: string, init?: ProgressEventInit) {
+    super(type, init);
+    this.lengthComputable = init?.lengthComputable ?? false;
+    this.loaded = init?.loaded ?? 0;
+    this.total = init?.total ?? 0;
   }
-  (globalThis as { ProgressEvent?: unknown }).ProgressEvent = ProgressEventPolyfill;
-}
+};
 
 // Start MSW server before all tests
 beforeAll(() => server.listen({ onUnhandledRequest: 'warn' }));


### PR DESCRIPTION
## Summary

- Fixes a pre-existing CI failure in the Admin UI test suite: `ReferenceError: ProgressEvent is not defined`
- All 336 tests pass, but an unhandled rejection from MSW's XHR interceptor (firing after jsdom teardown) causes vitest to exit with code 1
- Root cause: the polyfill in `setupTests.ts` had a conditional `if (typeof globalThis.ProgressEvent === 'undefined')` that **never fires** because jsdom provides `ProgressEvent` during tests. After jsdom tears down, the Node worker global loses it
- Fix: remove the guard — always pin the polyfill unconditionally

## Test plan

- [ ] CI Admin UI Tests job passes (no unhandled ProgressEvent rejection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)