### PR TITLE
feat(admin-ui): add missing realm settings — session limits, adaptive auth, event retention, SCIM toggles

### DIFF
--- a/admin-ui/src/__tests__/routes.test.ts
+++ b/admin-ui/src/__tests__/routes.test.ts
@@ -47,6 +47,17 @@ const NAV_PATHS: string[] = [
   ...[...layoutSrc.matchAll(/\bto:\s*'(\/[^']+)'/g)].map(([, p]) => p),
 ];
 
+/**
+ * Routes that legitimately have no direct sidebar nav entry.
+ * Add here when a route is intentionally reachable without appearing in the nav.
+ */
+const ROUTE_NAV_WHITELIST = new Set([
+  '/console/login',
+  '/setup',
+  '/console/realms/:name',         // realm overview — clicked from the realm list
+  '/console/realms/:name/nhi-analytics', // NHI analytics — linked from NHI list page
+]);
+
 describe('nav route coverage', () => {
   it('extracts at least one app route from App.tsx', () => {
     expect(APP_ROUTES.size).toBeGreaterThan(0);
@@ -61,6 +72,24 @@ describe('nav route coverage', () => {
     expect(
       orphaned,
       `Orphaned nav items (no matching route in App.tsx):\n  ${orphaned.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+
+  it('every navigable route has a nav entry or is whitelisted', () => {
+    const routesNeedingNav = [...APP_ROUTES].filter((route) => {
+      // Explicit whitelist (standalone / non-nav pages)
+      if (ROUTE_NAV_WHITELIST.has(route)) return false;
+      // Detail pages with two or more dynamic segments — reached via list-row clicks
+      if ((route.match(/:/g) ?? []).length >= 2) return false;
+      // Creation / new-item pages — reached via "Add" / "Create" buttons, not nav
+      if (/\/(create|new)$/.test(route)) return false;
+      return true;
+    });
+
+    const noNav = routesNeedingNav.filter((route) => !NAV_PATHS.includes(route));
+    expect(
+      noNav,
+      `Routes with no nav entry (add to ROUTE_NAV_WHITELIST if intentional):\n  ${noNav.join('\n  ')}`,
     ).toHaveLength(0);
   });
 });

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -130,6 +130,10 @@ export default function RealmDetailPage() {
     // Risk Thresholds
     riskThresholdStepUp: 50,
     riskThresholdBlock: 80,
+    // Session Limits
+    maxSessionsPerUser: 0,
+    // Adaptive Authentication
+    adaptiveAuthEnabled: false,
     // Locale
     defaultLocale: 'en',
     supportedLocales: [] as string[],
@@ -137,6 +141,9 @@ export default function RealmDetailPage() {
     eventsEnabled: false,
     eventsExpiration: 604800,
     adminEventsEnabled: false,
+    loginEventRetentionDays: 30,
+    adminEventRetentionDays: 90,
+    deletionGracePeriodDays: 14,
     // Theme
     themeName: 'idenplane',
     loginTheme: 'idenplane',
@@ -191,6 +198,10 @@ export default function RealmDetailPage() {
         // Risk Thresholds
         riskThresholdStepUp: (realm as any).riskThresholdStepUp ?? 50,
         riskThresholdBlock: (realm as any).riskThresholdBlock ?? 80,
+        // Session Limits
+        maxSessionsPerUser: (realm as any).maxSessionsPerUser ?? 0,
+        // Adaptive Authentication
+        adaptiveAuthEnabled: (realm as any).adaptiveAuthEnabled ?? false,
         // Locale
         defaultLocale: (realm as any).defaultLocale ?? 'en',
         supportedLocales: (realm as any).supportedLocales ?? [],
@@ -198,6 +209,9 @@ export default function RealmDetailPage() {
         eventsEnabled: realm.eventsEnabled ?? false,
         eventsExpiration: realm.eventsExpiration ?? 604800,
         adminEventsEnabled: realm.adminEventsEnabled ?? false,
+        loginEventRetentionDays: (realm as any).loginEventRetentionDays ?? 30,
+        adminEventRetentionDays: (realm as any).adminEventRetentionDays ?? 90,
+        deletionGracePeriodDays: (realm as any).deletionGracePeriodDays ?? 14,
         // Theme
         themeName: realm.themeName ?? 'idenplane',
         loginTheme: realm.loginTheme ?? 'idenplane',
@@ -957,6 +971,52 @@ export default function RealmDetailPage() {
             </div>
           </div>
 
+          {/* Session Limits */}
+          <div className="space-y-6 border-t border-gray-200 pt-6">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Session Limits</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Limit the number of concurrent active sessions per user.
+              </p>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Max sessions per user</label>
+              <input type="number" min={0} value={form.maxSessionsPerUser}
+                onChange={(e) => setForm({ ...form, maxSessionsPerUser: Number(e.target.value) })}
+                className="w-40 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none" />
+              <p className="mt-1 text-xs text-gray-400">
+                Maximum concurrent active sessions per user. When the limit is reached the oldest session is evicted.
+                Set to 0 for unlimited.
+              </p>
+            </div>
+          </div>
+
+          {/* Adaptive Authentication */}
+          <div className="space-y-6 border-t border-gray-200 pt-6">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Adaptive Authentication</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Enable AI-powered risk scoring to dynamically adjust authentication requirements.
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="adaptiveAuthEnabled"
+                checked={form.adaptiveAuthEnabled}
+                onChange={(e) => setForm({ ...form, adaptiveAuthEnabled: e.target.checked })}
+                className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <label htmlFor="adaptiveAuthEnabled" className="text-sm font-medium text-gray-700">
+                Enable adaptive authentication
+              </label>
+            </div>
+            <p className="ml-6 -mt-4 text-xs text-gray-400">
+              When enabled, each login attempt is scored for risk. High-risk logins trigger step-up MFA or are
+              blocked based on the thresholds above.
+            </p>
+          </div>
+
           {updateMutation.isSuccess && (
             <div className="rounded-md bg-green-50 p-3 text-sm text-green-700">
               Security settings updated successfully.
@@ -1044,6 +1104,51 @@ export default function RealmDetailPage() {
               </div>
               <p className="mt-1 text-xs text-gray-400">
                 How long events are kept before automatic cleanup. Default: 7 days (604800s).
+              </p>
+            </div>
+          </div>
+
+          {/* Event Retention */}
+          <div className="space-y-6 border-t border-gray-200 pt-6">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">Event Retention</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                How many days event records are retained in the database before being purged.
+              </p>
+            </div>
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Login event retention (days)</label>
+                <input type="number" min={1} value={form.loginEventRetentionDays}
+                  onChange={(e) => setForm({ ...form, loginEventRetentionDays: Number(e.target.value) })}
+                  className="w-40 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none" />
+                <p className="mt-1 text-xs text-gray-400">Days to keep login/auth event records. Default: 30.</p>
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700">Admin event retention (days)</label>
+                <input type="number" min={1} value={form.adminEventRetentionDays}
+                  onChange={(e) => setForm({ ...form, adminEventRetentionDays: Number(e.target.value) })}
+                  className="w-40 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none" />
+                <p className="mt-1 text-xs text-gray-400">Days to keep admin audit event records. Default: 90.</p>
+              </div>
+            </div>
+          </div>
+
+          {/* User Lifecycle */}
+          <div className="space-y-6 border-t border-gray-200 pt-6">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">User Lifecycle</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Configure how long deleted user accounts are retained before permanent removal.
+              </p>
+            </div>
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700">Deletion grace period (days)</label>
+              <input type="number" min={0} value={form.deletionGracePeriodDays}
+                onChange={(e) => setForm({ ...form, deletionGracePeriodDays: Number(e.target.value) })}
+                className="w-40 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none" />
+              <p className="mt-1 text-xs text-gray-400">
+                Days before a soft-deleted account is permanently purged. Set to 0 to disable soft-deletion. Default: 14.
               </p>
             </div>
           </div>

--- a/admin-ui/src/pages/scim/ScimConfigPage.tsx
+++ b/admin-ui/src/pages/scim/ScimConfigPage.tsx
@@ -25,6 +25,8 @@ export default function ScimConfigPage() {
   const queryClient = useQueryClient();
 
   const [scimEnabledToggle, setScimEnabledToggle] = useState(false);
+  const [scimUserAutocreate, setScimUserAutocreate] = useState(true);
+  const [scimGroupSyncEnabled, setScimGroupSyncEnabled] = useState(true);
 
   const [showCreateToken, setShowCreateToken] = useState(false);
   const [tokenForm, setTokenForm] = useState({
@@ -54,11 +56,14 @@ export default function ScimConfigPage() {
   useEffect(() => {
     if (realm !== undefined) {
       setScimEnabledToggle(realm.scimEnabled ?? false);
+      setScimUserAutocreate(realm.scimUserAutocreate ?? true);
+      setScimGroupSyncEnabled(realm.scimGroupSyncEnabled ?? true);
     }
   }, [realm]);
 
   const updateRealmMutation = useMutation({
-    mutationFn: (scimEnabled: boolean) => updateRealm(name!, { scimEnabled }),
+    mutationFn: (payload: { scimEnabled: boolean; scimUserAutocreate: boolean; scimGroupSyncEnabled: boolean }) =>
+      updateRealm(name!, payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['realm', name] });
       queryClient.invalidateQueries({ queryKey: ['scim-status', name] });
@@ -195,7 +200,7 @@ export default function ScimConfigPage() {
           <div className="mt-3 flex items-center gap-3">
             <button
               type="button"
-              onClick={() => updateRealmMutation.mutate(scimEnabledToggle)}
+              onClick={() => updateRealmMutation.mutate({ scimEnabled: scimEnabledToggle, scimUserAutocreate, scimGroupSyncEnabled })}
               disabled={updateRealmMutation.isPending}
               className="rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
             >
@@ -222,18 +227,32 @@ export default function ScimConfigPage() {
             </div>
             <div>
               <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">User Autocreate</dt>
-              <dd className="mt-1">
-                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${status.userAutocreate ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
-                  {status.userAutocreate ? 'On' : 'Off'}
-                </span>
+              <dd className="mt-1 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="scimUserAutocreate"
+                  checked={scimUserAutocreate}
+                  onChange={(e) => setScimUserAutocreate(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <label htmlFor="scimUserAutocreate" className="text-sm text-gray-700">
+                  {scimUserAutocreate ? 'On' : 'Off'}
+                </label>
               </dd>
             </div>
             <div>
               <dt className="text-xs font-medium uppercase tracking-wider text-gray-500">Group Sync</dt>
-              <dd className="mt-1">
-                <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${status.groupSyncEnabled ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
-                  {status.groupSyncEnabled ? 'Enabled' : 'Disabled'}
-                </span>
+              <dd className="mt-1 flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="scimGroupSyncEnabled"
+                  checked={scimGroupSyncEnabled}
+                  onChange={(e) => setScimGroupSyncEnabled(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                <label htmlFor="scimGroupSyncEnabled" className="text-sm text-gray-700">
+                  {scimGroupSyncEnabled ? 'Enabled' : 'Disabled'}
+                </label>
               </dd>
             </div>
             <div>

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -79,6 +79,15 @@ export interface Realm {
   eventsEnabled: boolean;
   eventsExpiration: number;
   adminEventsEnabled: boolean;
+  loginEventRetentionDays?: number;
+  adminEventRetentionDays?: number;
+  deletionGracePeriodDays?: number;
+  maxSessionsPerUser?: number;
+  adaptiveAuthEnabled?: boolean;
+  riskThresholdStepUp?: number;
+  riskThresholdBlock?: number;
+  scimUserAutocreate?: boolean;
+  scimGroupSyncEnabled?: boolean;
   themeName: string;
   theme: RealmTheme | null;
   loginTheme: string;

--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -553,4 +553,49 @@ export class CreateRealmDto {
   @IsOptional()
   @IsBoolean()
   scimEnabled?: boolean;
+
+  @ApiPropertyOptional({
+    default: true,
+    description: 'Automatically create users on SCIM provision if they do not exist',
+  })
+  @IsOptional()
+  @IsBoolean()
+  scimUserAutocreate?: boolean;
+
+  @ApiPropertyOptional({
+    default: true,
+    description: 'Sync SCIM group membership changes to realm groups',
+  })
+  @IsOptional()
+  @IsBoolean()
+  scimGroupSyncEnabled?: boolean;
+
+  // Event retention
+  @ApiPropertyOptional({
+    default: 30,
+    description: 'Number of days to retain login event records',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  loginEventRetentionDays?: number;
+
+  @ApiPropertyOptional({
+    default: 90,
+    description: 'Number of days to retain admin event records',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  adminEventRetentionDays?: number;
+
+  // User lifecycle
+  @ApiPropertyOptional({
+    default: 14,
+    description: 'Grace period in days before a soft-deleted user account is permanently removed',
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  deletionGracePeriodDays?: number;
 }

--- a/src/realms/realms.service.ts
+++ b/src/realms/realms.service.ts
@@ -299,6 +299,13 @@ export class RealmsService {
       captchaScoreThreshold: dto.captchaScoreThreshold,
       // SCIM provisioning
       scimEnabled: dto.scimEnabled,
+      scimUserAutocreate: dto.scimUserAutocreate,
+      scimGroupSyncEnabled: dto.scimGroupSyncEnabled,
+      // Event retention
+      loginEventRetentionDays: dto.loginEventRetentionDays,
+      adminEventRetentionDays: dto.adminEventRetentionDays,
+      // User lifecycle
+      deletionGracePeriodDays: dto.deletionGracePeriodDays,
     };
 
     // Only update password if a real value is provided (not the redacted placeholder)


### PR DESCRIPTION
## Summary

- **Security tab**: Session Limits section (`maxSessionsPerUser`) and Adaptive Authentication section (`adaptiveAuthEnabled`) added after Risk Thresholds
- **Events tab**: Event Retention section (`loginEventRetentionDays`, `adminEventRetentionDays`) and User Lifecycle section (`deletionGracePeriodDays`) added
- **SCIM config page**: `scimUserAutocreate` and `scimGroupSyncEnabled` are now editable checkboxes saved alongside `scimEnabled` (previously read-only status badges)
- **Backend**: `loginEventRetentionDays`, `adminEventRetentionDays`, `deletionGracePeriodDays`, `scimUserAutocreate`, `scimGroupSyncEnabled` added to `CreateRealmDto` and the `realms.service.ts` update data map; frontend `Realm` type updated to match

All fields were already present in the Prisma schema — this PR wires them up through the DTO, service, and UI.

## Test plan

- [ ] Open a realm's Security tab — verify Session Limits and Adaptive Authentication sections appear and save correctly
- [ ] Open a realm's Events tab — verify Event Retention (login/admin days) and User Lifecycle (deletion grace period) fields appear and save correctly
- [ ] Open SCIM Configuration — verify User Autocreate and Group Sync are checkboxes that persist across page reload
- [ ] Confirm the admin-ui build passes (`cd admin-ui && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)