### PR TITLE
fix(admin-ui): invisible Save button on Registration pages (undefined primary-xxx color)

### DIFF
--- a/admin-ui/src/pages/registration/PendingRegistrationsPage.tsx
+++ b/admin-ui/src/pages/registration/PendingRegistrationsPage.tsx
@@ -35,7 +35,7 @@ export default function PendingRegistrationsPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-32">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
       </div>
     );
   }
@@ -146,7 +146,7 @@ export default function PendingRegistrationsPage() {
               <textarea
                 value={rejectReason}
                 onChange={(e) => setRejectReason(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 rows={3}
                 placeholder="Provide a reason for the rejection..."
               />

--- a/admin-ui/src/pages/registration/PublicRegistrationPage.tsx
+++ b/admin-ui/src/pages/registration/PublicRegistrationPage.tsx
@@ -92,7 +92,7 @@ export default function PublicRegistrationPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-100">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600"></div>
       </div>
     );
   }
@@ -145,7 +145,7 @@ export default function PublicRegistrationPage() {
                 required
                 minLength={3}
                 pattern="^[a-zA-Z0-9_-]+$"
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="Choose a username"
               />
             </div>
@@ -159,7 +159,7 @@ export default function PublicRegistrationPage() {
                 value={form.email}
                 onChange={(e) => setForm({ ...form, email: e.target.value })}
                 required
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="you@example.com"
               />
             </div>
@@ -174,7 +174,7 @@ export default function PublicRegistrationPage() {
                 onChange={(e) => setForm({ ...form, password: e.target.value })}
                 required
                 minLength={8}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="Create a password"
               />
             </div>
@@ -186,7 +186,7 @@ export default function PublicRegistrationPage() {
                   type="text"
                   value={form.firstName}
                   onChange={(e) => setForm({ ...form, firstName: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 />
               </div>
               <div>
@@ -195,7 +195,7 @@ export default function PublicRegistrationPage() {
                   type="text"
                   value={form.lastName}
                   onChange={(e) => setForm({ ...form, lastName: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 />
               </div>
             </div>
@@ -212,7 +212,7 @@ export default function PublicRegistrationPage() {
                     value={customAttributes[field.name ?? ''] || ''}
                     onChange={(e) => setCustomAttributes({ ...customAttributes, [field.name!]: e.target.value })}
                     required={field.required}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                   >
                     <option value="">Select...</option>
                     {field.options.map((opt) => (
@@ -224,7 +224,7 @@ export default function PublicRegistrationPage() {
                     type="checkbox"
                     checked={customAttributes[field.name ?? ''] === 'true'}
                     onChange={(e) => setCustomAttributes({ ...customAttributes, [field.name!]: e.target.checked.toString() })}
-                    className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                    className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                   />
                 ) : (
                   <input
@@ -234,7 +234,7 @@ export default function PublicRegistrationPage() {
                     required={field.required}
                     placeholder={field.placeholder}
                     pattern={field.type === 'text' ? field.name ?? undefined : undefined}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                   />
                 )}
                 {field.helpText && (
@@ -259,15 +259,15 @@ export default function PublicRegistrationPage() {
                   checked={form.acceptTerms}
                   onChange={(e) => setForm({ ...form, acceptTerms: e.target.checked })}
                   required
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500 mt-1"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 mt-1"
                 />
                 <label className="ml-2 text-sm text-gray-700">
                   I accept the{' '}
-                  <a href={realm.termsOfServiceUrl} target="_blank" rel="noopener noreferrer" className="text-primary-600 hover:text-primary-500">
+                  <a href={realm.termsOfServiceUrl} target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:text-indigo-500">
                     Terms of Service
                   </a>
                   {realm.privacyPolicyUrl && (
-                    <> and <a href={realm.privacyPolicyUrl} target="_blank" rel="noopener noreferrer" className="text-primary-600 hover:text-primary-500">
+                    <> and <a href={realm.privacyPolicyUrl} target="_blank" rel="noopener noreferrer" className="text-indigo-600 hover:text-indigo-500">
                       Privacy Policy
                     </a></>
                   )}
@@ -278,14 +278,14 @@ export default function PublicRegistrationPage() {
             <button
               type="submit"
               disabled={isSubmitting}
-              className="w-full py-2 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:opacity-50"
+              className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
             >
               {isSubmitting ? 'Creating Account...' : 'Create Account'}
             </button>
           </form>
 
           <div className="mt-6 text-center">
-            <a href={`/console/login`} className="text-sm text-primary-600 hover:text-primary-500">
+            <a href={`/console/login`} className="text-sm text-indigo-600 hover:text-indigo-500">
               Already have an account? Sign in
             </a>
           </div>

--- a/admin-ui/src/pages/registration/RegistrationFieldsPage.tsx
+++ b/admin-ui/src/pages/registration/RegistrationFieldsPage.tsx
@@ -114,7 +114,7 @@ export default function RegistrationFieldsPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-32">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
       </div>
     );
   }
@@ -138,7 +138,7 @@ export default function RegistrationFieldsPage() {
         </div>
         <button
           onClick={() => { resetForm(); setShowCreate(true); }}
-          className="mt-4 sm:mt-0 px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700"
+          className="mt-4 sm:mt-0 px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700"
         >
           Add Field
         </button>
@@ -157,7 +157,7 @@ export default function RegistrationFieldsPage() {
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
                 disabled={!!editingField}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-100"
                 placeholder="e.g., company_name"
               />
             </div>
@@ -167,7 +167,7 @@ export default function RegistrationFieldsPage() {
                 type="text"
                 value={form.displayName}
                 onChange={(e) => setForm({ ...form, displayName: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="e.g., Company Name"
               />
             </div>
@@ -176,7 +176,7 @@ export default function RegistrationFieldsPage() {
               <select
                 value={form.type}
                 onChange={(e) => setForm({ ...form, type: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
               >
                 {FIELD_TYPES.map((t) => (
                   <option key={t} value={t}>{t}</option>
@@ -189,7 +189,7 @@ export default function RegistrationFieldsPage() {
                 type="text"
                 value={form.placeholder}
                 onChange={(e) => setForm({ ...form, placeholder: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>
             <div className="md:col-span-2">
@@ -198,7 +198,7 @@ export default function RegistrationFieldsPage() {
                 type="text"
                 value={form.helpText}
                 onChange={(e) => setForm({ ...form, helpText: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>
             {form.type === 'select' && (
@@ -208,7 +208,7 @@ export default function RegistrationFieldsPage() {
                   type="text"
                   value={form.options}
                   onChange={(e) => setForm({ ...form, options: e.target.value })}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                   placeholder="Option A, Option B, Option C"
                 />
               </div>
@@ -219,7 +219,7 @@ export default function RegistrationFieldsPage() {
                 type="text"
                 value={form.validationPattern}
                 onChange={(e) => setForm({ ...form, validationPattern: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="e.g., ^[A-Za-z]+$"
               />
             </div>
@@ -229,7 +229,7 @@ export default function RegistrationFieldsPage() {
                 type="text"
                 value={form.defaultValue}
                 onChange={(e) => setForm({ ...form, defaultValue: e.target.value })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>
             <div>
@@ -238,7 +238,7 @@ export default function RegistrationFieldsPage() {
                 type="number"
                 value={form.sortOrder}
                 onChange={(e) => setForm({ ...form, sortOrder: parseInt(e.target.value, 10) || 0 })}
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
               />
             </div>
             <div className="flex items-center">
@@ -247,7 +247,7 @@ export default function RegistrationFieldsPage() {
                   type="checkbox"
                   checked={form.required}
                   onChange={(e) => setForm({ ...form, required: e.target.checked })}
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
                 <span className="ml-2 text-sm text-gray-700">Required field</span>
               </label>
@@ -258,7 +258,7 @@ export default function RegistrationFieldsPage() {
                   type="checkbox"
                   checked={form.enabled}
                   onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
                 <span className="ml-2 text-sm text-gray-700">Enabled</span>
               </label>
@@ -274,7 +274,7 @@ export default function RegistrationFieldsPage() {
             <button
               onClick={() => editingField ? updateMutation.mutate() : createMutation.mutate()}
               disabled={createMutation.isPending || updateMutation.isPending}
-              className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:opacity-50"
             >
               {editingField ? 'Update' : 'Create'}
             </button>
@@ -332,7 +332,7 @@ export default function RegistrationFieldsPage() {
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                     <button
                       onClick={() => startEdit(field)}
-                      className="text-primary-600 hover:text-primary-900 mr-4"
+                      className="text-indigo-600 hover:text-indigo-900 mr-4"
                     >
                       Edit
                     </button>

--- a/admin-ui/src/pages/registration/RegistrationSettingsPage.tsx
+++ b/admin-ui/src/pages/registration/RegistrationSettingsPage.tsx
@@ -75,7 +75,7 @@ export default function RegistrationSettingsPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-32">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
       </div>
     );
   }
@@ -95,7 +95,7 @@ export default function RegistrationSettingsPage() {
                   type="checkbox"
                   checked={form.registrationAllowed}
                   onChange={(e) => setForm({ ...form, registrationAllowed: e.target.checked })}
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
                 <span className="ml-2 text-sm text-gray-700">Allow self-registration</span>
               </label>
@@ -105,7 +105,7 @@ export default function RegistrationSettingsPage() {
                   type="checkbox"
                   checked={form.registrationApprovalRequired}
                   onChange={(e) => setForm({ ...form, registrationApprovalRequired: e.target.checked })}
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
                 <span className="ml-2 text-sm text-gray-700">Require admin approval</span>
               </label>
@@ -115,7 +115,7 @@ export default function RegistrationSettingsPage() {
                   type="checkbox"
                   checked={form.requireEmailVerification}
                   onChange={(e) => setForm({ ...form, requireEmailVerification: e.target.checked })}
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
                 <span className="ml-2 text-sm text-gray-700">Require email verification</span>
               </label>
@@ -133,7 +133,7 @@ export default function RegistrationSettingsPage() {
                 type="text"
                 value={form.allowedEmailDomains}
                 onChange={(e) => setForm({ ...form, allowedEmailDomains: e.target.value })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                 placeholder="example.com, company.org"
               />
             </div>
@@ -149,7 +149,7 @@ export default function RegistrationSettingsPage() {
                   type="url"
                   value={form.termsOfServiceUrl}
                   onChange={(e) => setForm({ ...form, termsOfServiceUrl: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                   placeholder="https://example.com/terms"
                 />
               </div>
@@ -159,7 +159,7 @@ export default function RegistrationSettingsPage() {
                   type="url"
                   value={form.privacyPolicyUrl}
                   onChange={(e) => setForm({ ...form, privacyPolicyUrl: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                   placeholder="https://example.com/privacy"
                 />
               </div>
@@ -175,7 +175,7 @@ export default function RegistrationSettingsPage() {
                   type="checkbox"
                   checked={form.captchaEnabled}
                   onChange={(e) => setForm({ ...form, captchaEnabled: e.target.checked })}
-                  className="h-4 w-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  className="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500"
                 />
                 <span className="ml-2 text-sm text-gray-700">Enable CAPTCHA</span>
               </label>
@@ -187,7 +187,7 @@ export default function RegistrationSettingsPage() {
                     <select
                       value={form.captchaProvider}
                       onChange={(e) => setForm({ ...form, captchaProvider: e.target.value })}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                      className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                     >
                       <option value="recaptcha">reCAPTCHA v3</option>
                       <option value="hcaptcha">hCaptcha</option>
@@ -202,7 +202,7 @@ export default function RegistrationSettingsPage() {
                           type="text"
                           value={form.recaptchaSiteKey}
                           onChange={(e) => setForm({ ...form, recaptchaSiteKey: e.target.value })}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                         />
                       </div>
                       <div>
@@ -211,7 +211,7 @@ export default function RegistrationSettingsPage() {
                           type="password"
                           value={form.recaptchaSecretKey}
                           onChange={(e) => setForm({ ...form, recaptchaSecretKey: e.target.value })}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                         />
                       </div>
                       <div>
@@ -223,7 +223,7 @@ export default function RegistrationSettingsPage() {
                           max="1"
                           value={form.captchaScoreThreshold}
                           onChange={(e) => setForm({ ...form, captchaScoreThreshold: parseFloat(e.target.value) })}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                         />
                         <p className="mt-1 text-xs text-gray-500">Lower values are more restrictive (default: 0.5)</p>
                       </div>
@@ -236,7 +236,7 @@ export default function RegistrationSettingsPage() {
                           type="text"
                           value={form.hcaptchaSiteKey}
                           onChange={(e) => setForm({ ...form, hcaptchaSiteKey: e.target.value })}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                         />
                       </div>
                       <div>
@@ -245,7 +245,7 @@ export default function RegistrationSettingsPage() {
                           type="password"
                           value={form.hcaptchaSecretKey}
                           onChange={(e) => setForm({ ...form, hcaptchaSecretKey: e.target.value })}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500"
+                          className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
                         />
                       </div>
                     </>
@@ -259,7 +259,7 @@ export default function RegistrationSettingsPage() {
             <button
               type="submit"
               disabled={mutation.isPending}
-              className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:opacity-50"
+              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:opacity-50"
             >
               {mutation.isPending ? 'Saving...' : 'Save Changes'}
             </button>


### PR DESCRIPTION
## Problem

The Save Changes button (and spinners, checkboxes, input focus rings) on all four Registration pages were completely invisible. The button renders with `text-white` on a transparent background because `bg-primary-600` isn't defined anywhere in the Tailwind v4 config.

**Affected pages:**
- Registration Settings → Save Changes button invisible
- Registration Fields → Add Field button invisible  
- Pending Registrations → action links invisible
- Public Registration Page → Submit button invisible, checkbox + link colours broken

## Root cause

The project uses Tailwind v4 (`@import "tailwindcss"`) with a custom CSS-var token system (`--accent`, `--fg`, etc.), but **no `primary` colour scale**. These four pages were authored with `primary-xxx` classes that produce zero CSS output in Tailwind v4 — the utility simply doesn't exist.

All other pages (RealmDetailPage, UsersPage, etc.) correctly use `indigo-xxx` from Tailwind's built-in palette.

## Fix

Replaced every `primary-{n}` reference with `indigo-{n}` across all four files — identical to the pattern used by every other working form in the admin UI.

`primary-500 → indigo-500`, `primary-600 → indigo-600`, `primary-700 → indigo-700`, `primary-900 → indigo-900`

Build passes ✓ (4 files changed, 46 insertions, 46 deletions — pure class rename).