### PR TITLE
fix(upgrade): refuse an upgrade that could not be rolled back

### DIFF
--- a/admin-ui/src/api/upgrade.ts
+++ b/admin-ui/src/api/upgrade.ts
@@ -18,7 +18,10 @@ export interface UpgradeResult {
   fromVersion?: string;
   toVersion: string;
   stages: UpgradeStageResult[];
+  /** A rollback was attempted. Read `rollbackSucceeded` for whether it worked. */
   rollbackTriggered: boolean;
+  /** Whether the attempted rollback completed. Absent if none was attempted. */
+  rollbackSucceeded?: boolean;
   duration: number;
   error?: string;
 }
@@ -157,7 +160,9 @@ export interface SystemVersion {
 /**
  * Start a new upgrade to the target version.
  */
-export async function startUpgrade(request: UpgradeRequest): Promise<UpgradeResult> {
+export async function startUpgrade(
+  request: UpgradeRequest,
+): Promise<UpgradeResult> {
   const { data } = await apiClient.post<UpgradeResult>('/upgrade', request);
   return data;
 }
@@ -166,25 +171,36 @@ export async function startUpgrade(request: UpgradeRequest): Promise<UpgradeResu
  * Get the status of the most recent upgrade.
  */
 export async function getUpgradeStatus(): Promise<UpgradeAuditEntry | null> {
-  const { data } = await apiClient.get<UpgradeAuditEntry | null>('/upgrade/status');
+  const { data } = await apiClient.get<UpgradeAuditEntry | null>(
+    '/upgrade/status',
+  );
   return data;
 }
 
 /**
  * Get upgrade history for audit purposes.
  */
-export async function getUpgradeHistory(limit = 10): Promise<UpgradeAuditEntry[]> {
-  const { data } = await apiClient.get<UpgradeAuditEntry[]>('/upgrade/history', {
-    params: { limit },
-  });
+export async function getUpgradeHistory(
+  limit = 10,
+): Promise<UpgradeAuditEntry[]> {
+  const { data } = await apiClient.get<UpgradeAuditEntry[]>(
+    '/upgrade/history',
+    {
+      params: { limit },
+    },
+  );
   return data;
 }
 
 /**
  * Get the current state of a specific upgrade operation.
  */
-export async function getUpgradeState(upgradeId: string): Promise<UpgradeState | null> {
-  const { data } = await apiClient.get<UpgradeState | null>(`/upgrade/${upgradeId}`);
+export async function getUpgradeState(
+  upgradeId: string,
+): Promise<UpgradeState | null> {
+  const { data } = await apiClient.get<UpgradeState | null>(
+    `/upgrade/${upgradeId}`,
+  );
   return data;
 }
 
@@ -192,7 +208,9 @@ export async function getUpgradeState(upgradeId: string): Promise<UpgradeState |
  * Run pre-upgrade validation checks to verify the system is ready.
  */
 export async function runPreValidation(): Promise<PreUpgradeValidationResult> {
-  const { data } = await apiClient.get<PreUpgradeValidationResult>('/upgrade/pre-validation');
+  const { data } = await apiClient.get<PreUpgradeValidationResult>(
+    '/upgrade/pre-validation',
+  );
   return data;
 }
 
@@ -207,10 +225,15 @@ export async function runHealthCheck(): Promise<UpgradeHealthResult> {
 /**
  * Check configuration compatibility for a target version.
  */
-export async function checkConfigCompatibility(version?: string): Promise<ConfigCompatibilityResult> {
-  const { data } = await apiClient.get<ConfigCompatibilityResult>('/upgrade/config-compatibility', {
-    params: version ? { version } : undefined,
-  });
+export async function checkConfigCompatibility(
+  version?: string,
+): Promise<ConfigCompatibilityResult> {
+  const { data } = await apiClient.get<ConfigCompatibilityResult>(
+    '/upgrade/config-compatibility',
+    {
+      params: version ? { version } : undefined,
+    },
+  );
   return data;
 }
 
@@ -218,14 +241,18 @@ export async function checkConfigCompatibility(version?: string): Promise<Config
  * Check if rollback is possible.
  */
 export async function checkRollbackCapability(): Promise<RollbackCapability> {
-  const { data } = await apiClient.get<RollbackCapability>('/upgrade/rollback/capability');
+  const { data } = await apiClient.get<RollbackCapability>(
+    '/upgrade/rollback/capability',
+  );
   return data;
 }
 
 /**
  * Execute a rollback to the previous version.
  */
-export async function executeRollback(upgradeId?: string): Promise<RollbackResult> {
+export async function executeRollback(
+  upgradeId?: string,
+): Promise<RollbackResult> {
   // `confirm` is mandatory server-side: a rollback restores a dump over the
   // live database and discards every write since that backup. The literal is
   // sent here rather than threaded through the caller because the UI already

--- a/admin-ui/src/pages/upgrade/StartUpgradePage.tsx
+++ b/admin-ui/src/pages/upgrade/StartUpgradePage.tsx
@@ -123,14 +123,21 @@ export default function StartUpgradePage() {
           {result.fromVersion ?? currentVersion} → {result.toVersion}
         </p>
 
+        {/* A rollback that ran and failed is the state an operator most needs
+            to tell apart from one that ran and worked — the database is left
+            modified with no recovery applied. Never report a restore that did
+            not happen. */}
         {result.rollbackTriggered && (
           <div className="mb-6 rounded border border-red-200 bg-red-50 p-4">
             <p className="text-sm font-medium text-red-800">
-              A rollback was triggered.
+              {result.rollbackSucceeded === false
+                ? 'A rollback was attempted and failed.'
+                : 'A rollback was triggered.'}
             </p>
             <p className="text-sm text-red-700 mt-1">
-              The upgrade failed after the database was modified and the backup
-              was restored. Verify the system state before retrying.
+              {result.rollbackSucceeded === false
+                ? 'The upgrade failed after the database was modified, and the backup could not be restored. The database is still in its post-migration state — restore it manually before using this instance.'
+                : 'The upgrade failed after the database was modified and the backup was restored. Verify the system state before retrying.'}
             </p>
           </div>
         )}
@@ -223,7 +230,9 @@ export default function StartUpgradePage() {
           <div>
             <p className="text-sm text-gray-500">Current version</p>
             <p className="text-lg font-medium text-gray-900">
-              {versionQuery.isLoading ? 'Loading…' : (currentVersion ?? 'unknown')}
+              {versionQuery.isLoading
+                ? 'Loading…'
+                : (currentVersion ?? 'unknown')}
             </p>
           </div>
 

--- a/src/upgrade/pre-upgrade-validator.service.spec.ts
+++ b/src/upgrade/pre-upgrade-validator.service.spec.ts
@@ -142,6 +142,59 @@ describe('PreUpgradeValidatorService', () => {
   });
 
   describe('checkPendingMigrations', () => {
+    // Verbatim `prisma migrate status` output, captured from a real database
+    // with one pending migration during an upgrade rehearsal. The previous
+    // parser looked for a `[ ]` checkbox that Prisma does not emit, so it found
+    // nothing, fell through to the "cannot determine status" branch and
+    // reported a hard failure — making canProceed false in exactly the
+    // situation an upgrade exists for. The fixture is real output rather than
+    // invented text precisely so the parser cannot drift away from it again.
+    const REAL_PENDING_OUTPUT = [
+      'Loaded Prisma config from prisma.config.ts.',
+      '',
+      'Prisma schema loaded from prisma\\schema.prisma.',
+      'Datasource "db": PostgreSQL database "idenplane_rehearsal", schema "public" at "localhost:5432"',
+      '',
+      '45 migrations found in prisma/migrations',
+      'Following migration have not yet been applied:',
+      '99990101000000_rehearsal_add_column',
+      '',
+      'To apply migrations in development run prisma migrate dev.',
+      'To apply migrations in production run prisma migrate deploy.',
+    ].join('\n');
+
+    it('reports a pending migration as a warning, not a failure', () => {
+      (execSync as jest.Mock).mockImplementation(() => {
+        const err = new Error('exit 1') as NodeJS.ErrnoException & {
+          stdout: string;
+        };
+        err.stdout = REAL_PENDING_OUTPUT;
+        throw err;
+      });
+
+      const check = (validatorService as any).checkPendingMigrations();
+
+      expect(check.status).toBe('warn');
+      expect(check.message).toContain('1 pending migration');
+      expect(check.details).toContain('99990101000000_rehearsal_add_column');
+    });
+
+    it('does not swallow the prose that follows the list', () => {
+      (execSync as jest.Mock).mockImplementation(() => {
+        const err = new Error('exit 1') as NodeJS.ErrnoException & {
+          stdout: string;
+        };
+        err.stdout = REAL_PENDING_OUTPUT;
+        throw err;
+      });
+
+      const check = (validatorService as any).checkPendingMigrations();
+
+      // "To apply migrations in development run prisma migrate dev." must not
+      // be mistaken for a migration name.
+      expect(check.details).not.toMatch(/To apply|prisma migrate/);
+    });
+
     it('should return pass when no pending migrations', async () => {
       (execSync as jest.Mock).mockReturnValue('All migrations are up to date.');
 

--- a/src/upgrade/pre-upgrade-validator.service.ts
+++ b/src/upgrade/pre-upgrade-validator.service.ts
@@ -207,7 +207,40 @@ export class PreUpgradeValidatorService {
     const lines = output.split('\n');
     const pending: string[] = [];
 
-    for (const line of lines) {
+    // Prisma lists pending migrations as bare names under a heading:
+    //
+    //   Following migration have not yet been applied:
+    //   99990101000000_add_column
+    //
+    // Everything after that heading, up to the next blank line, is a migration
+    // name. The previous implementation looked for a `[ ]` checkbox marker,
+    // which Prisma does not emit — so it never matched, `pending` stayed empty,
+    // and the caller fell through to its "cannot determine status" branch and
+    // reported a hard FAILURE. That made canProceed false precisely when
+    // migrations were pending, i.e. in the only situation an upgrade is ever
+    // run: the operator's choice became "abandon" or "--force past every safety
+    // check". Found by rehearsing an upgrade against a database with a genuine
+    // pending migration.
+    let inPendingList = false;
+    for (const raw of lines) {
+      const line = raw.trim();
+
+      if (/have not yet been applied/i.test(line)) {
+        inPendingList = true;
+        continue;
+      }
+
+      if (inPendingList) {
+        // The list ends at the first blank line or prose sentence.
+        if (!line || /\s/.test(line)) {
+          inPendingList = false;
+          continue;
+        }
+        pending.push(line);
+        continue;
+      }
+
+      // Kept for any Prisma version that does use a checkbox form.
       const notApplied = line.match(/\[\s*\]\s+(\S+)/);
       if (notApplied) {
         pending.push(notApplied[1]);

--- a/src/upgrade/upgrade.service.spec.ts
+++ b/src/upgrade/upgrade.service.spec.ts
@@ -77,6 +77,11 @@ describe('UpgradeService', () => {
     // IN_PROGRESS row would leak that row into every test after it.
     mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue(null);
 
+    // A real upgrade now refuses to start unless it could be rolled back.
+    // These tests exercise the pipeline itself, so the precondition is
+    // satisfied; the tests that assert the refusal clear it explicitly.
+    process.env.UPGRADE_ALLOW_LIVE_RESTORE = 'true';
+
     upgradeService = new UpgradeService(
       mockPrisma as any,
       mockPreUpgradeValidator,
@@ -233,6 +238,84 @@ describe('UpgradeService', () => {
             }),
           }),
         );
+      });
+    });
+
+    describe('refuses an upgrade it could not undo', () => {
+      // Found by rehearsing a failing upgrade against a real database: with
+      // only UPGRADE_API_ENABLED set, the upgrade migrated the database, failed
+      // its health check, and then could not roll back — because restoring over
+      // a live database is gated separately. Starting was strictly worse than
+      // refusing.
+      const savedFlag = process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+
+      afterEach(() => {
+        if (savedFlag === undefined)
+          delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+        else process.env.UPGRADE_ALLOW_LIVE_RESTORE = savedFlag;
+      });
+
+      it('refuses before touching anything when live restore is disabled', async () => {
+        delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+
+        await expect(upgradeService.upgrade('2.1.0')).rejects.toThrow(
+          ConflictException,
+        );
+        expect(mockPrisma.upgradeAuditLog.create).not.toHaveBeenCalled();
+        expect(mockDatabaseBackupService.createBackup).not.toHaveBeenCalled();
+      });
+
+      it('names the variable to set, so the refusal is actionable', async () => {
+        delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+
+        await expect(upgradeService.upgrade('2.1.0')).rejects.toThrow(
+          /UPGRADE_ALLOW_LIVE_RESTORE/,
+        );
+      });
+
+      it('does not block a dry run, which has nothing to undo', async () => {
+        delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+        mockPreUpgradeValidator.validate.mockResolvedValue({
+          canProceed: true,
+          checks: [],
+          summary: { passed: 8, warnings: 0, failures: 0 },
+        });
+        mockConfigCompatibility.checkCompatibility.mockResolvedValue({
+          compatible: true,
+          version: '2.1.0',
+          issues: [],
+          summary: { errors: 0, warnings: 0 },
+        });
+        mockUpgradeHealthService.checkHealth.mockResolvedValue({
+          healthy: true,
+          version: '2.1.0',
+          checks: [],
+          summary: { passed: 7, warnings: 0, failures: 0 },
+        });
+        mockPrisma.upgradeAuditLog.create.mockResolvedValue({ id: 'upg-1' });
+        mockPrisma.upgradeAuditLog.update.mockResolvedValue({ id: 'upg-1' });
+
+        const result = await upgradeService.upgrade('2.1.0', { dryRun: true });
+
+        expect(result.success).toBe(true);
+      });
+
+      it('lets force through — the documented escape hatch', async () => {
+        delete process.env.UPGRADE_ALLOW_LIVE_RESTORE;
+        mockPreUpgradeValidator.validate.mockResolvedValue({
+          canProceed: false,
+          checks: [],
+          summary: { passed: 0, warnings: 0, failures: 1 },
+        });
+        mockPrisma.upgradeAuditLog.create.mockResolvedValue({ id: 'upg-1' });
+        mockPrisma.upgradeAuditLog.update.mockResolvedValue({ id: 'upg-1' });
+        mockPrisma.upgradeAuditLog.findFirst.mockResolvedValue(null);
+
+        // Reaches the pipeline rather than being refused outright.
+        await expect(
+          upgradeService.upgrade('2.1.0', { force: true }),
+        ).resolves.toBeDefined();
+        expect(mockPrisma.upgradeAuditLog.create).toHaveBeenCalled();
       });
     });
 

--- a/src/upgrade/upgrade.service.ts
+++ b/src/upgrade/upgrade.service.ts
@@ -47,7 +47,17 @@ export interface UpgradeResult {
   toVersion: string;
   stages: UpgradeStageResult[];
   backupResult?: BackupResult;
+  /**
+   * A rollback was attempted. Says nothing about whether it worked — read
+   * `rollbackSucceeded` for that.
+   *
+   * This previously meant "a rollback succeeded", so a rollback that ran and
+   * failed reported `false` and was indistinguishable from one that never
+   * happened. That is the case an operator most needs to tell apart.
+   */
   rollbackTriggered: boolean;
+  /** Whether the attempted rollback completed. Undefined if none was attempted. */
+  rollbackSucceeded?: boolean;
   duration: number;
   error?: string;
 }
@@ -116,16 +126,33 @@ export class UpgradeService {
       ipAddress?: string;
     } = {},
   ): Promise<UpgradeResult> {
-    // Two guards against concurrent upgrades, because two processes running
-    // `prisma migrate deploy` against one database is a corruption scenario,
-    // not merely a race. docker-compose.cluster.yml runs two app replicas and
-    // the Helm chart supports autoscaling, so this is a real configuration.
-    //
-    // A dry run writes nothing, so it is exempt.
+    // A dry run writes nothing, so neither precondition below applies to it.
     if (options.dryRun) {
       return this.runUpgrade(toVersion, options);
     }
 
+    // Do not start what cannot be undone.
+    //
+    // Rolling back restores a dump over the live database, which is gated
+    // separately by UPGRADE_ALLOW_LIVE_RESTORE. Without that gate open the
+    // automatic rollback fails too — so an upgrade would migrate the database,
+    // fail its health check, and then find it has no way back. That is strictly
+    // worse than not starting: the operator ends up with a modified database
+    // and no recovery, having been told nothing beforehand.
+    //
+    // Checked here rather than in pre-validation because it is a property of
+    // the requested operation, not of the host: pre-validation answers "is this
+    // system healthy", this answers "is this action recoverable". force remains
+    // the documented escape hatch for an operator who takes backups by other
+    // means, and is already logged at error level by the controller.
+    if (!options.force) {
+      this.assertRollbackAvailable();
+    }
+
+    // Two guards against concurrent upgrades, because two processes running
+    // `prisma migrate deploy` against one database is a corruption scenario,
+    // not merely a race. docker-compose.cluster.yml runs two app replicas and
+    // the Helm chart supports autoscaling, so this is a real configuration.
     await this.assertNoUpgradeInProgress(toVersion);
 
     // finally, not a reset at each return site: runUpgrade has a dozen exit
@@ -543,6 +570,30 @@ export class UpgradeService {
   private static readonly IN_PROGRESS_TTL_MS = 2 * 60 * 60 * 1000;
   private inFlight = false;
 
+  /**
+   * Refuse an upgrade whose failure could not be undone.
+   *
+   * RollbackService declines to restore over the live database unless
+   * UPGRADE_ALLOW_LIVE_RESTORE is set. That check is right — a restore takes
+   * ACCESS EXCLUSIVE locks that conflict with other replicas — but it applies
+   * to the *automatic* rollback as well, so with only UPGRADE_API_ENABLED set
+   * an upgrade will migrate the database, fail, and then discover it has no way
+   * back. Found by rehearsing a failing upgrade against a real database.
+   */
+  private assertRollbackAvailable(): void {
+    if (process.env.UPGRADE_ALLOW_LIVE_RESTORE === 'true') {
+      return;
+    }
+
+    throw new ConflictException(
+      'Refusing to start: this upgrade could not be rolled back. Restoring a ' +
+        'backup over the running database requires UPGRADE_ALLOW_LIVE_RESTORE=true, ' +
+        'which is unset — so a failure after the migration would leave the database ' +
+        'modified with no automatic recovery. Scale to a single instance and set ' +
+        'that variable, or pass force to proceed without a recovery path.',
+    );
+  }
+
   private async assertNoUpgradeInProgress(toVersion: string): Promise<void> {
     if (this.inFlight) {
       throw new ConflictException(
@@ -883,6 +934,21 @@ export class UpgradeService {
   }
 
   /**
+   * Derive the rollback fields of an UpgradeResult from the stage list, so the
+   * two can never disagree about whether a rollback happened.
+   */
+  private static rollbackOutcome(stages: UpgradeStageResult[]): {
+    rollbackTriggered: boolean;
+    rollbackSucceeded?: boolean;
+  } {
+    const rollback = stages.find((s) => s.stage === UpgradeStage.ROLLBACK);
+
+    return rollback
+      ? { rollbackTriggered: true, rollbackSucceeded: rollback.success }
+      : { rollbackTriggered: false };
+  }
+
+  /**
    * Build a failure result object.
    */
   private buildFailureResult(
@@ -897,9 +963,7 @@ export class UpgradeService {
       upgradeId,
       toVersion,
       stages,
-      rollbackTriggered: stages.some(
-        (s) => s.stage === UpgradeStage.ROLLBACK && s.success,
-      ),
+      ...UpgradeService.rollbackOutcome(stages),
       duration: Date.now() - startTime,
       error: errorMessage,
     };


### PR DESCRIPTION
Two defects found by **rehearsing an upgrade end to end against a real database** — 200k users, 78 MB, a genuine pending migration, driven over HTTP against the running app rather than through the service directly.

Neither was reachable by any test that mocks the shell, and neither existed before this feature was wired up — both were introduced by earlier slices in this series.

---

## 1. Pre-validation rejected every upgrade that had anything to do

`parsePendingMigrations` looked for a `[ ]` checkbox marker. Prisma doesn't emit one — it prints a heading followed by bare names:

```
Following migration have not yet been applied:
99990101000000_add_column
```

So the parser matched nothing, `pending` stayed empty, and the caller fell through to its *"cannot determine status"* branch — reporting a hard **failure** and `canProceed: false`.

That's the state of any database with a migration waiting. **Which is the only state from which an upgrade is ever run.**

Observed live before the fix:

```
canProceed: false | {"passed":7,"warnings":0,"failures":1}
   fail  pending_migrations — Unable to determine migration status
         details: "...Following migration have not yet been applied:
                   99990101000000_rehearsal_add_column..."
```

Prisma said it plainly; the check couldn't read it. The operator's remaining options were to abandon, or pass `force` — which skips *every* pre-validation check, including the ones verifying a backup can be taken at all.

After:
```
canProceed: true  | {"passed":7,"warnings":1,"failures":0}
   warn  pending_migrations — 1 pending migration(s) found
```

The spec now uses output **captured verbatim from a live `prisma migrate status`** rather than invented text, so the parser can't drift away from reality again.

---

## 2. An upgrade would start with no way back

`RollbackService` declines to restore over a live database unless `UPGRADE_ALLOW_LIVE_RESTORE` is set — correct in itself, since a restore takes `ACCESS EXCLUSIVE` locks that conflict with other replicas. But that gate applies to the **automatic** rollback too.

With only `UPGRADE_API_ENABLED` set — the configuration the docs lead you to — the rehearsal produced:

```
ok   BACKUP                680ms
ok   DATABASE_MIGRATION   1956ms
FAIL POST_HEALTH_CHECK    3352ms  Health check failed with 1 failure(s)
FAIL ROLLBACK                3ms  Live database restore is disabled
```

**The database was migrated, the upgrade failed, and there was no recovery** — the worst of both outcomes, reached without warning.

`upgrade()` now refuses to start unless a rollback would be possible:

```
http 409
Refusing to start: this upgrade could not be rolled back. Restoring a backup
over the running database requires UPGRADE_ALLOW_LIVE_RESTORE=true, which is
unset — so a failure after the migration would leave the database modified
with no automatic recovery. Scale to a single instance and set that variable,
or pass force to proceed without a recovery path.
```

Checked in `upgrade()` rather than in pre-validation because it's a property of the **requested operation**, not of the host: pre-validation answers *"is this system healthy"*, this answers *"is this action recoverable"*. Dry runs are exempt — nothing to undo — and `force` remains the documented escape hatch.

---

## Also: `rollbackTriggered` lied

It was computed from whether the rollback **succeeded**, so a rollback that ran and failed reported `false` — indistinguishable from one that never happened. That's precisely the case an operator most needs to tell apart.

Now means *attempted*, with `rollbackSucceeded` alongside, both derived from the stage list by one helper so they can't disagree. The wizard's banner no longer claims a backup was restored when the restore failed.

---

## Rehearsal results, for the record

Local PostgreSQL 16, 78 MB / 200k users / 5k clients / 50 realms:

| step | time | outcome |
|---|---|---|
| dry run | 7.6s | nothing written |
| **real upgrade** | **10.2s** | column added, verified present afterwards |
| ├ backup | 0.7s | |
| ├ migration | 2.1s | |
| └ health check | 3.4s | |
| refusal (no rollback available) | — | 409 before touching anything |

Also confirmed live: flag off → **503**; no auth → **401**; `ADMIN_API_KEY` under 32 chars → refuses to boot.

## Still not covered

The published image ships **pg client 18** against a **server 16** in compose. Supported direction, still untested — the rehearsal was 16/16.

Verified: 1974 backend tests / 120 suites, 353 admin-ui tests, lint, build, admin-ui typecheck all clean.

Refs #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)