### PR TITLE
fix(roles): resolve 500 on Keycloak-style payload; accept bare-array Keycloak convention

### DIFF
--- a/src/groups/groups.controller.spec.ts
+++ b/src/groups/groups.controller.spec.ts
@@ -1,6 +1,8 @@
 jest.mock('../crypto/jwk.service.js', () => ({ JwkService: jest.fn() }));
 
+import { plainToInstance } from 'class-transformer';
 import { GroupsController } from './groups.controller.js';
+import { AssignRolesDto } from '../roles/dto/assign-role.dto.js';
 import type { Realm } from '@prisma/client';
 
 describe('GroupsController', () => {
@@ -186,11 +188,13 @@ describe('GroupsController', () => {
   });
 
   describe('assignRoles', () => {
-    it('should call groupsService.assignRolesToGroup with realm, groupId, and roleNames', () => {
-      const body = { roleNames: ['admin', 'editor'] };
+    it('should call groupsService.assignRolesToGroup with roleNames from roleNames format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roleNames: ['admin', 'editor'],
+      });
       mockGroupsService.assignRolesToGroup.mockReturnValue(undefined);
 
-      const result = controller.assignRoles(realm, 'group-1', body);
+      const result = controller.assignRoles(realm, 'group-1', dto);
 
       expect(mockGroupsService.assignRolesToGroup).toHaveBeenCalledWith(
         realm,
@@ -199,14 +203,29 @@ describe('GroupsController', () => {
       );
       expect(result).toBeUndefined();
     });
+
+    it('should call groupsService.assignRolesToGroup with roleNames from Keycloak roles format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'admin' }],
+      });
+      mockGroupsService.assignRolesToGroup.mockReturnValue(undefined);
+
+      controller.assignRoles(realm, 'group-1', dto);
+
+      expect(mockGroupsService.assignRolesToGroup).toHaveBeenCalledWith(
+        realm,
+        'group-1',
+        ['admin'],
+      );
+    });
   });
 
   describe('removeRoles', () => {
-    it('should call groupsService.removeRolesFromGroup with realm, groupId, and roleNames', () => {
-      const body = { roleNames: ['editor'] };
+    it('should call groupsService.removeRolesFromGroup with roleNames from roleNames format', () => {
+      const dto = plainToInstance(AssignRolesDto, { roleNames: ['editor'] });
       mockGroupsService.removeRolesFromGroup.mockReturnValue(undefined);
 
-      const result = controller.removeRoles(realm, 'group-1', body);
+      const result = controller.removeRoles(realm, 'group-1', dto);
 
       expect(mockGroupsService.removeRolesFromGroup).toHaveBeenCalledWith(
         realm,
@@ -214,6 +233,21 @@ describe('GroupsController', () => {
         ['editor'],
       );
       expect(result).toBeUndefined();
+    });
+
+    it('should call groupsService.removeRolesFromGroup with Keycloak roles format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ id: 'abc', name: 'editor' }],
+      });
+      mockGroupsService.removeRolesFromGroup.mockReturnValue(undefined);
+
+      controller.removeRoles(realm, 'group-1', dto);
+
+      expect(mockGroupsService.removeRolesFromGroup).toHaveBeenCalledWith(
+        realm,
+        'group-1',
+        ['editor'],
+      );
     });
   });
 });

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -21,7 +21,6 @@ import { GroupsService } from './groups.service.js';
 import { CreateGroupDto } from './dto/create-group.dto.js';
 import { UpdateGroupDto } from './dto/update-group.dto.js';
 import { AssignRolesDto } from '../roles/dto/assign-role.dto.js';
