### PR TITLE
fix(auth): survive page reload via httpOnly cookie + session bootstrap

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { useEffect } from 'react';
 import ErrorBoundary from './components/ErrorBoundary';
 import Layout from './components/Layout';
 import LoginPage from './pages/LoginPage';
@@ -63,20 +64,45 @@ import NhiDetailPage from './pages/nhi/NhiDetailPage';
 import NhiAnalyticsPage from './pages/nhi/NhiAnalyticsPage';
 import PluginsPage from './pages/plugins/PluginsPage';
 import NotFoundPage from './pages/NotFoundPage';
-import { hasCredentials } from './api/client';
+import { hasCredentials, refreshSession } from './api/client';
+import { useAuthContext } from './context/AuthContext';
 
 function ProtectedRoute() {
-  // hasCredentials() reads from the in-memory module-level store — no
-  // sessionStorage involved (see issue #330 fix).
+  const { bootstrapped } = useAuthContext();
+  // Wait for the bootstrap refresh call to complete before deciding to redirect.
+  // Without this, a page reload would always redirect to login even when a valid
+  // admin_rt cookie exists (fixes #1095).
+  if (!bootstrapped) {
+    return null;
+  }
   if (!hasCredentials()) {
     return <Navigate to="/console/login" replace />;
   }
   return <Outlet />;
 }
 
