### PR TITLE
feat(upgrade): register UpgradeModule and fix the blockers that made it unusable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,22 @@ BASE_URL=http://localhost:3000
 # "if an account exists, we sent a link" message even when SMTP is unset — this
 # is intentional, to avoid account enumeration. Configure SMTP per realm before
 # relying on email-based flows (reset / verification).
+
+# ─── Upgrade / migration ───────────────────────────────────────────────────
+# The read-only upgrade endpoints (status, history, health, pre-validation,
+# config-compatibility) are always available to an authenticated admin.
+#
+# The two endpoints that MUTATE the database — POST /admin/upgrade, which runs
+# `prisma migrate deploy`, and POST /admin/upgrade/rollback, which restores a
+# pg_dump over the live database — are disabled unless you opt in here. They
+# additionally require the super-admin role.
+#
+# Do not enable this until pg_dump/pg_restore are available to the process and
+# BACKUP_DIR points at durable storage, or an upgrade can fail with no usable
+# backup to roll back to.
+# UPGRADE_API_ENABLED=true
+
+# Where database backups are written before an upgrade. Defaults to ./backups,
+# which is fine for local development but should be a mounted volume in
+# production — a backup on a container's ephemeral filesystem is not a backup.
+# BACKUP_DIR=/var/lib/idenplane/backups

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ logs/security/
 
 # Local redesign verification screenshots
 admin-ui/.redesign-screens/
+
+# Database backups written by the upgrade flow (BACKUP_DIR, default ./backups).
+# These are full production dumps — they must never be committed.
+backups/

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -64,6 +64,7 @@ import { RegistrationModule } from './registration/registration.module.js';
 import { ScimModule } from './scim/scim.module.js';
 import { NhiModule } from './nhi/nhi.module.js';
 import { ContinuousVerificationModule } from './continuous-verification/continuous-verification.module.js';
+import { UpgradeModule } from './upgrade/upgrade.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -140,6 +141,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     ScimModule,
     NhiModule,
     ContinuousVerificationModule,
