### PR TITLE
ci: cancel superseded workflow runs via concurrency groups

### DIFF
--- a/.github/workflows/breaking-change-check.yml
+++ b/.github/workflows/breaking-change-check.yml
@@ -11,6 +11,12 @@ on:
       - 'src/**'
       - 'prisma/**'
 
+# Re-pushing to a PR supersedes the previous API surface, so only the latest
+# push needs checking.
+concurrency:
+  group: breaking-change-${{ github.ref }}
+  cancel-in-progress: true
+
 # Minimal default token permissions; the job only reads repo contents.
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main, dev]
 
+# Only the newest commit per branch is worth testing; superseded runs are
+# cancelled so a burst of merges (e.g. clearing a Dependabot backlog) doesn't
+# queue dozens of runs against commits that are already stale.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 # Minimal default token permissions; all jobs only read repo contents
 # (checkout, install, test, build, upload-artifact). Elevate per-job if a
 # future job needs write access.

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -10,6 +10,12 @@ on:
   pull_request:
     branches: [main]
 
+# Re-pushing to a PR supersedes the previous diff, so only the latest push
+# needs checking.
+concurrency:
+  group: pr-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
 # Minimal default token permissions; the job only reads the diff.
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Clearing the Dependabot backlog pushed 22 commits to `main` in quick succession. `ci.yml` has no `concurrency` group, so every push started a full CI run and none were cancelled — **70 runs active on `main` at once, 64 of them testing commits that were already superseded.**

`docker-publish.yml` and `sync-dev-to-main.yml` already declare their own groups; the rest never got one.

## Change

Per-ref `concurrency` group with `cancel-in-progress: true` on the three workflows where only the newest commit matters:

| workflow | trigger | why |
|---|---|---|
| `ci.yml` | push (main/dev) + every PR | the storm above |
| `pr-hygiene.yml` | pull_request | a re-push supersedes the previous diff |
| `breaking-change-check.yml` | pull_request | a re-push supersedes the API surface |

## Deliberately not changed

- **`benchmark.yml`** — runs on `release: published`. Each release is a distinct event; cancelling one because another shipped would lose its benchmark report.
- **`release-version-check.yml`** — runs on `v*` tag push. Each tag must be validated independently; this workflow exists precisely to catch drift on a specific tag.

## Trade-off

On `main`, intermediate commits in a rapid series will no longer each get their own completed run — only the newest does. That is the intended effect (it is what makes the burst cheap), and HEAD is always verified. Bisecting a range later means re-running CI on the specific commit.

## Verification

`main` was confirmed fully green at `e058f2c5` (Lint & Unit, E2E, Admin UI, Build) **before** this branch was cut, so this PR's own run is a clean test of the new config — it exercises the `pull_request` path of all three modified workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)