+function SessionBootstrap() {
+  const { setBootstrapped, setToken } = useAuthContext();
+
+  useEffect(() => {
+    let cancelled = false;
+    refreshSession().then((token) => {
+      if (cancelled) return;
+      if (token) {
+        setToken(token);
+      }
+      setBootstrapped(true);
+    });
+    return () => { cancelled = true; };
+  }, [setBootstrapped, setToken]);
+
+  return null;
+}
+
 export default function App() {
   return (
     <ErrorBoundary>
+    <SessionBootstrap />
     <Routes>
       <Route path="/console/login" element={<LoginPage />} />
       <Route path="/setup" element={<SetupWizardPage />} />

--- a/admin-ui/src/api/client.ts
+++ b/admin-ui/src/api/client.ts
@@ -32,6 +32,26 @@ export function hasCredentials(): boolean {
   return _apiKey !== null || _token !== null;
 }
 
+/**
+ * Attempts to rehydrate the in-memory access token from the httpOnly
+ * admin_rt cookie via GET /admin/auth/refresh.  Returns the token on
+ * success, null if the cookie is missing or expired.
+ */
+export async function refreshSession(): Promise<string | null> {
+  try {
+    const resp = await axios.get<{ access_token: string }>('/admin/auth/refresh', {
+      withCredentials: true,
+    });
+    const token = resp.data.access_token;
+    if (token) {
+      setCredentials({ token });
+    }
+    return token ?? null;
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Axios instances
 // ---------------------------------------------------------------------------

--- a/admin-ui/src/context/AuthContext.tsx
+++ b/admin-ui/src/context/AuthContext.tsx
@@ -5,9 +5,8 @@
  * memory, never written to sessionStorage/localStorage.  This eliminates the
  * XSS-theft vector described in issue #330.
  *
- * Trade-off: credentials are lost on a full page reload (F5).  Users will be
- * redirected to /console/login and must log in again, which is acceptable for
- * an admin console.
+ * Session survival across page reloads is handled by the httpOnly admin_rt
+ * cookie + GET /admin/auth/refresh bootstrap call in App.tsx (fixes #1095).
  */
 
 import {
@@ -29,6 +28,8 @@ interface AuthContextValue extends AuthState {
   setApiKey: (key: string) => void;
   setToken: (token: string) => void;
   clearAuth: () => void;
+  bootstrapped: boolean;
+  setBootstrapped: (v: boolean) => void;
   /** Ref giving the api/client interceptor synchronous access to the latest credentials. */
   credentialsRef: React.RefObject<AuthState>;
 }
@@ -37,6 +38,7 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [auth, setAuth] = useState<AuthState>({ apiKey: null, token: null });
+  const [bootstrapped, setBootstrapped] = useState(false);
 
   // Keep a ref in sync so the axios interceptor (which runs outside React's
   // render cycle) can read the latest value synchronously without a closure
@@ -64,8 +66,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const value = useMemo<AuthContextValue>(
-    () => ({ ...auth, setApiKey, setToken, clearAuth, credentialsRef }),
-    [auth, setApiKey, setToken, clearAuth, credentialsRef],
+    () => ({ ...auth, setApiKey, setToken, clearAuth, bootstrapped, setBootstrapped, credentialsRef }),
+    [auth, setApiKey, setToken, clearAuth, bootstrapped, credentialsRef],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -61,5 +61,7 @@ export function useAuth() {
     navigate('/console/login');
   }, [clearAuthState, navigate]);
 
-  return { isAuthenticated, login, loginWithCredentials, logout, clearAuthState };
+  const { bootstrapped } = useAuthContext();
+
+  return { isAuthenticated, bootstrapped, login, loginWithCredentials, logout, clearAuthState };
 }

--- a/src/admin-auth/admin-auth.controller.spec.ts
+++ b/src/admin-auth/admin-auth.controller.spec.ts
@@ -15,13 +15,22 @@ function makeReqRes(
       ? { 'x-forwarded-for': overrides.forwardedFor }
       : {},
     socket: { remoteAddress: overrides.ip ?? '127.0.0.1' },
+    cookies: {},
   };
   const headers: Record<string, string> = {};
+  const cookies: Record<string, string> = {};
   const res: any = {
     setHeader: (name: string, value: string) => {
       headers[name] = value;
     },
+    cookie: (name: string, value: string) => {
+      cookies[name] = value;
+    },
+    clearCookie: (name: string) => {
+      delete cookies[name];
+    },
     _headers: headers,
+    _cookies: cookies,
   };
   return { req, res };
 }

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
   UseGuards,
+  Logger,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -24,10 +25,15 @@ import { RateLimitGuard } from '../rate-limit/rate-limit.guard.js';
 import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 import { AdminLoginDto } from './dto/login.dto.js';
 
+const ADMIN_RT_COOKIE = 'admin_rt';
+const TOKEN_TTL_MS = 3600 * 1000;
+
 @ApiTags('Admin Auth')
 @Controller('admin/auth')
 @ApiSecurity('admin-api-key')
 export class AdminAuthController {
+  private readonly logger = new Logger(AdminAuthController.name);
+
   constructor(
     private readonly adminAuthService: AdminAuthService,
     private readonly config: ConfigService,
@@ -76,7 +82,38 @@ export class AdminAuthController {
       res.setHeader(name, value);
     }
 
+    const isProduction = this.config.get<string>('NODE_ENV') === 'production';
+    res.cookie(ADMIN_RT_COOKIE, tokenResponse.access_token, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'strict',
+      maxAge: TOKEN_TTL_MS,
+      path: '/admin/auth',
+    });
+
     return tokenResponse;
+  }
+
+  @Get('refresh')
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Rehydrate admin session from httpOnly cookie' })
+  @ApiResponse({ status: 200, description: 'Session refreshed, returns access token' })
+  @ApiResponse({ status: 401, description: 'No valid session cookie' })
+  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const token = (req.cookies as Record<string, string | undefined>)[ADMIN_RT_COOKIE];
+    if (!token) {
+      throw new UnauthorizedException('No session cookie');
+    }
+
+    try {
+      await this.adminAuthService.validateAdminToken(token);
+    } catch {
+      res.clearCookie(ADMIN_RT_COOKIE, { path: '/admin/auth' });
+      throw new UnauthorizedException('Session expired');
+    }
+
+    return { access_token: token, token_type: 'Bearer' };
   }
 
   @Post('logout')
@@ -86,11 +123,18 @@ export class AdminAuthController {
   @ApiOperation({ summary: 'Admin logout – revoke current token' })
   @ApiResponse({ status: 200, description: 'Logged out successfully' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
-  async logout(@Req() req: Request) {
+  async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
     const authHeader = req.headers['authorization'];
     if (authHeader?.startsWith('Bearer ')) {
       await this.adminAuthService.revokeToken(authHeader.slice(7));
     }
+    const cookieToken = (req.cookies as Record<string, string | undefined>)[ADMIN_RT_COOKIE];
+    if (cookieToken) {
+      await this.adminAuthService.revokeToken(cookieToken).catch((err: unknown) =>
+        this.logger.warn(`Failed to revoke cookie token: ${(err as Error).message}`),
+      );
+    }
+    res.clearCookie(ADMIN_RT_COOKIE, { path: '/admin/auth' });
     return { message: 'Logged out' };
   }
 


### PR DESCRIPTION
﻿## Summary

Admin session credentials lived only in JS heap memory (intentional XSS hardening from #330) with no rehydration mechanism. Any full page load — refresh, typed URL, deep link — wiped them and bounced the user to the login page.

This fix adds an httpOnly session cookie so the browser can silently rehydrate the in-memory token on every page load.

## Changes

**Backend (`src/admin-auth/admin-auth.controller.ts`)**
- `POST /admin/auth/login` -- now sets `admin_rt` httpOnly cookie (`secure` in production, `SameSite=strict`, 1-hour TTL, `path=/admin/auth`)
- `GET /admin/auth/refresh` (new) -- reads the cookie, validates the JWT, returns `{ access_token }`. Returns 401 + clears cookie if expired/invalid.
- `POST /admin/auth/logout` -- revokes the cookie token in addition to the Bearer token, and clears the `admin_rt` cookie.

**Frontend**
- `admin-ui/src/api/client.ts` -- adds `refreshSession()` helper (unauthenticated GET to `/admin/auth/refresh`, sets in-memory token on success)
- `admin-ui/src/context/AuthContext.tsx` -- adds `bootstrapped` / `setBootstrapped` state
- `admin-ui/src/App.tsx` -- adds `<SessionBootstrap>` component that calls `refreshSession()` on mount; `ProtectedRoute` now waits for `bootstrapped=true` before redirecting to login
- `admin-ui/src/hooks/useAuth.ts` -- exposes `bootstrapped` from context

**Tests**: `admin-auth.controller.spec.ts` -- extended `req`/`res` mock with `cookie`/`clearCookie` stubs so existing login tests pass.

## Test plan

- [ ] Log in to the admin console normally; session works as before
- [ ] Refresh the page (F5) -- stays on current page, no redirect to login
- [ ] Open a deep link directly (e.g. `/console/realms/master/users`) -- navigates to page without login redirect
- [ ] Wait for the 1-hour token to expire; refresh → redirected to login
- [ ] Click Logout -- cookie is cleared; subsequent refresh sends to login

Closes #1095