-import { NormalizeRoleBodyPipe } from '../roles/pipes/normalize-role-body.pipe.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
@@ -173,7 +172,7 @@ export class GroupsController {
   assignRoles(
     @CurrentRealm() realm: Realm,
     @Param('groupId') groupId: string,
-    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
+    @Body() dto: AssignRolesDto,
   ) {
     return this.groupsService.assignRolesToGroup(
       realm,
@@ -191,7 +190,7 @@ export class GroupsController {
   removeRoles(
     @CurrentRealm() realm: Realm,
     @Param('groupId') groupId: string,
-    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
+    @Body() dto: AssignRolesDto,
   ) {
     return this.groupsService.removeRolesFromGroup(
       realm,

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -21,6 +21,7 @@ import { GroupsService } from './groups.service.js';
 import { CreateGroupDto } from './dto/create-group.dto.js';
 import { UpdateGroupDto } from './dto/update-group.dto.js';
 import { AssignRolesDto } from '../roles/dto/assign-role.dto.js';
+import { NormalizeRoleBodyPipe } from '../roles/pipes/normalize-role-body.pipe.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
@@ -172,9 +173,13 @@ export class GroupsController {
   assignRoles(
     @CurrentRealm() realm: Realm,
     @Param('groupId') groupId: string,
-    @Body() dto: AssignRolesDto,
+    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
   ) {
-    return this.groupsService.assignRolesToGroup(realm, groupId, dto.roleNames);
+    return this.groupsService.assignRolesToGroup(
+      realm,
+      groupId,
+      dto.effectiveNames,
+    );
   }
 
   @Delete('groups/:groupId/role-mappings')
@@ -186,12 +191,12 @@ export class GroupsController {
   removeRoles(
     @CurrentRealm() realm: Realm,
     @Param('groupId') groupId: string,
-    @Body() dto: AssignRolesDto,
+    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
   ) {
     return this.groupsService.removeRolesFromGroup(
       realm,
       groupId,
-      dto.roleNames,
+      dto.effectiveNames,
     );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { AppModule } from './app.module.js';
 import { GlobalExceptionFilter } from './common/filters/http-exception.filter.js';
 import { registerHandlebarsHelpers } from './theme/handlebars-helpers.js';
 import { CorsOriginService } from './cors/cors-origin.service.js';
+import { NormalizeRoleBodyPipe } from './roles/pipes/normalize-role-body.pipe.js';
 
 /** Known-insecure / placeholder values that must never reach production. */
 const INSECURE_ADMIN_API_KEY_VALUES = new Set([
@@ -262,7 +263,12 @@ async function bootstrap() {
   // Register theme engine Handlebars helpers ({{msg}}, {{msgArgs}})
   registerHandlebarsHelpers();
 
+  // NormalizeRoleBodyPipe MUST be registered before ValidationPipe so that
+  // bare-array Keycloak-style bodies (e.g. [{ name: "admin" }]) are reshaped
+  // to { roleNames: [...] } before ValidationPipe rejects them.
+  // The pipe's metatype guard ensures it only activates for AssignRolesDto params.
   app.useGlobalPipes(
+    new NormalizeRoleBodyPipe(),
     new ValidationPipe({
       whitelist: true,
       forbidNonWhitelisted: true,

--- a/src/roles/dto/assign-role.dto.spec.ts
+++ b/src/roles/dto/assign-role.dto.spec.ts
@@ -1,0 +1,79 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { AssignRolesDto } from './assign-role.dto.js';
+
+describe('AssignRolesDto', () => {
+  describe('effectiveNames getter', () => {
+    it('resolves names from roleNames array', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roleNames: ['admin', 'user'],
+      });
+      expect(dto.effectiveNames).toEqual(['admin', 'user']);
+    });
+
+    it('resolves names from roles[].name when roleNames absent', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'admin' }],
+      });
+      expect(dto.effectiveNames).toEqual(['admin']);
+    });
+
+    it('resolves names from roles with extra id field (Keycloak shape)', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ id: 'abc-123', name: 'admin' }],
+      });
+      expect(dto.effectiveNames).toEqual(['admin']);
+    });
+
+    it('returns empty array when both roleNames and roles are absent', () => {
+      const dto = plainToInstance(AssignRolesDto, {});
+      expect(dto.effectiveNames).toEqual([]);
+    });
+
+    it('prefers roleNames over roles when both are present', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roleNames: ['admin'],
+        roles: [{ name: 'viewer' }],
+      });
+      expect(dto.effectiveNames).toEqual(['admin']);
+    });
+
+    it('never throws TypeError on undefined roleNames or roles', () => {
+      const dto = new AssignRolesDto();
+      expect(() => dto.effectiveNames).not.toThrow();
+      expect(dto.effectiveNames).toEqual([]);
+    });
+  });
+
+  describe('validation', () => {
+    it('passes validation for roleNames format', async () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roleNames: ['admin', 'user'],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('passes validation for roles format without id', async () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'admin' }],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('passes validation for Keycloak shape with id field', async () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ id: 'abc-123', name: 'admin' }],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('passes validation for empty object (no crash)', async () => {
+      const dto = plainToInstance(AssignRolesDto, {});
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+});

--- a/src/roles/dto/assign-role.dto.ts
+++ b/src/roles/dto/assign-role.dto.ts
@@ -1,11 +1,21 @@
-import { IsArray, IsString, IsOptional, ValidateNested } from 'class-validator';
-import { Type, Transform } from 'class-transformer';
+import {
+  IsArray,
+  IsString,
+  IsOptional,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 /**
- * Represents a role entry in the Keycloak-style format: { name: string }
+ * Represents a role entry in the Keycloak-style format.
+ * Accepts both `{ name: string }` and `{ id: string, name: string }` shapes.
  */
 class RoleEntry {
+  @IsOptional()
+  @IsString()
+  id?: string;
+
   @IsString()
   name!: string;
 }
@@ -15,11 +25,11 @@ class RoleEntry {
  *
  * Accepts two equivalent formats:
  *   - `roleNames: string[]`  – simple string array (preferred)
- *   - `roles: { name: string }[]` – Keycloak-compatible object array
+ *   - `roles: { name: string }[]` – Keycloak-compatible object array (id is optional)
  *
- * After class-transformer processing, `roleNames` is always populated from
- * whichever format the caller used.  The controller continues to reference
- * `dto.roleNames` without any change.
+ * Use `dto.effectiveNames` in controllers/services — it resolves names from
+ * whichever format the caller used, without relying on @Transform which does not
+ * fire for absent properties.
  */
 export class AssignRolesDto {
   @ApiPropertyOptional({
@@ -29,46 +39,10 @@ export class AssignRolesDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
-  /**
-   * If the caller sent `roles: [{name: …}]` instead of `roleNames: […]`,
-   * extract the names here so that the rest of the codebase can keep using
-   * `dto.roleNames` without modification.
-   */
-  @Transform(
-    ({
-      value,
-      obj,
-    }: {
-      value: unknown;
-      obj: Record<string, unknown>;
-    }): string[] => {
-      // Already provided as roleNames — keep only the string entries.
-      if (Array.isArray(value) && value.length > 0) {
-        return (value as unknown[]).filter(
-          (v): v is string => typeof v === 'string',
-        );
-      }
-      // Fall back to the Keycloak-style `roles: [{ name }]` field.
-      const roles = obj['roles'];
-      if (Array.isArray(roles)) {
-        return (roles as unknown[])
-          .map((r): string | undefined => {
-            if (typeof r === 'string') return r;
-            if (r && typeof r === 'object' && 'name' in r) {
-              const n = r.name;
-              return typeof n === 'string' ? n : undefined;
-            }
-            return undefined;
-          })
-          .filter((n): n is string => n !== undefined);
-      }
-      return [];
-    },
-  )
-  roleNames!: string[];
+  roleNames?: string[];
 
   @ApiPropertyOptional({
-    example: [{ name: 'admin' }, { name: 'user' }],
+    example: [{ name: 'admin' }, { id: 'abc', name: 'user' }],
     description: 'Keycloak-compatible role list (alternative to roleNames)',
   })
   @IsOptional()
@@ -76,4 +50,20 @@ export class AssignRolesDto {
   @ValidateNested({ each: true })
   @Type(() => RoleEntry)
   roles?: RoleEntry[];
+
+  /**
+   * Resolves role names from whichever format the caller used.
+   * Prefer this over `dto.roleNames` directly.
+   */
+  get effectiveNames(): string[] {
+    if (this.roleNames && this.roleNames.length > 0) {
+      return this.roleNames;
+    }
+    if (this.roles && this.roles.length > 0) {
+      return this.roles
+        .map((r) => r.name)
+        .filter((n): n is string => typeof n === 'string' && n.length > 0);
+    }
+    return [];
+  }
 }

--- a/src/roles/pipes/normalize-role-body.pipe.integration.spec.ts
+++ b/src/roles/pipes/normalize-role-body.pipe.integration.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration spec: verifies that NormalizeRoleBodyPipe correctly handles
+ * bare-array bodies in the full NestJS HTTP pipeline (global ValidationPipe +
+ * parameter-level NormalizeRoleBodyPipe).
+ *
+ * This test spins up a minimal NestJS app with the global ValidationPipe
+ * configured exactly as in main.ts, then sends real HTTP requests via
+ * supertest to confirm the pipe ordering works correctly.
+ */
+
+import { Controller, Post, Body, ValidationPipe, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { NormalizeRoleBodyPipe } from './normalize-role-body.pipe.js';
+import { AssignRolesDto } from '../dto/assign-role.dto.js';
+
+@Controller()
+class ProbeController {
+  @Post('probe')
+  handle(@Body() dto: AssignRolesDto): string[] {
+    return dto.effectiveNames;
+  }
+}
+
+@Module({ controllers: [ProbeController] })
+class ProbeModule {}
+
+describe('NormalizeRoleBodyPipe (integration — full HTTP pipeline)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ProbeModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    // NormalizeRoleBodyPipe is registered as a GLOBAL pipe, BEFORE ValidationPipe.
+    // This is the production wiring: global pipes run in registration order,
+    // and the normalizer must reshape bare-array bodies before ValidationPipe
+    // rejects them with forbidNonWhitelisted: true.
+    app.useGlobalPipes(
+      new NormalizeRoleBodyPipe(),
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('accepts bare array [{ name }] and normalizes to effectiveNames', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send([{ name: 'admin' }])
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual(['admin']);
+  });
+
+  it('accepts bare array [{ id, name }] (Keycloak shape) and normalizes correctly', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send([{ id: 'abc-123', name: 'editor' }])
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual(['editor']);
+  });
+
+  it('accepts bare array with multiple roles', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send([{ name: 'admin' }, { name: 'editor' }])
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual(['admin', 'editor']);
+  });
+
+  it('accepts { roleNames: [...] } object body', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send({ roleNames: ['admin'] })
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual(['admin']);
+  });
+
+  it('accepts { roles: [{ name }] } Keycloak object body', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send({ roles: [{ name: 'admin' }] })
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual(['admin']);
+  });
+
+  it('accepts { roles: [{ id, name }] } Keycloak object body with id field', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send({ roles: [{ id: 'abc', name: 'admin' }] })
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(201);
+    expect(resp.body).toEqual(['admin']);
+  });
+
+  it('rejects empty bare array [] with 400', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send([])
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(400);
+  });
+
+  it('rejects bare array with entries missing name with 400', async () => {
+    const resp = await request(app.getHttpServer())
+      .post('/probe')
+      .send([{ id: 'abc' }])
+      .set('Content-Type', 'application/json');
+
+    expect(resp.status).toBe(400);
+  });
+});

--- a/src/roles/pipes/normalize-role-body.pipe.ts
+++ b/src/roles/pipes/normalize-role-body.pipe.ts
@@ -1,17 +1,35 @@
-import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+import {
+  PipeTransform,
+  Injectable,
+  BadRequestException,
+  ArgumentMetadata,
+} from '@nestjs/common';
+import { AssignRolesDto } from '../dto/assign-role.dto.js';
 
 /**
- * Pre-processes bare-array role-mapping bodies (Keycloak convention) into
- * the canonical `{ roleNames: string[] }` object format before the global
- * ValidationPipe runs.
+ * Global pipe that normalizes bare-array role-mapping bodies (Keycloak convention)
+ * into the canonical `{ roleNames: string[] }` object format before the global
+ * ValidationPipe sees the value.
  *
  * This handles the case where clients send `[{ name: "admin" }]` instead of
- * `{ "roleNames": ["admin"] }`.  Must be applied as the first pipe in @Body()
- * so it runs before the ValidationPipe sees the value.
+ * `{ "roleNames": ["admin"] }`.
+ *
+ * Registration: must be added via `app.useGlobalPipes()` BEFORE ValidationPipe
+ * (global pipes run in registration order). Do NOT use as a param-level pipe
+ * with @Body(NormalizeRoleBodyPipe) — param-level pipes run AFTER global pipes,
+ * which means ValidationPipe would reject the bare array first.
+ *
+ * The metatype guard ensures this pipe is a no-op for every endpoint except those
+ * that accept AssignRolesDto, so it cannot accidentally mangle other array bodies.
  */
 @Injectable()
 export class NormalizeRoleBodyPipe implements PipeTransform {
-  transform(value: unknown): unknown {
+  transform(value: unknown, metadata: ArgumentMetadata): unknown {
+    // Only activate for AssignRolesDto parameters — no-op for everything else.
+    if (metadata.metatype !== AssignRolesDto) {
+      return value;
+    }
+
     if (!Array.isArray(value)) {
       return value;
     }

--- a/src/roles/pipes/normalize-role-body.pipe.ts
+++ b/src/roles/pipes/normalize-role-body.pipe.ts
@@ -1,0 +1,38 @@
+import { PipeTransform, Injectable, BadRequestException } from '@nestjs/common';
+
+/**
+ * Pre-processes bare-array role-mapping bodies (Keycloak convention) into
+ * the canonical `{ roleNames: string[] }` object format before the global
+ * ValidationPipe runs.
+ *
+ * This handles the case where clients send `[{ name: "admin" }]` instead of
+ * `{ "roleNames": ["admin"] }`.  Must be applied as the first pipe in @Body()
+ * so it runs before the ValidationPipe sees the value.
+ */
+@Injectable()
+export class NormalizeRoleBodyPipe implements PipeTransform {
+  transform(value: unknown): unknown {
+    if (!Array.isArray(value)) {
+      return value;
+    }
+
+    if (value.length === 0) {
+      throw new BadRequestException('Provide at least one role');
+    }
+
+    const names = value
+      .map((r: unknown) => {
+        if (r && typeof r === 'object' && 'name' in r) {
+          return (r as Record<string, unknown>)['name'];
+        }
+        return undefined;
+      })
+      .filter((n): n is string => typeof n === 'string' && n.length > 0);
+
+    if (names.length === 0) {
+      throw new BadRequestException('Each role entry must have a name');
+    }
+
+    return { roleNames: names };
+  }
+}

--- a/src/roles/roles.controller.spec.ts
+++ b/src/roles/roles.controller.spec.ts
@@ -1,6 +1,8 @@
 jest.mock('../crypto/jwk.service.js', () => ({ JwkService: jest.fn() }));
 
+import { plainToInstance } from 'class-transformer';
 import { RolesController } from './roles.controller.js';
+import { AssignRolesDto } from './dto/assign-role.dto.js';
 import type { Realm } from '@prisma/client';
 
 describe('RolesController', () => {
@@ -120,18 +122,49 @@ describe('RolesController', () => {
   });
 
   describe('assignRealmRoles', () => {
-    it('should call rolesService.assignRealmRoles with realm, userId, and roleNames', () => {
-      const dto = { roleNames: ['admin', 'editor'] };
+    it('passes roleNames from roleNames format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roleNames: ['admin', 'editor'],
+      });
       mockRolesService.assignRealmRoles.mockReturnValue(undefined);
 
-      const result = controller.assignRealmRoles(realm, 'user-1', dto);
+      controller.assignRealmRoles(realm, 'user-1', dto);
 
       expect(mockRolesService.assignRealmRoles).toHaveBeenCalledWith(
         realm,
         'user-1',
         ['admin', 'editor'],
       );
-      expect(result).toBeUndefined();
+    });
+
+    it('passes roleNames from Keycloak roles[].name format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'admin' }],
+      });
+      mockRolesService.assignRealmRoles.mockReturnValue(undefined);
+
+      controller.assignRealmRoles(realm, 'user-1', dto);
+
+      expect(mockRolesService.assignRealmRoles).toHaveBeenCalledWith(
+        realm,
+        'user-1',
+        ['admin'],
+      );
+    });
+
+    it('passes roleNames from Keycloak roles with id field', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ id: 'abc-123', name: 'admin' }],
+      });
+      mockRolesService.assignRealmRoles.mockReturnValue(undefined);
+
+      controller.assignRealmRoles(realm, 'user-1', dto);
+
+      expect(mockRolesService.assignRealmRoles).toHaveBeenCalledWith(
+        realm,
+        'user-1',
+        ['admin'],
+      );
     });
   });
 
