### PR TITLE
fix(plugins): bind lifecycle hooks at extraction rather than at call

### DIFF
--- a/src/plugins/plugin-manager.service.spec.ts
+++ b/src/plugins/plugin-manager.service.spec.ts
@@ -137,6 +137,34 @@ describe('PluginManagerService', () => {
       expect(plugin.onInstall).toHaveBeenCalled();
     });
 
+    // The existing lifecycle assertions use jest.fn() mocks, which are
+    // indifferent to `this` — so they would pass whether or not the hook is
+    // invoked with its plugin bound. A plugin written as an object with methods
+    // that reach for `this` is the normal case, and the only thing that catches
+    // a regression in how invokeLifecycle dispatches.
+    it('invokes a lifecycle hook with `this` bound to the plugin', async () => {
+      let seenName: string | undefined;
+      const plugin = {
+        ...makeEventListenerPlugin('this-aware'),
+        onInstall(this: { name: string }) {
+          seenName = this?.name;
+          return Promise.resolve();
+        },
+      };
+
+      (loader.discoverAll as jest.Mock).mockResolvedValue([
+        { plugin, source: 'directory', sourcePath: '/plugins/this-aware' },
+      ]);
+      prisma.installedPlugin.findUnique.mockResolvedValue(null);
+      prisma.installedPlugin.create.mockResolvedValue(
+        makeDbRecord({ name: 'this-aware' }),
+      );
+
+      await service.onModuleInit();
+
+      expect(seenName).toBe('this-aware');
+    });
+
     it('should continue loading other plugins when one fails', async () => {
       const badPlugin = makeEventListenerPlugin('bad-plugin');
       const goodPlugin = makeEventListenerPlugin('good-plugin');

--- a/src/plugins/plugin-manager.service.ts
+++ b/src/plugins/plugin-manager.service.ts
@@ -368,11 +368,17 @@ export class PluginManagerService implements OnModuleInit {
     hook: 'onInstall' | 'onEnable' | 'onDisable' | 'onUninstall',
     context: PluginContext,
   ): Promise<void> {
-    const fn = plugin[hook];
+    // Bind at the point of extraction rather than pulling the method off the
+    // object and restoring `this` later with .call(). The previous form was
+    // correct — .call(plugin, ...) rebound it — but it left an unbound method
+    // reference in a local, which typescript-eslint 8.65's unbound-method rule
+    // reports: a plugin author reading this could reasonably pass `fn` on,
+    // and it would then be invoked with the wrong `this`.
+    const fn = plugin[hook]?.bind(plugin);
     if (typeof fn !== 'function') return;
 
     try {
-      await fn.call(plugin, context);
+      await fn(context);
     } catch (err) {
       this.logger.warn(
         `Plugin '${plugin.name}' threw during '${hook}': ${(err as Error).message}`,


### PR DESCRIPTION
`typescript-eslint` 8.65 — proposed by #1213 — reports `unbound-method` on `invokeLifecycle`:

```
src/plugins/plugin-manager.service.ts:371
A method that is not declared with `this: void` may cause unintentional
scoping of `this` when separated from its object.
```

## The old code was correct, and still worth changing

It pulled the hook off the plugin and restored the receiver at the call site:

```ts
const fn = plugin[hook];
if (typeof fn !== 'function') return;
await fn.call(plugin, context);   // ← correct
```

But it left an **unbound method sitting in a local**. That's a shape a later reader can easily misuse — pass `fn` anywhere else and it runs with the wrong `this`, and nothing about the local warns you. Binding at extraction removes the hazard instead of working around it:

```ts
const fn = plugin[hook]?.bind(plugin);
if (typeof fn !== 'function') return;
await fn(context);
```

## A test for the behaviour, not the syntax

The existing lifecycle assertions use `jest.fn()` mocks, which are **indifferent to `this`** — they'd pass whether or not the hook is dispatched correctly. The new test registers a plugin whose `onInstall` reads `this.name`, which is how a plugin written as an object with methods actually behaves.

**Verified it fails when the bind is removed:**
```
● PluginManagerService › invokes a lifecycle hook with `this` bound to the plugin
Tests: 1 failed, 25 passed
```

## Why now

This is a **prerequisite for #1213** (dev-dependencies group, which carries the typescript-eslint bump) — without it that PR cannot go green. Worth noting the linter earned its keep here: it found a genuine footgun in code that happened to be right.

Verified: 1979 tests / 120 suites, tsc clean, and eslint clean under **both** the current typescript-eslint and 8.65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)