### PR TITLE
fix(upgrade): require the pg client and server majors to match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,28 @@ WORKDIR /app
 # abort at pre-validation (by design — an upgrade that cannot be rolled back
 # should not start), so this is what makes UPGRADE_API_ENABLED usable at all.
 #
-# The client major version must be >= the server's; compose ships postgres 16
-# and the Alpine default here is newer, which is the supported direction.
-# Verified at build time so a base-image change cannot silently regress it.
-RUN apk add --no-cache postgresql-client \
+# The client major must EQUAL the server major. An earlier revision of this file
+# claimed "client >= server is the supported direction"; that is true for taking
+# a dump and false for restoring one. Measured against a PostgreSQL 16 server:
+#
+#   pg_dump 18   → archive written fine
+#   pg_restore 18 → ERROR: unrecognized configuration parameter
+#                   "transaction_timeout"      (that GUC arrived in PG 17)
+#   pg_restore 16 on that same archive
+#                 → ERROR: unsupported version (1.16) in file header
+#
+# So a newer client produces backups that nothing can restore onto an older
+# server — the rollback is broken exactly when it is needed. An older client is
+# no better: pg_dump refuses to dump a newer server outright.
+#
+# Alpine's default postgresql-client tracks the newest release, so pinning is
+# required rather than optional. PG_MAJOR must match the PostgreSQL server this
+# image will be pointed at; docker-compose.yml ships postgres:16-alpine.
+# The application also verifies this at runtime (pre-validation check
+# `pg_client_version`) and refuses to upgrade on a mismatch, so a wrong value
+# here fails loudly rather than silently disabling rollback.
+ARG PG_MAJOR=16
+RUN apk add --no-cache "postgresql${PG_MAJOR}-client" \
     && pg_dump --version \
     && pg_restore --version
 

--- a/src/upgrade/database-backup.service.ts
+++ b/src/upgrade/database-backup.service.ts
@@ -430,11 +430,27 @@ export class DatabaseBackupService {
       } catch {
         return {
           available: false,
-          detail: `${tool} was not found on PATH. Install postgresql-client (client major version >= the server's).`,
+          detail: `${tool} was not found on PATH. Install postgresql-client matching the server's major version.`,
         };
       }
     }
     return { available: true, detail: 'pg_dump and pg_restore are available' };
