### PR TITLE
fix(admin-ui): register Theme Builder route and add sidebar nav entry

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -57,6 +57,7 @@ import ScimConfigPage from './pages/scim/ScimConfigPage';
 import PolicyListPage from './pages/authorization/PolicyListPage';
 import PolicyCreatePage from './pages/authorization/PolicyCreatePage';
 import PolicyDetailPage from './pages/authorization/PolicyDetailPage';
+import ThemeBuilderPage from './pages/theme-builder/ThemeBuilderPage';
 import NhiListPage from './pages/nhi/NhiListPage';
 import NhiDetailPage from './pages/nhi/NhiDetailPage';
 import NhiAnalyticsPage from './pages/nhi/NhiAnalyticsPage';
@@ -137,6 +138,7 @@ export default function App() {
           <Route path="/console/realms/:name/authorization-policies" element={<PolicyListPage />} />
           <Route path="/console/realms/:name/authorization-policies/new" element={<PolicyCreatePage />} />
           <Route path="/console/realms/:name/authorization-policies/:policyId" element={<PolicyDetailPage />} />
+          <Route path="/console/realms/:name/theme-builder" element={<ThemeBuilderPage />} />
           <Route path="/console/realms/:name/nhi" element={<NhiListPage />} />
           <Route path="/console/realms/:name/nhi/:id" element={<NhiDetailPage />} />
           <Route path="/console/realms/:name/nhi-analytics" element={<NhiAnalyticsPage />} />

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -67,6 +67,7 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/custom-attributes`, label: 'Custom Attributes', icon: Icons.Code },
         { to: `/console/realms/${currentRealm}/scim`, label: 'SCIM', icon: Icons.Database },
         { to: `/console/realms/${currentRealm}/authorization-policies`, label: 'Authorization', icon: Icons.Roles },
+        { to: `/console/realms/${currentRealm}/theme-builder`, label: 'Theme Builder', icon: Icons.Sun },
         { to: `/console/realms/${currentRealm}/nhi`, label: 'Non-Human Identity', icon: Icons.Server },
       ]
     : [];


### PR DESCRIPTION
﻿## Summary

The Theme Builder was advertised in CHANGELOG 0.3.0 as a delivered feature ("Theme Builder with server-side live preview") but was completely unreachable -- ThemeBuilderPage and its sub-components existed but no route or sidebar link pointed to them.

**Changes:**
- `admin-ui/src/App.tsx` -- added route `/console/realms/:name/theme-builder`
- `admin-ui/src/components/Layout.tsx` -- added "Theme Builder" sidebar entry with Sun icon

Only `ThemeBuilderPage.tsx` is a routable entry point; the other files in `pages/theme-builder/` (ThemeCanvas, ThemeTemplates, ThemeVersionHistory, LivePreview, StyleEditor, ComponentPalette, ImageUploader) are sub-components composed within it.

## Test plan

- [ ] Navigate to a realm in the admin console
- [ ] Verify "Theme Builder" appears in the sidebar
- [ ] Confirm clicking it opens the Theme Builder page
- [ ] Confirm the theme builder UI renders (canvas, templates panel, etc.)

Closes #1100
