### PR TITLE
feat(upgrade): make backup and restore actually work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,18 @@ RUN cp -r admin-ui/dist dist/admin-ui
 FROM node:22-alpine AS production
 WORKDIR /app
 
+# pg_dump / pg_restore, used by the upgrade flow to take a backup before running
+# migrations and to restore it on rollback. Without these the upgrade endpoints
+# abort at pre-validation (by design — an upgrade that cannot be rolled back
+# should not start), so this is what makes UPGRADE_API_ENABLED usable at all.
+#
+# The client major version must be >= the server's; compose ships postgres 16
+# and the Alpine default here is newer, which is the supported direction.
+# Verified at build time so a base-image change cannot silently regress it.
+RUN apk add --no-cache postgresql-client \
+    && pg_dump --version \
+    && pg_restore --version
+
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/prisma ./prisma

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,15 @@ services:
       THROTTLE_TTL: ${THROTTLE_TTL:-60000}
       THROTTLE_LIMIT: ${THROTTLE_LIMIT:-100}
       BASE_URL: ${BASE_URL:-http://localhost:3000}
+      # Where the upgrade flow writes pre-migration backups. Points at the
+      # `backups` volume below so a dump survives the container being replaced —
+      # a backup on the container filesystem is not a backup.
+      BACKUP_DIR: /var/lib/idenplane/backups
       # Uncomment to enable Redis cache (requires the redis service above):
       # REDIS_URL: redis://redis:6379
       # SESSION_STORE: ${SESSION_STORE:-database}
+    volumes:
+      - backups:/var/lib/idenplane/backups
     depends_on:
       db:
         condition: service_healthy
@@ -59,3 +65,4 @@ services:
 
 volumes:
   pgdata:
+  backups:

--- a/helm/idenplane/templates/configmap.yaml
+++ b/helm/idenplane/templates/configmap.yaml
@@ -11,4 +11,9 @@ data:
   BASE_URL: {{ .Values.env.BASE_URL | quote }}
   THROTTLE_TTL: {{ .Values.env.THROTTLE_TTL | quote }}
   THROTTLE_LIMIT: {{ .Values.env.THROTTLE_LIMIT | quote }}
+  {{- if .Values.backups.enabled }}
+  # Kept in step with the volumeMount in deployment.yaml — the app writes dumps
+  # here, so a mismatch would silently write them to the container filesystem.
+  BACKUP_DIR: {{ .Values.backups.mountPath | quote }}
+  {{- end }}
   SESSION_STORE: {{ .Values.env.SESSION_STORE | quote }}

--- a/helm/idenplane/templates/deployment.yaml
+++ b/helm/idenplane/templates/deployment.yaml
@@ -83,14 +83,23 @@ spec:
             - name: themes-storage
               mountPath: /app/themes
             {{- end }}
+            {{- if .Values.backups.enabled }}
+            - name: backups-storage
+              mountPath: {{ .Values.backups.mountPath }}
+            {{- end }}
           {{- end }}
-      {{- if or .Values.volumes .Values.persistence.enabled }}
+      {{- if or .Values.volumes .Values.persistence.enabled .Values.backups.enabled }}
       volumes:
         {{- toYaml .Values.volumes | nindent 8 }}
         {{- if .Values.persistence.enabled }}
         - name: themes-storage
           persistentVolumeClaim:
             claimName: {{ include "idenplane.fullname" . }}-themes
+        {{- end }}
+        {{- if .Values.backups.enabled }}
+        - name: backups-storage
+          persistentVolumeClaim:
+            claimName: {{ include "idenplane.fullname" . }}-backups
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/helm/idenplane/templates/pvc.yaml
+++ b/helm/idenplane/templates/pvc.yaml
@@ -25,3 +25,34 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if .Values.backups.enabled }}
+---
+# Separate claim from themes: pre-upgrade database dumps are large, written
+# rarely, and must outlive the pod. Sharing the themes volume would couple the
+# lifecycle of a rollback artefact to a UI asset store.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "idenplane.fullname" . }}-backups
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "idenplane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backups-storage
+  {{- with .Values.backups.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.backups.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.backups.size }}
+  {{- with .Values.backups.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.backups.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/idenplane/values.yaml
+++ b/helm/idenplane/values.yaml
@@ -189,6 +189,24 @@ persistence:
   # not both).
   selector: {}
 
+# ── Upgrade backups ────────────────────────────────────────────────────────────
+# Durable storage for the database dumps the upgrade flow takes before running
+# migrations. Required if you intend to set UPGRADE_API_ENABLED: a dump written
+# to the container filesystem does not survive the pod, so there would be
+# nothing to roll back to — which is precisely when it is needed.
+backups:
+  enabled: false
+  # Mounted here, and BACKUP_DIR below must match.
+  mountPath: /var/lib/idenplane/backups
+  # Dumps are roughly the size of the database and several are retained
+  # (cleanupOldBackups keeps a minimum of 3), so size this generously.
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  storageClass: ""
+  annotations: {}
+  selector: {}
+
 # ── Idenplane Application Configuration ─────────────────────────────────────────
 env:
   # ── Server ────────────────────────────────────────────────────────────────

--- a/src/upgrade/database-backup.service.spec.ts
+++ b/src/upgrade/database-backup.service.spec.ts
@@ -1,0 +1,242 @@
+jest.mock('child_process', () => ({
+  execFileSync: jest.fn(),
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  statSync: jest.fn(),
+  readdirSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  readFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
+}));
+
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import { DatabaseBackupService } from './database-backup.service.js';
+
+const mockExec = execFileSync as jest.Mock;
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+/** Flatten an execFileSync call into "cmd arg arg …" for readable assertions. */
+const callToString = (call: unknown[]) =>
+  `${String(call[0])} ${(call[1] as string[]).join(' ')}`;
+
+const findCall = (cmd: string) =>
+  mockExec.mock.calls.find((c) => c[0] === cmd) as unknown[] | undefined;
+
+describe('DatabaseBackupService', () => {
+  const ORIGINAL_ENV = process.env;
+
+  const buildService = (env: Record<string, string | undefined> = {}) => {
+    process.env = { ...ORIGINAL_ENV, ...env } as NodeJS.ProcessEnv;
+    return new DatabaseBackupService();
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExec.mockReturnValue('');
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.statSync.mockReturnValue({ size: 5_000_000 } as fs.Stats);
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('connection parameters', () => {
+    // The bug this guards: only the database *name* was read from DATABASE_URL.
+    // Host/port/user fell back to localhost/5432/postgres, so in Docker — where
+    // DATABASE_URL points at host `db` — pg_dump dialled localhost and failed.
+    it('takes host, port, user and database from DATABASE_URL', () => {
+      const service = buildService({
+        DATABASE_URL: 'postgresql://appuser:secret@db:6543/idenplane',
+        PGHOST: undefined,
+        PGPORT: undefined,
+        PGUSER: undefined,
+        PGPASSWORD: undefined,
+        DATABASE_USERNAME: undefined,
+        DATABASE_PASSWORD: undefined,
+      });
+
+      service.createBackup('test');
+
+      const args = callToString(findCall('pg_dump')!);
+      expect(args).toContain('-h db');
+      expect(args).toContain('-p 6543');
+      expect(args).toContain('-U appuser');
+      expect(args).toContain('-d idenplane');
+      expect(args).not.toContain('localhost');
+    });
+
+    it('decodes percent-encoded credentials', () => {
+      // A password of  p@ss/w:rd  must round-trip, or auth fails in a way that
+      // looks like a wrong password rather than a parsing bug.
+      const service = buildService({
+        DATABASE_URL:
+          'postgresql://user%40corp:p%40ss%2Fw%3Ard@db:5432/idenplane',
+        PGUSER: undefined,
+        PGPASSWORD: undefined,
+        DATABASE_USERNAME: undefined,
+        DATABASE_PASSWORD: undefined,
+      });
+
+      service.createBackup();
+
+      const call = findCall('pg_dump')!;
+      expect(callToString(call)).toContain('-U user@corp');
+      expect((call[2] as { env: NodeJS.ProcessEnv }).env.PGPASSWORD).toBe(
+        'p@ss/w:rd',
+      );
+    });
+
+    it('never puts the password in argv', () => {
+      const service = buildService({
+        DATABASE_URL: 'postgresql://u:hunter2@db:5432/idenplane',
+      });
+
+      service.createBackup();
+
+      expect(callToString(findCall('pg_dump')!)).not.toContain('hunter2');
+    });
+
+    it('treats PGHOST as an override, not a default', () => {
+      const service = buildService({
+        DATABASE_URL: 'postgresql://u:p@db:5432/idenplane',
+        PGHOST: 'pgbouncer',
+      });
+
+      service.createBackup();
+
+      expect(callToString(findCall('pg_dump')!)).toContain('-h pgbouncer');
+    });
+
+    it('fails loudly on a non-postgres DATABASE_URL rather than dumping the wrong database', () => {
+      const service = buildService({
+        DATABASE_URL: 'mysql://u:p@db:3306/idenplane',
+      });
+
+      const result = service.createBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/PostgreSQL/i);
+      expect(findCall('pg_dump')).toBeUndefined();
+    });
+  });
+
+  describe('archive format', () => {
+    // pg_dump -Fc writes a custom-format archive whose magic bytes are "PGDMP".
+    // It was being written to a file named .sql.gz, and restoreBackup branched
+    // on that suffix and ran gunzipSync — which throws on every archive this
+    // service has ever produced.
+    it('writes a .dump file, not .sql.gz', () => {
+      const service = buildService({
+        DATABASE_URL: 'postgresql://u:p@db:5432/idenplane',
+      });
+
+      const result = service.createBackup('pre-upgrade-1.0.0');
+
+      expect(result.backupPath).toMatch(/\.dump$/);
+      expect(result.backupPath).not.toMatch(/\.gz$/);
+    });
+
+    it('restores straight from the file with no decompression step', () => {
+      const service = buildService({
+        DATABASE_URL: 'postgresql://u:p@db:5432/idenplane',
+      });
+
+      service.restoreBackup('/backups/idenplane-backup-x.dump');
+
+      const call = findCall('pg_restore')!;
+      expect((call[1] as string[]).at(-1)).toBe(
+        '/backups/idenplane-backup-x.dump',
+      );
+      // No stdin piping — the previous zlib path fed decompressed bytes in.
+      expect((call[2] as { input?: unknown }).input).toBeUndefined();
+      expect(mockFs.readFileSync).not.toHaveBeenCalled();
+    });
+
+    it('restores with --clean so a populated database does not reject it', () => {
+      const service = buildService({
+        DATABASE_URL: 'postgresql://u:p@db:5432/idenplane',
+      });
+
+      service.restoreBackup('/backups/x.dump');
+
+      const args = callToString(findCall('pg_restore')!);
+      // Without --clean every restore into a live database dies on
+      // "relation already exists" — i.e. exactly when a rollback is needed.
+      expect(args).toContain('--clean');
+      expect(args).toContain('--if-exists');
+      // A rollback that half-applies is worse than one that fails cleanly.
+      expect(args).toContain('--single-transaction');
+      expect(args).toContain('--exit-on-error');
+    });
+
+    it('lists only .dump archives', () => {
+      const service = buildService({ BACKUP_DIR: '/backups' });
+      mockFs.readdirSync.mockReturnValue([
+        'idenplane-backup-new.dump',
+        'idenplane-backup-legacy.sql.gz', // never actually gzip, unrestorable
+        'notes.txt',
+      ] as unknown as fs.Dirent[]);
+      mockFs.statSync.mockReturnValue({
+        size: 1000,
+        birthtime: new Date(),
+      } as fs.Stats);
+
+      const listed = service.listBackups().map((b) => b.filename);
+
+      expect(listed).toEqual(['idenplane-backup-new.dump']);
+    });
+  });
+
+  describe('verifyBackup', () => {
+    it('reads the archive table of contents, not just the file size', () => {
+      const service = buildService();
+
+      expect(service.verifyBackup('/backups/x.dump')).toBe(true);
+
+      const args = callToString(findCall('pg_restore')!);
+      expect(args).toContain('--list');
+    });
+
+    it('rejects an archive whose table of contents cannot be read', () => {
+      // A file truncated by a full disk still passes a size check but has no
+      // readable TOC — and this runs immediately before a rollback trusts it.
+      const service = buildService();
+      mockExec.mockImplementation(() => {
+        throw new Error('pg_restore: error: did not find magic string');
+      });
+
+      expect(service.verifyBackup('/backups/truncated.dump')).toBe(false);
+    });
+
+    it('rejects a missing or trivially small file without shelling out', () => {
+      const service = buildService();
+      mockFs.existsSync.mockReturnValue(false);
+
+      expect(service.verifyBackup('/backups/missing.dump')).toBe(false);
+      expect(mockExec).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pgToolsAvailable', () => {
+    it('reports available when both binaries respond', () => {
+      expect(buildService().pgToolsAvailable().available).toBe(true);
+    });
+
+    it('reports unavailable, naming the missing binary', () => {
+      const service = buildService();
+      mockExec.mockImplementation((cmd: string) => {
+        if (cmd === 'pg_restore') throw new Error('ENOENT');
+        return '';
+      });
+
+      const { available, detail } = service.pgToolsAvailable();
+
+      expect(available).toBe(false);
+      expect(detail).toContain('pg_restore');
+    });
+  });
+});

--- a/src/upgrade/database-backup.service.ts
+++ b/src/upgrade/database-backup.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { execFileSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as zlib from 'zlib';
+import { createHash } from 'crypto';
 
 export interface BackupResult {
   success: boolean;
@@ -57,7 +57,12 @@ export class DatabaseBackupService {
     const timestamp = new Date();
     const timestampStr = timestamp.toISOString().replace(/[:.]/g, '-');
     const safeLabel = label ? `-${label.replace(/[^a-zA-Z0-9-_]/g, '')}` : '';
-    const backupFilename = `idenplane-backup-${timestampStr}${safeLabel}.sql.gz`;
+    // `.dump`, not `.sql.gz`: pg_dump is invoked with -Fc, which writes a
+    // PostgreSQL custom-format archive (magic bytes "PGDMP"), not gzipped SQL.
+    // The old name was a lie that restoreBackup then believed — it branched on
+    // the .gz suffix and ran gunzipSync, which throws on every archive this
+    // service has ever produced.
+    const backupFilename = `idenplane-backup-${timestampStr}${safeLabel}.dump`;
     const backupPath = path.join(this.backupDirectory, backupFilename);
 
     this.logger.log(`Starting database backup: ${backupFilename}`);
@@ -66,9 +71,8 @@ export class DatabaseBackupService {
       // Ensure backup directory exists
       this.ensureBackupDirectory();
 
-      // Get database name from Prisma
-      const databaseUrl = process.env.DATABASE_URL || '';
-      const dbName = this.extractDatabaseName(databaseUrl);
+      // Connection details come from DATABASE_URL (PG* override them).
+      const { database: dbName } = this.pgConnParams();
 
       // Build pg_dump argument vector and run it WITHOUT a shell. Passing args
       // as an array to execFileSync means no value is ever interpreted by a
@@ -136,33 +140,21 @@ export class DatabaseBackupService {
     }
 
     try {
-      // Get database name from connection string
-      const databaseUrl = process.env.DATABASE_URL || '';
-      const dbName = this.extractDatabaseName(databaseUrl);
+      const { database: dbName } = this.pgConnParams();
 
       // Run pg_restore WITHOUT a shell (arg array → no command injection).
-      // Compressed (.gz) backups are decompressed in-process with zlib and fed
-      // to pg_restore over stdin, replacing the previous `gunzip -c | pg_restore`
-      // shell pipe (CodeQL js/command-line-injection / shell-command-injection).
+      // There is exactly one code path: pg_dump -Fc writes a custom-format
+      // archive and pg_restore reads it directly from the file. The previous
+      // zlib branch existed only to service the misleading .sql.gz name.
       const restoreArgs = this.buildRestoreArgs(dbName);
-      const env = this.pgEnv();
 
       this.logger.debug(`Executing: pg_restore ${restoreArgs.join(' ')}`);
 
-      if (backupPath.endsWith('.gz')) {
-        const decompressed = zlib.gunzipSync(fs.readFileSync(backupPath));
-        execFileSync('pg_restore', restoreArgs, {
-          input: decompressed,
-          stdio: ['pipe', 'pipe', 'pipe'],
-          env,
-        });
-      } else {
-        execFileSync('pg_restore', [...restoreArgs, backupPath], {
-          encoding: 'utf-8',
-          stdio: ['pipe', 'pipe', 'pipe'],
-          env,
-        });
-      }
+      execFileSync('pg_restore', [...restoreArgs, backupPath], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: this.pgEnv(),
+      });
 
       const duration = Date.now() - startTime;
 
@@ -210,7 +202,11 @@ export class DatabaseBackupService {
       const now = new Date();
 
       for (const file of files) {
-        if (!file.endsWith('.sql.gz') && !file.endsWith('.sql')) {
+        // Only custom-format archives this service can actually restore.
+        // Legacy .sql.gz files (which were never gzip despite the name) are
+        // deliberately excluded — listing one would offer the operator a
+        // rollback target that cannot be restored.
+        if (!file.endsWith('.dump')) {
           continue;
         }
 
@@ -289,39 +285,153 @@ export class DatabaseBackupService {
       }
 
       const stats = fs.statSync(backupPath);
-      // Minimum reasonable backup size (at least 1KB)
-      return stats.size > 1024;
-    } catch {
+      if (stats.size <= 1024) {
+        return false;
+      }
+
+      // A size check cannot distinguish a complete archive from one truncated
+      // by a full disk or a killed process — and this is called immediately
+      // before a rollback depends on it. `pg_restore --list` reads the archive's
+      // table of contents, which lives at the end of the file, so it fails on a
+      // truncated or wrong-format file without touching the database.
+      execFileSync('pg_restore', ['--list', backupPath], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      return true;
+    } catch (err) {
+      this.logger.warn(
+        `Backup verification failed for ${backupPath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
       return false;
     }
   }
 
   /**
-   * Extract database name from DATABASE_URL connection string.
+   * SHA-256 of a backup file, so a restore can confirm it is reading the same
+   * bytes that were written. BackupMetadata has always declared a `checksum`
+   * field; nothing ever populated it.
    */
-  private extractDatabaseName(databaseUrl: string): string {
-    // Handle postgresql://user:pass@host:5432/dbname format
-    const match = databaseUrl.match(/\/([^/?]+)(\?|$)/);
-    return match ? match[1] : 'default';
+  checksum(backupPath: string): string | undefined {
+    try {
+      return createHash('sha256')
+        .update(fs.readFileSync(backupPath))
+        .digest('hex');
+    } catch {
+      return undefined;
+    }
   }
 
   /**
-   * Build pg_dump command with appropriate options for backup.
+   * Connection parameters for the pg_* tools.
+   *
+   * Previously only the database *name* was taken from DATABASE_URL; host, port
+   * and user fell back to hardcoded defaults of localhost/5432/postgres. In the
+   * shipped Docker setup DATABASE_URL points at host `postgres`, so pg_dump
+   * dialled localhost and the backup failed — and none of PGHOST/PGPORT/PGUSER
+   * are set anywhere in docker-compose, the Dockerfile or the Helm chart.
+   *
+   * DATABASE_URL is now the source of truth and the PG* variables are
+   * *overrides*, for the case where the pg tools must reach the server by a
+   * different route than the app does (a sidecar, a bouncer, a socket path).
    */
-  /** Connection params for the pg_* tools, sourced from the environment. */
   private pgConnParams(): {
     host: string;
     port: string;
     user: string;
     password: string;
+    database: string;
   } {
     const env = process.env;
+    const parsed = this.parseDatabaseUrl(env.DATABASE_URL);
+
     return {
-      host: env.PGHOST || 'localhost',
-      port: env.PGPORT || '5432',
-      user: env.PGUSER || env.DATABASE_USERNAME || 'postgres',
-      password: env.PGPASSWORD || env.DATABASE_PASSWORD || '',
+      host: env.PGHOST || parsed.host,
+      port: env.PGPORT || parsed.port,
+      user: env.PGUSER || env.DATABASE_USERNAME || parsed.user,
+      password: env.PGPASSWORD || env.DATABASE_PASSWORD || parsed.password,
+      database: parsed.database,
     };
+  }
+
+  /**
+   * Parse a postgres connection URL into its components.
+   *
+   * Uses the URL parser rather than a regex so percent-encoded credentials are
+   * decoded correctly — a password containing '@' or '/' is encoded in the URL
+   * and must be decoded before it reaches PGPASSWORD, or authentication fails
+   * in a way that looks like a wrong password.
+   */
+  private parseDatabaseUrl(databaseUrl: string | undefined): {
+    host: string;
+    port: string;
+    user: string;
+    password: string;
+    database: string;
+  } {
+    const empty = {
+      host: 'localhost',
+      port: '5432',
+      user: 'postgres',
+      password: '',
+      database: 'postgres',
+    };
+
+    if (!databaseUrl) {
+      return empty;
+    }
+
+    try {
+      const url = new URL(databaseUrl);
+
+      if (!/^postgres(ql)?:$/.test(url.protocol)) {
+        throw new Error(
+          `Unsupported database protocol '${url.protocol}' — the upgrade ` +
+            'backup flow requires PostgreSQL.',
+        );
+      }
+
+      return {
+        host: url.hostname || empty.host,
+        port: url.port || empty.port,
+        user: url.username ? decodeURIComponent(url.username) : empty.user,
+        password: url.password ? decodeURIComponent(url.password) : '',
+        database: url.pathname.replace(/^\//, '') || empty.database,
+      };
+    } catch (err) {
+      // A malformed URL must not silently degrade to dumping the wrong
+      // database on localhost — surface it to the caller.
+      throw new Error(
+        `Could not parse DATABASE_URL: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { cause: err },
+      );
+    }
+  }
+
+  /**
+   * Whether the pg_dump / pg_restore binaries are reachable on PATH.
+   *
+   * The production image does not install postgresql-client today, so this
+   * returns false there and the pre-upgrade validator fails the run *before*
+   * anything touches the database — rather than at the backup stage, or worse,
+   * at rollback time when a backup is already needed.
+   */
+  pgToolsAvailable(): { available: boolean; detail: string } {
+    for (const tool of ['pg_dump', 'pg_restore'] as const) {
+      try {
+        execFileSync(tool, ['--version'], { stdio: ['pipe', 'pipe', 'pipe'] });
+      } catch {
+        return {
+          available: false,
+          detail: `${tool} was not found on PATH. Install postgresql-client (client major version >= the server's).`,
+        };
+      }
+    }
+    return { available: true, detail: 'pg_dump and pg_restore are available' };
   }
 
   /**
@@ -347,7 +457,7 @@ export class DatabaseBackupService {
       user,
       '-d',
       databaseName,
-      '-Fc', // Custom format for compression
+      '-Fc', // Custom format — required for pg_restore's selective/parallel modes
       '-Z',
       '6', // Compression level 6
       '-f',
@@ -355,10 +465,41 @@ export class DatabaseBackupService {
     ];
   }
 
-  /** pg_restore argument vector (target db); the source is the file/stdin. */
+  /**
+   * pg_restore argument vector (target db); the archive path is appended by the
+   * caller.
+   *
+   * The flags matter for a rollback into a database that already has a schema,
+   * which is the only situation this is ever used in:
+   *
+   *   --clean --if-exists   drop each object before recreating it. Without this
+   *                         every restore into a populated database dies on
+   *                         "relation already exists".
+   *   --no-owner            do not reassign ownership; the app's role is rarely
+   *                         --no-privileges  the owner recorded in the dump.
+   *   --single-transaction  all-or-nothing. A rollback that half-applies is
+   *                         worse than one that fails cleanly.
+   *   --exit-on-error       stop at the first failure rather than continuing and
+   *                         reporting success at the end.
+   */
   private buildRestoreArgs(databaseName: string): string[] {
     const { host, port, user } = this.pgConnParams();
-    return ['-h', host, '-p', port, '-U', user, '-d', databaseName];
+    return [
+      '-h',
+      host,
+      '-p',
+      port,
+      '-U',
+      user,
+      '-d',
+      databaseName,
+      '--clean',
+      '--if-exists',
+      '--no-owner',
+      '--no-privileges',
+      '--single-transaction',
+      '--exit-on-error',
+    ];
   }
 
   /**

--- a/src/upgrade/pre-upgrade-validator.service.spec.ts
+++ b/src/upgrade/pre-upgrade-validator.service.spec.ts
@@ -10,17 +10,47 @@ jest.mock('child_process', () => ({
   execSync: jest.fn(),
 }));
 
+// fs is mocked as a module rather than spied on: its exports are
+// non-configurable under Node 22, so jest.spyOn throws "Cannot redefine
+// property". Mocking keeps the suite hermetic — checkBackupDirectory writes a
+// probe file, which must not touch the real working tree.
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
+  statfsSync: jest.fn(),
+}));
+
 import { PreUpgradeValidatorService } from './pre-upgrade-validator.service.js';
 import { execSync } from 'child_process';
+import * as fs from 'fs';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { DatabaseBackupService } from './database-backup.service.js';
 
 describe('PreUpgradeValidatorService', () => {
   let validatorService: PreUpgradeValidatorService;
+  let mockBackupService: jest.Mocked<DatabaseBackupService>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockBackupService = {
+      pgToolsAvailable: jest
+        .fn()
+        .mockReturnValue({ available: true, detail: 'ok' }),
+    } as unknown as jest.Mocked<DatabaseBackupService>;
+
+    // Defaults: directory usable, plenty of space. Individual tests override.
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
+    (fs.statfsSync as jest.Mock).mockReturnValue({
+      bavail: 5_000_000,
+      bsize: 4096,
+    });
+
     validatorService = new PreUpgradeValidatorService(
       mockPrisma as unknown as PrismaService,
+      mockBackupService,
     );
   });
 
@@ -159,41 +189,55 @@ migration-3   [x] Applied
   });
 
   describe('checkDiskSpace', () => {
-    it('should return pass when sufficient disk space (>=1GB)', async () => {
-      (execSync as jest.Mock).mockReturnValue(
-        'Filesystem  1K-blocks  Used Available Use% Mounted on\n/dev/sda1  100000000  50000000  50000000  50% /',
-      );
+    // These used to mock `df -k .`. That shell-out is gone: `df` does not exist
+    // on Windows, and `.` is the process cwd rather than BACKUP_DIR, so the
+    // check could pass on a roomy root while the backup volume was full.
+    // statfsSync measures the filesystem the backups actually land on.
+    const withFreeBytes = (bytes: number) => {
+      (fs.statfsSync as jest.Mock).mockReturnValue({
+        bavail: bytes / 4096,
+        bsize: 4096,
+      });
+      (fs.existsSync as jest.Mock).mockReturnValue(true);
+    };
 
-      const check = await (validatorService as any).checkDiskSpace();
+    it('should return pass when sufficient disk space (>=1GB)', () => {
+      withFreeBytes(50 * 1024 * 1024 * 1024);
+
+      const check = (validatorService as any).checkDiskSpace();
 
       expect(check.name).toBe('disk_space');
       expect(check.status).toBe('pass');
       expect(check.message).toContain('GB');
     });
 
-    it('should return warn when low disk space (256MB-1GB)', async () => {
-      // 500MB available
-      (execSync as jest.Mock).mockReturnValue(
-        'Filesystem  1K-blocks  Used Available Use% Mounted on\n/dev/sda1  1000000  500000  500000  50% /',
-      );
+    it('should return warn when low disk space (256MB-1GB)', () => {
+      withFreeBytes(500 * 1024 * 1024);
 
-      const check = await (validatorService as any).checkDiskSpace();
+      const check = (validatorService as any).checkDiskSpace();
 
-      expect(check.name).toBe('disk_space');
       expect(check.status).toBe('warn');
     });
 
-    it('should return fail when insufficient disk space (<256MB)', async () => {
-      // 100MB available
-      (execSync as jest.Mock).mockReturnValue(
-        'Filesystem  1K-blocks  Used Available Use% Mounted on\n/dev/sda1  1000000  900000  100000  90% /',
-      );
+    it('should return fail when insufficient disk space (<256MB)', () => {
+      withFreeBytes(100 * 1024 * 1024);
 
-      const check = await (validatorService as any).checkDiskSpace();
+      const check = (validatorService as any).checkDiskSpace();
 
-      expect(check.name).toBe('disk_space');
       expect(check.status).toBe('fail');
       expect(check.message).toContain('Insufficient');
+    });
+
+    it('measures BACKUP_DIR rather than the process working directory', () => {
+      process.env.BACKUP_DIR = '/var/lib/idenplane/backups';
+      withFreeBytes(50 * 1024 * 1024 * 1024);
+
+      (validatorService as any).checkDiskSpace();
+
+      expect(fs.statfsSync).toHaveBeenCalledWith(
+        expect.stringContaining('backups'),
+      );
+      delete process.env.BACKUP_DIR;
     });
   });
 

--- a/src/upgrade/pre-upgrade-validator.service.ts
+++ b/src/upgrade/pre-upgrade-validator.service.ts
@@ -1,6 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
 import { PrismaService } from '../prisma/prisma.service.js';
+import { DatabaseBackupService } from './database-backup.service.js';
 
 export interface PreUpgradeCheck {
   name: string;
@@ -34,7 +37,10 @@ export interface PreUpgradeValidationResult {
 @Injectable()
 export class PreUpgradeValidatorService {
   private readonly logger = new Logger(PreUpgradeValidatorService.name);
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly databaseBackupService: DatabaseBackupService,
+  ) {}
 
   /**
    * Run all pre-upgrade validation checks.
@@ -90,6 +96,25 @@ export class PreUpgradeValidatorService {
     checks.push(txCheck);
     if (txCheck.status === 'pass') passed++;
     else if (txCheck.status === 'warn') warnings++;
+    else failures++;
+
+    // 7. Backup tooling — a hard failure, deliberately.
+    //
+    // Without pg_dump the upgrade would previously get all the way to the BACKUP
+    // stage before discovering it cannot take one, and a failure any time after
+    // DATABASE_MIGRATION would then have nothing to roll back to. Failing here
+    // aborts before anything has been touched.
+    const toolingCheck = this.checkBackupTooling();
+    checks.push(toolingCheck);
+    if (toolingCheck.status === 'pass') passed++;
+    else if (toolingCheck.status === 'warn') warnings++;
+    else failures++;
+
+    // 8. Backup directory must be writable, for the same reason.
+    const backupDirCheck = this.checkBackupDirectory();
+    checks.push(backupDirCheck);
+    if (backupDirCheck.status === 'pass') passed++;
+    else if (backupDirCheck.status === 'warn') warnings++;
     else failures++;
 
     const canProceed = failures === 0;
@@ -193,56 +218,126 @@ export class PreUpgradeValidatorService {
   }
 
   /**
-   * Check available disk space for backups.
-   * Requires at least 1GB of free space.
+   * Verify pg_dump / pg_restore are reachable, since the whole safety story of
+   * an upgrade rests on being able to take a backup and put it back.
+   */
+  private checkBackupTooling(): PreUpgradeCheck {
+    const { available, detail } = this.databaseBackupService.pgToolsAvailable();
+
+    return available
+      ? {
+          name: 'backup_tooling',
+          status: 'pass',
+          message: 'Backup tooling is available',
+          details: detail,
+        }
+      : {
+          name: 'backup_tooling',
+          status: 'fail',
+          message:
+            'Backup tooling is missing — an upgrade cannot be rolled back',
+          details: detail,
+        };
+  }
+
+  /**
+   * Verify the backup directory can actually be written to.
+   *
+   * Writes and removes a probe file rather than checking permission bits: a
+   * read-only mount, a full filesystem and a wrong-uid container all present
+   * differently in the metadata but identically here — as a failed write.
+   */
+  private checkBackupDirectory(): PreUpgradeCheck {
+    const backupDir = process.env.BACKUP_DIR || './backups';
+    const configured = Boolean(process.env.BACKUP_DIR);
+
+    try {
+      fs.mkdirSync(backupDir, { recursive: true });
+
+      const probe = path.join(
+        backupDir,
+        `.idenplane-write-probe-${process.pid}`,
+      );
+      fs.writeFileSync(probe, 'probe');
+      fs.unlinkSync(probe);
+
+      if (!configured && process.env.NODE_ENV === 'production') {
+        return {
+          name: 'backup_directory',
+          status: 'warn',
+          message: 'BACKUP_DIR is not set; using the default ./backups',
+          details:
+            'In production this is usually a container filesystem that does not ' +
+            'survive a restart. Point BACKUP_DIR at mounted, durable storage.',
+        };
+      }
+
+      return {
+        name: 'backup_directory',
+        status: 'pass',
+        message: `Backup directory is writable: ${backupDir}`,
+      };
+    } catch (err) {
+      return {
+        name: 'backup_directory',
+        status: 'fail',
+        message: `Backup directory is not writable: ${backupDir}`,
+        details: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Check available disk space where backups will actually be written.
+   *
+   * Previously shelled out to `df -k .`, which had two problems: `df` does not
+   * exist on Windows (so this silently degraded to a warning on every developer
+   * machine), and `.` is the process working directory, not BACKUP_DIR — the
+   * check could pass on a roomy root filesystem while the mounted backup volume
+   * was full. statfsSync measures the right filesystem and needs no shell.
    */
   private checkDiskSpace(): PreUpgradeCheck {
+    const backupDir = process.env.BACKUP_DIR || './backups';
+
     try {
-      const output = execSync('df -k . 2>&1', {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+      // statfs needs an existing path; walk up to the nearest one that exists
+      // so an as-yet-uncreated backup directory still reports its volume.
+      let probe = path.resolve(backupDir);
+      while (!fs.existsSync(probe)) {
+        const parent = path.dirname(probe);
+        if (parent === probe) break;
+        probe = parent;
+      }
 
-      const lines = output.split('\n');
-      if (lines.length >= 2) {
-        const lastLine = lines[lines.length - 1];
-        const parts = lastLine.split(/\s+/);
-        if (parts.length >= 4) {
-          const availableKb = parseInt(parts[3], 10);
-          const availableMb = availableKb / 1024;
-          const availableGb = availableMb / 1024;
+      const stats = fs.statfsSync(probe);
+      const availableBytes = stats.bavail * stats.bsize;
+      const availableMb = availableBytes / (1024 * 1024);
+      const availableGb = availableMb / 1024;
+      const where = `${availableMb.toFixed(0)} MB available on the filesystem holding ${probe}`;
 
-          // Require at least 1GB (1024MB)
-          if (availableGb >= 1) {
-            return {
-              name: 'disk_space',
-              status: 'pass',
-              message: `Sufficient disk space available: ${availableGb.toFixed(2)} GB`,
-              details: `${availableMb.toFixed(0)} MB available`,
-            };
-          } else if (availableMb >= 256) {
-            return {
-              name: 'disk_space',
-              status: 'warn',
-              message: `Low disk space: ${availableGb.toFixed(2)} GB available`,
-              details: `${availableMb.toFixed(0)} MB available (recommended: 1 GB minimum)`,
-            };
-          } else {
-            return {
-              name: 'disk_space',
-              status: 'fail',
-              message: `Insufficient disk space: ${availableMb.toFixed(0)} MB available`,
-              details: 'Minimum 1 GB recommended for safe backups',
-            };
-          }
-        }
+      if (availableGb >= 1) {
+        return {
+          name: 'disk_space',
+          status: 'pass',
+          message: `Sufficient disk space available: ${availableGb.toFixed(2)} GB`,
+          details: where,
+        };
+      }
+
+      if (availableMb >= 256) {
+        return {
+          name: 'disk_space',
+          status: 'warn',
+          message: `Low disk space: ${availableGb.toFixed(2)} GB available`,
+          details: `${where} (recommended: 1 GB minimum)`,
+        };
       }
 
       return {
         name: 'disk_space',
-        status: 'warn',
-        message: 'Unable to determine disk space',
-        details: output.trim(),
+        status: 'fail',
+        message: `Insufficient disk space: ${availableMb.toFixed(0)} MB available`,
+        details: `${where}. Minimum 1 GB recommended for safe backups.`,
       };
     } catch (err) {
       return {

--- a/src/upgrade/rollback.service.ts
+++ b/src/upgrade/rollback.service.ts
@@ -322,13 +322,19 @@ export class RollbackService {
         fromVersion: originalUpgrade.toVersion,
         toVersion: originalUpgrade.fromVersion,
         status: success ? 'ROLLBACK_COMPLETED' : 'ROLLBACK_FAILED',
-        startedAt: originalUpgrade.startedAt ?? now,
+        // The rollback started now — it must not inherit the original upgrade's
+        // startedAt. Copying it made the two rows tie on every
+        // `orderBy: { startedAt: 'desc' }`, so getLatestUpgradeStatus() and
+        // getUpgradeHistory() could return the failed upgrade *after* it had
+        // been rolled back, reporting the rollback as though it never happened.
+        startedAt: now,
         completedAt: now,
         initiatedBy: 'ROLLBACK_SERVICE',
         backupId: backupPath ?? null,
         rollbackTriggered: true,
         details: {
           rollbackFromVersion: originalUpgrade.toVersion,
+          originalStartedAt: originalUpgrade.startedAt?.toISOString() ?? null,
           errorMessage: error ?? null,
         },
       },

--- a/src/upgrade/upgrade.service.spec.ts
+++ b/src/upgrade/upgrade.service.spec.ts
@@ -16,9 +16,11 @@ jest.mock('@prisma/client', () => ({
   PrismaClient: jest.fn(() => mockPrisma),
 }));
 
-// Mock child_process execSync
+// runDatabaseMigration uses execFileSync (no shell); getCurrentVersion no
+// longer shells out at all.
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
+  execFileSync: jest.fn(),
 }));
 
 import { UpgradeService, UpgradeStage } from './upgrade.service.js';
@@ -30,7 +32,7 @@ import {
 import { ConfigCompatibilityService } from './config-compatibility.service.js';
 import { RollbackService } from './rollback.service.js';
 import { UpgradeHealthService } from './upgrade-health.service.js';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -148,7 +150,7 @@ describe('UpgradeService', () => {
         // In dry-run, backup should NOT be called
         expect(mockDatabaseBackupService.createBackup).not.toHaveBeenCalled();
         // Migration step should be skipped
-        expect(execSync).not.toHaveBeenCalledWith(
+        expect(execFileSync).not.toHaveBeenCalledWith(
           expect.stringContaining('prisma migrate deploy'),
           expect.any(Object),
         );
@@ -225,6 +227,89 @@ describe('UpgradeService', () => {
             }),
           }),
         );
+      });
+    });
+
+    describe('backup identity persistence', () => {
+      // Regression guard for the defect that made automatic rollback
+      // unreachable: backupId used to be recovered at COMPLETION by regexing
+      // the stage's own log message. An upgrade that fails never reaches
+      // completion, so the audit row still had backupId = null when
+      // attemptRollback() looked it up — and RollbackService refuses with
+      // "Upgrade does not have an associated backup for rollback".
+      const arrangeSuccessfulBackup = () => {
+        mockPreUpgradeValidator.validate.mockResolvedValue({
+          canProceed: true,
+          checks: [],
+          summary: { passed: 8, warnings: 0, failures: 0 },
+        });
+        mockConfigCompatibility.checkCompatibility.mockResolvedValue({
+          compatible: true,
+          version: '2.1.0',
+          issues: [],
+          summary: { errors: 0, warnings: 0 },
+        });
+        mockDatabaseBackupService.createBackup.mockReturnValue({
+          success: true,
+          backupPath: '/backups/idenplane-backup-x.dump',
+          backupSize: '12.5 MB',
+          timestamp: new Date(),
+        } as BackupResult);
+        mockPrisma.upgradeAuditLog.create.mockResolvedValue({ id: 'upg-123' });
+        mockPrisma.upgradeAuditLog.update.mockResolvedValue({ id: 'upg-123' });
+      };
+
+      it('persists the backup path on the audit row during the BACKUP stage', async () => {
+        arrangeSuccessfulBackup();
+        mockUpgradeHealthService.checkHealth.mockResolvedValue({
+          healthy: true,
+          version: '2.1.0',
+          checks: [],
+          summary: { passed: 7, warnings: 0, failures: 0 },
+        });
+
+        await upgradeService.upgrade('2.1.0');
+
+        expect(mockPrisma.upgradeAuditLog.update).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              backupId: '/backups/idenplane-backup-x.dump',
+              backupPath: '/backups/idenplane-backup-x.dump',
+              backupSize: '12.5 MB',
+            }),
+          }),
+        );
+      });
+
+      it('persists it even when a later stage fails — the rollback path depends on it', async () => {
+        arrangeSuccessfulBackup();
+        // Health check fails, so the upgrade never reaches completeUpgrade().
+        mockUpgradeHealthService.checkHealth.mockResolvedValue({
+          healthy: false,
+          version: '2.1.0',
+          checks: [
+            {
+              name: 'schema_integrity',
+              status: 'fail',
+              message: 'boom',
+            },
+          ],
+          summary: { passed: 0, warnings: 0, failures: 1 },
+        });
+        mockRollbackService.executeRollback.mockResolvedValue({
+          success: true,
+          timestamp: new Date(),
+        } as never);
+
+        const result = await upgradeService.upgrade('2.1.0');
+
+        expect(result.success).toBe(false);
+        const wroteBackupId = mockPrisma.upgradeAuditLog.update.mock.calls.some(
+          (call) =>
+            (call[0] as { data?: { backupId?: string } })?.data?.backupId ===
+            '/backups/idenplane-backup-x.dump',
+        );
+        expect(wroteBackupId).toBe(true);
       });
     });
 
@@ -317,7 +402,7 @@ describe('UpgradeService', () => {
           summary: { errors: 0, warnings: 0 },
         });
 
-        (execSync as jest.Mock).mockReturnValue('Database reset completed');
+        (execFileSync as jest.Mock).mockReturnValue('Database reset completed');
 
         mockUpgradeHealthService.checkHealth.mockResolvedValue({
           healthy: true,
@@ -394,7 +479,7 @@ describe('UpgradeService', () => {
           summary: { errors: 0, warnings: 0 },
         });
 
-        (execSync as jest.Mock).mockReturnValue('Migration applied');
+        (execFileSync as jest.Mock).mockReturnValue('Migration applied');
 
         mockUpgradeHealthService.checkHealth.mockResolvedValue({
           healthy: true,
@@ -517,7 +602,7 @@ describe('UpgradeService', () => {
           }),
         );
         // Migration should not be attempted
-        expect(execSync).not.toHaveBeenCalledWith(
+        expect(execFileSync).not.toHaveBeenCalledWith(
           expect.stringContaining('prisma migrate deploy'),
           expect.any(Object),
         );
@@ -629,7 +714,7 @@ describe('UpgradeService', () => {
           summary: { errors: 0, warnings: 0 },
         });
 
-        (execSync as jest.Mock).mockReturnValue('Migration applied');
+        (execFileSync as jest.Mock).mockReturnValue('Migration applied');
 
         // Health check fails
         mockUpgradeHealthService.checkHealth.mockResolvedValue({

--- a/src/upgrade/upgrade.service.ts
+++ b/src/upgrade/upgrade.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { PreUpgradeValidatorService } from './pre-upgrade-validator.service.js';
 import {
   DatabaseBackupService,
@@ -165,13 +165,32 @@ export class UpgradeService {
     if (!dryRun) {
       const backupStageResult = await this.executeStage(
         UpgradeStage.BACKUP,
-        () => {
+        async () => {
           backupResult = this.databaseBackupService.createBackup(
             `pre-upgrade-${toVersion}`,
           );
           if (!backupResult.success) {
             throw new Error(`Backup failed: ${backupResult.error}`);
           }
+
+          // Record the backup on the audit row NOW, not at completion.
+          //
+          // completeUpgrade() used to recover this by regexing its own log
+          // message (/Backup created: (.+)/), which meant the row carried
+          // backupId = null for the entire window in which an upgrade can
+          // fail. attemptRollback() looks the row up and bails with "Upgrade
+          // does not have an associated backup for rollback" when backupId is
+          // null — so the automatic rollback was unreachable in exactly the
+          // situation it exists for.
+          await this.prisma.upgradeAuditLog.update({
+            where: { id: upgradeId },
+            data: {
+              backupId: backupResult.backupPath,
+              backupPath: backupResult.backupPath,
+              backupSize: backupResult.backupSize,
+            },
+          });
+
           return {
             success: true,
             message: `Backup created: ${backupResult.backupPath}`,
@@ -567,10 +586,21 @@ export class UpgradeService {
     try {
       this.logger.log(`Running database migrations for ${toVersion}...`);
 
-      const output = execSync('npx prisma migrate deploy 2>&1', {
-        encoding: 'utf-8',
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+      // execFileSync, not execSync: no shell means no `2>&1` redirect to parse
+      // and nothing interpretable in the argument vector. The explicit --schema
+      // matters because prisma.config.ts is not present in the production image
+      // (docker-entrypoint.sh generates a prisma.config.js at runtime, which
+      // will not exist if the process was started any other way).
+      const output = execFileSync(
+        'npx',
+        ['prisma', 'migrate', 'deploy', '--schema', 'prisma/schema.prisma'],
+        {
+          encoding: 'utf-8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 10 * 60 * 1000,
+          maxBuffer: 10 * 1024 * 1024,
+        },
+      );
 
       return {
         success: true,
@@ -630,18 +660,17 @@ export class UpgradeService {
     void initiatedBy;
     try {
       const stageNames = stages.filter((s) => s.success).map((s) => s.stage);
-      const backupStage = stages.find(
-        (s) => s.stage === UpgradeStage.BACKUP && s.success,
-      );
-      const backupIdMatch = backupStage?.message?.match(/Backup created: (.+)/);
-      const backupId = backupIdMatch ? backupIdMatch[1] : null;
 
+      // backupId is deliberately not written here: the BACKUP stage persists it
+      // the moment the archive exists, which is what makes it available to
+      // attemptRollback() on the failure path. Re-deriving it from a log message
+      // at completion (the previous behaviour) both duplicated the write and
+      // made it useless, since an upgrade that fails never reaches completion.
       await this.prisma.upgradeAuditLog.update({
         where: { id: upgradeId },
         data: {
           status: 'COMPLETED',
           completedAt: new Date(),
-          backupId,
 
           details: {
             stepsCompleted: stageNames,


### PR DESCRIPTION
Slice B of #1150. [#1197](https://github.com/idenplane/idenplane/pull/1197) registered the module and fixed the read-only paths; this fixes the write paths, which **could not have worked**.

The destructive endpoints stay behind `UPGRADE_API_ENABLED`. This makes turning it on viable — it does not turn it on.

## Four independent reasons a rollback could never have succeeded

**1. The archive format contradicted the filename.** `pg_dump -Fc` writes a custom-format archive (magic bytes `PGDMP`) — into a file named `*.sql.gz`. `restoreBackup` then branched on that suffix and ran `zlib.gunzipSync`, which throws on **every archive this service has ever produced**. Now `.dump`, zlib deleted, one code path.

**2. It dialled the wrong host.** Only the database *name* came from `DATABASE_URL`; host/port/user fell back to `localhost/5432/postgres`. Compose sets `postgresql://idenplane:idenplane@db:5432/idenplane` — so `pg_dump` went to localhost and failed. And `PGHOST`/`PGPORT`/`PGUSER` are set *nowhere* in compose, the Dockerfile, or the chart.

Now parsed with the URL parser, so percent-encoded credentials decode properly — a password containing `@` or `/` previously failed as though it were simply wrong. `PG*` became overrides rather than defaults, and a non-postgres URL fails loudly instead of quietly dumping `default` on localhost.

**3. The binaries weren't there.** The production image never installed `postgresql-client`, so `execFileSync('pg_dump', …)` threw `ENOENT`. Added, with `pg_dump --version && pg_restore --version` at build time so a base-image change can't silently regress it.

**4. The backup ID was lost exactly when it mattered.** `backupId` was recovered at COMPLETION by regexing the stage's own log message (`/Backup created: (.+)/`). An upgrade that *fails* never reaches completion — so the row still had `backupId = null` when `attemptRollback()` looked it up, and `RollbackService` refuses with *"Upgrade does not have an associated backup for rollback"*.

It's now written the moment the archive exists, with `backupPath`/`backupSize` (columns that existed in the schema and were never populated). Two tests cover it, including one asserting it survives a later-stage failure — **both fail if the write is removed** (verified).

## Restore flags that were missing

| flag | why |
|---|---|
| `--clean --if-exists` | without it every restore into a populated database dies on "relation already exists" — i.e. exactly when a rollback is needed |
| `--single-transaction` `--exit-on-error` | a rollback that half-applies is worse than one that fails cleanly |
| `--no-owner --no-privileges` | the app's role is rarely the owner recorded in the dump |

`verifyBackup` now runs `pg_restore --list` instead of checking the file is bigger than 1KB. A file truncated by a full disk passes a size check but has no readable table of contents — and this runs immediately before a rollback trusts it.

## Failing earlier, where it's still safe to fail

- **New pre-validation checks** for pg tooling and a writable `BACKUP_DIR`, both hard failures. Previously a missing `pg_dump` surfaced at the BACKUP stage; anything failing after `DATABASE_MIGRATION` then had nothing to roll back to. Now it aborts before touching anything.
- **`checkDiskSpace`** replaced `df -k .` with `fs.statfsSync(BACKUP_DIR)`. `df` doesn't exist on Windows (so this silently degraded to a warning on every dev machine), and `.` is the process cwd — the check could pass on a roomy root while the mounted backup volume was full.

## Also

- `runDatabaseMigration` uses `execFileSync` with an explicit `--schema` (needed because `prisma.config.ts` isn't in the production image) instead of `execSync` with a `2>&1` shell redirect.
- `recordRollbackAttempt` copied the original upgrade's `startedAt` onto the rollback row, so the two **tied** on every `orderBy: { startedAt: 'desc' }` — `getLatestUpgradeStatus()` could report a failed upgrade *after* it had been rolled back. Fixed, original preserved in `details.originalStartedAt`.
- `BackupMetadata.checksum` has always been declared and never populated; added a SHA-256 helper.

## Infrastructure

- **compose**: named `backups` volume + `BACKUP_DIR` pointing at it.
- **Helm**: optional `backups` PVC, deliberately separate from `themes` — dumps are large, written rarely, and must outlive the pod. Wired through the configmap so `BACKUP_DIR` and the mountPath can't drift apart.

## Testing

`database-backup.service.ts` had **no spec at all** despite carrying both shell-outs. It now has 14: argv construction, credential decoding, the password never appearing in argv, format, and verification.

- 1954 tests / 120 suites pass; lint + prettier clean; `nest build` clean.
- **Caveat:** the Helm changes are not rendered anywhere — there's no `helm` CLI available here and no chart job in CI. I checked the templates for balanced conditionals and that `values.yaml` parses, but `helm template` has not been run. Worth a manual render before relying on the PVC.

## Still not enabled

Slice C is what actually flips `UPGRADE_API_ENABLED` on: type-to-confirm, single-flight 409 (two replicas can currently both start an upgrade), and gating live-restore separately since `--clean` issues `DROP TABLE` against tables other replicas hold locks on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)