### PR TITLE
chore(version): sync admin-ui to 0.3.0, add [Unreleased] CHANGELOG, add release version CI guard

### DIFF
--- a/.github/workflows/release-version-check.yml
+++ b/.github/workflows/release-version-check.yml
@@ -1,0 +1,47 @@
+name: Release Version Check
+
+# Guards against the version-mismatch class of bug in
+# https://github.com/idenplane/idenplane/issues — a pushed release tag
+# must agree with package.json and have a matching CHANGELOG.md entry,
+# otherwise it's too easy for the tag, the package version, and the
+# changelog to silently drift apart.
+#
+# Triggers on every v* tag push (the same trigger docker-publish.yml
+# uses to build release images) so it fails before/alongside the image
+# build rather than after the fact.
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-consistency:
+    name: Verify tag matches package.json and CHANGELOG.md
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compare tag, package.json, and CHANGELOG.md
+        run: |
+          set -e
+
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+
+          echo "Tag:            ${GITHUB_REF_NAME} (${TAG_VERSION})"
+          echo "package.json:   ${PKG_VERSION}"
+
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match package.json version (${PKG_VERSION})"
+            exit 1
+          fi
+
+          if ! grep -qE "^## \[${TAG_VERSION}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no dated '## [${TAG_VERSION}] - YYYY-MM-DD' heading. Move the [Unreleased] entries under a heading for this release before tagging."
+            exit 1
+          fi
+
+          echo "Tag, package.json, and CHANGELOG.md agree on ${TAG_VERSION}."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 For full per-commit detail, see the [GitHub Releases](https://github.com/idenplane/idenplane/releases).
 
+## [Unreleased]
+
+### Added
+- `@idenplane/mcp` — first-party stdio MCP server for AI agent integration
+- Multi-provider email abstraction (Resend, SendGrid, Mailgun, Postmark, SMTP)
+- SMS provider configuration UI with card-grid selector
+- Admin UI: webhooks, service accounts, organizations, custom attributes, SCIM, authorization policies, plugins, impersonation, and risk-assessment routing pages
+
+### Security
+- Fixed all outstanding Dependabot vulnerability alerts via npm overrides
+
 ## [0.3.0] - 2026-05-21
 
 Enterprise provisioning, GraphQL Admin, and the Idenplane rebrand under AGPL-3.0.

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "admin-ui",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "admin-ui",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-ui",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
﻿## Summary

- **admin-ui/package.json** - version bumped from `0.0.0` to `0.3.0` to match the root `package.json` and the latest release tag (fixes the version inconsistency reported in Issue #1)
- **CHANGELOG.md** - added `[Unreleased]` section per the Keep a Changelog format, documenting features already merged but not yet released
- **.github/workflows/release-version-check.yml** - new CI workflow triggered on `v*` tag pushes; fails if the tag version does not match `package.json` or if `CHANGELOG.md` has no matching dated heading -- prevents silent version drift in future releases

## Test plan

- [ ] Verify `admin-ui/package.json` shows `"version": "0.3.0"`
- [ ] Verify `CHANGELOG.md` has an `[Unreleased]` section above `## [0.3.0]`
- [ ] Verify `.github/workflows/release-version-check.yml` exists with `on: push: tags: ['v*']` trigger
- [ ] After merge to `dev` and eventual release, move `[Unreleased]` entries to a dated `## [0.4.0] - YYYY-MM-DD` heading before tagging

Generated with Claude Code