@@ -151,32 +184,43 @@ describe('RolesController', () => {
   });
 
   describe('removeUserRealmRoles', () => {
-    it('should call rolesService.removeUserRealmRoles with realm, userId, and roleNames', () => {
-      const dto = { roleNames: ['admin'] };
+    it('passes roleNames from roleNames format', () => {
+      const dto = plainToInstance(AssignRolesDto, { roleNames: ['admin'] });
       mockRolesService.removeUserRealmRoles.mockReturnValue(undefined);
 
-      const result = controller.removeUserRealmRoles(realm, 'user-1', dto);
+      controller.removeUserRealmRoles(realm, 'user-1', dto);
 
       expect(mockRolesService.removeUserRealmRoles).toHaveBeenCalledWith(
         realm,
         'user-1',
         ['admin'],
       );
-      expect(result).toBeUndefined();
+    });
+
+    it('passes roleNames from Keycloak roles format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'admin' }],
+      });
+      mockRolesService.removeUserRealmRoles.mockReturnValue(undefined);
+
+      controller.removeUserRealmRoles(realm, 'user-1', dto);
+
+      expect(mockRolesService.removeUserRealmRoles).toHaveBeenCalledWith(
+        realm,
+        'user-1',
+        ['admin'],
+      );
     });
   });
 
   describe('assignClientRoles', () => {
-    it('should call rolesService.assignClientRoles with realm, userId, clientId, and roleNames', () => {
-      const dto = { roleNames: ['editor', 'viewer'] };
+    it('passes roleNames from roleNames format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roleNames: ['editor', 'viewer'],
+      });
       mockRolesService.assignClientRoles.mockReturnValue(undefined);
 
-      const result = controller.assignClientRoles(
-        realm,
-        'user-1',
-        'client-1',
-        dto,
-      );
+      controller.assignClientRoles(realm, 'user-1', 'client-1', dto);
 
       expect(mockRolesService.assignClientRoles).toHaveBeenCalledWith(
         realm,
@@ -184,7 +228,22 @@ describe('RolesController', () => {
         'client-1',
         ['editor', 'viewer'],
       );
-      expect(result).toBeUndefined();
+    });
+
+    it('passes roleNames from Keycloak roles format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'editor' }],
+      });
+      mockRolesService.assignClientRoles.mockReturnValue(undefined);
+
+      controller.assignClientRoles(realm, 'user-1', 'client-1', dto);
+
+      expect(mockRolesService.assignClientRoles).toHaveBeenCalledWith(
+        realm,
+        'user-1',
+        'client-1',
+        ['editor'],
+      );
     });
   });
 
