### PR TITLE
fix(admin-ui): correct route param names in webhook & service-account detail pages (#1141)

### DIFF
--- a/admin-ui/src/__tests__/routes.test.ts
+++ b/admin-ui/src/__tests__/routes.test.ts
@@ -93,3 +93,92 @@ describe('nav route coverage', () => {
     ).toHaveLength(0);
   });
 });
+
+/**
+ * Route-param ↔ useParams consistency guard.
+ *
+ * Catches the silent failure where a route declares one param name but its page
+ * component reads a different one (e.g. route `:webhookId`, component
+ * `useParams<{ id }>()`). React Router hands back `undefined` for the missing
+ * key, the page's data query is disabled, and the user sees a permanent
+ * "not found" — with no error, no failed request, and nothing the nav-coverage
+ * test above would catch. (idenplane#1141)
+ *
+ * Invariant enforced: every param a component reads via `useParams<{...}>()`
+ * must be declared as `:param` in every route that renders that component.
+ */
+
+// Map of imported component name → resolved source path (default imports only).
+const COMPONENT_IMPORTS = new Map<string, string>(
+  [...appSrc.matchAll(/import\s+(\w+)\s+from\s+'(\.\/[^']+)'/g)].map(
+    ([, comp, rel]) => [comp, path.resolve(__dirname, '..', rel + '.tsx')],
+  ),
+);
+
+// Every <Route path="..." element={<Component ... />} /> pairing.
+const ROUTE_ELEMENTS = [
+  ...appSrc.matchAll(
+    /<Route\s+path="([^"]+)"\s+element=\{<(\w+)\s*\/?>\s*\}/g,
+  ),
+].map(([, routePath, comp]) => ({ routePath, comp }));
+
+/** Param names declared in a route path, e.g. `/x/:name/y/:webhookId` → [name, webhookId]. */
+function declaredParams(routePath: string): string[] {
+  return [...routePath.matchAll(/:(\w+)/g)].map(([, p]) => p);
+}
+
+/** Param keys a component expects, read from its `useParams<{...}>()` generic. */
+function readParamKeys(source: string): string[] {
+  const keys = new Set<string>();
+  for (const [, body] of source.matchAll(/useParams<\{([^}]*)\}>/g)) {
+    for (const [, key] of body.matchAll(/(\w+)\s*\??\s*:/g)) keys.add(key);
+  }
+  return [...keys];
+}
+
+describe('route param consistency', () => {
+  it('finds routes wired to imported page components', () => {
+    const wired = ROUTE_ELEMENTS.filter((r) => COMPONENT_IMPORTS.has(r.comp));
+    expect(wired.length).toBeGreaterThan(0);
+  });
+
+  it('every param a page reads is declared in its route path', () => {
+    const violations: string[] = [];
+
+    for (const { comp } of ROUTE_ELEMENTS) {
+      const file = COMPONENT_IMPORTS.get(comp);
+      if (!file) continue; // inline/wrapped element, not a default-imported page
+
+      let source: string;
+      try {
+        source = readFileSync(file, 'utf-8');
+      } catch {
+        continue; // component resolved to a non-.tsx path; skip
+      }
+
+      const expected = readParamKeys(source);
+      if (expected.length === 0) continue; // page reads no route params
+
+      // Union of params across every route that renders this component.
+      const provided = new Set(
+        ROUTE_ELEMENTS.filter((r) => r.comp === comp).flatMap((r) =>
+          declaredParams(r.routePath),
+        ),
+      );
+
+      for (const key of expected) {
+        if (!provided.has(key)) {
+          violations.push(
+            `${comp} reads useParams key '${key}', but no route rendering it declares ':${key}' ` +
+              `(declared: ${[...provided].map((p) => ':' + p).join(', ') || 'none'})`,
+          );
+        }
+      }
+    }
+
+    expect(
+      violations,
+      `Route param mismatches (page reads a param its route never provides):\n  ${violations.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/admin-ui/src/pages/service-accounts/ServiceAccountDetailPage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountDetailPage.tsx
@@ -14,7 +14,7 @@ import {
 import ConfirmDialog from '../../components/ConfirmDialog';
 
 export default function ServiceAccountDetailPage() {
-  const { name, id } = useParams<{ name: string; id: string }>();
+  const { name, accountId: id } = useParams<{ name: string; accountId: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [showDelete, setShowDelete] = useState(false);

--- a/admin-ui/src/pages/webhooks/WebhookDetailPage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookDetailPage.tsx
@@ -26,7 +26,7 @@ const EVENT_TYPES = [
 ];
 
 export default function WebhookDetailPage() {
-  const { name, id } = useParams<{ name: string; id: string }>();
+  const { name, webhookId: id } = useParams<{ name: string; webhookId: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [showDelete, setShowDelete] = useState(false);


### PR DESCRIPTION
## Summary

Fixes #1141 — the **Webhook** and **Service Account** detail pages always rendered "not found", making view/edit/test/delete unreachable through the UI.

Found during a full Playwright QA sweep of the console on the QA environment.

## Root cause

Route/param name mismatch:

| Route (`App.tsx`) | Component read (`useParams`) |
|---|---|
| `webhooks/:webhookId` | `{ id }` → `undefined` |
| `service-accounts/:accountId` | `{ id }` → `undefined` |

With `id` undefined the React Query is disabled (`enabled: !!name && !!id`), so **no fetch fires** and the page falls straight to the "not found" branch — silent, no console error, no failed request.

## Fix

Alias the descriptive route param to the local `id` the components already use everywhere — matching the convention in sibling pages (`PolicyDetailPage` → `policyId`, `GroupDetailPage` → `groupId`):

```ts
const { name, webhookId: id } = useParams<{ name: string; webhookId: string }>();
const { name, accountId: id } = useParams<{ name: string; accountId: string }>();
```

## Regression test

Added a **route-param consistency** test to `routes.test.ts`: for every `<Route>` wired to an imported page, it asserts every param the page reads via `useParams<{...}>()` is declared in the route path. The existing nav-coverage test could not catch this class (the route and nav were both fine — only the param name inside the component was wrong).

Verified the test **fails on the pre-fix code** with a precise message:
```
WebhookDetailPage reads useParams key 'id', but no route rendering it declares ':id' (declared: :name, :webhookId)
```

I also cross-checked every other second-param page against its route — no other mismatches exist in the reachable app.

## Verification

- `npm run build` (admin-ui) — clean
- `vitest run routes.test.ts` — 6/6 pass (fails as expected when the bug is reintroduced)
- ESLint on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)