+  }
+
+  /**
+   * Major version of the installed pg_dump, or null if it cannot be determined.
+   */
+  clientMajorVersion(): number | null {
+    try {
+      const out = execFileSync('pg_dump', ['--version'], {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+      const match = out.match(/(\d+)/);
+      return match ? parseInt(match[1], 10) : null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/src/upgrade/pre-upgrade-validator.service.spec.ts
+++ b/src/upgrade/pre-upgrade-validator.service.spec.ts
@@ -39,6 +39,8 @@ describe('PreUpgradeValidatorService', () => {
       pgToolsAvailable: jest
         .fn()
         .mockReturnValue({ available: true, detail: 'ok' }),
+      // Matching majors by default; the version-match tests override this.
+      clientMajorVersion: jest.fn().mockReturnValue(16),
     } as unknown as jest.Mocked<DatabaseBackupService>;
 
     // Defaults: directory usable, plenty of space. Individual tests override.
@@ -138,6 +140,63 @@ describe('PreUpgradeValidatorService', () => {
       expect(check.name).toBe('database_connection');
       expect(check.status).toBe('fail');
       expect(check.message).toBe('Cannot connect to database');
+    });
+  });
+
+  describe('checkPgVersionMatch', () => {
+    // Measured against a real PostgreSQL 16 server: pg_dump 18 writes an
+    // archive fine, but pg_restore 18 fails with "unrecognized configuration
+    // parameter transaction_timeout" (a PG 17 GUC) and pg_restore 16 fails with
+    // "unsupported version (1.16) in file header". A newer client therefore
+    // produces backups nothing can restore onto that server — no rollback, and
+    // you only find out when you need one. Equality is the requirement.
+    const withVersions = (client: number | null, serverNum: string | null) => {
+      mockBackupService.clientMajorVersion = jest.fn().mockReturnValue(client);
+      mockPrisma.$queryRaw.mockImplementation(() =>
+        serverNum === null
+          ? Promise.reject(new Error('no server version'))
+          : Promise.resolve([{ server_version_num: serverNum }]),
+      );
+    };
+
+    it('passes when the majors match', async () => {
+      withVersions(16, '160014');
+
+      const check = await (validatorService as any).checkPgVersionMatch();
+
+      expect(check.status).toBe('pass');
+      expect(check.message).toContain('16');
+    });
+
+    it('fails when the client is newer than the server', async () => {
+      withVersions(18, '160014');
+
+      const check = await (validatorService as any).checkPgVersionMatch();
+
+      expect(check.status).toBe('fail');
+      expect(check.message).toMatch(/18.*16/);
+      // The remedy must name the version to install, not just state the problem.
+      expect(check.details).toContain('postgresql-client 16');
+    });
+
+    it('fails when the client is older than the server', async () => {
+      withVersions(16, '180004');
+
+      const check = await (validatorService as any).checkPgVersionMatch();
+
+      expect(check.status).toBe('fail');
+    });
+
+    it('warns rather than fails when either version is unknown', async () => {
+      withVersions(null, '160014');
+      expect(
+        (await (validatorService as any).checkPgVersionMatch()).status,
+      ).toBe('warn');
+
+      withVersions(16, null);
+      expect(
+        (await (validatorService as any).checkPgVersionMatch()).status,
+      ).toBe('warn');
     });
   });
 

--- a/src/upgrade/pre-upgrade-validator.service.ts
+++ b/src/upgrade/pre-upgrade-validator.service.ts
@@ -117,6 +117,14 @@ export class PreUpgradeValidatorService {
     else if (backupDirCheck.status === 'warn') warnings++;
     else failures++;
 
+    // 9. Client and server majors must match, or the restore silently is not
+    //    one — see checkPgVersionMatch.
+    const versionCheck = await this.checkPgVersionMatch();
+    checks.push(versionCheck);
+    if (versionCheck.status === 'pass') passed++;
+    else if (versionCheck.status === 'warn') warnings++;
+    else failures++;
+
     const canProceed = failures === 0;
 
     this.logger.log(
@@ -271,6 +279,86 @@ export class PreUpgradeValidatorService {
             'Backup tooling is missing — an upgrade cannot be rolled back',
           details: detail,
         };
+  }
+
+  /**
+   * The pg client major must equal the server major, or the backup cannot be
+   * restored — which means there is no rollback, discovered only at the moment
+   * one is needed.
+   *
+   * Measured, not assumed. Against a PostgreSQL 16 server:
+   *
+   *   pg_dump 18 → archive written fine (624 KB, PGDMP header)
+   *   pg_restore 18 → ERROR: unrecognized configuration parameter
+   *                   "transaction_timeout"   (added in PG 17)
+   *   pg_restore 16 on that archive → ERROR: unsupported version (1.16)
+   *                   in file header
+   *   pg_dump 16 + pg_restore 16 → restores, rows come back
+   *
+   * So a newer client is not merely "the supported direction": it produces
+   * backups nothing can restore onto that server. An older client is no better,
+   * since pg_dump refuses to dump a newer server at all. Equality is the rule.
+   *
+   * This matters for the published image specifically: it installs Alpine's
+   * default postgresql-client, which is currently 18, while docker-compose.yml
+   * ships postgres:16-alpine. That combination has no working rollback.
+   */
+  /** Server major, or null if it cannot be read. server_version_num is MMmmpp. */
+  private async readServerMajorVersion(): Promise<number | null> {
+    try {
+      const rows = await this.prisma.$queryRaw<
+        Array<{ server_version_num: string }>
+      >`SHOW server_version_num`;
+      const num = Number(rows[0]?.server_version_num);
+      return Number.isFinite(num) ? Math.floor(num / 10000) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async checkPgVersionMatch(): Promise<PreUpgradeCheck> {
+    const clientMajor = this.databaseBackupService.clientMajorVersion();
+
+    if (clientMajor === null) {
+      return {
+        name: 'pg_client_version',
+        status: 'warn',
+        message: 'Could not determine the pg_dump version',
+        details:
+          'Unable to verify that the client and server majors match, which a ' +
+          'restore requires.',
+      };
+    }
+
+    const serverMajor = await this.readServerMajorVersion();
+
+    if (serverMajor === null) {
+      return {
+        name: 'pg_client_version',
+        status: 'warn',
+        message: 'Could not determine the PostgreSQL server version',
+        details: `Client is ${clientMajor}; server version unavailable.`,
+      };
+    }
+
+    if (clientMajor !== serverMajor) {
+      return {
+        name: 'pg_client_version',
+        status: 'fail',
+        message: `pg client ${clientMajor} does not match server ${serverMajor}`,
+        details:
+          `A backup taken by pg_dump ${clientMajor} cannot be restored onto a ` +
+          `PostgreSQL ${serverMajor} server, so this upgrade would have no ` +
+          `rollback. Install postgresql-client ${serverMajor} (or run a ` +
+          `PostgreSQL ${clientMajor} server).`,
+      };
+    }
+
+    return {
+      name: 'pg_client_version',
+      status: 'pass',
+      message: `pg client and server majors match (${clientMajor})`,
+    };
   }
 
   /**


### PR DESCRIPTION
You asked me to install Docker and test the version skew. Docker can't run Linux containers on this box — it's a Vultr VM with no nested virtualisation (`SecondLevelAddressTranslation: False`). So I tested the actual risk directly instead: installed the **same client version the image ships (18.4)** alongside the existing **PostgreSQL 16** server.

**The shipped stack has no working rollback.**

## Measured, not reasoned about

The Dockerfile said *"client >= server, which is the supported direction"*. That's true for taking a dump and **false for restoring one**:

```
pg_dump 18                    → archive written fine, 624 KB, PGDMP header
pg_restore 18 → server 16     → ERROR: unrecognized configuration parameter
                                "transaction_timeout"     ← that GUC arrived in PG 17
pg_restore 16 → same archive  → ERROR: unsupported version (1.16) in file header
pg_dump 16 + pg_restore 16    → rows come back ✓
```

Deleted 11,111 rows, ran the restore, and they **stayed deleted**. Both directions fail: a newer client emits SQL the older server rejects, and an older client can't read the newer archive format.

An older client is no better — `pg_dump` refuses to dump a newer server outright. **Equality is the requirement, not an inequality.**

## Two changes, because either alone leaves a hole

**Dockerfile** pins `postgresql${PG_MAJOR}-client`, defaulting to 16 to match the compose stack, as a build arg so a deployment on a different major can build a matching image.

> Verified `postgresql16/17/18-client` all exist in Alpine v3.20 → edge before changing this, so the pin can't break the build on a base-image bump. I can't run `docker build` here, hence checking the package index rather than assuming.

**A pre-validation check** compares `pg_dump`'s major against `server_version_num` and fails on mismatch, naming the version to install. The image can be built wrong, or pointed at a different server than it was built for — this catches that at the only useful moment, *before* the upgrade, rather than during the rollback that needed it.

## Verified live, over HTTP against the running app

```
client 18 / server 16 → canProceed: false
  fail pg_client_version — pg client 18 does not match server 16
  "A backup taken by pg_dump 18 cannot be restored onto a PostgreSQL 16 server,
   so this upgrade would have no rollback. Install postgresql-client 16
   (or run a PostgreSQL 18 server)."

client 16 / server 16 → canProceed: true, 9 passed
  pass pg_client_version — pg client and server majors match (16)
```

## Why this mattered

This was the last item on the pre-enablement list, and the one I was most tempted to tick off by inspection — "newer client, supported direction, fine". Had I done that, the feature would have shipped with a rollback that could never run, and nobody would have found out until the first upgrade failed.

Verified: 1978 tests across 120 suites, lint and build clean.

Refs #1150

🤖 Generated with [Claude Code](https://claude.com/claude-code)