### PR TITLE
fix: repair functional bugs found in QA console sweep (#1146–#1150)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -60,6 +60,7 @@ import PolicyCreatePage from './pages/authorization/PolicyCreatePage';
 import PolicyDetailPage from './pages/authorization/PolicyDetailPage';
 import ThemeBuilderPage from './pages/theme-builder/ThemeBuilderPage';
 import NhiListPage from './pages/nhi/NhiListPage';
+import NhiCreatePage from './pages/nhi/NhiCreatePage';
 import NhiDetailPage from './pages/nhi/NhiDetailPage';
 import NhiAnalyticsPage from './pages/nhi/NhiAnalyticsPage';
 import PluginsPage from './pages/plugins/PluginsPage';
@@ -167,6 +168,7 @@ export default function App() {
           <Route path="/console/realms/:name/authorization-policies/:policyId" element={<PolicyDetailPage />} />
           <Route path="/console/realms/:name/theme-builder" element={<ThemeBuilderPage />} />
           <Route path="/console/realms/:name/nhi" element={<NhiListPage />} />
+          <Route path="/console/realms/:name/nhi/new" element={<NhiCreatePage />} />
           <Route path="/console/realms/:name/nhi/:id" element={<NhiDetailPage />} />
           <Route path="/console/realms/:name/nhi-analytics" element={<NhiAnalyticsPage />} />
           <Route path="/console/plugins" element={<PluginsPage />} />

--- a/admin-ui/src/__tests__/routes.test.ts
+++ b/admin-ui/src/__tests__/routes.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { readFileSync, readdirSync } from 'fs';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
@@ -179,6 +179,90 @@ describe('route param consistency', () => {
     expect(
       violations,
       `Route param mismatches (page reads a param its route never provides):\n  ${violations.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+});
+
+/**
+ * In-app link-target coverage guard.
+ *
+ * Catches the "hard 404" class where a page's `<Link to>` or `navigate()` points
+ * at an absolute `/console/...` path that no route in App.tsx registers
+ * (idenplane#1147: the risk pages linked to `/continuous-verification/*` while
+ * the registered routes are `/risk-*`). The nav-coverage test above only checks
+ * Layout.tsx nav items, so links buried inside page components slip past it and
+ * surface only as a runtime "Page Not Found".
+ *
+ * Invariant enforced: every absolute `/console/...` target a component links to
+ * or navigates to must match some registered route in App.tsx.
+ */
+
+// Registered routes as concrete-path matchers (`:param` → one path segment).
+const ROUTE_MATCHERS = [...APP_ROUTES].map(
+  (p) => new RegExp('^' + p.replace(/:[^/]+/g, '[^/]+') + '$'),
+);
+
+/**
+ * Files intentionally excluded from this guard. The upgrade/migration pages are
+ * unrouted dead code (idenplane#1150) that link to `/console/upgrade` — drop
+ * this exclusion once that feature is wired up or removed.
+ */
+const LINK_GUARD_IGNORE = /[/\\]pages[/\\]upgrade[/\\]/;
+
+function walkTsx(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walkTsx(full));
+    else if (full.endsWith('.tsx')) out.push(full);
+  }
+  return out;
+}
+
+/** Absolute `/console/...` targets from `to={\`…\`}` / `to="…"` / `navigate(…)`. */
+function extractConsoleTargets(src: string): string[] {
+  const targets: string[] = [];
+  for (const [, lit] of src.matchAll(
+    /(?:\bto=\{|navigate\()\s*`(\/console[^`]*)`/g,
+  ))
+    targets.push(lit);
+  for (const [, lit] of src.matchAll(
+    /(?:\bto=|navigate\()\s*['"](\/console[^'"]*)['"]/g,
+  ))
+    targets.push(lit);
+  return targets;
+}
+
+/** Strip query/hash and collapse `${…}` template segments to a placeholder. */
+function normalizeConsoleTarget(t: string): string {
+  const s = t.split('?')[0].split('#')[0].replace(/\$\{[^}]+\}/g, 'X');
+  return s.replace(/\/+$/, '') || '/';
+}
+
+describe('in-app link target coverage', () => {
+  const scanDirs = ['../pages', '../components'].map((d) =>
+    path.resolve(__dirname, d),
+  );
+
+  it('every absolute /console link/navigate target matches a registered route', () => {
+    const violations: string[] = [];
+    for (const dir of scanDirs) {
+      for (const file of walkTsx(dir)) {
+        if (LINK_GUARD_IGNORE.test(file)) continue;
+        const src = readFileSync(file, 'utf-8');
+        for (const raw of extractConsoleTargets(src)) {
+          const norm = normalizeConsoleTarget(raw);
+          if (!ROUTE_MATCHERS.some((re) => re.test(norm))) {
+            violations.push(
+              `${path.relative(path.resolve(__dirname, '..'), file)} → ${raw}`,
+            );
+          }
+        }
+      }
+    }
+    expect(
+      violations,
+      `In-app links pointing at unregistered routes (hard 404s):\n  ${violations.join('\n  ')}`,
     ).toHaveLength(0);
   });
 });

--- a/admin-ui/src/api/themes.ts
+++ b/admin-ui/src/api/themes.ts
@@ -75,7 +75,7 @@ export async function updateTheme(
   id: string,
   payload: UpdateThemePayload,
 ): Promise<Theme> {
-  const { data } = await apiClient.patch<Theme>(
+  const { data } = await apiClient.put<Theme>(
     `/realms/${realmName}/themes/${id}`,
     payload,
   );
@@ -144,10 +144,10 @@ export async function getThemeVersions(
 export async function rollbackTheme(
   realmName: string,
   id: string,
-  versionId: string,
+  version: number,
 ): Promise<Theme> {
   const { data } = await apiClient.post<Theme>(
-    `/realms/${realmName}/themes/${id}/rollback/${versionId}`,
+    `/realms/${realmName}/themes/${id}/restore/${version}`,
   );
   return data;
 }

--- a/admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx
+++ b/admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx
@@ -234,7 +234,7 @@ export default function ContinuousRiskDashboard() {
         </div>
         <div className="flex gap-2">
           <Link
-            to={`/console/realms/${realmName}/continuous-verification/policies`}
+            to={`/console/realms/${realmName}/risk-policies`}
             className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             Risk Policies

--- a/admin-ui/src/pages/continuous-verification/RiskPolicyListPage.tsx
+++ b/admin-ui/src/pages/continuous-verification/RiskPolicyListPage.tsx
@@ -260,7 +260,7 @@ export default function RiskPolicyListPage() {
         </div>
         <div className="flex gap-3">
           <Link
-            to={`/console/realms/${realmName}/continuous-verification/dashboard`}
+            to={`/console/realms/${realmName}/risk-dashboard`}
             className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
           >
             Dashboard

--- a/admin-ui/src/pages/continuous-verification/SessionRiskDetailPage.tsx
+++ b/admin-ui/src/pages/continuous-verification/SessionRiskDetailPage.tsx
@@ -409,7 +409,7 @@ export default function SessionRiskDetailPage() {
         <div>
           <div className="flex items-center gap-3">
             <Link
-              to={`/console/realms/${realmName}/continuous-verification/dashboard`}
+              to={`/console/realms/${realmName}/risk-dashboard`}
               className="text-sm text-gray-500 hover:text-gray-700"
             >
               ← Back to Dashboard

--- a/admin-ui/src/pages/nhi/NhiCreatePage.tsx
+++ b/admin-ui/src/pages/nhi/NhiCreatePage.tsx
@@ -1,0 +1,191 @@
+import { useState, type FormEvent } from 'react';
+import { Link, useParams, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { createNhiIdentity } from '../../api/nhi';
+import type { NhiIdentityType } from '../../types';
+
+const IDENTITY_TYPES: { value: NhiIdentityType; label: string }[] = [
+  { value: 'MACHINE_TO_MACHINE', label: 'Machine to Machine' },
+  { value: 'IOT_DEVICE', label: 'IoT Device' },
+  { value: 'AI_AGENT', label: 'AI Agent' },
+  { value: 'BOT', label: 'Bot' },
+];
+
+/** Split a comma/newline separated string into a trimmed, de-empted list. */
+function toList(raw: string): string[] {
+  return raw
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export default function NhiCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [form, setForm] = useState({
+    name: '',
+    identityType: 'MACHINE_TO_MACHINE' as NhiIdentityType,
+    description: '',
+    agentPurpose: '',
+    permissionScopes: '',
+    tags: '',
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createNhiIdentity(name!, {
+        name: form.name,
+        identityType: form.identityType,
+        description: form.description || undefined,
+        agentPurpose: form.agentPurpose || undefined,
+        permissionScopes: form.permissionScopes
+          ? toList(form.permissionScopes)
+          : undefined,
+        tags: form.tags ? toList(form.tags) : undefined,
+      }),
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['nhi-identities', name] });
+      navigate(`/console/realms/${name}/nhi/${result.id}`);
+    },
+  });
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    mutation.mutate();
+  }
+
+  const set = (field: string, value: string) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Create Non-Human Identity</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Provision a new machine identity in <span className="font-medium">{name}</span>
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-gray-200 bg-white p-6 shadow-sm">
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="field-nhi-name" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Name *
+              </label>
+              <input
+                id="field-nhi-name"
+                type="text"
+                required
+                placeholder="e.g. billing-service"
+                value={form.name}
+                onChange={(e) => set('name', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="field-nhi-type" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Identity Type
+              </label>
+              <select
+                id="field-nhi-type"
+                value={form.identityType}
+                onChange={(e) => set('identityType', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              >
+                {IDENTITY_TYPES.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="field-nhi-description" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Description
+            </label>
+            <textarea
+              id="field-nhi-description"
+              rows={2}
+              value={form.description}
+              onChange={(e) => set('description', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+          </div>
+
+          {form.identityType === 'AI_AGENT' && (
+            <div>
+              <label htmlFor="field-nhi-purpose" className="mb-1.5 block text-sm font-medium text-gray-700">
+                Agent Purpose
+              </label>
+              <input
+                id="field-nhi-purpose"
+                type="text"
+                placeholder="What this agent is authorized to do"
+                value={form.agentPurpose}
+                onChange={(e) => set('agentPurpose', e.target.value)}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+              />
+            </div>
+          )}
+
+          <div>
+            <label htmlFor="field-nhi-scopes" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Permission Scopes
+            </label>
+            <input
+              id="field-nhi-scopes"
+              type="text"
+              placeholder="scope-a, scope-b"
+              value={form.permissionScopes}
+              onChange={(e) => set('permissionScopes', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+            <p className="mt-1 text-xs text-gray-500">Comma-separated</p>
+          </div>
+
+          <div>
+            <label htmlFor="field-nhi-tags" className="mb-1.5 block text-sm font-medium text-gray-700">
+              Tags
+            </label>
+            <input
+              id="field-nhi-tags"
+              type="text"
+              placeholder="prod, region-eu"
+              value={form.tags}
+              onChange={(e) => set('tags', e.target.value)}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+            />
+            <p className="mt-1 text-xs text-gray-500">Comma-separated</p>
+          </div>
+        </div>
+
+        {mutation.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700">
+            {(mutation.error as Error)?.message || 'Failed to create identity.'}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 border-t border-gray-200 pt-4">
+          <Link
+            to={`/console/realms/${name}/nhi`}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating...' : 'Create Identity'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/theme-builder/ThemeBuilderPage.tsx
+++ b/admin-ui/src/pages/theme-builder/ThemeBuilderPage.tsx
@@ -193,7 +193,7 @@ export default function ThemeBuilderPage() {
     setRollbackSuccess(null);
 
     try {
-      const updatedTheme = await rollbackTheme(realmName || '', themeId, version.id);
+      const updatedTheme = await rollbackTheme(realmName || '', themeId, version.version);
       // Update theme state with the rolled-back data
       if (updatedTheme.styles) {
         setStyles(updatedTheme.styles);

--- a/src/upgrade/upgrade.controller.ts
+++ b/src/upgrade/upgrade.controller.ts
@@ -174,29 +174,6 @@ export class UpgradeController {
   }
 
   /**
-   * GET /admin/upgrade/:upgradeId
-   *
-   * Returns the current state of a specific upgrade operation.
-   */
-  @Get(':upgradeId')
-  @ApiParam({
-    name: 'upgradeId',
-    description: 'The unique identifier of the upgrade',
-  })
-  @ApiOperation({ summary: 'Get upgrade state by ID' })
-  @ApiResponse({ status: 200, description: 'Upgrade state with current stage' })
-  @ApiResponse({
-    status: 401,
-    description: 'Unauthorized — missing or invalid admin API key',
-  })
-  @ApiResponse({ status: 404, description: 'Upgrade not found' })
-  async getUpgradeState(
-    @Param('upgradeId') upgradeId: string,
-  ): Promise<UpgradeState | null> {
-    return this.upgradeService.getUpgradeState(upgradeId);
-  }
-
-  /**
    * GET /admin/upgrade/rollback/capability
    *
    * Returns whether a rollback is possible and information about the last
@@ -306,5 +283,33 @@ export class UpgradeController {
   ): Promise<ConfigCompatibilityResult> {
     const targetVersion = version ?? this.upgradeService.getCurrentVersion();
     return this.configCompatibility.checkCompatibility(targetVersion);
+  }
+
+  /**
+   * GET /admin/upgrade/:upgradeId
+   *
+   * Returns the current state of a specific upgrade operation.
+   *
+   * NOTE: this dynamic ':upgradeId' route MUST be declared AFTER all static
+   * single-segment GET routes (pre-validation, health, config-compatibility),
+   * otherwise it shadows them — Express matches routes in declaration order,
+   * so a bare ':upgradeId' placed earlier captures '/pre-validation' etc.
+   */
+  @Get(':upgradeId')
+  @ApiParam({
+    name: 'upgradeId',
+    description: 'The unique identifier of the upgrade',
+  })
+  @ApiOperation({ summary: 'Get upgrade state by ID' })
+  @ApiResponse({ status: 200, description: 'Upgrade state with current stage' })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — missing or invalid admin API key',
+  })
+  @ApiResponse({ status: 404, description: 'Upgrade not found' })
+  async getUpgradeState(
+    @Param('upgradeId') upgradeId: string,
+  ): Promise<UpgradeState | null> {
+    return this.upgradeService.getUpgradeState(upgradeId);
   }
 }


### PR DESCRIPTION
Fixes for user-facing functional bugs found while exercising every feature against the QA admin console. All verified by static analysis, live network probes on the QA server, and the test suite.

## Bugs fixed

| Issue | Bug | Fix |
|-------|-----|-----|
| #1146 | **NHI "Create Identity" broken** — navigated to `/nhi/new`, which had no route and fell through to the detail page in `id="new"` mode → failing `GET /nhi/new` + `/nhi/new/credentials`. | Added `NhiCreatePage` + `/console/realms/:name/nhi/new` route (registered before `:name/nhi/:id`). |
| #1147 | **Risk pages → hard 404** — Dashboard/Policies links used `continuous-verification/*` but the routes are `risk-*`. | Repointed the 3 `<Link to>` targets to `risk-dashboard` / `risk-policies`. |
| #1148 | **Theme Builder can't save** — `updateTheme()` sent `PATCH`; backend only serves `PUT` → every save (manual + auto) 404'd. | `updateTheme()` now issues `PUT`. |
| #1149 | **Theme version restore 404** — called `/rollback/:versionId`; backend serves `/restore/:version`. | `rollbackTheme()` POSTs `/restore/:version` with the version **number** (`version.version`). |
| #1150 | **Upgrade route-ordering shadow** — `@Get(':upgradeId')` declared before `pre-validation`/`health`/`config-compatibility`, shadowing them. | Moved `@Get(':upgradeId')` below the static GETs. (Partial — the dead-feature wire-up/removal decision remains in #1150.) |

## Regression guard

Extended `admin-ui/src/__tests__/routes.test.ts` with an **in-app link-target coverage** test: every absolute `/console/...` `<Link>`/`navigate()` target must match a registered route. This asserts across **102 links / 55 files** and would have failed CI on #1147. (The unrouted upgrade pages from #1150 are explicitly excluded until that feature is wired up or removed.)

## Verification

- Frontend `tsc --noEmit`: clean · Backend `tsc --noEmit`: clean
- `admin-ui` full suite: **343 passed / 2 skipped** (incl. the new guard)
- Backend `upgrade.controller` spec: **20 passed**
- ESLint (no `--fix`) on all changed files: clean
- Live-confirmed on QA before the fix: theme `PATCH`→404 vs `PUT`→401; `rollback`→404 vs `restore`→401; NHI `/nhi/new`→404; risk "Dashboard" link → 404 page

Closes #1146
Closes #1147
Closes #1148
Closes #1149
Refs #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)