### PR TITLE
fix(admin-ui): fix risk session detail link path in ContinuousRiskDashboard

### DIFF
--- a/admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx
+++ b/admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx
@@ -182,7 +182,7 @@ function HighRiskRow({ profile, realmName }: { profile: SessionRiskProfile; real
       </td>
       <td className="whitespace-nowrap px-4 py-3 text-right">
         <Link
-          to={`/console/realms/${realmName}/continuous-verification/session/${profile.sessionId}`}
+          to={`/console/realms/${realmName}/risk-sessions/${profile.sessionId}`}
           className="text-sm font-medium text-indigo-600 hover:text-indigo-900"
         >
           Details


### PR DESCRIPTION
﻿## Summary

The "Details" link in the high-risk sessions table navigated to the wrong path:

- **Was:** `/console/realms/:name/continuous-verification/session/:sessionId`
- **Fixed:** `/console/realms/:name/risk-sessions/:sessionId` (matches the route registered in App.tsx)

The link always 404'd because the route was never registered at the old path.

**File changed:** `admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx` — one-line fix.

## Test plan

- [ ] Navigate to Risk Dashboard for a realm that has risk session data
- [ ] Click "Details" on any high-risk session row
- [ ] Verify it navigates to the Session Risk Detail page (not 404)

Closes #1116
