### PR TITLE
feat(admin-ui): route the upgrade pages and add a start-upgrade wizard

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -65,6 +65,9 @@ import NhiDetailPage from './pages/nhi/NhiDetailPage';
 import NhiAnalyticsPage from './pages/nhi/NhiAnalyticsPage';
 import PluginsPage from './pages/plugins/PluginsPage';
 import SystemStatusPage from './pages/system/SystemStatusPage';
+import UpgradeStatusPage from './pages/upgrade/UpgradeStatusPage';
+import StartUpgradePage from './pages/upgrade/StartUpgradePage';
+import MigrationHistoryPage from './pages/upgrade/MigrationHistoryPage';
 import NotFoundPage from './pages/NotFoundPage';
 import { hasCredentials, refreshSession } from './api/client';
 import { useAuthContext } from './context/AuthContext';
@@ -173,6 +176,9 @@ export default function App() {
           <Route path="/console/realms/:name/nhi-analytics" element={<NhiAnalyticsPage />} />
           <Route path="/console/plugins" element={<PluginsPage />} />
           <Route path="/console/system-status" element={<SystemStatusPage />} />
+          <Route path="/console/upgrade" element={<UpgradeStatusPage />} />
+          <Route path="/console/upgrade/new" element={<StartUpgradePage />} />
+          <Route path="/console/upgrade/history" element={<MigrationHistoryPage />} />
           {/* Catch-all for unknown /console/... paths — rendered inside the Layout shell */}
           <Route path="*" element={<NotFoundPage />} />
         </Route>

--- a/admin-ui/src/__tests__/routes.test.ts
+++ b/admin-ui/src/__tests__/routes.test.ts
@@ -56,6 +56,7 @@ const ROUTE_NAV_WHITELIST = new Set([
   '/setup',
   '/console/realms/:name',         // realm overview — clicked from the realm list
   '/console/realms/:name/nhi-analytics', // NHI analytics — linked from NHI list page
+  '/console/upgrade/history',      // migration history — linked from the upgrade status page
 ]);
 
 describe('nav route coverage', () => {
@@ -202,13 +203,6 @@ const ROUTE_MATCHERS = [...APP_ROUTES].map(
   (p) => new RegExp('^' + p.replace(/:[^/]+/g, '[^/]+') + '$'),
 );
 
-/**
- * Files intentionally excluded from this guard. The upgrade/migration pages are
- * unrouted dead code (idenplane#1150) that link to `/console/upgrade` — drop
- * this exclusion once that feature is wired up or removed.
- */
-const LINK_GUARD_IGNORE = /[/\\]pages[/\\]upgrade[/\\]/;
-
 function walkTsx(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
@@ -248,7 +242,6 @@ describe('in-app link target coverage', () => {
     const violations: string[] = [];
     for (const dir of scanDirs) {
       for (const file of walkTsx(dir)) {
-        if (LINK_GUARD_IGNORE.test(file)) continue;
         const src = readFileSync(file, 'utf-8');
         for (const raw of extractConsoleTargets(src)) {
           const norm = normalizeConsoleTarget(raw);

--- a/admin-ui/src/api/upgrade.ts
+++ b/admin-ui/src/api/upgrade.ts
@@ -32,6 +32,13 @@ export interface UpgradeAuditEntry {
   completedAt: Date | null;
   backupId: string | null;
   errorMessage: string | null;
+  /**
+   * Per-stage check results. The server has always returned this and the UI
+   * has always dropped it, even though it is the richest diagnostic available
+   * when an upgrade fails. Optional so existing call sites and test factories
+   * keep type-checking.
+   */
+  checksPassed?: Record<string, unknown> | null;
 }
 
 export interface UpgradeState {
@@ -123,7 +130,24 @@ export interface UpgradeRequest {
   toVersion: string;
   dryRun?: boolean;
   force?: boolean;
-  initiatedBy?: string;
+  /**
+   * Free-text note recorded with the upgrade. Note this is NOT the actor —
+   * the server derives that from the authenticated principal and ignores
+   * anything the client claims here.
+   */
+  note?: string;
+  /**
+   * Must equal `toVersion` for a real upgrade; the server rejects the request
+   * otherwise. Not required for a dry run, which writes nothing.
+   */
+  confirm?: string;
+}
+
+export interface SystemVersion {
+  version: string;
+  schemaVersion: string | null;
+  pendingMigrations: string[];
+  databaseUpToDate: boolean;
 }
 
 // ============================================================================
@@ -202,6 +226,38 @@ export async function checkRollbackCapability(): Promise<RollbackCapability> {
  * Execute a rollback to the previous version.
  */
 export async function executeRollback(upgradeId?: string): Promise<RollbackResult> {
-  const { data } = await apiClient.post<RollbackResult>('/upgrade/rollback', { upgradeId });
+  // `confirm` is mandatory server-side: a rollback restores a dump over the
+  // live database and discards every write since that backup. The literal is
+  // sent here rather than threaded through the caller because the UI already
+  // gates this behind its own explicit confirmation dialog — the server check
+  // guards against a hand-written or replayed request, not against this page.
+  const { data } = await apiClient.post<RollbackResult>('/upgrade/rollback', {
+    upgradeId,
+    confirm: 'ROLLBACK',
+  });
+  return data;
+}
+
+/**
+ * Paginated audit entries. Prefer this over `getUpgradeHistory` when a caller
+ * needs more than a handful of rows: `/upgrade/audit` returns `{entries, total}`
+ * and clamps `limit` to 1..100 server-side.
+ */
+export async function getUpgradeAudit(
+  limit = 100,
+): Promise<{ entries: UpgradeAuditEntry[]; total: number }> {
+  const { data } = await apiClient.get<{
+    entries: UpgradeAuditEntry[];
+    total: number;
+  }>('/upgrade/audit', { params: { limit } });
+  return data;
+}
+
+/**
+ * Current application version and migration state. Lives here rather than in a
+ * new module because the upgrade wizard is its only consumer.
+ */
+export async function getSystemVersion(): Promise<SystemVersion> {
+  const { data } = await apiClient.get<SystemVersion>('/system/version');
   return data;
 }

--- a/admin-ui/src/components/Breadcrumbs.tsx
+++ b/admin-ui/src/components/Breadcrumbs.tsx
@@ -71,6 +71,8 @@ function useBreadcrumbs(): Crumb[] {
     // Known static segments
     const staticLabels: Record<string, string> = {
       realms: 'Realms',
+      upgrade: 'Upgrade',
+      history: 'History',
       create: 'Create',
       users: 'Users',
       clients: 'Clients',

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -77,6 +77,7 @@ export default function Layout() {
     { to: '/console/realms', label: 'Realms', icon: Icons.Realms, end: false },
     { to: '/console/plugins', label: 'Plugins', icon: Icons.Zap, end: false },
     { to: '/console/system-status', label: 'System Status', icon: Icons.Server, end: false },
+    { to: '/console/upgrade', label: 'Upgrade', icon: Icons.Upgrade, end: false },
   ];
 
   const navLinkClass = ({ isActive }: { isActive: boolean }) =>

--- a/admin-ui/src/components/ui/icons.tsx
+++ b/admin-ui/src/components/ui/icons.tsx
@@ -94,6 +94,9 @@ export const Icons = {
   Copy: makeIcon(['M20 9h-9a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2-2v-9a2 2 0 0 0-2-2z', 'M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1']),
   Download: makeIcon(['M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4', 'M7 10l5 5 5-5', 'M12 15V3']),
   Refresh: makeIcon(['M3 12a9 9 0 0 1 15-6.7L21 8', 'M21 3v5h-5', 'M21 12a9 9 0 0 1-15 6.7L3 16', 'M3 21v-5h5']),
+  // Upward arrow out of a bar — Download inverted. Deliberately not reusing
+  // Download (arrow points down, wrong direction) or Refresh (a sync loop).
+  Upgrade: makeIcon(['M5 3h14', 'm18 13-6-6-6 6', 'M12 7v14']),
   External: makeIcon(['M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6', 'M15 3h6v6', 'M10 14 21 3']),
   Pin: makeIcon(['M12 17v5', 'M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z']),
 

--- a/admin-ui/src/pages/__tests__/MigrationHistoryPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/MigrationHistoryPage.test.tsx
@@ -89,7 +89,9 @@ describe('MigrationHistoryPage', () => {
 
   it('shows empty state when no history is available', async () => {
     server.use(
-      http.get('/admin/upgrade/history', () => HttpResponse.json([])),
+      http.get('/admin/upgrade/audit', () =>
+        HttpResponse.json({ entries: [], total: 0 }),
+      ),
     );
     renderMigrationHistoryPage();
     await waitFor(() => {
@@ -99,9 +101,9 @@ describe('MigrationHistoryPage', () => {
 
   it('shows loading state', async () => {
     server.use(
-      http.get('/admin/upgrade/history', async () => {
+      http.get('/admin/upgrade/audit', async () => {
         await new Promise((r) => setTimeout(r, 100));
-        return HttpResponse.json([]);
+        return HttpResponse.json({ entries: [], total: 0 });
       }),
     );
     renderMigrationHistoryPage();
@@ -113,7 +115,7 @@ describe('MigrationHistoryPage', () => {
 
   it('shows error state when API fails', async () => {
     server.use(
-      http.get('/admin/upgrade/history', () => HttpResponse.json({}, { status: 500 })),
+      http.get('/admin/upgrade/audit', () => HttpResponse.json({}, { status: 500 })),
     );
     renderMigrationHistoryPage();
     await waitFor(() => {
@@ -123,7 +125,7 @@ describe('MigrationHistoryPage', () => {
 
   it('displays pagination controls when there are more entries', async () => {
     server.use(
-      http.get('/admin/upgrade/history', () => {
+      http.get('/admin/upgrade/audit', () => {
         const entries = Array.from({ length: 15 }, (_, i) => ({
           id: `upgrade-${i}`,
           fromVersion: '1.0.0',
@@ -134,7 +136,7 @@ describe('MigrationHistoryPage', () => {
           backupId: null,
           errorMessage: null,
         }));
-        return HttpResponse.json(entries);
+        return HttpResponse.json({ entries, total: entries.length });
       }),
     );
     renderMigrationHistoryPage();
@@ -147,7 +149,7 @@ describe('MigrationHistoryPage', () => {
 
   it('navigates to previous page when Previous is clicked', async () => {
     server.use(
-      http.get('/admin/upgrade/history', () => {
+      http.get('/admin/upgrade/audit', () => {
         const entries = Array.from({ length: 15 }, (_, i) => ({
           id: `upgrade-${i}`,
           fromVersion: '1.0.0',
@@ -158,7 +160,7 @@ describe('MigrationHistoryPage', () => {
           backupId: null,
           errorMessage: null,
         }));
-        return HttpResponse.json(entries);
+        return HttpResponse.json({ entries, total: entries.length });
       }),
     );
     renderMigrationHistoryPage();
@@ -179,19 +181,22 @@ describe('MigrationHistoryPage', () => {
 
   it('displays error message in detail modal for failed upgrades', async () => {
     server.use(
-      http.get('/admin/upgrade/history', () =>
-        HttpResponse.json([
-          {
-            id: 'upgrade-3',
-            fromVersion: '1.0.0',
-            toVersion: '1.2.0',
-            status: 'FAILED',
-            startedAt: new Date('2024-01-01T10:00:00.000Z').toISOString(),
-            completedAt: new Date('2024-01-01T10:05:00.000Z').toISOString(),
-            backupId: 'backup-123',
-            errorMessage: 'Database migration failed due to schema conflict',
-          },
-        ]),
+      http.get('/admin/upgrade/audit', () =>
+        HttpResponse.json({
+          entries: [
+            {
+              id: 'upgrade-3',
+              fromVersion: '1.0.0',
+              toVersion: '1.2.0',
+              status: 'FAILED',
+              startedAt: new Date('2024-01-01T10:00:00.000Z').toISOString(),
+              completedAt: new Date('2024-01-01T10:05:00.000Z').toISOString(),
+              backupId: 'backup-123',
+              errorMessage: 'Database migration failed due to schema conflict',
+            },
+          ],
+          total: 1,
+        }),
       ),
     );
     renderMigrationHistoryPage();
@@ -199,6 +204,37 @@ describe('MigrationHistoryPage', () => {
     act(() => { viewDetailsButton.click(); });
     await waitFor(() => {
       expect(screen.getByText('Database migration failed due to schema conflict')).toBeInTheDocument();
+    });
+  });
+
+  // The server has always returned checksPassed and the UI always dropped it.
+  it('renders checksPassed in the detail modal when present', async () => {
+    server.use(
+      http.get('/admin/upgrade/audit', () =>
+        HttpResponse.json({
+          entries: [
+            {
+              id: 'upgrade-4',
+              fromVersion: '1.0.0',
+              toVersion: '1.3.0',
+              status: 'FAILED',
+              startedAt: new Date('2024-01-01T10:00:00.000Z').toISOString(),
+              completedAt: null,
+              backupId: null,
+              errorMessage: null,
+              checksPassed: { schema_integrity: 'fail', disk_space: 'pass' },
+            },
+          ],
+          total: 1,
+        }),
+      ),
+    );
+    renderMigrationHistoryPage();
+    const viewDetailsButton = await screen.findByRole('button', { name: /view details/i });
+    act(() => { viewDetailsButton.click(); });
+    await waitFor(() => {
+      expect(screen.getByText(/check results/i)).toBeInTheDocument();
+      expect(screen.getByText(/schema_integrity/)).toBeInTheDocument();
     });
   });
 });

--- a/admin-ui/src/pages/upgrade/MigrationHistoryPage.tsx
+++ b/admin-ui/src/pages/upgrade/MigrationHistoryPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { getUpgradeHistory, type UpgradeAuditEntry } from '../../api/upgrade';
+import { getUpgradeAudit, type UpgradeAuditEntry } from '../../api/upgrade';
 
 // ─── Status Badge ─────────────────────────────────────────────────────────────
 
@@ -216,6 +216,19 @@ function DetailModal({
               <p className="mt-1 text-sm text-red-700">{entry.errorMessage}</p>
             </div>
           )}
+          {/* The per-stage check results. The server has always returned these
+              and the UI has always dropped them, even though on a failed
+              upgrade they are the most useful thing on the record. */}
+          {entry.checksPassed && (
+            <details>
+              <summary className="cursor-pointer text-xs font-medium uppercase tracking-wider text-gray-500">
+                Check results
+              </summary>
+              <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-gray-50 p-3 text-xs text-gray-700">
+                {JSON.stringify(entry.checksPassed, null, 2)}
+              </pre>
+            </details>
+          )}
         </div>
         <div className="flex justify-end border-t border-gray-200 px-6 py-4">
           <button
@@ -257,11 +270,13 @@ export default function MigrationHistoryPage() {
   const { data: response, isLoading, isError, error } = useQuery<{ data: UpgradeAuditEntry[]; total: number }>({
     queryKey: ['migration-history', page],
     queryFn: async () => {
-      const data = await getUpgradeHistory(100);
-      return {
-        data,
-        total: data.length,
-      };
+      // /upgrade/audit rather than /upgrade/history: audit honours ?limit
+      // (clamped 1..100 server-side) and returns {entries, total}. history
+      // ignored ?limit entirely until #1197, which meant this page's
+      // pagination worked against the MSW mock and never in production —
+      // the mock honoured the parameter while the server capped at 10.
+      const { entries, total } = await getUpgradeAudit(100);
+      return { data: entries, total };
     },
     refetchInterval: 60_000,
   });

--- a/admin-ui/src/pages/upgrade/StartUpgradePage.tsx
+++ b/admin-ui/src/pages/upgrade/StartUpgradePage.tsx
@@ -1,0 +1,523 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import ConfirmDialog from '../../components/ConfirmDialog';
+import {
+  getSystemVersion,
+  runPreValidation,
+  checkConfigCompatibility,
+  startUpgrade,
+  type UpgradeResult,
+  type PreUpgradeCheck,
+} from '../../api/upgrade';
+
+const SEMVER = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
+
+function CheckRow({ check }: { check: PreUpgradeCheck }) {
+  const tone =
+    check.status === 'pass'
+      ? 'bg-green-100 text-green-700'
+      : check.status === 'warn'
+        ? 'bg-yellow-100 text-yellow-700'
+        : 'bg-red-100 text-red-700';
+
+  return (
+    <li className="flex items-start gap-3 py-2 border-b border-gray-100 last:border-0">
+      <span
+        className={`px-2 py-0.5 rounded text-xs font-medium uppercase ${tone}`}
+      >
+        {check.status}
+      </span>
+      <div className="min-w-0">
+        <p className="text-sm text-gray-900">{check.message}</p>
+        <p className="text-xs text-gray-500">{check.name}</p>
+        {check.details && (
+          <p className="text-xs text-gray-500 mt-1 break-words">
+            {check.details}
+          </p>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default function StartUpgradePage() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [step, setStep] = useState(0);
+  const [toVersion, setToVersion] = useState('');
+  // Simulation is the default action. A real upgrade must be chosen.
+  const [dryRun, setDryRun] = useState(true);
+  const [force, setForce] = useState(false);
+  const [note, setNote] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [typedConfirm, setTypedConfirm] = useState('');
+  const [result, setResult] = useState<UpgradeResult | null>(null);
+
+  const versionQuery = useQuery({
+    queryKey: ['system-version'],
+    queryFn: getSystemVersion,
+  });
+
+  const preValidation = useQuery({
+    queryKey: ['preValidation'],
+    queryFn: runPreValidation,
+    enabled: step === 1,
+  });
+
+  const compatibility = useQuery({
+    queryKey: ['configCompatibility', toVersion],
+    queryFn: () => checkConfigCompatibility(toVersion),
+    enabled: step === 1 && SEMVER.test(toVersion),
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      startUpgrade({
+        toVersion,
+        dryRun,
+        force,
+        note: note || undefined,
+        // Only meaningful for a real upgrade; the server ignores it on dry runs.
+        ...(dryRun ? {} : { confirm: toVersion }),
+      }),
+    retry: false,
+    onSuccess: (data) => {
+      setResult(data);
+      setConfirmOpen(false);
+      for (const key of [
+        'upgradeStatus',
+        'upgradeHistory',
+        'migration-history',
+        'rollbackCapability',
+        'system-version',
+      ]) {
+        void queryClient.invalidateQueries({ queryKey: [key] });
+      }
+    },
+  });
+
+  const currentVersion = versionQuery.data?.version;
+  const versionValid = SEMVER.test(toVersion) && toVersion !== currentVersion;
+
+  const blockingChecks =
+    preValidation.data?.checks.filter((c) => c.status === 'fail') ?? [];
+  const compatibilityErrors = compatibility.data?.summary.errors ?? 0;
+  const preflightBlocked =
+    preValidation.data?.canProceed === false || compatibilityErrors > 0;
+  // Mirror the server's own gates, so the UI never promises what it will reject.
+  const canProceedPastPreflight =
+    !preValidation.isLoading &&
+    !preValidation.isError &&
+    (!preflightBlocked || force);
+
+  // ── Result view ───────────────────────────────────────────────────────────
+  if (result) {
+    return (
+      <div className="max-w-3xl">
+        <h1 className="text-2xl font-semibold text-gray-900 mb-1">
+          {dryRun ? 'Dry run complete' : 'Upgrade complete'}
+        </h1>
+        <p className="text-sm text-gray-500 mb-6">
+          {result.fromVersion ?? currentVersion} → {result.toVersion}
+        </p>
+
+        {result.rollbackTriggered && (
+          <div className="mb-6 rounded border border-red-200 bg-red-50 p-4">
+            <p className="text-sm font-medium text-red-800">
+              A rollback was triggered.
+            </p>
+            <p className="text-sm text-red-700 mt-1">
+              The upgrade failed after the database was modified and the backup
+              was restored. Verify the system state before retrying.
+            </p>
+          </div>
+        )}
+
+        {result.error && (
+          <div className="mb-6 rounded border border-red-200 bg-red-50 p-4">
+            <p className="text-sm text-red-800 break-words">{result.error}</p>
+          </div>
+        )}
+
+        <div className="bg-white border border-gray-200 rounded-lg p-4 mb-6">
+          <h2 className="text-sm font-semibold text-gray-900 mb-3">Stages</h2>
+          <ol className="space-y-2">
+            {result.stages.map((s, i) => (
+              <li key={`${s.stage}-${i}`} className="flex items-start gap-3">
+                <span
+                  className={`mt-0.5 px-2 py-0.5 rounded text-xs font-medium ${
+                    s.success
+                      ? 'bg-green-100 text-green-700'
+                      : 'bg-red-100 text-red-700'
+                  }`}
+                >
+                  {s.success ? 'OK' : 'FAIL'}
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm text-gray-900">{s.stage}</p>
+                  <p className="text-xs text-gray-600 break-words">
+                    {s.message}
+                  </p>
+                  {s.details && (
+                    <p className="text-xs text-gray-500 mt-0.5 break-words">
+                      {s.details}
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            onClick={() => navigate('/console/upgrade')}
+            className="px-4 py-2 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700"
+          >
+            Back to Upgrade
+          </button>
+          {/* Staying put on failure is deliberate: navigating away from a
+              failure report is the wrong default. */}
+          <button
+            onClick={() => {
+              setResult(null);
+              setStep(0);
+            }}
+            className="px-4 py-2 rounded border border-gray-300 text-gray-700 text-sm hover:bg-gray-50"
+          >
+            Start another
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Wizard ────────────────────────────────────────────────────────────────
+  return (
+    <div className="max-w-3xl">
+      <h1 className="text-2xl font-semibold text-gray-900 mb-1">
+        Start an upgrade
+      </h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Step {step + 1} of 3 &middot;{' '}
+        {['Target', 'Preflight checks', 'Review'][step]}
+      </p>
+
+      {mutation.isPending && (
+        <div className="mb-6 rounded border border-blue-200 bg-blue-50 p-4">
+          <p className="text-sm font-medium text-blue-900">
+            {dryRun ? 'Running dry run…' : 'Applying upgrade…'}
+          </p>
+          <p className="text-sm text-blue-800 mt-1">
+            Do not close this tab. The request completes only when every stage
+            has finished, which can take several minutes.
+          </p>
+        </div>
+      )}
+
+      {/* Step 1 — target */}
+      {step === 0 && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+          <div>
+            <p className="text-sm text-gray-500">Current version</p>
+            <p className="text-lg font-medium text-gray-900">
+              {versionQuery.isLoading ? 'Loading…' : (currentVersion ?? 'unknown')}
+            </p>
+          </div>
+
+          {versionQuery.data?.databaseUpToDate === false && (
+            <div className="rounded border border-yellow-200 bg-yellow-50 p-3">
+              <p className="text-sm font-medium text-yellow-900">
+                The database has pending migrations.
+              </p>
+              <p className="text-xs text-yellow-800 mt-1 break-words">
+                {versionQuery.data.pendingMigrations.join(', ')}
+              </p>
+            </div>
+          )}
+
+          <div>
+            <label
+              htmlFor="toVersion"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Target version
+            </label>
+            <input
+              id="toVersion"
+              value={toVersion}
+              onChange={(e) => setToVersion(e.target.value)}
+              placeholder="0.4.0"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            />
+            {toVersion && !SEMVER.test(toVersion) && (
+              <p className="text-xs text-red-600 mt-1">
+                Expected a semantic version, e.g. 0.4.0
+              </p>
+            )}
+            {toVersion && toVersion === currentVersion && (
+              <p className="text-xs text-red-600 mt-1">
+                That is the version already running.
+              </p>
+            )}
+          </div>
+
+          <label className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              checked={dryRun}
+              onChange={(e) => setDryRun(e.target.checked)}
+              className="mt-1"
+            />
+            <span className="text-sm text-gray-700">
+              Dry run
+              <span className="block text-xs text-gray-500">
+                Simulates the upgrade. No backup is taken and no migration is
+                applied.
+              </span>
+            </span>
+          </label>
+
+          <div>
+            <label
+              htmlFor="note"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Note <span className="text-gray-400">(optional)</span>
+            </label>
+            <input
+              id="note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Ticket or change reference"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              disabled={!versionValid}
+              onClick={() => setStep(1)}
+              className="px-4 py-2 rounded bg-indigo-600 text-white text-sm disabled:bg-gray-300 hover:bg-indigo-700"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 2 — preflight */}
+      {step === 1 && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-gray-900">
+              Preflight checks
+            </h2>
+            <button
+              onClick={() => {
+                void preValidation.refetch();
+                void compatibility.refetch();
+              }}
+              className="text-sm text-indigo-600 hover:underline"
+            >
+              Re-run checks
+            </button>
+          </div>
+
+          {preValidation.isLoading && (
+            <p className="text-sm text-gray-500">Running checks…</p>
+          )}
+          {preValidation.isError && (
+            <p className="text-sm text-red-600">
+              Could not run pre-upgrade validation.
+            </p>
+          )}
+
+          {preValidation.data && (
+            <ul>
+              {preValidation.data.checks.map((c) => (
+                <CheckRow key={c.name} check={c} />
+              ))}
+            </ul>
+          )}
+
+          {compatibility.data && compatibility.data.issues.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-900 mt-4 mb-2">
+                Configuration
+              </h3>
+              <ul className="space-y-1">
+                {compatibility.data.issues.map((issue, i) => (
+                  <li key={`${issue.path}-${i}`} className="text-sm">
+                    <span
+                      className={
+                        issue.type === 'error'
+                          ? 'text-red-700'
+                          : 'text-yellow-700'
+                      }
+                    >
+                      {issue.path}
+                    </span>
+                    <span className="text-gray-600"> — {issue.message}</span>
+                    {issue.requiredValue && (
+                      <span className="text-gray-500">
+                        {' '}
+                        (expected {issue.requiredValue})
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {preflightBlocked && (
+            <div className="rounded border border-red-200 bg-red-50 p-3">
+              <p className="text-sm font-medium text-red-800">
+                {blockingChecks.length + compatibilityErrors} blocking issue(s).
+              </p>
+              <label className="flex items-start gap-2 mt-3">
+                <input
+                  type="checkbox"
+                  checked={force}
+                  onChange={(e) => setForce(e.target.checked)}
+                  className="mt-1"
+                />
+                <span className="text-sm text-red-800">
+                  Proceed anyway (force)
+                  <span className="block text-xs text-red-700">
+                    Skips pre-validation entirely — including the checks that
+                    verify a backup can be taken. An upgrade forced past these
+                    may not be recoverable.
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <button
+              onClick={() => setStep(0)}
+              className="px-4 py-2 rounded border border-gray-300 text-gray-700 text-sm hover:bg-gray-50"
+            >
+              Back
+            </button>
+            <button
+              disabled={!canProceedPastPreflight}
+              onClick={() => setStep(2)}
+              className="px-4 py-2 rounded bg-indigo-600 text-white text-sm disabled:bg-gray-300 hover:bg-indigo-700"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Step 3 — review */}
+      {step === 2 && (
+        <div className="bg-white border border-gray-200 rounded-lg p-4 space-y-4">
+          <h2 className="text-sm font-semibold text-gray-900">Review</h2>
+
+          <dl className="text-sm">
+            <div className="flex justify-between py-1 border-b border-gray-100">
+              <dt className="text-gray-500">From</dt>
+              <dd className="text-gray-900">{currentVersion ?? 'unknown'}</dd>
+            </div>
+            <div className="flex justify-between py-1 border-b border-gray-100">
+              <dt className="text-gray-500">To</dt>
+              <dd className="text-gray-900">{toVersion}</dd>
+            </div>
+            <div className="flex justify-between py-1 border-b border-gray-100">
+              <dt className="text-gray-500">Mode</dt>
+              <dd className="text-gray-900">
+                {dryRun ? 'Dry run (nothing is written)' : 'Real upgrade'}
+              </dd>
+            </div>
+            <div className="flex justify-between py-1 border-b border-gray-100">
+              <dt className="text-gray-500">Backup</dt>
+              <dd className="text-gray-900">
+                {dryRun ? 'Skipped' : 'Taken before migrating'}
+              </dd>
+            </div>
+            {force && (
+              <div className="flex justify-between py-1 border-b border-gray-100">
+                <dt className="text-gray-500">Force</dt>
+                <dd className="text-red-700">Pre-validation skipped</dd>
+              </div>
+            )}
+          </dl>
+
+          {mutation.isError && (
+            <div className="rounded border border-red-200 bg-red-50 p-3">
+              <p className="text-sm text-red-800">
+                The request failed. Nothing was started.
+              </p>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <button
+              onClick={() => setStep(1)}
+              disabled={mutation.isPending}
+              className="px-4 py-2 rounded border border-gray-300 text-gray-700 text-sm disabled:opacity-50 hover:bg-gray-50"
+            >
+              Back
+            </button>
+            {dryRun ? (
+              <button
+                onClick={() => mutation.mutate()}
+                disabled={mutation.isPending}
+                className="px-4 py-2 rounded bg-indigo-600 text-white text-sm disabled:bg-gray-300 hover:bg-indigo-700"
+              >
+                Run dry run
+              </button>
+            ) : (
+              <button
+                onClick={() => {
+                  setTypedConfirm('');
+                  setConfirmOpen(true);
+                }}
+                disabled={mutation.isPending}
+                className="px-4 py-2 rounded bg-red-600 text-white text-sm disabled:bg-gray-300 hover:bg-red-700"
+              >
+                Start upgrade
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        title="Start a real upgrade?"
+        confirmText="Start upgrade"
+        confirmDisabled={typedConfirm !== toVersion || mutation.isPending}
+        onCancel={() => setConfirmOpen(false)}
+        onConfirm={() => mutation.mutate()}
+        // ConfirmDialog renders `message` inside a <p>, so this must be
+        // phrasing content — a <div> or nested <p> here is invalid HTML.
+        message={
+          <>
+            <span className="block">
+              This applies database migrations to the live database. A backup is
+              taken first, and a failure after that point triggers a rollback.
+            </span>
+            <label className="block mt-3">
+              <span className="block text-sm text-gray-700 mb-1">
+                Type <strong>{toVersion}</strong> to confirm
+              </span>
+              <input
+                aria-label="Type the target version to confirm"
+                value={typedConfirm}
+                onChange={(e) => setTypedConfirm(e.target.value)}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm"
+              />
+            </label>
+          </>
+        }
+      />
+    </div>
+  );
+}

--- a/admin-ui/src/pages/upgrade/UpgradeStatusPage.tsx
+++ b/admin-ui/src/pages/upgrade/UpgradeStatusPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getUpgradeStatus,
@@ -397,7 +397,17 @@ export default function UpgradeStatusPage() {
 
       {/* Upgrade History */}
       <div>
-        <h2 className="mb-4 text-base font-semibold text-gray-900">Upgrade History</h2>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-900">Upgrade History</h2>
+          {/* The table below is a recent-activity preview; the history page is
+              the paginated deep dive. Nothing linked forward to it before. */}
+          <Link
+            to="/console/upgrade/history"
+            className="text-sm text-indigo-600 hover:underline"
+          >
+            View full history
+          </Link>
+        </div>
         {historyLoading ? (
           <div className="animate-pulse rounded-lg border border-gray-200 bg-gray-100 p-8">
             <div className="h-4 w-32 rounded bg-gray-200" />

--- a/admin-ui/src/pages/upgrade/__tests__/StartUpgradePage.test.tsx
+++ b/admin-ui/src/pages/upgrade/__tests__/StartUpgradePage.test.tsx
@@ -1,0 +1,252 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { Route, Routes } from 'react-router-dom';
+import { render } from '../../../test/utils';
+import { server } from '../../../test/mocks/server';
+import StartUpgradePage from '../StartUpgradePage';
+
+const renderPage = () =>
+  render(
+    <Routes>
+      <Route path="/console/upgrade/new" element={<StartUpgradePage />} />
+      <Route path="/console/upgrade" element={<div>upgrade status stub</div>} />
+    </Routes>,
+    { initialUrl: '/console/upgrade/new' },
+  );
+
+/** Fill in the target version and advance to the preflight step. */
+async function goToPreflight(user: ReturnType<typeof userEvent.setup>, version = '1.2.0') {
+  await screen.findByText('1.1.0'); // current version has loaded
+  await user.type(screen.getByLabelText(/target version/i), version);
+  await user.click(screen.getByRole('button', { name: /^next$/i }));
+}
+
+describe('StartUpgradePage', () => {
+  it('shows the current version from /system/version', async () => {
+    renderPage();
+
+    expect(await screen.findByText('1.1.0')).toBeInTheDocument();
+  });
+
+  it('warns when the database has pending migrations', async () => {
+    server.use(
+      http.get('/admin/system/version', () =>
+        HttpResponse.json({
+          version: '1.1.0',
+          schemaVersion: null,
+          pendingMigrations: ['20260101_add_widgets'],
+          databaseUpToDate: false,
+        }),
+      ),
+    );
+    renderPage();
+
+    expect(
+      await screen.findByText(/pending migrations/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/20260101_add_widgets/)).toBeInTheDocument();
+  });
+
+  it('keeps Next disabled for a non-semver target or the running version', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('1.1.0');
+
+    const input = screen.getByLabelText(/target version/i);
+    const next = screen.getByRole('button', { name: /^next$/i });
+
+    await user.type(input, 'not-a-version');
+    expect(next).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, '1.1.0'); // already running
+    expect(next).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, '1.2.0');
+    expect(next).toBeEnabled();
+  });
+
+  it('runs both preflight checks, passing the target to config-compatibility', async () => {
+    const seen: string[] = [];
+    server.use(
+      http.get('/admin/upgrade/config-compatibility', ({ request }) => {
+        seen.push(new URL(request.url).searchParams.get('version') ?? '');
+        return HttpResponse.json({
+          compatible: true,
+          version: '1.2.0',
+          issues: [],
+          summary: { errors: 0, warnings: 0 },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await goToPreflight(user);
+
+    await waitFor(() => expect(seen).toContain('1.2.0'));
+  });
+
+  // The UI mirrors the server's own gate so it never offers an action the
+  // server will reject.
+  it('blocks the step when pre-validation fails, until force is checked', async () => {
+    server.use(
+      http.get('/admin/upgrade/pre-validation', () =>
+        HttpResponse.json({
+          canProceed: false,
+          checks: [
+            {
+              name: 'backup_tooling',
+              status: 'fail',
+              message: 'pg_dump was not found on PATH',
+            },
+          ],
+          summary: { passed: 0, warnings: 0, failures: 1 },
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await goToPreflight(user);
+
+    await screen.findByText(/pg_dump was not found/i);
+    const next = screen.getByRole('button', { name: /^next$/i });
+    expect(next).toBeDisabled();
+
+    await user.click(screen.getByRole('checkbox', { name: /proceed anyway/i }));
+    expect(next).toBeEnabled();
+  });
+
+  it('sends a dry run without a confirm field and shows the stages', async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post('/admin/upgrade', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          success: true,
+          upgradeId: 'upg-1',
+          fromVersion: '1.1.0',
+          toVersion: '1.2.0',
+          stages: [
+            { stage: 'PRE_VALIDATION', success: true, message: 'ok', duration: 5 },
+          ],
+          rollbackTriggered: false,
+          duration: 5,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await goToPreflight(user);
+
+    await screen.findByRole('heading', { name: /preflight checks/i });
+    await user.click(await screen.findByRole('button', { name: /^next$/i }));
+    await user.click(await screen.findByRole('button', { name: /run dry run/i }));
+
+    await screen.findByText(/dry run complete/i);
+    expect(body).toEqual({ toVersion: '1.2.0', dryRun: true, force: false });
+    expect(screen.getByText('PRE_VALIDATION')).toBeInTheDocument();
+  });
+
+  it('requires typing the version before a real upgrade can be confirmed', async () => {
+    let body: Record<string, unknown> | undefined;
+    server.use(
+      http.post('/admin/upgrade', async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          success: true,
+          toVersion: '1.2.0',
+          stages: [],
+          rollbackTriggered: false,
+          duration: 1,
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText('1.1.0');
+    await user.click(screen.getByRole('checkbox', { name: /dry run/i })); // opt out
+    await user.type(screen.getByLabelText(/target version/i), '1.2.0');
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+
+    await screen.findByRole('heading', { name: /preflight checks/i });
+    await user.click(await screen.findByRole('button', { name: /^next$/i }));
+    await user.click(await screen.findByRole('button', { name: /start upgrade/i }));
+
+    // Two "Start upgrade" buttons exist once the dialog opens — the trigger on
+    // the review step and the dialog's confirm. Scope to the dialog.
+    const dialog = await screen.findByRole('alertdialog');
+    const confirmButton = within(dialog).getByRole('button', {
+      name: /^start upgrade$/i,
+    });
+    const typeBox = within(dialog).getByLabelText(
+      /type the target version to confirm/i,
+    );
+
+    await user.type(typeBox, '1.2.');
+    expect(confirmButton).toBeDisabled();
+
+    await user.type(typeBox, '0');
+    await waitFor(() => expect(confirmButton).toBeEnabled());
+
+    await user.click(confirmButton);
+    await waitFor(() =>
+      expect(body).toEqual({
+        toVersion: '1.2.0',
+        dryRun: false,
+        force: false,
+        confirm: '1.2.0',
+      }),
+    );
+  });
+
+  it('surfaces a rollback banner when the server reports one', async () => {
+    server.use(
+      http.post('/admin/upgrade', () =>
+        HttpResponse.json({
+          success: false,
+          toVersion: '1.2.0',
+          stages: [
+            { stage: 'POST_HEALTH_CHECK', success: false, message: 'unhealthy', duration: 9 },
+          ],
+          rollbackTriggered: true,
+          duration: 9,
+          error: 'Health check failed',
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await goToPreflight(user);
+    await screen.findByRole('heading', { name: /preflight checks/i });
+    await user.click(await screen.findByRole('button', { name: /^next$/i }));
+    await user.click(await screen.findByRole('button', { name: /run dry run/i }));
+
+    expect(await screen.findByText(/a rollback was triggered/i)).toBeInTheDocument();
+    expect(screen.getByText('Health check failed')).toBeInTheDocument();
+  });
+
+  it('stays on the review step when the request itself fails', async () => {
+    server.use(
+      http.post('/admin/upgrade', () => HttpResponse.json({}, { status: 500 })),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+    await goToPreflight(user);
+    await screen.findByRole('heading', { name: /preflight checks/i });
+    await user.click(await screen.findByRole('button', { name: /^next$/i }));
+    await user.click(await screen.findByRole('button', { name: /run dry run/i }));
+
+    expect(await screen.findByText(/the request failed/i)).toBeInTheDocument();
+    // Not navigated away, and no result view.
+    expect(screen.queryByText(/dry run complete/i)).not.toBeInTheDocument();
+    expect(screen.queryByText('upgrade status stub')).not.toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/test/mocks/handlers.ts
+++ b/admin-ui/src/test/mocks/handlers.ts
@@ -231,6 +231,69 @@ export const handlers = [
     return HttpResponse.json(makeRollbackCapability());
   }),
 
+  // /upgrade/audit is what MigrationHistoryPage uses: unlike /history it
+  // honours ?limit server-side. Clamped to 100 here to mirror the server, so
+  // the mock cannot be more permissive than production — that mismatch is
+  // exactly what hid the broken pagination.
+  http.get(`${BASE}/upgrade/audit`, ({ request }) => {
+    const url = new URL(request.url);
+    const raw = Number(url.searchParams.get('limit') ?? 20);
+    const limit = Math.min(Math.max(Number.isNaN(raw) ? 20 : raw, 1), 100);
+    const entries = [
+      makeUpgradeAuditEntry({ id: 'upgrade-1', status: 'COMPLETED' }),
+      makeUpgradeAuditEntry({ id: 'upgrade-2', status: 'COMPLETED', fromVersion: '0.9.0', toVersion: '1.0.0' }),
+      makeUpgradeAuditEntry({ id: 'upgrade-3', status: 'FAILED', toVersion: '1.2.0', errorMessage: 'Database migration failed' }),
+    ].slice(0, limit);
+    return HttpResponse.json({ entries, total: entries.length });
+  }),
+
+  http.get(`${BASE}/upgrade/config-compatibility`, () => {
+    return HttpResponse.json({
+      compatible: true,
+      version: '1.2.0',
+      issues: [],
+      summary: { errors: 0, warnings: 0 },
+    });
+  }),
+
+  http.post(`${BASE}/upgrade`, async ({ request }) => {
+    const body = (await request.json()) as { toVersion: string; dryRun?: boolean };
+    return HttpResponse.json({
+      success: true,
+      upgradeId: 'upg-mock',
+      fromVersion: '1.1.0',
+      toVersion: body.toVersion,
+      stages: [
+        { stage: 'INITIALIZATION', success: true, message: 'Initialized', duration: 10 },
+        { stage: 'PRE_VALIDATION', success: true, message: 'Checks passed', duration: 20 },
+      ],
+      rollbackTriggered: false,
+      duration: 30,
+    });
+  }),
+
+  // Previously absent, so UpgradeStatusPage's rollback mutation fired at
+  // nothing and that path was never exercised.
+  http.post(`${BASE}/upgrade/rollback`, () => {
+    return HttpResponse.json({
+      success: true,
+      rollbackVersion: '1.0.0',
+      previousVersion: '1.1.0',
+      backupRestored: true,
+      duration: 1200,
+      timestamp: new Date().toISOString(),
+    });
+  }),
+
+  http.get(`${BASE}/system/version`, () => {
+    return HttpResponse.json({
+      version: '1.1.0',
+      schemaVersion: '20260101000000_init',
+      pendingMigrations: [],
+      databaseUpToDate: true,
+    });
+  }),
+
   // Theme versions
   http.get(`${BASE}/realms/:name/themes/:themeId/versions`, () => {
     return HttpResponse.json([


### PR DESCRIPTION
Slice D of #1150 — **the first slice that changes anything a user can see.**

[#1197](https://github.com/idenplane/idenplane/pull/1197)–[#1200](https://github.com/idenplane/idenplane/pull/1200) made the backend correct, gave it a backup that verifiably restores, and gated the destructive endpoints. The two pages that drive all of it were still unreachable — written, tested, and wired to nothing.

## Contract fix first

Slice C made `confirm` **mandatory** on both destructive endpoints. The existing frontend sent neither — the rollback button would have returned **400**. Nobody was affected because nothing was routed, but shipping routes without this would have shipped a broken button.

## Routes and nav

| route | page | |
|---|---|---|
| `/console/upgrade` | `UpgradeStatusPage` | nav entry, `Icons.Upgrade` |
| `/console/upgrade/new` | `StartUpgradePage` | **new** |
| `/console/upgrade/history` | `MigrationHistoryPage` | whitelisted; linked from status |

Added an `Upgrade` icon rather than reusing `Download` (arrow points *down*) or `Refresh` (a sync loop). **One** nav entry, not two — history is one click away, and the status page now links forward to it. That link is what justifies the whitelist entry instead of a second Global entry.

### The guard that was suppressed

`routes.test.ts` carried:

```ts
/**
 * … The upgrade/migration pages are unrouted dead code (idenplane#1150) …
 * drop this exclusion once that feature is wired up or removed.
 */
const LINK_GUARD_IGNORE = /[/\]pages[/\]upgrade[/\]/;
```

Deleted, as its own comment asked. It had been hiding `UpgradeStatusPage`'s `navigate('/console/upgrade/new')` — a link to a page that did not exist.

**Verified the guard is live** by removing the new route:
```
pages\upgrade\UpgradeStatusPage.tsx → /console/upgrade/new: expected [] to have length +0 but got 1
```

## The wizard

Three steps: target → preflight → review.

- **`dryRun` defaults to checked.** The default action is a simulation; a real upgrade must be chosen.
- Step 2 runs pre-validation and config-compatibility, gating Next on `canProceed`/`compatible` — **mirroring the server's own gates**, so the UI never offers an action the server will reject. Warnings never block.
- `force` is only offered *after* a check actually fails, stating plainly that it skips the checks verifying a backup can be taken.
- Dry run → plain button. Real upgrade → **type the target version** into `ConfirmDialog` (its `confirmDisabled` prop exists for exactly this), giving that component a third consumer instead of a fourth bespoke modal.
- `POST /admin/upgrade` is synchronous and axios sets no timeout, so a blocking *"do not close this tab"* panel renders while pending.
- **On failure the page stays put** and shows the stage list. Navigating away from a failure report is the wrong default.

## The same false-confidence shape as the flaky tests

`MigrationHistoryPage` now reads `/upgrade/audit` instead of `/upgrade/history`.

`/audit` honours `?limit` (clamped 1–100 server-side). `/history` **ignored it** until #1197 — so this page's pagination worked against the MSW mock and never in production, because *the mock honoured the parameter while the server capped at 10*. A mock more permissive than the thing it stands in for, exactly like the earlier flaky-test work. The new `/audit` handler clamps to 100 to mirror the server.

Also surfaces `checksPassed` in the detail modal — the server has always returned it and the UI has always dropped it, though on a failed upgrade it is the most useful thing on the record.

## Fixed while testing

`ConfirmDialog` wraps `message` in a `<p>`, and I passed it a `<div>` containing a `<p>` — invalid HTML that React warned about. Restructured to phrasing content.

## Styling: legacy Tailwind, deliberately

**78 of 80 pages** use it; only Dashboard, Login and SystemStatus use design tokens, and `index.css` frames that layer as explicitly additive. Restyling here would make the chrome change *mid-flow on a destructive operation*, and would double the diff on the PR that most needs careful review. Worth doing — as one sweep, separately.

## Verification

- admin-ui: **353 tests / 34 files**; backend: **1967 / 120**; tsc, lint, vite build clean.

## Still disabled by default

With `UPGRADE_API_ENABLED` unset the wizard's final step returns **503**. The pages are useful regardless — status, history, health and pre-validation are all read-only and now reachable for the first time.

Closes #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)