+    UpgradeModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/upgrade/config-compatibility.service.ts
+++ b/src/upgrade/config-compatibility.service.ts
@@ -1,5 +1,12 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { APP_VERSION } from '../versioning/app-version.js';
+
+/**
+ * Minimum PostgreSQL major version. The schema uses native scalar-list arrays
+ * and JSONB, and Prisma 7's postgres adapter drops support below 13.
+ */
+const MIN_POSTGRES_MAJOR = 13;
 
 export interface ConfigCompatibilityIssue {
   type: 'error' | 'warning';
@@ -23,68 +30,47 @@ export interface VersionSchema {
   version: string;
   minConfigVersion: string;
   requiredEnvVars: string[];
+  /** Required only when NODE_ENV=production, matching docker-entrypoint.sh. */
+  productionRequiredEnvVars?: string[];
   optionalEnvVars: string[];
   deprecatedEnvVars: string[];
   removedFeatures: string[];
   breakingChanges: string[];
 }
 
-// Schema definitions for supported versions
-const VERSION_SCHEMAS: Record<string, VersionSchema> = {
-  '2.5.0': {
-    version: '2.5.0',
-    minConfigVersion: '2.0.0',
-    requiredEnvVars: ['DATABASE_URL'],
-    optionalEnvVars: [
-      'REDIS_URL',
-      'JWT_SECRET',
-      'SMTP_HOST',
-      'LOG_LEVEL',
-      'BACKUP_DIR',
-      'PGHOST',
-      'PGPORT',
-      'PGUSER',
-    ],
-    deprecatedEnvVars: ['AUTH_VERSION', 'LEGACY_AUTH'],
-    removedFeatures: ['v1-auth-endpoints', 'legacy-sessions'],
-    breakingChanges: [
-      'JWT tokens now require RS256 algorithm',
-      'Session cookies renamed from session to idenplane_session',
-    ],
-  },
-  '2.4.0': {
-    version: '2.4.0',
-    minConfigVersion: '2.0.0',
-    requiredEnvVars: ['DATABASE_URL'],
-    optionalEnvVars: [
-      'REDIS_URL',
-      'JWT_SECRET',
-      'SMTP_HOST',
-      'LOG_LEVEL',
-      'BACKUP_DIR',
-      'PGHOST',
-      'PGPORT',
-      'PGUSER',
-    ],
-    deprecatedEnvVars: ['AUTH_VERSION'],
-    removedFeatures: [],
-    breakingChanges: [],
-  },
-  '2.3.0': {
-    version: '2.3.0',
-    minConfigVersion: '2.0.0',
-    requiredEnvVars: ['DATABASE_URL'],
-    optionalEnvVars: [
-      'REDIS_URL',
-      'JWT_SECRET',
-      'SMTP_HOST',
-      'LOG_LEVEL',
-      'BACKUP_DIR',
-    ],
-    deprecatedEnvVars: [],
-    removedFeatures: [],
-    breakingChanges: [],
-  },
+/**
+ * Configuration contract for the running application.
+ *
+ * This replaces a hand-maintained `VERSION_SCHEMAS` map keyed on '2.3.0' /
+ * '2.4.0' / '2.5.0'. The project has never shipped a 2.x — package.json is on
+ * 0.x — so every lookup missed and silently fell through to a "latest schema"
+ * fallback, and the breaking-change strings it carried described releases that
+ * do not exist.
+ *
+ * Rather than invent an entry per version, describe what the *current* binary
+ * actually requires. The required list mirrors what docker-entrypoint.sh
+ * refuses to start without, so this check and startup agree.
+ */
+const CURRENT_SCHEMA: VersionSchema = {
+  version: APP_VERSION,
+  minConfigVersion: APP_VERSION,
+  requiredEnvVars: ['DATABASE_URL'],
+  // Enforced by docker-entrypoint.sh only when NODE_ENV=production.
+  productionRequiredEnvVars: ['ADMIN_API_KEY'],
+  optionalEnvVars: [
+    'REDIS_URL',
+    'JWT_SECRET',
+    'SMTP_HOST',
+    'LOG_LEVEL',
+    'BACKUP_DIR',
+    'ADMIN_USER',
+    'PGHOST',
+    'PGPORT',
+    'PGUSER',
+  ],
+  deprecatedEnvVars: [],
+  removedFeatures: [],
+  breakingChanges: [],
 };
 
 /**
@@ -97,11 +83,7 @@ const VERSION_SCHEMAS: Record<string, VersionSchema> = {
 @Injectable()
 export class ConfigCompatibilityService {
   private readonly logger = new Logger(ConfigCompatibilityService.name);
-  private readonly prisma: PrismaClient;
-
-  constructor() {
-    this.prisma = new PrismaClient();
-  }
+  constructor(private readonly prisma: PrismaService) {}
 
   /**
    * Check configuration compatibility for a target version.
@@ -118,8 +100,7 @@ export class ConfigCompatibilityService {
 
     const issues: ConfigCompatibilityIssue[] = [];
 
-    // Get schema for target version (or use latest schema as fallback)
-    const schema = VERSION_SCHEMAS[targetVersion] ?? this.getLatestSchema();
+    const schema = CURRENT_SCHEMA;
 
     // 1. Check required environment variables
     const requiredIssues = this.checkRequiredEnvVars(schema);
@@ -162,7 +143,14 @@ export class ConfigCompatibilityService {
   ): ConfigCompatibilityIssue[] {
     const issues: ConfigCompatibilityIssue[] = [];
 
-    for (const varName of schema.requiredEnvVars) {
+    const required = [
+      ...schema.requiredEnvVars,
+      ...(process.env.NODE_ENV === 'production'
+        ? (schema.productionRequiredEnvVars ?? [])
+        : []),
+    ];
+
+    for (const varName of required) {
       if (!process.env[varName]) {
         issues.push({
           type: 'error',
@@ -247,7 +235,7 @@ export class ConfigCompatibilityService {
    * Check database configuration compatibility.
    */
   private async checkDatabaseCompatibility(
-    targetVersion: string,
+    _targetVersion: string,
   ): Promise<ConfigCompatibilityIssue[]> {
     const issues: ConfigCompatibilityIssue[] = [];
 
@@ -259,17 +247,13 @@ export class ConfigCompatibilityService {
 
       if (result.length > 0) {
         const dbVersion = result[0].version;
-        const isCompatible = this.isDatabaseVersionCompatible(
-          dbVersion,
-          targetVersion,
-        );
-
-        if (!isCompatible) {
+        if (!this.isDatabaseVersionCompatible(dbVersion)) {
           issues.push({
             type: 'error',
             path: 'database.version',
-            message: `Database version may not be compatible with ${targetVersion}`,
+            message: `PostgreSQL ${MIN_POSTGRES_MAJOR} or newer is required`,
             currentValue: dbVersion,
+            requiredValue: `PostgreSQL >= ${MIN_POSTGRES_MAJOR}`,
           });
         }
       }
@@ -302,49 +286,22 @@ export class ConfigCompatibilityService {
   /**
    * Check if database version is compatible with target version.
    */
-  private isDatabaseVersionCompatible(
-    dbVersion: string,
-    targetVersion: string,
-  ): boolean {
-    // Parse database version string
-    const pgMatch = dbVersion.match(/PostgreSQL (\d+)\.(\d+)/);
-    if (!pgMatch) {
-      return true; // Assume compatible if we can't parse
-    }
-
-    const majorVersion = parseInt(pgMatch[1], 10);
-    const minorVersion = parseInt(pgMatch[2], 10);
-
-    // Require PostgreSQL 12+ for latest versions
-    if (targetVersion >= '2.5.0') {
-      return majorVersion >= 13 || (majorVersion === 12 && minorVersion >= 1);
-    }
-
-    // Require PostgreSQL 11+ for earlier versions
-    return majorVersion >= 11;
-  }
-
   /**
-   * Get the latest version schema definition.
+   * The previous implementation branched on `targetVersion >= '2.5.0'`, a
+   * *string* comparison — so '0.10.0' < '0.9.0' and '10.0.0' < '2.0.0'. It also
+   * keyed off versions this project has never shipped. The Postgres floor does
+   * not vary by app version, so drop the branch entirely.
+   *
+   * PostgreSQL 13 is the floor: the schema uses native scalar-list arrays and
+   * JSONB, and Prisma 7's postgres adapter drops support below 13.
    */
-  private getLatestSchema(): VersionSchema {
-    const versions = Object.keys(VERSION_SCHEMAS).sort((a, b) => {
-      const [aMajor, aMinor, aPatch] = a.split('.').map(Number);
-      const [bMajor, bMinor, bPatch] = b.split('.').map(Number);
-      return bMajor - aMajor || bMinor - aMinor || bPatch - aPatch;
-    });
+  private isDatabaseVersionCompatible(dbVersion: string): boolean {
+    const pgMatch = dbVersion.match(/PostgreSQL (\d+)/);
+    if (!pgMatch) {
+      return true; // Unparseable banner — don't block the upgrade on it.
+    }
 
-    return (
-      VERSION_SCHEMAS[versions[0]] ?? {
-        version: 'unknown',
-        minConfigVersion: '2.0.0',
-        requiredEnvVars: ['DATABASE_URL'],
-        optionalEnvVars: [],
-        deprecatedEnvVars: [],
-        removedFeatures: [],
-        breakingChanges: [],
-      }
-    );
+    return parseInt(pgMatch[1], 10) >= MIN_POSTGRES_MAJOR;
   }
 
   /**
@@ -353,9 +310,8 @@ export class ConfigCompatibilityService {
    * @param targetVersion The version to check
    * @returns List of breaking change descriptions
    */
-  getBreakingChanges(targetVersion: string): string[] {
-    const schema = VERSION_SCHEMAS[targetVersion];
-    return schema?.breakingChanges ?? [];
+  getBreakingChanges(_targetVersion: string): string[] {
+    return CURRENT_SCHEMA.breakingChanges;
   }
 
   /**
@@ -364,8 +320,8 @@ export class ConfigCompatibilityService {
    * @param targetVersion The version to check
    * @returns List of deprecated variable names
    */
-  getDeprecatedEnvVars(targetVersion: string): string[] {
-    const schema = VERSION_SCHEMAS[targetVersion];
+  getDeprecatedEnvVars(_targetVersion: string): string[] {
+    const schema = CURRENT_SCHEMA;
     return schema?.deprecatedEnvVars ?? [];
   }
 
@@ -476,12 +432,5 @@ export class ConfigCompatibilityService {
     }
 
     return null;
-  }
-
-  /**
-   * Clean up Prisma client connections.
-   */
-  async onModuleDestroy(): Promise<void> {
-    await this.prisma.$disconnect();
   }
 }

--- a/src/upgrade/database-backup.service.ts
+++ b/src/upgrade/database-backup.service.ts
@@ -3,7 +3,6 @@ import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as zlib from 'zlib';
-import { PrismaClient } from '@prisma/client';
 
 export interface BackupResult {
   success: boolean;
@@ -40,11 +39,9 @@ export interface BackupListing {
 @Injectable()
 export class DatabaseBackupService {
   private readonly logger = new Logger(DatabaseBackupService.name);
-  private readonly prisma: PrismaClient;
   private readonly backupDirectory: string;
 
   constructor() {
-    this.prisma = new PrismaClient();
     // Default backup directory within project
     this.backupDirectory = process.env.BACKUP_DIR || './backups';
   }
@@ -406,12 +403,5 @@ export class DatabaseBackupService {
     }
 
     return `${size.toFixed(1)} ${units[unitIndex]}`;
-  }
-
-  /**
-   * Clean up Prisma client connections.
-   */
-  async onModuleDestroy(): Promise<void> {
-    await this.prisma.$disconnect();
   }
 }

--- a/src/upgrade/guards/upgrade-enabled.guard.spec.ts
+++ b/src/upgrade/guards/upgrade-enabled.guard.spec.ts
@@ -1,0 +1,37 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { UpgradeEnabledGuard } from './upgrade-enabled.guard.js';
+
+describe('UpgradeEnabledGuard', () => {
+  const guardWith = (value: unknown) =>
+    new UpgradeEnabledGuard({
+      get: jest.fn().mockReturnValue(value),
+    } as unknown as ConfigService);
+
+  it('allows the request when UPGRADE_API_ENABLED is exactly "true"', () => {
+    expect(guardWith('true').canActivate()).toBe(true);
+  });
+
+  // Default-off is the whole point: an operator who has never heard of this
+  // flag must not be able to trigger `prisma migrate deploy` or a pg_restore
+  // over the live database.
+  it.each([
+    [undefined, 'unset'],
+    ['', 'empty'],
+    ['false', 'false'],
+    ['1', 'truthy-but-not-true'],
+    ['yes', 'yes'],
+    ['TRUE', 'wrong case'],
+    [true, 'boolean true rather than the string'],
+  ])('rejects when the flag is %s (%s)', (value) => {
+    expect(() => guardWith(value).canActivate()).toThrow(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('names the env var in the error so the 503 is actionable', () => {
+    expect(() => guardWith(undefined).canActivate()).toThrow(
+      /UPGRADE_API_ENABLED/,
+    );
+  });
+});

--- a/src/upgrade/guards/upgrade-enabled.guard.ts
+++ b/src/upgrade/guards/upgrade-enabled.guard.ts
@@ -1,0 +1,43 @@
+import {
+  CanActivate,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Gates the two destructive upgrade endpoints (POST /admin/upgrade and
+ * POST /admin/upgrade/rollback) behind an explicit opt-in.
+ *
+ * RBAC answers "who may do this"; this answers "is this deployment prepared
+ * for it at all". They are independent questions and both need a yes:
+ *
+ *   - Starting an upgrade shells out to `prisma migrate deploy` against the
+ *     live database.
+ *   - Rolling back restores a pg_dump over it.
+ *
+ * Neither is safe on a deployment that has not provisioned a backup volume and
+ * verified that pg_dump/pg_restore exist in the image, so the default is off.
+ * Read-only upgrade endpoints (status, history, health, pre-validation) are
+ * deliberately NOT gated — they are useful precisely when deciding whether to
+ * turn this on.
+ */
+@Injectable()
+export class UpgradeEnabledGuard implements CanActivate {
+  constructor(private readonly config: ConfigService) {}
+
+  canActivate(): boolean {
+    const enabled = this.config.get<string>('UPGRADE_API_ENABLED');
+
+    if (enabled !== 'true') {
+      throw new ServiceUnavailableException(
+        'Upgrade execution is disabled. Set UPGRADE_API_ENABLED=true to enable ' +
+          'it, and ensure pg_dump/pg_restore are available and BACKUP_DIR points ' +
+          'at durable storage before doing so. Read-only upgrade endpoints ' +
+          'remain available.',
+      );
+    }
+
+    return true;
+  }
+}

--- a/src/upgrade/pre-upgrade-validator.service.spec.ts
+++ b/src/upgrade/pre-upgrade-validator.service.spec.ts
@@ -5,10 +5,6 @@ const mockPrisma = {
   $disconnect: jest.fn(),
 };
 
-jest.mock('@prisma/client', () => ({
-  PrismaClient: jest.fn(() => mockPrisma),
-}));
-
 // Mock child_process execSync
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
@@ -16,17 +12,16 @@ jest.mock('child_process', () => ({
 
 import { PreUpgradeValidatorService } from './pre-upgrade-validator.service.js';
 import { execSync } from 'child_process';
+import { PrismaService } from '../prisma/prisma.service.js';
 
 describe('PreUpgradeValidatorService', () => {
   let validatorService: PreUpgradeValidatorService;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    validatorService = new PreUpgradeValidatorService();
-  });
-
-  afterEach(async () => {
-    await validatorService.onModuleDestroy();
+    validatorService = new PreUpgradeValidatorService(
+      mockPrisma as unknown as PrismaService,
+    );
   });
 
   describe('validate', () => {
@@ -137,7 +132,9 @@ migration-3   [x] Applied
       `;
 
       (execSync as jest.Mock).mockImplementation(() => {
-        const err = new Error('Migration pending') as NodeJS.ErrnoException & { stdout: string };
+        const err = new Error('Migration pending') as NodeJS.ErrnoException & {
+          stdout: string;
+        };
         err.stdout = output;
         throw err;
       });

--- a/src/upgrade/pre-upgrade-validator.service.ts
+++ b/src/upgrade/pre-upgrade-validator.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { execSync } from 'child_process';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
 
 export interface PreUpgradeCheck {
   name: string;
@@ -34,11 +34,7 @@ export interface PreUpgradeValidationResult {
 @Injectable()
 export class PreUpgradeValidatorService {
   private readonly logger = new Logger(PreUpgradeValidatorService.name);
-  private readonly prisma: PrismaClient;
-
-  constructor() {
-    this.prisma = new PrismaClient();
-  }
+  constructor(private readonly prisma: PrismaService) {}
 
   /**
    * Run all pre-upgrade validation checks.
@@ -409,12 +405,5 @@ export class PreUpgradeValidatorService {
         details: err instanceof Error ? err.message : String(err),
       };
     }
-  }
-
-  /**
-   * Clean up Prisma client connections.
-   */
-  async onModuleDestroy(): Promise<void> {
-    await this.prisma.$disconnect();
   }
 }

--- a/src/upgrade/rollback.service.spec.ts
+++ b/src/upgrade/rollback.service.spec.ts
@@ -10,16 +10,13 @@ const mockPrisma = {
   },
 };
 
-jest.mock('@prisma/client', () => ({
-  PrismaClient: jest.fn(() => mockPrisma),
-}));
-
 import {
   RollbackService,
   RollbackResult,
   RollbackCapability,
 } from './rollback.service.js';
 import { DatabaseBackupService } from './database-backup.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
 
 describe('RollbackService', () => {
   let rollbackService: RollbackService;
@@ -35,11 +32,10 @@ describe('RollbackService', () => {
       createBackup: jest.fn(),
     } as unknown as jest.Mocked<DatabaseBackupService>;
 
-    rollbackService = new RollbackService(mockDatabaseBackupService);
-  });
-
-  afterEach(async () => {
-    await rollbackService.onModuleDestroy();
+    rollbackService = new RollbackService(
+      mockPrisma as unknown as PrismaService,
+      mockDatabaseBackupService,
+    );
   });
 
   describe('checkRollbackCapability', () => {

--- a/src/upgrade/rollback.service.ts
+++ b/src/upgrade/rollback.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
-import { DatabaseBackupService } from './database-backup.service';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { DatabaseBackupService } from './database-backup.service.js';
 
 export interface RollbackResult {
   success: boolean;
@@ -48,11 +48,10 @@ export interface UpgradeAuditEntry {
 @Injectable()
 export class RollbackService {
   private readonly logger = new Logger(RollbackService.name);
-  private readonly prisma: PrismaClient;
-
-  constructor(private readonly databaseBackupService: DatabaseBackupService) {
-    this.prisma = new PrismaClient();
-  }
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly databaseBackupService: DatabaseBackupService,
+  ) {}
 
   /**
    * Check if a rollback is possible and retrieve the last successful upgrade.
@@ -334,12 +333,5 @@ export class RollbackService {
         },
       },
     });
-  }
-
-  /**
-   * Clean up Prisma client connections.
-   */
-  async onModuleDestroy(): Promise<void> {
-    await this.prisma.$disconnect();
   }
 }

--- a/src/upgrade/upgrade-health.service.spec.ts
+++ b/src/upgrade/upgrade-health.service.spec.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { CRITICAL_TABLES } from './upgrade-health.service.js';
+
+/**
+ * Guard for the class of bug that made the whole upgrade feature unusable
+ * (idenplane#1150): `CRITICAL_TABLES` listed Prisma *model* names in the
+ * singular ('realm', 'user', 'client', 'scope') while the check runs against
+ * `pg_tables`, which only ever sees the physical `@@map(...)` names.
+ *
+ * Every entry was therefore reported missing, so `GET /admin/upgrade/health`
+ * could only ever return healthy:false — which in turn made `POST /admin/upgrade`
+ * fail at POST_HEALTH_CHECK *after* `prisma migrate deploy` had already run.
+ *
+ * This parses the real schema rather than restating the names, so a future
+ * `@@map` rename fails here instead of silently breaking upgrades again.
+ */
+describe('CRITICAL_TABLES', () => {
+  const schema = readFileSync(
+    join(__dirname, '..', '..', 'prisma', 'schema.prisma'),
+    'utf8',
+  );
+
+  const mappedTables = new Set(
+    [...schema.matchAll(/@@map\((?:name:\s*)?["']([^"']+)["']\)/g)].map(
+      (m) => m[1],
+    ),
+  );
+
+  it('parses a plausible number of @@map names from the schema', () => {
+    // Guards the guard: if the regex ever stops matching, the assertions below
+    // would vacuously pass against an empty set.
+    expect(mappedTables.size).toBeGreaterThan(20);
+  });
+
+  it.each([...CRITICAL_TABLES])(
+    'critical table %s exists in schema.prisma',
+    (table) => {
+      expect(mappedTables.has(table)).toBe(true);
+    },
+  );
+
+  it('lists physical table names, not Prisma model names', () => {
+    // The exact mistake that shipped: singular model names that no @@map emits.
+    for (const modelName of ['realm', 'user', 'client', 'role', 'scope']) {
+      expect(CRITICAL_TABLES as readonly string[]).not.toContain(modelName);
+    }
+  });
+});

--- a/src/upgrade/upgrade-health.service.ts
+++ b/src/upgrade/upgrade-health.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { execSync } from 'child_process';
-import { PrismaClient } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
 
 export interface UpgradeHealthCheck {
   name: string;
@@ -31,14 +31,31 @@ export interface UpgradeHealthResult {
  *   - Service connectivity (Redis, etc.)
  *   - Configuration consistency
  */
+
+/**
+ * Tables whose absence means the schema is unusable after an upgrade.
+ *
+ * These are the physical table names — i.e. the `@@map(...)` values in
+ * prisma/schema.prisma, not the Prisma model names. They are checked against
+ * `pg_tables`, which only ever sees the mapped names. `upgrade-health.service.spec.ts`
+ * parses the schema and asserts every entry here still exists, so a future
+ * `@@map` rename fails the suite instead of silently making every upgrade
+ * abort at POST_HEALTH_CHECK.
+ */
+export const CRITICAL_TABLES = [
+  'realms',
+  'users',
+  'clients',
+  'roles',
+  'client_scopes',
+  'sessions',
+  'upgrade_audit_log',
+] as const;
+
 @Injectable()
 export class UpgradeHealthService {
   private readonly logger = new Logger(UpgradeHealthService.name);
-  private readonly prisma: PrismaClient;
-
-  constructor() {
-    this.prisma = new PrismaClient();
-  }
+  constructor(private readonly prisma: PrismaService) {}
 
   /**
    * Run all post-upgrade health checks.
@@ -154,18 +171,8 @@ export class UpgradeHealthService {
         ORDER BY tablename
       `;
 
-      // Check for critical tables that must exist
-      const criticalTables = [
-        'realm',
-        'client',
-        'user',
-        'role',
-        'scope',
-        'session',
-      ];
-
       const existingTables = new Set(tables.map((t) => t.tablename));
-      const missingTables = criticalTables.filter(
+      const missingTables = CRITICAL_TABLES.filter(
         (t) => !existingTables.has(t),
       );
 
@@ -182,7 +189,7 @@ export class UpgradeHealthService {
         name: 'schema_integrity',
         status: 'pass',
         message: `Schema integrity verified (${tables.length} tables found)`,
-        details: `All ${criticalTables.length} critical tables present`,
+        details: `All ${CRITICAL_TABLES.length} critical tables present`,
       };
     } catch (err) {
       this.logger.error('Schema integrity check failed', err);
@@ -266,49 +273,41 @@ export class UpgradeHealthService {
   }
 
   /**
-   * Check data integrity by verifying referential integrity.
+   * Check referential integrity.
+   *
+   * Deliberately does NOT hand-write orphan queries. Every relationship here is
+   * backed by a real FK constraint created by Prisma migrations, so a validated
+   * constraint cannot have orphans — such a query can only ever return 0.
+   *
+   * What *can* actually go wrong after an upgrade or a restore is a constraint
+   * left NOT VALID: `pg_restore` adds constraints without re-checking existing
+   * rows, so a partial or out-of-order restore leaves them unvalidated and the
+   * data underneath them unverified. That is the real post-upgrade failure mode,
+   * and it is what this checks.
    */
   private async checkDataIntegrity(): Promise<UpgradeHealthCheck> {
     try {
-      // Check for orphaned foreign keys by verifying a few critical relationships
-      const checks = await Promise.all([
-        // Check for realms with invalid parent references
-        this.prisma.$queryRaw<Array<{ count: bigint }>>`
-          SELECT count(*) as count FROM realm
-          WHERE parent_id IS NOT NULL
-          AND parent_id NOT IN (SELECT id FROM realm WHERE id != realm.id)
-        `,
-        // Check for clients with invalid realm references
-        this.prisma.$queryRaw<Array<{ count: bigint }>>`
-          SELECT count(*) as count FROM client
-          WHERE realm_id NOT IN (SELECT id FROM realm)
-        `,
-        // Check for users with invalid realm references
-        this.prisma.$queryRaw<Array<{ count: bigint }>>`
-          SELECT count(*) as count FROM "user"
-          WHERE realm_id NOT IN (SELECT id FROM realm)
-        `,
-      ]);
+      const unvalidated = await this.prisma.$queryRaw<
+        Array<{ conname: string; table_name: string }>
+      >`
+        SELECT c.conname, rel.relname AS table_name
+        FROM pg_constraint c
+        JOIN pg_class rel ON rel.oid = c.conrelid
+        JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+        WHERE ns.nspname = 'public'
+          AND c.contype = 'f'
+          AND NOT c.convalidated
+        ORDER BY rel.relname, c.conname
+      `;
 
-      const orphanedRealms = Number(checks[0][0]?.count ?? 0);
-      const orphanedClients = Number(checks[1][0]?.count ?? 0);
-      const orphanedUsers = Number(checks[2][0]?.count ?? 0);
-      const totalOrphans = orphanedRealms + orphanedClients + orphanedUsers;
-
-      if (totalOrphans > 0) {
-        const details = [
-          orphanedRealms > 0 ? `${orphanedRealms} orphaned realm(s)` : null,
-          orphanedClients > 0 ? `${orphanedClients} orphaned client(s)` : null,
-          orphanedUsers > 0 ? `${orphanedUsers} orphaned user(s)` : null,
-        ]
-          .filter(Boolean)
-          .join(', ');
-
+      if (unvalidated.length > 0) {
         return {
           name: 'data_integrity',
           status: 'fail',
-          message: `Data integrity issues detected: ${totalOrphans} orphaned records`,
-          details,
+          message: `${unvalidated.length} foreign key constraint(s) are not validated`,
+          details: unvalidated
+            .map((c) => `${c.table_name}.${c.conname}`)
+            .join(', '),
         };
       }
 
@@ -316,7 +315,7 @@ export class UpgradeHealthService {
         name: 'data_integrity',
         status: 'pass',
         message: 'Data integrity verified',
-        details: 'No orphaned foreign key references detected',
+        details: 'All foreign key constraints are validated',
       };
     } catch (err) {
       this.logger.warn('Data integrity check failed, skipping', err);
@@ -443,37 +442,33 @@ export class UpgradeHealthService {
   private async checkCriticalTables(): Promise<UpgradeHealthCheck> {
     try {
       const issues: string[] = [];
+      const warnings: string[] = [];
 
-      // Check realms have at least one enabled realm
-      const enabledRealms = await this.prisma.$queryRaw<
-        Array<{ count: bigint; enabled: boolean }>
-      >`
-        SELECT count(*) as count, enabled FROM realm GROUP BY enabled
-      `;
-
-      const hasEnabledRealm = enabledRealms.some(
-        (r) => r.enabled && Number(r.count) > 0,
-      );
-      if (!hasEnabledRealm) {
+      // Use the Prisma accessors rather than raw SQL: Prisma applies the
+      // @@map(...) names, hand-written SQL does not.
+      const enabledRealmCount = await this.prisma.realm.count({
+        where: { enabled: true },
+      });
+      if (enabledRealmCount === 0) {
         issues.push('No enabled realms found');
       }
 
-      // Check that master realm exists
       const masterRealm = await this.prisma.realm.findFirst({
         where: { name: 'master' },
       });
-
       if (!masterRealm) {
         issues.push('Master realm not found');
       }
 
-      // Check for admin users
-      const adminUsers = await this.prisma.$queryRaw<Array<{ count: bigint }>>`
-        SELECT count(*) as count FROM "user" WHERE username = 'admin'
-      `;
-
-      if (Number(adminUsers[0]?.count ?? 0) === 0) {
-        issues.push('Admin user not found');
+      // The seeded admin username is configurable (ADMIN_USER, see
+      // AdminSeedService), and an install that has moved to SSO may have
+      // removed it entirely — so its absence is a warning, not a failure.
+      const adminUsername = process.env.ADMIN_USER || 'admin';
+      const adminUserCount = await this.prisma.user.count({
+        where: { username: adminUsername },
+      });
+      if (adminUserCount === 0) {
+        warnings.push(`Admin user '${adminUsername}' not found`);
       }
 
       if (issues.length > 0) {
@@ -481,7 +476,16 @@ export class UpgradeHealthService {
           name: 'critical_tables',
           status: 'fail',
           message: `Critical data missing: ${issues.length} issue(s)`,
-          details: issues.join('; '),
+          details: [...issues, ...warnings].join('; '),
+        };
+      }
+
+      if (warnings.length > 0) {
+        return {
+          name: 'critical_tables',
+          status: 'warn',
+          message: 'Critical tables present, with warnings',
+          details: warnings.join('; '),
         };
       }
 
@@ -500,12 +504,5 @@ export class UpgradeHealthService {
         details: err instanceof Error ? err.message : String(err),
       };
     }
-  }
-
-  /**
-   * Clean up Prisma client connections.
-   */
-  async onModuleDestroy(): Promise<void> {
-    await this.prisma.$disconnect();
   }
 }

--- a/src/upgrade/upgrade.controller.spec.ts
+++ b/src/upgrade/upgrade.controller.spec.ts
@@ -171,6 +171,28 @@ describe('UpgradeController', () => {
       expect(mockRollbackService.getUpgradeHistory).toHaveBeenCalled();
       expect(result).toEqual(mockHistory);
     });
+
+    // The endpoint previously declared no @Query at all, so the ?limit the
+    // admin console sends (20 on the status page, 100 for migration history)
+    // was silently dropped and every caller got the service default of 10.
+    it.each([
+      ['50', 50],
+      ['1', 1],
+      ['100', 100],
+      ['500', 100], // clamped up-bound
+      ['0', 1], // clamped low-bound
+      ['-7', 1],
+      ['abc', 10], // unparseable falls back to the default
+      [undefined, 10],
+    ])('passes limit=%s to the service as %s', async (input, expected) => {
+      mockRollbackService.getUpgradeHistory.mockResolvedValue([]);
+
+      await controller.getUpgradeHistory(input as string | undefined);
+
+      expect(mockRollbackService.getUpgradeHistory).toHaveBeenCalledWith(
+        expected,
+      );
+    });
   });
 
   describe('getUpgradeState', () => {

--- a/src/upgrade/upgrade.controller.ts
+++ b/src/upgrade/upgrade.controller.ts
@@ -40,6 +40,9 @@ import {
   UpgradeHealthResult,
 } from './upgrade-health.service.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
+import { AdminRolesGuard } from '../common/guards/admin-roles.guard.js';
+import { RequireAdminRoles } from '../common/decorators/require-admin-roles.decorator.js';
+import { UpgradeEnabledGuard } from './guards/upgrade-enabled.guard.js';
 
 class UpgradeRequestDto {
   @IsString()
@@ -66,7 +69,7 @@ class RollbackRequestDto {
 
 @ApiTags('Upgrade')
 @ApiSecurity('admin-api-key')
-@UseGuards(AdminApiKeyGuard)
+@UseGuards(AdminApiKeyGuard, AdminRolesGuard)
 @Controller('admin/upgrade')
 export class UpgradeController {
   constructor(
@@ -85,6 +88,8 @@ export class UpgradeController {
    * migration, and post-upgrade health checks.
    */
   @Post()
+  @UseGuards(UpgradeEnabledGuard)
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Start an upgrade to a target version' })
   @ApiResponse({
     status: 200,
@@ -98,7 +103,15 @@ export class UpgradeController {
     status: 401,
     description: 'Unauthorized — missing or invalid admin API key',
   })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — requires super-admin role',
+  })
   @ApiResponse({ status: 409, description: 'Upgrade already in progress' })
+  @ApiResponse({
+    status: 503,
+    description: 'Upgrade execution disabled — set UPGRADE_API_ENABLED=true',
+  })
   async startUpgrade(@Body() dto: UpgradeRequestDto): Promise<UpgradeResult> {
     return this.upgradeService.upgrade(dto.toVersion, {
       dryRun: dto.dryRun ?? false,
@@ -131,13 +144,23 @@ export class UpgradeController {
    */
   @Get('history')
   @ApiOperation({ summary: 'Get upgrade history' })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Maximum number of entries to return (1-100, default 10)',
+    type: Number,
+  })
   @ApiResponse({ status: 200, description: 'Array of upgrade audit entries' })
   @ApiResponse({
     status: 401,
     description: 'Unauthorized — missing or invalid admin API key',
   })
-  async getUpgradeHistory(): Promise<UpgradeAuditEntry[]> {
-    return this.rollbackService.getUpgradeHistory();
+  async getUpgradeHistory(
+    @Query('limit') limit?: string,
+  ): Promise<UpgradeAuditEntry[]> {
+    return this.rollbackService.getUpgradeHistory(
+      UpgradeController.parseLimit(limit, 10),
+    );
   }
 
   /**
@@ -168,9 +191,21 @@ export class UpgradeController {
     total: number;
   }> {
     const entries = await this.rollbackService.getUpgradeHistory(
-      limit ? Math.min(Math.max(parseInt(limit, 10), 1), 100) : 20,
+      UpgradeController.parseLimit(limit, 20),
     );
     return { entries, total: entries.length };
+  }
+
+  /**
+   * Clamp a caller-supplied ?limit into 1..100, falling back to `fallback`
+   * when absent or unparseable. `parseInt('abc')` is NaN, and NaN survives
+   * Math.min/Math.max — so the isNaN check is load-bearing, not defensive.
+   */
+  private static parseLimit(limit: string | undefined, fallback: number) {
+    if (limit === undefined) return fallback;
+    const parsed = parseInt(limit, 10);
+    if (Number.isNaN(parsed)) return fallback;
+    return Math.min(Math.max(parsed, 1), 100);
   }
 
   /**
@@ -197,11 +232,21 @@ export class UpgradeController {
    * rolls back the most recent successful upgrade.
    */
   @Post('rollback')
+  @UseGuards(UpgradeEnabledGuard)
+  @RequireAdminRoles(['super-admin'])
   @ApiOperation({ summary: 'Execute rollback to previous version' })
   @ApiResponse({ status: 200, description: 'Rollback result with outcome' })
   @ApiResponse({
     status: 401,
     description: 'Unauthorized — missing or invalid admin API key',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden — requires super-admin role',
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Upgrade execution disabled — set UPGRADE_API_ENABLED=true',
   })
   @ApiResponse({ status: 404, description: 'No upgrade found to roll back' })
   @ApiResponse({

--- a/src/upgrade/upgrade.module.ts
+++ b/src/upgrade/upgrade.module.ts
@@ -7,6 +7,7 @@ import { DatabaseBackupService } from './database-backup.service.js';
 import { ConfigCompatibilityService } from './config-compatibility.service.js';
 import { UpgradeHealthService } from './upgrade-health.service.js';
 import { PrismaModule } from '../prisma/prisma.module.js';
+import { UpgradeEnabledGuard } from './guards/upgrade-enabled.guard.js';
 
 @Module({
   imports: [PrismaModule],
@@ -18,14 +19,11 @@ import { PrismaModule } from '../prisma/prisma.module.js';
     DatabaseBackupService,
     ConfigCompatibilityService,
     UpgradeHealthService,
+    UpgradeEnabledGuard,
   ],
-  exports: [
-    UpgradeService,
-    RollbackService,
-    PreUpgradeValidatorService,
-    DatabaseBackupService,
-    ConfigCompatibilityService,
-    UpgradeHealthService,
-  ],
+  // Nothing outside this module consumes these services — the controller and
+  // the CLI are the only entry points. Kept empty rather than re-exporting a
+  // list that would drift.
+  exports: [],
 })
 export class UpgradeModule {}

--- a/src/upgrade/upgrade.service.spec.ts
+++ b/src/upgrade/upgrade.service.spec.ts
@@ -31,6 +31,8 @@ import { ConfigCompatibilityService } from './config-compatibility.service.js';
 import { RollbackService } from './rollback.service.js';
 import { UpgradeHealthService } from './upgrade-health.service.js';
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 describe('UpgradeService', () => {
   let upgradeService: UpgradeService;
@@ -75,10 +77,6 @@ describe('UpgradeService', () => {
       mockRollbackService,
       mockUpgradeHealthService,
     );
-  });
-
-  afterEach(async () => {
-    await upgradeService.onModuleDestroy();
   });
 
   describe('upgrade', () => {
@@ -769,22 +767,29 @@ describe('UpgradeService', () => {
     });
 
     describe('getCurrentVersion', () => {
-      it('should return current version from package.json', async () => {
-        (execSync as jest.Mock).mockReturnValue('2.5.0');
+      // These used to assert against a mocked execSync return value, which is
+      // why the broken shell quoting in the old implementation went unnoticed:
+      // in production it threw every time and the catch returned 'unknown'.
+      // getCurrentVersion now returns APP_VERSION, read from package.json at
+      // module load, so assert against that real value.
+      it('should return the real application version', () => {
+        const pkg = JSON.parse(
+          readFileSync(join(__dirname, '..', '..', 'package.json'), 'utf-8'),
+        ) as { version: string };
 
-        const version = await upgradeService.getCurrentVersion();
-
-        expect(version).toBe('2.5.0');
+        expect(upgradeService.getCurrentVersion()).toBe(pkg.version);
       });
 
-      it('should return unknown if reading package.json fails', async () => {
-        (execSync as jest.Mock).mockImplementation(() => {
-          throw new Error('File not found');
-        });
+      it('should never return the placeholder the old implementation returned', () => {
+        expect(upgradeService.getCurrentVersion()).not.toBe('unknown');
+      });
 
-        const version = await upgradeService.getCurrentVersion();
+      it('should not shell out', () => {
+        (execSync as jest.Mock).mockClear();
 
-        expect(version).toBe('unknown');
+        upgradeService.getCurrentVersion();
+
+        expect(execSync).not.toHaveBeenCalled();
       });
     });
 

--- a/src/upgrade/upgrade.service.ts
+++ b/src/upgrade/upgrade.service.ts
@@ -9,6 +9,7 @@ import { ConfigCompatibilityService } from './config-compatibility.service.js';
 import { RollbackService } from './rollback.service.js';
 import { UpgradeHealthService } from './upgrade-health.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { APP_VERSION } from '../versioning/app-version.js';
 
 /**
  * Upgrade stage enumeration tracking progress through the upgrade workflow.
@@ -760,21 +761,16 @@ export class UpgradeService {
 
   /**
    * Get the current Idenplane version.
+   *
+   * Previously shelled out to `node -p "require("./package.json").version"`.
+   * The shell stripped the inner quotes, so node evaluated
+   * `require(./package.json).version` — a SyntaxError — and the catch returned
+   * 'unknown' every single time. Every upgrade_audit_log.fromVersion written
+   * before this fix therefore reads 'unknown'. APP_VERSION reads the same
+   * package.json directly and is already used by the versioning module.
    */
   getCurrentVersion(): string {
-    try {
-      // Try to read version from package.json
-      const output = execSync(
-        'node -p "require("./package.json").version" 2>&1',
-        {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-        },
-      );
-      return output.trim();
-    } catch {
-      return 'unknown';
-    }
+    return APP_VERSION;
   }
 
   /**
@@ -784,12 +780,5 @@ export class UpgradeService {
     const timestamp = Date.now().toString(36);
     const random = Math.random().toString(36).substring(2, 8);
     return `upg-${timestamp}-${random}`;
-  }
-
-  /**
-   * Clean up Prisma client connections.
-   */
-  async onModuleDestroy(): Promise<void> {
-    await this.prisma.$disconnect();
   }
 }


### PR DESCRIPTION
Slice A of wiring up the dead upgrade/migration feature (#1150). **No user-visible change yet** — nothing in the admin UI is routed, and the two destructive endpoints ship disabled.

## Why registering it wasn't enough

`UpgradeModule` was never imported in `app.module.ts`, so every `/admin/upgrade/*` route 404'd — while `admin-ui/src/api/upgrade.ts` and the CLI both already call them. But several paths **could not succeed as written**:

### 🔴 The health check could never pass

`upgrade-health.service.ts` looked for tables `realm`, `client`, `user`, `role`, `scope`, `session`. Those are Prisma *model* names — the check runs against `pg_tables`, which only sees the physical `@@map` values (`realms`, `users`, `clients`, `roles`, `client_scopes`, `sessions`). There is no `scope` table at all.

All six were always reported missing. So `GET /health` could only ever return `healthy:false`, and `POST /upgrade` **always failed at `POST_HEALTH_CHECK` — after `prisma migrate deploy` had already run** — then auto-triggered a rollback.

The list is now `CRITICAL_TABLES`, exported, and guarded by a spec that parses `prisma/schema.prisma` and asserts each entry against the real `@@map` names:

```
read prisma/schema.prisma → collect every @@map("…")
→ assert CRITICAL_TABLES ⊆ that set
```

**Verified it actually catches the bug:** restoring the old list makes that spec fail 7 assertions.

The raw SQL had the same defect (`FROM realm WHERE parent_id …` — singular, and `Realm` has no `parentId`; only `Group` does). Rather than pluralise, the orphan queries are **deleted**: every relationship is backed by a validated FK, so they could only ever return 0. Replaced with a check for FK constraints left `NOT VALID` — which is what a partial `pg_restore` actually produces, i.e. the failure mode that matters here.

### 🔴 Destructive endpoints were ungated

`POST /admin/upgrade` (runs `prisma migrate deploy`) and `POST /admin/upgrade/rollback` (restores a `pg_dump` over the live DB) had **no role gating** — while deleting a single realm requires `super-admin`. Both now require it.

They're additionally behind a new `UpgradeEnabledGuard` (`UPGRADE_API_ENABLED`, 503 unless `'true'`). RBAC answers *who*; the flag answers *whether this deployment is prepared at all* — `pg_dump`/`pg_restore` aren't in the production image today and `BACKUP_DIR` has no volume. Read-only endpoints stay ungated: they're what you use to decide whether to enable it.

### 🟠 Correctness

| | |
|---|---|
| `getCurrentVersion()` | Shelled out to `node -p "require("./package.json").version"`. The shell stripped the inner quotes → SyntaxError → caught → **returned `'unknown'` every time**. Every `upgrade_audit_log.fromVersion` written so far reads `'unknown'`. Now returns `APP_VERSION`. |
| `GET /history` | Declared no `@Query`, so the `?limit` the console sends (20, and 100 for migration history) was dropped — every caller got 10. Added, sharing `parseLimit()` with `/audit`. |
| `VERSION_SCHEMAS` | Keyed on `2.3.0`/`2.4.0`/`2.5.0` with invented breaking changes ("JWT tokens now require RS256"). This project has never shipped a 2.x — it's on `0.3.0` — so every lookup missed. Replaced with one `CURRENT_SCHEMA` mirroring what `docker-entrypoint.sh` actually refuses to start without. |
| Version compare | `targetVersion >= '2.5.0'` is a **string** compare, under which `'0.10.0' < '0.9.0'`. Replaced with a flat PostgreSQL ≥ 13 floor. |

### 🟡 Consistency

Five services did `new PrismaClient()` — the only such calls in `src/`. This matters beyond style: `schema.prisma`'s datasource declares **no url** (it's in `prisma.config.ts`) and `PrismaService` constructs with a `PrismaPg` driver adapter, so a bare client has neither. All five now inject `PrismaService`. Also removed five copies of an `onModuleDestroy` that `$disconnect()`ed what is now the *shared global* client, and added the missing `.js` on `rollback.service.ts`'s import — the only extensionless relative import in `src/`.

## Note on the two tests that had to change

`getCurrentVersion`'s tests asserted a **mocked** `execSync` return value — which is precisely why the shell-quoting bug stayed invisible. They now assert against `package.json` and that no shell is spawned.

## Verification

- **1937 tests / 119 suites pass**; `tsc` and `nest build` clean
- Booted the app and dumped the router: all 10 routes mount, `:upgradeId` still last, both POSTs carry `UpgradeEnabledGuard` + `roles ["super-admin"]`, GETs ungated

```
POST  /admin/upgrade                    guards=[UpgradeEnabledGuard] roles={"roles":["super-admin"]}
GET   /admin/upgrade/status
GET   /admin/upgrade/history
GET   /admin/upgrade/audit
GET   /admin/upgrade/rollback/capability
POST  /admin/upgrade/rollback           guards=[UpgradeEnabledGuard] roles={"roles":["super-admin"]}
GET   /admin/upgrade/pre-validation
GET   /admin/upgrade/health
GET   /admin/upgrade/config-compatibility
GET   /admin/upgrade/:upgradeId
```

## ⚠️ Separate finding: `npm run lint` breaks the build

`npm run lint` runs eslint with `--fix`. On this repo it strips a **load-bearing** `as object | undefined` at `src/realms/realms.service.ts:57`, after which `nest build` fails on a Prisma `InputJsonValue` mismatch. It also reformats two unrelated DTOs. I reverted all three here — flagging it because anyone running `npm run lint` hits this, and it is not caused by this branch.

## What's next (not in this PR)

- **Slice B** — backup/restore actually works: the `.sql.gz`-named-but-`-Fc`-format bug, parsing host/user from `DATABASE_URL` instead of defaulting to localhost, persisting `backupId` at backup time (today it's regexed out of a log line at completion, so auto-rollback can't find it), and `postgresql-client` in the image.
- **Slice C** — enabling the destructive endpoints: confirm-to-type, single-flight 409, live-restore gating.
- **Slice D** — routing the admin UI pages and the new start-upgrade wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)