### PR TITLE
test(admin-ui): drain delayed MSW responses so the suite stops failing at random

### DIFF
--- a/admin-ui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/mocks/server';
 import { render } from '../../test/utils';
@@ -111,7 +111,7 @@ describe('DashboardPage', () => {
     expect(screen.getByText('View Logs')).toBeInTheDocument();
   });
 
-  it('shows loading state when realms are loading', () => {
+  it('shows loading state when realms are loading', async () => {
     // Delay the response
     server.use(
       http.get('/admin/realms', async () => {
@@ -121,6 +121,12 @@ describe('DashboardPage', () => {
     );
     renderDashboard();
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    // Let the delayed response land before the test ends. Without this the
+    // request is still in flight when this file's jsdom environment is torn
+    // down, and MSW's XHR interceptor then fires its callback against a global
+    // that no longer has ProgressEvent — an unhandled rejection that fails the
+    // whole run even though every test passed.
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
   });
 
   it('shows empty state when no realms exist', async () => {

--- a/admin-ui/src/pages/__tests__/LoginPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/LoginPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { render } from '../../test/utils';
@@ -53,6 +53,10 @@ describe('LoginPage – credentials mode', () => {
     await user.click(screen.getByRole('button', { name: /^sign in$/i }));
 
     expect(await screen.findByRole('button', { name: /verifying/i })).toBeInTheDocument();
+    // Let the delayed login response land before the test ends — see
+    // DashboardPage.test.tsx for why an in-flight request outliving the test
+    // breaks the whole run.
+    await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /verifying/i }));
   });
 
   it('shows an error message when credentials are wrong', async () => {

--- a/admin-ui/src/pages/__tests__/MigrationHistoryPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/MigrationHistoryPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen, waitFor, act } from '@testing-library/react';
+import { screen, waitFor, act, waitForElementToBeRemoved } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/mocks/server';
 import { render } from '../../test/utils';
@@ -97,7 +97,7 @@ describe('MigrationHistoryPage', () => {
     });
   });
 
-  it('shows loading state', () => {
+  it('shows loading state', async () => {
     server.use(
       http.get('/admin/upgrade/history', async () => {
         await new Promise((r) => setTimeout(r, 100));
@@ -106,6 +106,9 @@ describe('MigrationHistoryPage', () => {
     );
     renderMigrationHistoryPage();
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    // Drain the delayed response before the test ends — see DashboardPage.test.tsx
+    // for why an in-flight request outliving the test breaks the whole run.
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
   });
 
   it('shows error state when API fails', async () => {

--- a/admin-ui/src/pages/__tests__/UpgradeStatusPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/UpgradeStatusPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen, waitFor, act } from '@testing-library/react';
+import { screen, waitFor, act, waitForElementToBeRemoved } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../test/mocks/server';
 import { render } from '../../test/utils';
@@ -62,7 +62,7 @@ describe('UpgradeStatusPage', () => {
     expect(await screen.findByText(/no active or recent upgrades/i)).toBeInTheDocument();
   });
 
-  it('shows loading state', () => {
+  it('shows loading state', async () => {
     server.use(
       http.get('/admin/upgrade/status', async () => {
         await new Promise((r) => setTimeout(r, 100));
@@ -71,6 +71,9 @@ describe('UpgradeStatusPage', () => {
     );
     renderUpgradeStatusPage();
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    // Drain the delayed response before the test ends — see DashboardPage.test.tsx
+    // for why an in-flight request outliving the test breaks the whole run.
+    await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
   });
 
   it('displays failed status correctly', async () => {

--- a/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
+++ b/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../../test/mocks/server';
@@ -112,5 +112,8 @@ describe('ClientCreatePage', () => {
     await user.click(screen.getByRole('button', { name: /^create client$/i }));
 
     expect(await screen.findByRole('button', { name: /creating/i })).toBeInTheDocument();
+    // Let the delayed 201 land before the test ends — see DashboardPage.test.tsx
+    // for why an in-flight request outliving the test breaks the whole run.
+    await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /creating/i }));
   });
 });

--- a/admin-ui/src/pages/users/__tests__/UserCreatePage.test.tsx
+++ b/admin-ui/src/pages/users/__tests__/UserCreatePage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { server } from '../../../test/mocks/server';
@@ -103,6 +103,9 @@ describe('UserCreatePage', () => {
     await user.click(screen.getByRole('button', { name: /^create user$/i }));
 
     expect(await screen.findByRole('button', { name: /creating/i })).toBeInTheDocument();
+    // Let the delayed 201 land before the test ends — see DashboardPage.test.tsx
+    // for why an in-flight request outliving the test breaks the whole run.
+    await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /creating/i }));
   });
 
   it('can toggle the Enabled checkbox off', async () => {


### PR DESCRIPTION
## The symptom

The Admin UI job failed intermittently **with every test passing**:

```
Test Files  33 passed (33)
Tests       343 passed | 2 skipped (345)
Errors      1 error

ReferenceError: ProgressEvent is not defined
 ❯ createEvent @mswjs/interceptors/lib/node/XMLHttpRequest-*.mjs:92:55
 ❯ XMLHttpRequestController.respondWith
This error originated in "src/pages/__tests__/DashboardPage.test.tsx"
```

Three PRs were red for this today — **#1180, #1177, #1169**. All three went green on re-run with no code change. #1180 is a Java/Maven bump, which cannot affect Vitest at all.

## The cause

Six tests register an MSW handler that resolves after a deliberate delay so they can assert a pending state. All six end while that response is still in flight:

| test | why it leaks |
|---|---|
| `DashboardPage` · `MigrationHistoryPage` · `UpgradeStatusPage` | non-async `it(() => {…})` — asserts the loading text and returns in far under the handler's 100ms |
| `ClientCreatePage` · `UserCreatePage` · `LoginPage` | async, but `findByRole(/creating\|verifying/)` resolves as soon as the **pending** state renders — before the response lands |

When the file's jsdom environment is torn down with a request still pending, MSW's XHR interceptor later fires its callback against a global that no longer has `ProgressEvent`. That unhandled rejection makes Vitest exit non-zero even though every assertion passed.

**Why it looked random:** it only fails when the delayed response lands in the gap between one file's teardown and the next file's setup. On a fast machine the remaining tests in the file usually outlast the delay, so it passes. On CI the timing hits the gap often enough to be a recurring tax.

## The fix

Let each response settle inside the test that provoked it, so nothing outlives the environment:

```ts
expect(screen.getByText(/loading/i)).toBeInTheDocument();
await waitForElementToBeRemoved(() => screen.queryByText(/loading/i));
```

## About the existing polyfill

`setupTests.ts` already carries a `ProgressEvent` polyfill added for this exact symptom, with a comment claiming it fixes it. **It cannot.** `setupFiles` runs *inside* the jsdom environment, so the assignment lands on the environment global that Vitest restores during teardown — which is precisely when the callback fires. The failing run analysed here happened with that code in place. Left alone (harmless, and it documents the history), but it is not what makes this green.

## Verification

- Full suite: **343 passed / 2 skipped** — identical to before, so nothing was skipped or weakened
- `npm run test:coverage` (the variant CI runs): clean, no unhandled errors
- `tsc -b --noEmit`: clean
- Lint: no new findings (the 23 pre-existing errors are in `RealmDetailPage.tsx` / `ScimConfigPage.tsx`, untouched here)

**Honest caveat:** I could not reproduce the failure locally despite forcing the timing three different ways — this machine's worker scheduling closes the gap. The diagnosis rests on the stack trace, the attribution to `DashboardPage.test.tsx`, and that file being the only one with an un-awaited delayed response. The fix removes the race by construction rather than by tuning timings.

## Unrelated observation

The Admin UI job runs the suite **twice** — `npm test` then `npm run test:coverage` — and the second run already covers everything the first does. Dropping the first step would cut roughly a minute per CI run. Not changed here to keep this PR to one concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)