### PR TITLE
Promote dev → main: registration settings save fix (#1153)

### DIFF
--- a/src/realms/dto/create-realm.dto.ts
+++ b/src/realms/dto/create-realm.dto.ts
@@ -3,10 +3,12 @@ import {
   IsOptional,
   IsBoolean,
   IsInt,
+  IsNumber,
   IsArray,
   IsEnum,
   IsObject,
   Min,
+  Max,
   MinLength,
   Matches,
   ValidateNested,
@@ -540,9 +542,9 @@ export class CreateRealmDto {
     description: 'Minimum score threshold for reCAPTCHA v3 (0-1)',
   })
   @IsOptional()
-  @IsInt()
+  @IsNumber()
   @Min(0)
-  @Min(1)
+  @Max(1)
   captchaScoreThreshold?: number;
 
   // SCIM provisioning

--- a/src/realms/dto/update-realm.dto.spec.ts
+++ b/src/realms/dto/update-realm.dto.spec.ts
@@ -1,0 +1,42 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateRealmDto } from './update-realm.dto.js';
+
+/**
+ * Regression guard for idenplane#1153.
+ *
+ * The Registration Settings form always sends `captchaScoreThreshold: 0.5`
+ * (a reCAPTCHA v3 score in the range 0–1). The field was wrongly validated as
+ * `@IsInt() @Min(0) @Min(1)`, so every realm-settings save returned 400
+ * ("must be an integer number" / "must not be less than 1"). It must accept
+ * 0–1 floats and reject values outside that range.
+ *
+ * UpdateRealmDto inherits the field from CreateRealmDto via
+ * PartialType(OmitType(...)), and is the DTO the failing endpoint uses.
+ */
+async function scoreErrors(value: unknown): Promise<number> {
+  const dto = plainToInstance(UpdateRealmDto, { captchaScoreThreshold: value });
+  const errors = await validate(dto);
+  return errors.filter((e) => e.property === 'captchaScoreThreshold').length;
+}
+
+describe('UpdateRealmDto captchaScoreThreshold validation', () => {
+  it.each([0, 0.1, 0.5, 0.9, 1])(
+    'accepts in-range score %p (0.5 is the form default that previously 400ed)',
+    async (value) => {
+      expect(await scoreErrors(value)).toBe(0);
+    },
+  );
+
+  it.each([-0.1, 1.5, 2])('rejects out-of-range score %p', async (value) => {
+    expect(await scoreErrors(value)).toBeGreaterThan(0);
+  });
+
+  it('allows the field to be omitted (it is optional)', async () => {
+    const dto = plainToInstance(UpdateRealmDto, {});
+    const errors = await validate(dto);
+    expect(
+      errors.filter((e) => e.property === 'captchaScoreThreshold'),
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Promotes the registration-settings save fix from `dev` to `main` (closes the issue and deploys to QA).

Contains #1154 (`d0b5bd7`):

- **#1153** Registration Settings "Save Changes" always 400'd — `captchaScoreThreshold` (a 0–1 reCAPTCHA v3 score, default 0.5) was validated as `@IsInt() @Min(0) @Min(1)`, rejecting the `0.5` the form always sends. Fixed to `@IsNumber() @Min(0) @Max(1)`.
- Added a `UpdateRealmDto` regression test (accepts 0–1, rejects out-of-range).

All checks green on #1154 (Admin UI Tests, E2E, Lint & Unit, Build). Confirmed live on QA: `captchaScoreThreshold: 0.5` → 400 before, `1` → 200 (isolating the field).

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)