@@ -205,16 +264,11 @@ describe('RolesController', () => {
   });
 
   describe('removeUserClientRoles', () => {
-    it('should call rolesService.removeUserClientRoles with realm, userId, clientId, and roleNames', () => {
-      const dto = { roleNames: ['editor'] };
+    it('passes roleNames from roleNames format', () => {
+      const dto = plainToInstance(AssignRolesDto, { roleNames: ['editor'] });
       mockRolesService.removeUserClientRoles.mockReturnValue(undefined);
 
-      const result = controller.removeUserClientRoles(
-        realm,
-        'user-1',
-        'client-1',
-        dto,
-      );
+      controller.removeUserClientRoles(realm, 'user-1', 'client-1', dto);
 
       expect(mockRolesService.removeUserClientRoles).toHaveBeenCalledWith(
         realm,
@@ -222,7 +276,22 @@ describe('RolesController', () => {
         'client-1',
         ['editor'],
       );
-      expect(result).toBeUndefined();
+    });
+
+    it('passes roleNames from Keycloak roles format', () => {
+      const dto = plainToInstance(AssignRolesDto, {
+        roles: [{ name: 'editor' }],
+      });
+      mockRolesService.removeUserClientRoles.mockReturnValue(undefined);
+
+      controller.removeUserClientRoles(realm, 'user-1', 'client-1', dto);
+
+      expect(mockRolesService.removeUserClientRoles).toHaveBeenCalledWith(
+        realm,
+        'user-1',
+        'client-1',
+        ['editor'],
+      );
     });
   });
 });

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -22,7 +22,6 @@ import { RolesService } from './roles.service.js';
 import { CreateRoleDto } from './dto/create-role.dto.js';
 import { UpdateRoleDto } from './dto/update-role.dto.js';
 import { AssignRolesDto } from './dto/assign-role.dto.js';
-import { NormalizeRoleBodyPipe } from './pipes/normalize-role-body.pipe.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
@@ -156,7 +155,7 @@ export class RolesController {
   assignRealmRoles(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
-    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
+    @Body() dto: AssignRolesDto,
   ) {
     return this.rolesService.assignRealmRoles(
       realm,
@@ -186,7 +185,7 @@ export class RolesController {
   removeUserRealmRoles(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
-    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
+    @Body() dto: AssignRolesDto,
   ) {
     return this.rolesService.removeUserRealmRoles(
       realm,
@@ -208,7 +207,7 @@ export class RolesController {
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
     @Param('clientId') clientId: string,
-    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
+    @Body() dto: AssignRolesDto,
   ) {
     return this.rolesService.assignClientRoles(
       realm,
@@ -241,7 +240,7 @@ export class RolesController {
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
     @Param('clientId') clientId: string,
-    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
+    @Body() dto: AssignRolesDto,
   ) {
     return this.rolesService.removeUserClientRoles(
       realm,

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -22,6 +22,7 @@ import { RolesService } from './roles.service.js';
 import { CreateRoleDto } from './dto/create-role.dto.js';
 import { UpdateRoleDto } from './dto/update-role.dto.js';
 import { AssignRolesDto } from './dto/assign-role.dto.js';
+import { NormalizeRoleBodyPipe } from './pipes/normalize-role-body.pipe.js';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
@@ -155,9 +156,13 @@ export class RolesController {
   assignRealmRoles(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
-    @Body() dto: AssignRolesDto,
+    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
   ) {
-    return this.rolesService.assignRealmRoles(realm, userId, dto.roleNames);
+    return this.rolesService.assignRealmRoles(
+      realm,
+      userId,
+      dto.effectiveNames,
+    );
   }
 
   @Get('users/:userId/role-mappings/realm')
@@ -181,9 +186,13 @@ export class RolesController {
   removeUserRealmRoles(
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
-    @Body() dto: AssignRolesDto,
+    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
   ) {
-    return this.rolesService.removeUserRealmRoles(realm, userId, dto.roleNames);
+    return this.rolesService.removeUserRealmRoles(
+      realm,
+      userId,
+      dto.effectiveNames,
+    );
   }
 
   // ─── User Client Role Assignment ────────────────────────
@@ -199,13 +208,13 @@ export class RolesController {
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
     @Param('clientId') clientId: string,
-    @Body() dto: AssignRolesDto,
+    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
   ) {
     return this.rolesService.assignClientRoles(
       realm,
       userId,
       clientId,
-      dto.roleNames,
+      dto.effectiveNames,
     );
   }
 
@@ -232,13 +241,13 @@ export class RolesController {
     @CurrentRealm() realm: Realm,
     @Param('userId') userId: string,
     @Param('clientId') clientId: string,
-    @Body() dto: AssignRolesDto,
+    @Body(NormalizeRoleBodyPipe) dto: AssignRolesDto,
   ) {
     return this.rolesService.removeUserClientRoles(
       realm,
       userId,
       clientId,
-      dto.roleNames,
+      dto.effectiveNames,
     );
   }
 }

--- a/src/roles/roles.service.spec.ts
+++ b/src/roles/roles.service.spec.ts
@@ -1,4 +1,8 @@
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { RolesService } from './roles.service.js';
 import {
   createMockPrismaService,
@@ -249,6 +253,18 @@ describe('RolesService', () => {
         service.assignRealmRoles(mockRealm, 'user-1', ['admin', 'missing']),
       ).rejects.toThrow(NotFoundException);
     });
+
+    it('should throw BadRequestException when roleNames is empty', async () => {
+      await expect(
+        service.assignRealmRoles(mockRealm, 'user-1', []),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when roleNames is undefined (never throws TypeError)', async () => {
+      await expect(
+        service.assignRealmRoles(mockRealm, 'user-1', undefined as any),
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 
   describe('getUserRealmRoles', () => {
@@ -310,6 +326,18 @@ describe('RolesService', () => {
       ).rejects.toThrow(NotFoundException);
     });
 
+    it('should throw BadRequestException when roleNames is empty', async () => {
+      await expect(
+        service.removeUserRealmRoles(mockRealm, 'user-1', []),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when roleNames is undefined', async () => {
+      await expect(
+        service.removeUserRealmRoles(mockRealm, 'user-1', undefined as any),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('should handle removal of non-existent roles gracefully', async () => {
       prisma.user.findFirst.mockResolvedValue(mockUser);
       prisma.role.findMany.mockResolvedValue([]);
@@ -365,6 +393,23 @@ describe('RolesService', () => {
           'editor',
         ]),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw BadRequestException when roleNames is empty', async () => {
+      await expect(
+        service.assignClientRoles(mockRealm, 'user-1', 'my-app', []),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when roleNames is undefined', async () => {
+      await expect(
+        service.assignClientRoles(
+          mockRealm,
+          'user-1',
+          'my-app',
+          undefined as any,
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
@@ -466,6 +511,23 @@ describe('RolesService', () => {
       );
 
       expect(result).toEqual({ removed: ['nonexistent'] });
+    });
+
+    it('should throw BadRequestException when roleNames is empty', async () => {
+      await expect(
+        service.removeUserClientRoles(mockRealm, 'user-1', 'my-app', []),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException when roleNames is undefined', async () => {
+      await expect(
+        service.removeUserClientRoles(
+          mockRealm,
+          'user-1',
+          'my-app',
+          undefined as any,
+        ),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 });

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -1,5 +1,6 @@
 import {
   Injectable,
+  BadRequestException,
   ConflictException,
   NotFoundException,
 } from '@nestjs/common';
@@ -124,6 +125,10 @@ export class RolesService {
   // ─── Role Assignment ───────────────────────────────────
 
   async assignRealmRoles(realm: Realm, userId: string, roleNames: string[]) {
+    const names = roleNames ?? [];
+    if (names.length === 0) {
+      throw new BadRequestException('At least one role name must be provided');
+    }
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
     });
@@ -132,11 +137,11 @@ export class RolesService {
     }
 
     const roles = await this.prisma.role.findMany({
-      where: { realmId: realm.id, clientId: null, name: { in: roleNames } },
+      where: { realmId: realm.id, clientId: null, name: { in: names } },
     });
 
     const foundNames = roles.map((r) => r.name);
-    const missing = roleNames.filter((n) => !foundNames.includes(n));
+    const missing = names.filter((n) => !foundNames.includes(n));
     if (missing.length > 0) {
       throw new NotFoundException(`Roles not found: ${missing.join(', ')}`);
     }
@@ -165,6 +170,10 @@ export class RolesService {
     userId: string,
     roleNames: string[],
   ) {
+    const names = roleNames ?? [];
+    if (names.length === 0) {
+      throw new BadRequestException('At least one role name must be provided');
+    }
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
     });
@@ -173,7 +182,7 @@ export class RolesService {
     }
 
     const roles = await this.prisma.role.findMany({
-      where: { realmId: realm.id, clientId: null, name: { in: roleNames } },
+      where: { realmId: realm.id, clientId: null, name: { in: names } },
     });
 
     await this.prisma.userRole.deleteMany({
@@ -183,7 +192,7 @@ export class RolesService {
       },
     });
 
-    return { removed: roleNames };
+    return { removed: names };
   }
 
   // ─── Client Role Assignment ─────────────────────────────
@@ -194,6 +203,11 @@ export class RolesService {
     clientIdOrUuid: string,
     roleNames: string[],
   ) {
+    const names = roleNames ?? [];
+    if (names.length === 0) {
+      throw new BadRequestException('At least one role name must be provided');
+    }
+
     const user = await this.prisma.user.findFirst({
       where: { id: userId, realmId: realm.id },
     });
@@ -210,7 +224,7 @@ export class RolesService {
       where: {
         realmId: realm.id,
         clientId: client.id,
-        name: { in: roleNames },
+        name: { in: names },
       },
     });
 
@@ -228,6 +242,11 @@ export class RolesService {
     clientIdOrUuid: string,
     roleNames: string[],
   ) {
+    const names = roleNames ?? [];
+    if (names.length === 0) {
+      throw new BadRequestException('At least one role name must be provided');
+    }
+
     const client = await this.clientsService.findByClientId(
       realm,
       clientIdOrUuid,
@@ -244,7 +263,7 @@ export class RolesService {
       where: {
         realmId: realm.id,
         clientId: client.id,
-        name: { in: roleNames },
+        name: { in: names },
       },
     });
 
@@ -255,7 +274,7 @@ export class RolesService {
       },
     });
 
-    return { removed: roleNames };
+    return { removed: names };
   }
 
   async getUserClientRoles(


### PR DESCRIPTION
## Problem (fixes #1133)

Role-mapping endpoints crashed with `500` on Keycloak-style `{roles:[{name:admin}]}` payloads (undefined.filter TypeError) and returned `400` for bare-array `[{name:admin}]` bodies.

## Root causes

1. **500 on `{roles:[...]}` input**: `@Transform` on `roleNames` does not fire when that field is absent from the input. `dto.roleNames` was `undefined`, then `undefined.filter(...)` threw a TypeError → 500.

2. **400 on bare-array `[{...}]` input**: The global `ValidationPipe` (with `forbidNonWhitelisted: true`) ran **before** the parameter-level `@Body(NormalizeRoleBodyPipe)` pipe and rejected the array before it could be normalized. _(NestJS pipe ordering: global pipes run before parameter-level pipes.)_ This bug was initially missed because unit tests called controller methods directly and bypassed the HTTP pipeline entirely.

3. **400 on `{id:...,name:...}` Keycloak shape**: `RoleEntry` DTO lacked the `id` field, and `forbidNonWhitelisted: true` rejected it.

## Fixes

| What | How |
|---|---|
| `@Transform` / absent property | Removed `@Transform`; added `effectiveNames` getter that resolves role names lazily from whichever format was used |
| `id` field rejection | Added optional `id?: string` to `RoleEntry` class |
| Bare-array normalization (pipe ordering) | Moved `NormalizeRoleBodyPipe` from `@Body(NormalizeRoleBodyPipe)` param decorator to `app.useGlobalPipes()` in `main.ts`, registered **before** `ValidationPipe`. Added `metatype` guard (`if (metadata.metatype !== AssignRolesDto) return value`) so the pipe is a no-op for all other endpoints. |
| Service-level safety | Added `BadRequestException` guards in all 4 role-assignment service methods for empty `roleNames` arrays |
| Groups controller scope | `groups.controller.ts` shares `AssignRolesDto` — updated to use `dto.effectiveNames` |

## Verification

Added a real HTTP integration test (`normalize-role-body.pipe.integration.spec.ts`) that boots a minimal NestJS app with the exact global pipe configuration from `main.ts` and uses `supertest` to verify all payload shapes through the complete pipeline:

- `[{ name }]` bare array → 200 ✅
- `[{ id, name }]` Keycloak bare array → 200 ✅
- `{ roleNames: [...] }` → 200 ✅
- `{ roles: [{ name }] }` → 200 ✅
- `{ roles: [{ id, name }] }` → 200 ✅
- `[]` empty array → 400 ✅
- `[{ id }]` missing name → 400 ✅

**111 tests pass** (103 unit + 8 integration).

## Test plan

- [x] `npx jest roles groups normalize --no-coverage` → 111/111 pass
- [x] `npx tsc -p tsconfig.build.json --noEmit` → 0 errors
- [x] Integration spec confirms bare-array path works through full NestJS HTTP pipeline
- [ ] E2E test against running backend (requires PostgreSQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)