### PR TITLE
feat(upgrade): gate the destructive endpoints so they can be safely enabled

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,3 +103,12 @@ BASE_URL=http://localhost:3000
 # which is fine for local development but should be a mounted volume in
 # production — a backup on a container's ephemeral filesystem is not a backup.
 # BACKUP_DIR=/var/lib/idenplane/backups
+
+# Allow POST /admin/upgrade/rollback to restore a dump over the database this
+# process is connected to. Gated separately from UPGRADE_API_ENABLED because it
+# is strictly harder than running migrations: pg_restore --clean takes ACCESS
+# EXCLUSIVE locks, which conflict with any query another replica is running.
+#
+# Scale to a single replica before enabling. With it unset, a rollback request
+# is refused and returns the exact pg_restore command to run by hand instead.
+# UPGRADE_ALLOW_LIVE_RESTORE=true

--- a/src/upgrade/rollback.service.spec.ts
+++ b/src/upgrade/rollback.service.spec.ts
@@ -109,7 +109,64 @@ describe('RollbackService', () => {
     });
   });
 
+  describe('live-restore gating', () => {
+    // Restoring over the database this process is connected to needs its own
+    // opt-in: pg_restore --clean takes ACCESS EXCLUSIVE locks that conflict
+    // with any query another replica is running.
+    it('refuses when UPGRADE_ALLOW_LIVE_RESTORE is not set', async () => {
+      delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+      mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue({
+        id: 'upg-1',
+        backupPath: '/backups/x.dump',
+        status: 'COMPLETED',
+      });
+
+      const result = await rollbackService.executeRollback();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/UPGRADE_ALLOW_LIVE_RESTORE/);
+      expect(mockDatabaseBackupService.restoreBackup).not.toHaveBeenCalled();
+    });
+
+    it('returns the manual pg_restore command so the refusal is actionable', async () => {
+      delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+      mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue({
+        id: 'upg-1',
+        backupPath: '/backups/idenplane-backup-x.dump',
+        status: 'COMPLETED',
+      });
+
+      const result = await rollbackService.executeRollback();
+
+      expect(result.error).toContain('pg_restore');
+      expect(result.error).toContain('/backups/idenplane-backup-x.dump');
+      expect(result.error).toContain('--single-transaction');
+    });
+
+    it.each(['false', '1', 'yes', 'TRUE'])(
+      'refuses when the flag is %s rather than exactly "true"',
+      async (value) => {
+        process.env.UPGRADE_ALLOW_LIVE_RESTORE = value;
+        mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue(null);
+
+        const result = await rollbackService.executeRollback();
+
+        expect(result.success).toBe(false);
+        expect(mockDatabaseBackupService.restoreBackup).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   describe('executeRollback', () => {
+    // These exercise the restore path itself, so the gate is opened.
+    beforeEach(() => {
+      process.env.UPGRADE_ALLOW_LIVE_RESTORE = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+    });
+
     it('should successfully execute rollback when backup exists', async () => {
       const now = new Date();
 

--- a/src/upgrade/rollback.service.ts
+++ b/src/upgrade/rollback.service.ts
@@ -106,11 +106,72 @@ export class RollbackService {
    * @param upgradeId The ID of the upgrade to roll back (optional, defaults to most recent)
    * @returns RollbackResult with the outcome of the rollback operation
    */
+  /**
+   * The pg_restore invocation an operator would run by hand, with the archive
+   * this rollback would have used. Returned in the refusal so the 409 is
+   * actionable rather than merely a "no".
+   */
+  private async buildManualRestoreHint(upgradeId?: string): Promise<string> {
+    try {
+      const upgrade = upgradeId
+        ? await this.prisma.upgradeAuditLog.findUnique({
+            where: { id: upgradeId },
+          })
+        : await this.prisma.upgradeAuditLog.findFirst({
+            where: { status: 'COMPLETED' },
+            orderBy: { completedAt: 'desc' },
+          });
+
+      const archive = upgrade?.backupPath ?? upgrade?.backupId;
+      if (!archive) {
+        return '  (no backup is recorded for that upgrade — nothing to restore)';
+      }
+
+      return (
+        `  pg_restore --clean --if-exists --no-owner --no-privileges \\\n` +
+        `    --single-transaction --exit-on-error \\\n` +
+        `    -d "$DATABASE_URL" ${archive}`
+      );
+    } catch {
+      return '  (could not determine the backup archive for that upgrade)';
+    }
+  }
+
   async executeRollback(upgradeId?: string): Promise<RollbackResult> {
     const startTime = Date.now();
     const timestamp = new Date();
 
     this.logger.log('Starting upgrade rollback process');
+
+    // Restoring into the database this process is connected to is gated
+    // separately from UPGRADE_API_ENABLED, because it is a strictly harder
+    // operation than running migrations:
+    //
+    //   pg_restore --clean issues DROP TABLE for every object in the archive.
+    //   Those DROPs need ACCESS EXCLUSIVE locks, which conflict with any query
+    //   another replica is running. With more than one replica up, the restore
+    //   blocks — and once it does get the lock, the other replicas are talking
+    //   to a schema being dropped and recreated underneath them.
+    //
+    // Scaling to a single replica first is a deployment decision this service
+    // cannot make or verify, so the default is to refuse and hand the operator
+    // the exact command instead of half-performing it.
+    if (process.env.UPGRADE_ALLOW_LIVE_RESTORE !== 'true') {
+      const manual = await this.buildManualRestoreHint(upgradeId);
+      this.logger.warn(
+        'Rollback refused: UPGRADE_ALLOW_LIVE_RESTORE is not enabled',
+      );
+      return {
+        success: false,
+        timestamp,
+        error:
+          'Live database restore is disabled. Restoring over a running ' +
+          'database requires exclusive locks that conflict with other ' +
+          'replicas. Scale to a single instance, then either set ' +
+          'UPGRADE_ALLOW_LIVE_RESTORE=true or run the restore manually:\n' +
+          manual,
+      };
+    }
 
     try {
       // Find the upgrade to roll back

--- a/src/upgrade/upgrade.controller.spec.ts
+++ b/src/upgrade/upgrade.controller.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from '@nestjs/common';
 import { UpgradeController } from './upgrade.controller.js';
 import {
   UpgradeService,
@@ -68,52 +69,86 @@ describe('UpgradeController', () => {
   });
 
   describe('startUpgrade', () => {
-    it('should call upgradeService.upgrade with correct parameters', async () => {
-      const mockResult: UpgradeResult = {
-        success: true,
-        upgradeId: 'upg-123',
-        toVersion: '2.1.0',
-        stages: [],
-        rollbackTriggered: false,
-        duration: 5000,
-      };
+    const req = (userId = 'admin-42') =>
+      ({
+        adminUser: { userId, roles: ['super-admin'] },
+        headers: {},
+        socket: { remoteAddress: '10.1.2.3' },
+      }) as never;
 
+    const mockResult: UpgradeResult = {
+      success: true,
+      upgradeId: 'upg-123',
+      toVersion: '2.1.0',
+      stages: [],
+      rollbackTriggered: false,
+      duration: 5000,
+    };
+
+    it('passes the request through on a dry run without requiring confirm', async () => {
       mockUpgradeService.upgrade.mockResolvedValue(mockResult);
 
-      const result = await controller.startUpgrade({
-        toVersion: '2.1.0',
-        dryRun: true,
-        force: false,
-        initiatedBy: 'Test',
-      });
+      const result = await controller.startUpgrade(
+        { toVersion: '2.1.0', dryRun: true, force: false },
+        req(),
+      );
 
-      expect(mockUpgradeService.upgrade).toHaveBeenCalledWith('2.1.0', {
-        dryRun: true,
-        force: false,
-        initiatedBy: 'Test',
-      });
+      expect(mockUpgradeService.upgrade).toHaveBeenCalledWith(
+        '2.1.0',
+        expect.objectContaining({ dryRun: true, force: false }),
+      );
       expect(result).toEqual(mockResult);
     });
 
-    it('should use defaults when optional parameters not provided', async () => {
-      const mockResult: UpgradeResult = {
-        success: true,
-        toVersion: '2.1.0',
-        stages: [],
-        rollbackTriggered: false,
-        duration: 5000,
-      };
+    // A dry run writes nothing, so prompting there would only train operators
+    // to type past the prompt that matters.
+    it('requires confirm to equal toVersion for a real upgrade', async () => {
+      await expect(
+        controller.startUpgrade({ toVersion: '2.1.0' }, req()),
+      ).rejects.toThrow(BadRequestException);
 
+      await expect(
+        controller.startUpgrade(
+          { toVersion: '2.1.0', confirm: '2.1.1' },
+          req(),
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockUpgradeService.upgrade).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when confirm matches', async () => {
       mockUpgradeService.upgrade.mockResolvedValue(mockResult);
 
-      const result = await controller.startUpgrade({ toVersion: '2.1.0' });
+      await controller.startUpgrade(
+        { toVersion: '2.1.0', confirm: '2.1.0' },
+        req(),
+      );
 
-      expect(mockUpgradeService.upgrade).toHaveBeenCalledWith('2.1.0', {
-        dryRun: false,
-        force: false,
-        initiatedBy: 'API',
-      });
-      expect(result).toEqual(mockResult);
+      expect(mockUpgradeService.upgrade).toHaveBeenCalled();
+    });
+
+    // An audit trail the caller can write for itself is not an audit trail.
+    it('takes the actor from the authenticated principal, not the body', async () => {
+      mockUpgradeService.upgrade.mockResolvedValue(mockResult);
+
+      await controller.startUpgrade(
+        {
+          toVersion: '2.1.0',
+          confirm: '2.1.0',
+          note: 'ticket OPS-1',
+        },
+        req('real-admin'),
+      );
+
+      expect(mockUpgradeService.upgrade).toHaveBeenCalledWith(
+        '2.1.0',
+        expect.objectContaining({
+          initiatedBy: 'real-admin',
+          note: 'ticket OPS-1',
+          ipAddress: expect.any(String),
+        }),
+      );
     });
   });
 
@@ -266,6 +301,25 @@ describe('UpgradeController', () => {
   });
 
   describe('executeRollback', () => {
+    const rollbackReq = () =>
+      ({
+        adminUser: { userId: 'admin-42', roles: ['super-admin'] },
+        headers: {},
+        socket: { remoteAddress: '10.1.2.3' },
+      }) as never;
+
+    // The literal string, not a boolean: a stray `confirm: true` from a
+    // hand-written client must not restore a dump over the live database.
+    it('requires confirm to be exactly "ROLLBACK"', async () => {
+      for (const confirm of ['', 'rollback', 'yes', 'ROLLBACK ']) {
+        await expect(
+          controller.executeRollback({ confirm }, rollbackReq()),
+        ).rejects.toThrow(BadRequestException);
+      }
+
+      expect(mockRollbackService.executeRollback).not.toHaveBeenCalled();
+    });
+
     it('should execute rollback for specific upgrade', async () => {
       const mockResult: RollbackResult = {
         success: true,
@@ -278,7 +332,10 @@ describe('UpgradeController', () => {
 
       mockRollbackService.executeRollback.mockResolvedValue(mockResult);
 
-      const result = await controller.executeRollback({ upgradeId: 'upg-123' });
+      const result = await controller.executeRollback(
+        { upgradeId: 'upg-123', confirm: 'ROLLBACK' },
+        rollbackReq(),
+      );
 
       expect(mockRollbackService.executeRollback).toHaveBeenCalledWith(
         'upg-123',
@@ -298,7 +355,10 @@ describe('UpgradeController', () => {
 
       mockRollbackService.executeRollback.mockResolvedValue(mockResult);
 
-      const result = await controller.executeRollback({});
+      const result = await controller.executeRollback(
+        { confirm: 'ROLLBACK' },
+        rollbackReq(),
+      );
 
       expect(mockRollbackService.executeRollback).toHaveBeenCalledWith(
         undefined,
@@ -315,7 +375,10 @@ describe('UpgradeController', () => {
 
       mockRollbackService.executeRollback.mockResolvedValue(mockResult);
 
-      const result = await controller.executeRollback({ upgradeId: 'upg-123' });
+      const result = await controller.executeRollback(
+        { upgradeId: 'upg-123', confirm: 'ROLLBACK' },
+        rollbackReq(),
+      );
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Backup file not found');

--- a/src/upgrade/upgrade.controller.ts
+++ b/src/upgrade/upgrade.controller.ts
@@ -1,21 +1,33 @@
 import {
+  BadRequestException,
+  Body,
   Controller,
   Get,
-  Post,
-  Body,
+  Logger,
   Param,
+  Post,
   Query,
+  Req,
   UseGuards,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import {
   ApiTags,
   ApiOperation,
   ApiSecurity,
   ApiResponse,
   ApiParam,
+  ApiProperty,
+  ApiPropertyOptional,
   ApiQuery,
 } from '@nestjs/swagger';
 import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
+
+/** Request shape after AdminApiKeyGuard has attached the principal. */
+type AdminRequest = Request & {
+  adminUser?: { userId: string; roles: string[] };
+};
 import {
   UpgradeService,
   UpgradeResult,
@@ -45,26 +57,62 @@ import { RequireAdminRoles } from '../common/decorators/require-admin-roles.deco
 import { UpgradeEnabledGuard } from './guards/upgrade-enabled.guard.js';
 
 class UpgradeRequestDto {
+  @ApiProperty({ description: 'Target version, e.g. "0.4.0"' })
   @IsString()
   toVersion!: string;
 
+  @ApiPropertyOptional({
+    description:
+      'Simulate only: skips the backup and the migration. Defaults to false.',
+  })
   @IsOptional()
   @IsBoolean()
   dryRun?: boolean;
 
+  @ApiPropertyOptional({
+    description:
+      'Proceed even if pre-validation fails. This skips the checks that ' +
+      'verify a backup can be taken at all, so an upgrade run with force may ' +
+      'be unrecoverable. Requires confirm.',
+  })
   @IsOptional()
   @IsBoolean()
   force?: boolean;
 
+  @ApiPropertyOptional({
+    description:
+      'Free-text note recorded alongside the upgrade. The acting identity is ' +
+      'taken from the authenticated principal, not from this field.',
+  })
   @IsOptional()
   @IsString()
-  initiatedBy?: string;
+  note?: string;
+
+  @ApiProperty({
+    description:
+      'Must equal toVersion. Guards against a mis-click or a replayed request ' +
+      'starting a migration against a live database. Not required for dryRun.',
+  })
+  @IsOptional()
+  @IsString()
+  confirm?: string;
 }
 
 class RollbackRequestDto {
+  @ApiPropertyOptional({
+    description: 'Upgrade to roll back. Defaults to the most recent one.',
+  })
   @IsOptional()
   @IsString()
   upgradeId?: string;
+
+  @ApiProperty({
+    description:
+      'Must be the literal string "ROLLBACK". This restores a database dump ' +
+      'over the live database; every write since the backup is lost.',
+  })
+  @IsString()
+  confirm!: string;
 }
 
 @ApiTags('Upgrade')
@@ -72,6 +120,8 @@ class RollbackRequestDto {
 @UseGuards(AdminApiKeyGuard, AdminRolesGuard)
 @Controller('admin/upgrade')
 export class UpgradeController {
+  private readonly logger = new Logger(UpgradeController.name);
+
   constructor(
     private readonly upgradeService: UpgradeService,
     private readonly rollbackService: RollbackService,
@@ -112,11 +162,40 @@ export class UpgradeController {
     status: 503,
     description: 'Upgrade execution disabled — set UPGRADE_API_ENABLED=true',
   })
-  async startUpgrade(@Body() dto: UpgradeRequestDto): Promise<UpgradeResult> {
+  async startUpgrade(
+    @Body() dto: UpgradeRequestDto,
+    @Req() req: AdminRequest,
+  ): Promise<UpgradeResult> {
+    const dryRun = dto.dryRun ?? false;
+
+    // A dry run writes nothing, so requiring a confirmation there would only
+    // train operators to type past the prompt that matters.
+    if (!dryRun && dto.confirm !== dto.toVersion) {
+      throw new BadRequestException(
+        'confirm must equal toVersion to start a real upgrade. This endpoint ' +
+          'runs database migrations against the live database.',
+      );
+    }
+
+    // force skips pre-validation — including the checks added in #1198 that
+    // verify pg_dump exists and BACKUP_DIR is writable. An upgrade forced past
+    // those may have no usable backup, so it is logged at error level.
+    if (dto.force) {
+      this.logger.error(
+        `Upgrade to ${dto.toVersion} started with force=true by ` +
+          `${req.adminUser?.userId ?? 'unknown'} — pre-validation, including ` +
+          'the backup-tooling checks, will be skipped.',
+      );
+    }
+
     return this.upgradeService.upgrade(dto.toVersion, {
-      dryRun: dto.dryRun ?? false,
+      dryRun,
       force: dto.force ?? false,
-      initiatedBy: dto.initiatedBy ?? 'API',
+      // Taken from the authenticated principal, never from the body: an audit
+      // trail a caller can write for itself is not an audit trail.
+      initiatedBy: req.adminUser?.userId ?? 'API',
+      note: dto.note,
+      ipAddress: resolveClientIp(req),
     });
   }
 
@@ -255,7 +334,21 @@ export class UpgradeController {
   })
   async executeRollback(
     @Body() dto: RollbackRequestDto,
+    @Req() req: AdminRequest,
   ): Promise<RollbackResult> {
+    if (dto.confirm !== 'ROLLBACK') {
+      throw new BadRequestException(
+        'confirm must be the literal string "ROLLBACK". This restores a ' +
+          'database dump over the live database and discards every write made ' +
+          'since that backup was taken.',
+      );
+    }
+
+    this.logger.warn(
+      `Rollback requested by ${req.adminUser?.userId ?? 'unknown'} from ` +
+        `${resolveClientIp(req)}${dto.upgradeId ? ` for ${dto.upgradeId}` : ''}`,
+    );
+
     return this.rollbackService.executeRollback(dto.upgradeId);
   }
 

--- a/src/upgrade/upgrade.service.spec.ts
+++ b/src/upgrade/upgrade.service.spec.ts
@@ -23,6 +23,7 @@ jest.mock('child_process', () => ({
   execFileSync: jest.fn(),
 }));
 
+import { ConflictException } from '@nestjs/common';
 import { UpgradeService, UpgradeStage } from './upgrade.service.js';
 import { PreUpgradeValidatorService } from './pre-upgrade-validator.service.js';
 import {
@@ -70,6 +71,11 @@ describe('UpgradeService', () => {
 
     // Mock execSync for getCurrentVersion
     (execSync as jest.Mock).mockReturnValue('2.0.0');
+
+    // No upgrade in flight by default. jest.clearAllMocks() clears calls but
+    // NOT implementations, so without this a single-flight test that stubs an
+    // IN_PROGRESS row would leak that row into every test after it.
+    mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue(null);
 
     upgradeService = new UpgradeService(
       mockPrisma as any,
@@ -227,6 +233,109 @@ describe('UpgradeService', () => {
             }),
           }),
         );
+      });
+    });
+
+    describe('single-flight', () => {
+      // Two processes running `prisma migrate deploy` against one database is a
+      // corruption scenario, not merely a race — and docker-compose.cluster.yml
+      // runs two app replicas, so this is a real configuration, not a theory.
+      const arrangeHealthyRun = () => {
+        mockPreUpgradeValidator.validate.mockResolvedValue({
+          canProceed: true,
+          checks: [],
+          summary: { passed: 8, warnings: 0, failures: 0 },
+        });
+        mockConfigCompatibility.checkCompatibility.mockResolvedValue({
+          compatible: true,
+          version: '2.1.0',
+          issues: [],
+          summary: { errors: 0, warnings: 0 },
+        });
+        mockUpgradeHealthService.checkHealth.mockResolvedValue({
+          healthy: true,
+          version: '2.1.0',
+          checks: [],
+          summary: { passed: 7, warnings: 0, failures: 0 },
+        });
+        mockDatabaseBackupService.createBackup.mockReturnValue({
+          success: true,
+          backupPath: '/backups/x.dump',
+          backupSize: '1 MB',
+          timestamp: new Date(),
+        } as BackupResult);
+        mockPrisma.upgradeAuditLog.create.mockResolvedValue({ id: 'upg-1' });
+        mockPrisma.upgradeAuditLog.update.mockResolvedValue({ id: 'upg-1' });
+        // runDatabaseMigration reads the child process output.
+        (execFileSync as jest.Mock).mockReturnValue('Migration applied');
+      };
+
+      it('refuses when another instance has an upgrade IN_PROGRESS', async () => {
+        arrangeHealthyRun();
+        mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue({
+          id: 'upg-running',
+          toVersion: '2.1.0',
+          status: 'IN_PROGRESS',
+          startedAt: new Date(),
+        });
+
+        await expect(upgradeService.upgrade('2.1.0')).rejects.toThrow(
+          ConflictException,
+        );
+        expect(mockPrisma.upgradeAuditLog.create).not.toHaveBeenCalled();
+      });
+
+      it('ignores a stale IN_PROGRESS row past the TTL', async () => {
+        // A process killed mid-upgrade leaves its row IN_PROGRESS forever; a
+        // stale row must not wedge the endpoint permanently.
+        arrangeHealthyRun();
+        mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue(null);
+
+        const result = await upgradeService.upgrade('2.1.0');
+
+        expect(result.success).toBe(true);
+        // The TTL is expressed as a startedAt lower bound in the query.
+        expect(mockPrisma.upgradeAuditLog.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              status: 'IN_PROGRESS',
+              startedAt: { gte: expect.any(Date) },
+            }),
+          }),
+        );
+      });
+
+      it('releases the in-process lock after a failed run', async () => {
+        // If the flag leaked on the failure path, this instance would refuse
+        // every subsequent upgrade until it restarted.
+        arrangeHealthyRun();
+        mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue(null);
+        mockDatabaseBackupService.createBackup.mockReturnValueOnce({
+          success: false,
+          error: 'disk full',
+          timestamp: new Date(),
+        } as BackupResult);
+
+        const first = await upgradeService.upgrade('2.1.0');
+        expect(first.success).toBe(false);
+
+        // Second attempt must be admitted, not rejected by a stuck flag.
+        const second = await upgradeService.upgrade('2.1.0');
+        expect(second.success).toBe(true);
+      });
+
+      it('exempts dry runs from the lock', async () => {
+        arrangeHealthyRun();
+        mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue({
+          id: 'upg-running',
+          toVersion: '2.1.0',
+          status: 'IN_PROGRESS',
+          startedAt: new Date(),
+        });
+
+        const result = await upgradeService.upgrade('2.1.0', { dryRun: true });
+
+        expect(result.success).toBe(true);
       });
     });
 

--- a/src/upgrade/upgrade.service.ts
+++ b/src/upgrade/upgrade.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { ConflictException, Injectable, Logger } from '@nestjs/common';
 import { execFileSync } from 'child_process';
 import { PreUpgradeValidatorService } from './pre-upgrade-validator.service.js';
 import {
@@ -108,10 +108,53 @@ export class UpgradeService {
    */
   async upgrade(
     toVersion: string,
-    options: { dryRun?: boolean; force?: boolean; initiatedBy?: string } = {},
+    options: {
+      dryRun?: boolean;
+      force?: boolean;
+      initiatedBy?: string;
+      note?: string;
+      ipAddress?: string;
+    } = {},
+  ): Promise<UpgradeResult> {
+    // Two guards against concurrent upgrades, because two processes running
+    // `prisma migrate deploy` against one database is a corruption scenario,
+    // not merely a race. docker-compose.cluster.yml runs two app replicas and
+    // the Helm chart supports autoscaling, so this is a real configuration.
+    //
+    // A dry run writes nothing, so it is exempt.
+    if (options.dryRun) {
+      return this.runUpgrade(toVersion, options);
+    }
+
+    await this.assertNoUpgradeInProgress(toVersion);
+
+    // finally, not a reset at each return site: runUpgrade has a dozen exit
+    // paths and a missed one would wedge this instance until it restarts.
+    try {
+      return await this.runUpgrade(toVersion, options);
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  private async runUpgrade(
+    toVersion: string,
+    options: {
+      dryRun?: boolean;
+      force?: boolean;
+      initiatedBy?: string;
+      note?: string;
+      ipAddress?: string;
+    },
   ): Promise<UpgradeResult> {
     const startTime = Date.now();
-    const { dryRun = false, force = false, initiatedBy = 'CLI' } = options;
+    const {
+      dryRun = false,
+      force = false,
+      initiatedBy = 'CLI',
+      note,
+      ipAddress,
+    } = options;
     const upgradeId = this.generateUpgradeId();
     const stages: UpgradeStageResult[] = [];
 
@@ -122,7 +165,11 @@ export class UpgradeService {
     // Stage 1: Initialization
     const initResult = await this.executeStage(
       UpgradeStage.INITIALIZATION,
-      () => this.initializeUpgrade(upgradeId, toVersion, initiatedBy, dryRun),
+      () =>
+        this.initializeUpgrade(upgradeId, toVersion, initiatedBy, dryRun, {
+          note,
+          ipAddress,
+        }),
     );
     stages.push(initResult);
 
@@ -473,6 +520,56 @@ export class UpgradeService {
   }
 
   /**
+   * Refuse to start when another upgrade is already running.
+   *
+   * Two layers, because they fail differently:
+   *
+   *   1. An in-process flag catches a double-submit against this instance,
+   *      which the database check cannot: the losing request may arrive before
+   *      the winner's audit row is committed.
+   *   2. An IN_PROGRESS audit row catches a second *instance* — the case that
+   *      actually matters, since docker-compose.cluster.yml runs two replicas.
+   *
+   * Deliberately not pg_advisory_lock: a session-level advisory lock needs a
+   * pinned connection, which the PrismaPg pool does not guarantee, and the
+   * transaction-scoped variant would have to wrap the entire upgrade — which
+   * would deadlock against `prisma migrate deploy`.
+   *
+   * The TTL exists because a process killed mid-upgrade leaves its row
+   * IN_PROGRESS forever, and a stale row must not permanently wedge the
+   * endpoint. It is bounded rather than absent so a genuinely running upgrade
+   * is not overrun.
+   */
+  private static readonly IN_PROGRESS_TTL_MS = 2 * 60 * 60 * 1000;
+  private inFlight = false;
+
+  private async assertNoUpgradeInProgress(toVersion: string): Promise<void> {
+    if (this.inFlight) {
+      throw new ConflictException(
+        'An upgrade is already running on this instance.',
+      );
+    }
+
+    const cutoff = new Date(Date.now() - UpgradeService.IN_PROGRESS_TTL_MS);
+    const running = await this.prisma.upgradeAuditLog.findFirst({
+      where: { status: 'IN_PROGRESS', startedAt: { gte: cutoff } },
+      orderBy: { startedAt: 'desc' },
+    });
+
+    if (running) {
+      throw new ConflictException(
+        `An upgrade to ${running.toVersion} started at ` +
+          `${running.startedAt.toISOString()} is still in progress ` +
+          `(id ${running.id}). Refusing to start an upgrade to ${toVersion} ` +
+          'concurrently — two migrations against one database can corrupt it. ' +
+          'If that upgrade is known to have died, mark its row FAILED.',
+      );
+    }
+
+    this.inFlight = true;
+  }
+
+  /**
    * Initialize a new upgrade operation and record it in the audit log.
    */
   private async initializeUpgrade(
@@ -480,6 +577,7 @@ export class UpgradeService {
     toVersion: string,
     initiatedBy: string,
     dryRun: boolean,
+    meta: { note?: string; ipAddress?: string } = {},
   ): Promise<{ success: boolean; message: string }> {
     try {
       const currentVersion = this.getCurrentVersion();
@@ -492,10 +590,15 @@ export class UpgradeService {
           status: 'IN_PROGRESS',
           startedAt: new Date(),
           initiatedBy,
+          // Schema column that has existed since the table was created and was
+          // never written. Who ran an upgrade and from where is exactly what an
+          // audit log of a destructive operation is for.
+          ipAddress: meta.ipAddress ?? null,
           dryRun,
           details: {
             dryRun,
             initiatedBy,
+            ...(meta.note ? { note: meta.note } : {}),
           },
         },
       });


### PR DESCRIPTION
Slice C of #1150. [#1197](https://github.com/idenplane/idenplane/pull/1197) made the flow correct; [#1198](https://github.com/idenplane/idenplane/pull/1198) gave it a backup that actually restores. This adds the controls that make **turning it on** a defensible decision rather than a leap.

## Confirmation, and an audit trail the caller can't write for itself

`POST /admin/upgrade` now requires `confirm === toVersion`; `POST /admin/upgrade/rollback` requires the literal `"ROLLBACK"`. **A dry run is exempt** — it writes nothing, and prompting there would only train operators to type past the prompt that matters.

`initiatedBy` was read from the **request body**, so the audit log recorded whatever the caller claimed. It now comes from `req.adminUser.userId`. The old field survives as `note` — free text, clearly not an identity. The `ipAddress` column, present since the table was created and never written, now records the client IP.

`force` skips pre-validation — which since #1198 includes the checks that verify `pg_dump` exists and `BACKUP_DIR` is writable. It opts out of the only thing standing between the caller and an unrecoverable migration. Still permitted, now logged at error level naming the actor.

## Single-flight

The controller has **always documented a 409** for a concurrent upgrade and never emitted one. Meanwhile `docker-compose.cluster.yml` runs two app replicas and the chart supports autoscaling. Two processes running `prisma migrate deploy` against one database is a corruption scenario, not merely a race.

Two layers, because they fail differently:

| layer | catches |
|---|---|
| in-process flag | a double-submit against *this* instance — which the DB check can't, since the loser may arrive before the winner's row is committed |
| `IN_PROGRESS` audit row | a second *instance* — the case that actually matters |

A 2h TTL bounds it so a process killed mid-upgrade can't wedge the endpoint forever with a stale row.

**Deliberately not `pg_advisory_lock`:** the session-level form needs a pinned connection, which the PrismaPg pool doesn't guarantee; the transaction-scoped form would have to wrap the entire upgrade and would deadlock against `migrate deploy`.

`upgrade()` is split into a gate and `runUpgrade()`, with the flag released in a `finally` — `runUpgrade` has a dozen exit paths and one missed reset would wedge the instance until restart. There's a test for exactly that.

## Live restore gated separately from `UPGRADE_API_ENABLED`

`pg_restore --clean` issues `DROP TABLE` for every object in the archive, taking `ACCESS EXCLUSIVE` locks that conflict with any query another replica is running. With more than one replica the restore blocks — and once it *does* get the lock, the other replicas are talking to a schema being dropped and recreated underneath them.

Scaling to a single replica is a deployment decision this service can't make or verify, so `executeRollback` refuses unless `UPGRADE_ALLOW_LIVE_RESTORE=true`, and returns the exact command — with the specific archive that rollback would have used — rather than half-performing it:

```
pg_restore --clean --if-exists --no-owner --no-privileges \
  --single-transaction --exit-on-error \
  -d "$DATABASE_URL" /backups/idenplane-backup-….dump
```

## Verification

- **1967 tests / 120 suites** pass; lint, prettier, `nest build` clean.
- **Removing the concurrency guard fails 2 of the new tests** (checked, then restored) — the guard is load-bearing, not decorative.
- Guards checked against a real build:

```
POST  /admin/upgrade              guards: UpgradeEnabledGuard  roles: super-admin
POST  /admin/upgrade/rollback     guards: UpgradeEnabledGuard  roles: super-admin
GET   × 8                         guards: -                    roles: -
```

## Two notes

**`nest build` is incremental** and had left `dist/` missing a newly-referenced file; verifying locally needed `rm tsconfig.build.tsbuildinfo && rm -rf dist`. CI builds clean so it isn't affected, but it's worth knowing — a local build can pass while `dist/` is missing a module.

**Still off by default.** Both flags (`UPGRADE_API_ENABLED`, `UPGRADE_ALLOW_LIVE_RESTORE`) are unset, so this changes no runtime behaviour. Before anyone sets them, the checklist in the plan still applies — in particular, a real `pg_dump`/`pg_restore` round-trip against a scratch database, which is not covered by unit tests here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)