### PR TITLE
test(admin-ui): add nav route guard and remove dead exports

### DIFF
--- a/admin-ui/src/__tests__/routes.test.ts
+++ b/admin-ui/src/__tests__/routes.test.ts
@@ -1,0 +1,66 @@
+/**
+ * routes.test.ts
+ *
+ * Guard that every navigation item declared in Layout.tsx has a corresponding
+ * route registered in App.tsx.  Both sides are read from source at test-run
+ * time so the test stays honest: it catches the real failure (someone adds a
+ * nav item without wiring up the route) rather than just checking an internal
+ * copy against itself.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const layoutSrc = readFileSync(
+  path.resolve(__dirname, '../components/Layout.tsx'),
+  'utf-8',
+);
+const appSrc = readFileSync(path.resolve(__dirname, '../App.tsx'), 'utf-8');
+
+/**
+ * Routes registered in App.tsx — extracted from `path="..."` JSX attributes.
+ * Catch-all `*` entries are excluded because they don't represent real pages.
+ */
+const APP_ROUTES = new Set<string>(
+  [...appSrc.matchAll(/path="([^"]+)"/g)]
+    .map(([, p]) => p)
+    .filter((p) => p !== '*'),
+);
+
+/**
+ * Nav `to:` values from Layout.tsx — covers both the realm-scoped `navItems`
+ * (template literals) and the top-level `globalNav` (string literals).
+ * Template expressions like `${currentRealm}` are normalised to the React
+ * Router param placeholder `:name` so they match the registered route shape.
+ */
+const NAV_PATHS: string[] = [
+  // Template literals:  to: `/console/realms/${currentRealm}/users`
+  ...[...layoutSrc.matchAll(/\bto:\s*`(\/[^`]+)`/g)].map(([, p]) =>
+    p.replace(/\$\{[^}]+\}/g, ':name'),
+  ),
+  // String literals:  to: '/console'
+  ...[...layoutSrc.matchAll(/\bto:\s*'(\/[^']+)'/g)].map(([, p]) => p),
+];
+
+describe('nav route coverage', () => {
+  it('extracts at least one app route from App.tsx', () => {
+    expect(APP_ROUTES.size).toBeGreaterThan(0);
+  });
+
+  it('extracts at least one nav path from Layout.tsx', () => {
+    expect(NAV_PATHS.length).toBeGreaterThan(0);
+  });
+
+  it('every nav item has a corresponding registered route', () => {
+    const orphaned = NAV_PATHS.filter((p) => !APP_ROUTES.has(p));
+    expect(
+      orphaned,
+      `Orphaned nav items (no matching route in App.tsx):\n  ${orphaned.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/admin-ui/src/api/authorization.ts
+++ b/admin-ui/src/api/authorization.ts
@@ -53,17 +53,6 @@ export async function deletePolicy(realmName: string, id: string): Promise<void>
   await apiClient.delete(`/realms/${realmName}/policies/${id}`);
 }
 
-export async function evaluatePolicy(
-  realmName: string,
-  context: Record<string, unknown>,
-): Promise<unknown> {
-  const { data } = await apiClient.post<unknown>(
-    `/realms/${realmName}/policies/evaluate`,
-    context,
-  );
-  return data;
-}
-
 export async function testPolicy(
   realmName: string,
   id: string,

--- a/admin-ui/src/api/clientScopes.ts
+++ b/admin-ui/src/api/clientScopes.ts
@@ -62,19 +62,6 @@ export async function addMapper(
   return data;
 }
 
-export async function updateMapper(
-  realmName: string,
-  scopeId: string,
-  mapperId: string,
-  mapper: { name?: string; config?: Record<string, unknown> },
-): Promise<ProtocolMapper> {
-  const { data } = await apiClient.put<ProtocolMapper>(
-    `/realms/${realmName}/client-scopes/${scopeId}/protocol-mappers/${mapperId}`,
-    mapper,
-  );
-  return data;
-}
-
 export async function deleteMapper(
   realmName: string,
   scopeId: string,


### PR DESCRIPTION
## Summary

- Add \`admin-ui/src/__tests__/routes.test.ts\`: reads \`Layout.tsx\` and \`App.tsx\` at test-run time and asserts every nav sidebar item resolves to a registered React Router route. The source-reading approach (rather than hardcoded arrays) means the guard actually catches the real failure mode.
- Remove \`evaluatePolicy()\` from \`src/api/authorization.ts\` -- exported function with no callers anywhere in the codebase.
- Remove \`updateMapper()\` from \`src/api/clientScopes.ts\` -- exported function with no callers anywhere in the codebase.

All 33 test files pass (339 tests); tsc --noEmit is clean.

## Test plan

- [x] cd admin-ui && npm test -- --run -- 33 files, 339 tests, all pass
- [x] cd admin-ui && npx tsc --noEmit -- no errors
- [ ] Verify the guard catches a broken nav entry: add a fake to: in Layout.tsx pointing to a non-existent route -- the new test should fail

Generated with Claude Code