### PR TITLE
fix(csp): allow data: fonts so bundled woff2 loads in admin console (#1142)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -196,7 +196,9 @@ async function bootstrap() {
             "'unsafe-inline'",
             'https://fonts.googleapis.com',
           ],
-          fontSrc: ["'self'", 'https://fonts.gstatic.com'],
+          // 'data:' allows the admin-ui Vite bundle's inlined woff2 font,
+          // which is emitted as a data: URI (mirrors imgSrc below).
+          fontSrc: ["'self'", 'https://fonts.gstatic.com', 'data:'],
           imgSrc: ["'self'", 'data:', 'blob:'],
           connectSrc: ["'self'"],
           formAction: ["'self'"],


### PR DESCRIPTION
## Summary

Fixes #1142 — every admin console page logged a CSP violation and the intended font failed to load:

```
Loading the font 'data:font/woff2;base64,...' violates the following
Content Security Policy directive: "font-src 'self' https://fonts.gstatic.com".
```

The admin-ui Vite bundle inlines a small woff2 as a `data:` URI, but `font-src` didn't allow `data:`. Added it, mirroring how `imgSrc` already handles `data:`/`blob:`.

## Scope

Changed **only** `src/main.ts` (the SPA CSP). The server-rendered Handlebars theme CSP in `theme-render.service.ts` is a separate surface that does not inline data fonts and was deliberately left unchanged — I only saw the violation on the admin-ui pages.

## Severity

Low / cosmetic — a fallback font rendered, so no functional break, but the violation was logged on every page and the intended typeface didn't load.

## Verification

- `npx tsc -p tsconfig.build.json --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)