### PR TITLE
fix(admin-auth): persist API key sessions via JWT cookie exchange

### DIFF
--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -1,12 +1,11 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { getAllRealms } from '../api/realms';
 import apiClient, { setCredentials, clearCredentials } from '../api/client';
 import { useAuthContext } from '../context/AuthContext';
 
 export function useAuth() {
   const navigate = useNavigate();
-  const { apiKey, token, setApiKey, setToken, clearAuth } = useAuthContext();
+  const { apiKey, token, setToken, clearAuth } = useAuthContext();
 
   const isAuthenticated = apiKey !== null || token !== null;
 
@@ -18,19 +17,19 @@ export function useAuth() {
   const login = useCallback(
     async (key: string): Promise<boolean> => {
       clearAuthState();
-      // Optimistically load credentials so the probe request is authenticated.
-      setCredentials({ apiKey: key });
       try {
-        await getAllRealms();
-        // Probe succeeded — persist to React state.
-        setApiKey(key);
-        return true;
+        const { data } = await apiClient.post('/auth/login-with-api-key', { apiKey: key });
+        if (data.access_token) {
+          setCredentials({ token: data.access_token });
+          setToken(data.access_token);
+          return true;
+        }
+        return false;
       } catch {
-        clearCredentials();
         return false;
       }
     },
-    [clearAuthState, setApiKey],
+    [clearAuthState, setToken],
   );
 
   const loginWithCredentials = useCallback(

--- a/src/admin-auth/admin-auth.controller.ts
+++ b/src/admin-auth/admin-auth.controller.ts
@@ -24,6 +24,7 @@ import { AdminAuthService } from './admin-auth.service.js';
 import { RateLimitGuard } from '../rate-limit/rate-limit.guard.js';
 import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 import { AdminLoginDto } from './dto/login.dto.js';
+import { AdminApiKeyLoginDto } from './dto/api-key-login.dto.js';
 
 const ADMIN_RT_COOKIE = 'admin_rt';
 const TOKEN_TTL_MS = 3600 * 1000;
@@ -81,6 +82,31 @@ export class AdminAuthController {
     for (const [name, value] of Object.entries(rateLimitHeaders)) {
       res.setHeader(name, value);
     }
+
+    const isProduction = this.config.get<string>('NODE_ENV') === 'production';
+    res.cookie(ADMIN_RT_COOKIE, tokenResponse.access_token, {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: 'strict',
+      maxAge: TOKEN_TTL_MS,
+      path: '/admin/auth',
+    });
+
+    return tokenResponse;
+  }
+
+  @Post('login-with-api-key')
+  @Public()
+  @UseGuards(RateLimitGuard)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Exchange admin API key for a session token' })
+  @ApiResponse({ status: 200, description: 'Returns bearer token and sets session cookie' })
+  @ApiResponse({ status: 401, description: 'Invalid API key' })
+  async loginWithApiKey(
+    @Body() body: AdminApiKeyLoginDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const tokenResponse = await this.adminAuthService.loginWithApiKey(body.apiKey);
 
     const isProduction = this.config.get<string>('NODE_ENV') === 'production';
     res.cookie(ADMIN_RT_COOKIE, tokenResponse.access_token, {

--- a/src/admin-auth/admin-auth.service.ts
+++ b/src/admin-auth/admin-auth.service.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   OnModuleDestroy,
 } from '@nestjs/common';
+import { timingSafeEqual } from 'node:crypto';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { CryptoService } from '../crypto/crypto.service.js';
 import { JwkService } from '../crypto/jwk.service.js';
@@ -194,6 +195,63 @@ export class AdminAuthService implements OnModuleDestroy {
         `Failed to persist revoked admin token to DB: ${(err as Error).message}`,
       );
     }
+  }
+
+  async loginWithApiKey(apiKey: string): Promise<{
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+  }> {
+    const expectedKey = process.env['ADMIN_API_KEY'];
+    if (!expectedKey) {
+      throw new UnauthorizedException('API key authentication not configured');
+    }
+
+    let valid = false;
+    try {
+      const a = Buffer.from(apiKey);
+      const b = Buffer.from(expectedKey);
+      valid = a.length === b.length && timingSafeEqual(a, b);
+    } catch {
+      valid = false;
+    }
+
+    if (!valid) {
+      throw new UnauthorizedException('Invalid API key');
+    }
+
+    const masterRealm = await this.prisma.realm.findUnique({
+      where: { name: 'master' },
+    });
+
+    if (!masterRealm) {
+      throw new UnauthorizedException('Admin system not initialized');
+    }
+
+    const signingKey = await this.prisma.realmSigningKey.findFirst({
+      where: { realmId: masterRealm.id, active: true },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    if (!signingKey) {
+      throw new Error('No signing key found for master realm');
+    }
+
+    const baseUrl = process.env['BASE_URL'] ?? 'http://localhost:3000';
+    const token = await this.jwkService.signJwt(
+      {
+        iss: `${baseUrl}/realms/master`,
+        sub: 'api-key:admin',
+        typ: 'admin',
+        realm_access: { roles: ['super-admin'] },
+        preferred_username: 'api-key',
+      },
+      signingKey.privateKey,
+      signingKey.kid,
+      3600,
+    );
+
+    return { access_token: token, token_type: 'Bearer', expires_in: 3600 };
   }
 
   private extractJti(token: string): string | null {

--- a/src/admin-auth/admin-auth.service.ts
+++ b/src/admin-auth/admin-auth.service.ts
@@ -207,16 +207,17 @@ export class AdminAuthService implements OnModuleDestroy {
       throw new UnauthorizedException('API key authentication not configured');
     }
 
-    let valid = false;
-    try {
-      const a = Buffer.from(apiKey);
-      const b = Buffer.from(expectedKey);
-      valid = a.length === b.length && timingSafeEqual(a, b);
-    } catch {
-      valid = false;
-    }
+    const isValidKey = (() => {
+      try {
+        const a = Buffer.from(apiKey);
+        const b = Buffer.from(expectedKey);
+        return a.length === b.length && timingSafeEqual(a, b);
+      } catch {
+        return false;
+      }
+    })();
 
-    if (!valid) {
+    if (!isValidKey) {
       throw new UnauthorizedException('Invalid API key');
     }
 

--- a/src/admin-auth/dto/api-key-login.dto.ts
+++ b/src/admin-auth/dto/api-key-login.dto.ts
@@ -1,0 +1,10 @@
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AdminApiKeyLoginDto {
+  @ApiProperty({
+    description: 'Admin API key',
+  })
+  @IsString()
+  apiKey!: string;
+}


### PR DESCRIPTION
## Summary

- Adds `POST /admin/auth/login-with-api-key` backend endpoint that validates the static `ADMIN_API_KEY` with constant-time `timingSafeEqual`, mints a signed JWT, and sets the `admin_rt` httpOnly cookie — exactly like credential login does
- Frontend `login()` in `useAuth.ts` now calls this endpoint and stores the returned bearer token instead of holding the raw API key in heap memory
- On page reload, the existing `SessionBootstrap` / `refreshSession()` path restores the session from the httpOnly cookie, so direct URL navigation no longer logs the user out

## Root cause

API key sessions were stored as module-level `_apiKey` in `client.ts`. A full page reload (direct URL navigation, F5) reset that variable to `null`. The `SessionBootstrap` component only restored bearer-token sessions via the `admin_rt` cookie — it had no path to restore raw API key sessions. This fix eliminates the raw key path entirely by converting it to a bearer token at login time.

## Security

- Raw API key is never stored in the browser (heap, sessionStorage, localStorage) — stays server-side validation only, consistent with issue #330
- Uses `timingSafeEqual` to prevent timing attacks on key comparison
- Cookie options match existing credential login: `httpOnly`, `secure` in production, `sameSite: strict`, `path: /admin/auth`

## Test plan

- [ ] Login with API key → navigate directly to `/console/realms/master/users` → should stay logged in (no redirect to /login)
- [ ] Login with API key → F5 reload → session restored
- [ ] Login with username/password → session still persists on reload (regression check)
- [ ] Invalid API key returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)