### PR TITLE
fix(docs): align docs/API/SDK version references to v0.3.0

### DIFF
--- a/docs/docs/api/openapi.yaml
+++ b/docs/docs/api/openapi.yaml
@@ -18,7 +18,7 @@ info:
     ## Rate Limiting
 
     Some endpoints are rate-limited. See specific endpoint documentation for details.
-  version: 1.0.0
+  version: 0.3.0
   contact:
     name: Idenplane Project
     url: https://idenplane.com

--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -37,7 +37,7 @@ Add the dependency to your app or library module `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.github.Islamawad132:Idenplane:1.0.0")
+    implementation("com.github.Islamawad132:Idenplane:0.3.0")
 }
 ```
 

--- a/docs/docs/guides/sdks/ios.mdx
+++ b/docs/docs/guides/sdks/ios.mdx
@@ -29,7 +29,7 @@ Add the package to your `Package.swift` dependencies:
 dependencies: [
     .package(
         url: "https://github.com/idenplane/idenplane",
-        from: "1.0.0"
+        from: "0.3.0"
     )
 ]
 ```

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idenplane-docs",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idenplane-docs",
-      "version": "1.0.0",
+      "version": "0.3.0",
       "dependencies": {
         "@docusaurus/core": "^3.10.1",
         "@docusaurus/preset-classic": "^3.10.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idenplane-docs",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
All version references in the docs site advertised v1.0.0 while the server is at v0.3.0.

**Fixed:**
- `docs/docs/api/openapi.yaml` — OpenAPI `info.version` 1.0.0 → 0.3.0
- `docs/package.json` — docs package version 1.0.0 → 0.3.0
- `docs/package-lock.json` — lockfile version 1.0.0 → 0.3.0
- `docs/docs/guides/sdks/android.mdx` — Android SDK import 1.0.0 → 0.3.0
- `docs/docs/guides/sdks/ios.mdx` — iOS SPM `from:` 1.0.0 → 0.3.0

Closes #1114