### PR TITLE
fix(admin-ui): register NHI routes and add sidebar nav entry

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -57,6 +57,9 @@ import ScimConfigPage from './pages/scim/ScimConfigPage';
 import PolicyListPage from './pages/authorization/PolicyListPage';
 import PolicyCreatePage from './pages/authorization/PolicyCreatePage';
 import PolicyDetailPage from './pages/authorization/PolicyDetailPage';
+import NhiListPage from './pages/nhi/NhiListPage';
+import NhiDetailPage from './pages/nhi/NhiDetailPage';
+import NhiAnalyticsPage from './pages/nhi/NhiAnalyticsPage';
 import PluginsPage from './pages/plugins/PluginsPage';
 import NotFoundPage from './pages/NotFoundPage';
 import { hasCredentials } from './api/client';
@@ -134,6 +137,9 @@ export default function App() {
           <Route path="/console/realms/:name/authorization-policies" element={<PolicyListPage />} />
           <Route path="/console/realms/:name/authorization-policies/new" element={<PolicyCreatePage />} />
           <Route path="/console/realms/:name/authorization-policies/:policyId" element={<PolicyDetailPage />} />
+          <Route path="/console/realms/:name/nhi" element={<NhiListPage />} />
+          <Route path="/console/realms/:name/nhi/:id" element={<NhiDetailPage />} />
+          <Route path="/console/realms/:name/nhi-analytics" element={<NhiAnalyticsPage />} />
           <Route path="/console/plugins" element={<PluginsPage />} />
           {/* Catch-all for unknown /console/... paths — rendered inside the Layout shell */}
           <Route path="*" element={<NotFoundPage />} />

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -67,6 +67,7 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/custom-attributes`, label: 'Custom Attributes', icon: Icons.Code },
         { to: `/console/realms/${currentRealm}/scim`, label: 'SCIM', icon: Icons.Database },
         { to: `/console/realms/${currentRealm}/authorization-policies`, label: 'Authorization', icon: Icons.Roles },
+        { to: `/console/realms/${currentRealm}/nhi`, label: 'Non-Human Identity', icon: Icons.Server },
       ]
     : [];
 


### PR DESCRIPTION
﻿## Summary

The Non-Human Identity (NHI) feature was fully implemented -- `NhiListPage`, `NhiDetailPage`, `NhiAnalyticsPage`, API client (`nhi.ts`), and backend (`src/nhi/`) -- but the pages were never registered in the router and had no sidebar link, making the entire feature invisible in the admin console.

**Changes:**
- `admin-ui/src/App.tsx` -- added three routes: `/nhi`, `/nhi/:id`, `/nhi-analytics`
- `admin-ui/src/components/Layout.tsx` -- added "Non-Human Identity" sidebar entry using the Server icon

## Test plan

- [ ] Navigate to a realm in the admin console
- [ ] Verify "Non-Human Identity" appears in the sidebar
- [ ] Confirm clicking it opens the NHI list page
- [ ] Confirm clicking an NHI identity opens the detail page

Closes #1099
