### PR TITLE
fix(admin-ui): migrate from react-router-dom to react-router v8

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -14,7 +14,7 @@
         "axios": "^1.18.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router-dom": "^7.18.0"
+        "react-router": "^8.3.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -2475,6 +2475,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2483,6 +2484,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4539,41 +4546,24 @@
       "peer": true
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/redent": {
@@ -4682,12 +4672,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -19,7 +19,7 @@
     "axios": "^1.18.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router-dom": "^7.18.0"
+    "react-router": "^8.3.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -46,5 +46,8 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6"
+  },
+  "engines": {
+    "node": ">=22.22.0"
   }
 }

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { Routes, Route, Navigate, Outlet } from 'react-router-dom';
+import { Routes, Route, Navigate, Outlet } from 'react-router';
 import { useEffect } from 'react';
 import ErrorBoundary from './components/ErrorBoundary';
 import Layout from './components/Layout';

--- a/admin-ui/src/components/Breadcrumbs.tsx
+++ b/admin-ui/src/components/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation, useParams } from 'react-router-dom';
+import { Link, useLocation, useParams } from 'react-router';
 import { useEffect, useState } from 'react';
 import { getAuthFlowById } from '../api/authFlows';
 

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router-dom';
+import { NavLink, Outlet, useParams, useNavigate, useLocation } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getAllRealms } from '../api/realms';
 import { useAuth } from '../hooks/useAuth';

--- a/admin-ui/src/components/__tests__/Breadcrumbs.test.tsx
+++ b/admin-ui/src/components/__tests__/Breadcrumbs.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { render } from '@testing-library/react';
 import Breadcrumbs from '../Breadcrumbs';
 

--- a/admin-ui/src/hooks/useAuth.ts
+++ b/admin-ui/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import apiClient, { setCredentials, clearCredentials } from '../api/client';
 import { useAuthContext } from '../context/AuthContext';
 

--- a/admin-ui/src/main.tsx
+++ b/admin-ui/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // Self-hosted webfonts (shipped via node_modules, no external CDN).
 import '@fontsource-variable/inter';

--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { getAllRealms } from '../api/realms';
 import { getLoginEvents, getAdminEvents, type LoginEvent, type AdminEvent } from '../api/events';
 import { getRealmStats, getHealthStatus, type RealmStats } from '../api/stats';

--- a/admin-ui/src/pages/LoginPage.tsx
+++ b/admin-ui/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type FormEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useAuth } from '../hooks/useAuth';
 import apiClient from '../api/client';
 import PasswordInput from '../components/PasswordInput';

--- a/admin-ui/src/pages/NotFoundPage.tsx
+++ b/admin-ui/src/pages/NotFoundPage.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 
 export default function NotFoundPage() {
   const navigate = useNavigate();

--- a/admin-ui/src/pages/auth-flows/AuthFlowEditorPage.tsx
+++ b/admin-ui/src/pages/auth-flows/AuthFlowEditorPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import {
   getAuthFlowById,
   updateAuthFlow,

--- a/admin-ui/src/pages/auth-flows/AuthFlowListPage.tsx
+++ b/admin-ui/src/pages/auth-flows/AuthFlowListPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { getAuthFlows, createAuthFlow, deleteAuthFlow, type AuthFlow } from '../../api/authFlows';
 import { getErrorMessage } from '../../utils/getErrorMessage';
 import ConfirmDialog from '../../components/ConfirmDialog';

--- a/admin-ui/src/pages/authorization/PolicyCreatePage.tsx
+++ b/admin-ui/src/pages/authorization/PolicyCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createPolicy } from '../../api/authorization';
 import { getErrorMessage } from '../../utils/getErrorMessage';

--- a/admin-ui/src/pages/authorization/PolicyDetailPage.tsx
+++ b/admin-ui/src/pages/authorization/PolicyDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getPolicy, updatePolicy, deletePolicy, testPolicy } from '../../api/authorization';
 import ConfirmDialog from '../../components/ConfirmDialog';

--- a/admin-ui/src/pages/authorization/PolicyListPage.tsx
+++ b/admin-ui/src/pages/authorization/PolicyListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getPolicies } from '../../api/authorization';
 import { getErrorMessage } from '../../utils/getErrorMessage';

--- a/admin-ui/src/pages/client-scopes/ClientScopeCreatePage.tsx
+++ b/admin-ui/src/pages/client-scopes/ClientScopeCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { createClientScope } from '../../api/clientScopes';

--- a/admin-ui/src/pages/client-scopes/ClientScopeDetailPage.tsx
+++ b/admin-ui/src/pages/client-scopes/ClientScopeDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getClientScopeById, updateClientScope, deleteClientScope, addMapper, deleteMapper } from '../../api/clientScopes'
 import ConfirmDialog from '../../components/ConfirmDialog'

--- a/admin-ui/src/pages/client-scopes/ClientScopeListPage.tsx
+++ b/admin-ui/src/pages/client-scopes/ClientScopeListPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import type { ClientScope } from '../../types';
 import { getClientScopes } from '../../api/clientScopes';
 

--- a/admin-ui/src/pages/clients/ClientCreatePage.tsx
+++ b/admin-ui/src/pages/clients/ClientCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '../../api/clients';
 import { getErrorMessage } from '../../utils/getErrorMessage';

--- a/admin-ui/src/pages/clients/ClientDetailPage.tsx
+++ b/admin-ui/src/pages/clients/ClientDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getClientById, updateClient, deleteClient, regenerateSecret, getServiceAccountUser } from '../../api/clients';
 import {

--- a/admin-ui/src/pages/clients/ClientListPage.tsx
+++ b/admin-ui/src/pages/clients/ClientListPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { getClients } from '../../api/clients';
 import { getErrorMessage } from '../../utils/getErrorMessage';
 

--- a/admin-ui/src/pages/consent/ConsentCategoriesListPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoriesListPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import type { ConsentCategory } from '../../types';
 import { getConsentCategories } from '../../api/consent';
 

--- a/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentCategoryDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getConsentCategoryById,

--- a/admin-ui/src/pages/consent/ConsentStatisticsPage.tsx
+++ b/admin-ui/src/pages/consent/ConsentStatisticsPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   getConsentStatistics,
   type ConsentStatistics,

--- a/admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx
+++ b/admin-ui/src/pages/continuous-verification/ContinuousRiskDashboard.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import {
   getContinuousRiskDashboard,

--- a/admin-ui/src/pages/continuous-verification/RiskPolicyListPage.tsx
+++ b/admin-ui/src/pages/continuous-verification/RiskPolicyListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import apiClient from '../../api/client';
 import ConfirmDialog from '../../components/ConfirmDialog';

--- a/admin-ui/src/pages/continuous-verification/SessionRiskDetailPage.tsx
+++ b/admin-ui/src/pages/continuous-verification/SessionRiskDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getSessionRisk,

--- a/admin-ui/src/pages/custom-attributes/CustomAttributesPage.tsx
+++ b/admin-ui/src/pages/custom-attributes/CustomAttributesPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getCustomAttributes,

--- a/admin-ui/src/pages/events/AdminEventsPage.tsx
+++ b/admin-ui/src/pages/events/AdminEventsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, Fragment } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useQuery } from '@tanstack/react-query'
 import { getAdminEvents } from '../../api/events'
 

--- a/admin-ui/src/pages/events/LoginEventsPage.tsx
+++ b/admin-ui/src/pages/events/LoginEventsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useParams } from 'react-router-dom'
+import { useParams } from 'react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { getLoginEvents, clearLoginEvents, type LoginEvent } from '../../api/events'
 import ConfirmDialog from '../../components/ConfirmDialog'

--- a/admin-ui/src/pages/groups/GroupCreatePage.tsx
+++ b/admin-ui/src/pages/groups/GroupCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { createGroup, getGroups } from '../../api/groups';
 

--- a/admin-ui/src/pages/groups/GroupDetailPage.tsx
+++ b/admin-ui/src/pages/groups/GroupDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getGroupById,

--- a/admin-ui/src/pages/groups/GroupListPage.tsx
+++ b/admin-ui/src/pages/groups/GroupListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getGroups } from '../../api/groups';
 import type { Group } from '../../types';

--- a/admin-ui/src/pages/identity-providers/IdpCreatePage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createIdentityProvider } from '../../api/identityProviders';
 import PasswordInput from '../../components/PasswordInput';

--- a/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getIdentityProvider,

--- a/admin-ui/src/pages/identity-providers/IdpListPage.tsx
+++ b/admin-ui/src/pages/identity-providers/IdpListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getIdentityProviders } from '../../api/identityProviders';
 

--- a/admin-ui/src/pages/nhi/NhiAnalyticsPage.tsx
+++ b/admin-ui/src/pages/nhi/NhiAnalyticsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getNhiIdentities, getRotationStatusSummary, queryNhiAuditLogs } from '../../api/nhi';
 import type { NhiIdentityType, NhiLifecycleStatus } from '../../types';

--- a/admin-ui/src/pages/nhi/NhiCreatePage.tsx
+++ b/admin-ui/src/pages/nhi/NhiCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createNhiIdentity } from '../../api/nhi';
 import type { NhiIdentityType } from '../../types';

--- a/admin-ui/src/pages/nhi/NhiDetailPage.tsx
+++ b/admin-ui/src/pages/nhi/NhiDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getNhiIdentityById,

--- a/admin-ui/src/pages/nhi/NhiListPage.tsx
+++ b/admin-ui/src/pages/nhi/NhiListPage.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { getNhiIdentities } from '../../api/nhi';
 import type { NhiIdentityType, NhiLifecycleStatus } from '../../types';
 

--- a/admin-ui/src/pages/organizations/OrganizationCreatePage.tsx
+++ b/admin-ui/src/pages/organizations/OrganizationCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { Link, useParams, useNavigate } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createOrganization } from '../../api/organizations';
 

--- a/admin-ui/src/pages/organizations/OrganizationDetailPage.tsx
+++ b/admin-ui/src/pages/organizations/OrganizationDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getOrganization,

--- a/admin-ui/src/pages/organizations/OrganizationListPage.tsx
+++ b/admin-ui/src/pages/organizations/OrganizationListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getOrganizations } from '../../api/organizations';
 

--- a/admin-ui/src/pages/realms/RealmCreatePage.tsx
+++ b/admin-ui/src/pages/realms/RealmCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createRealm } from '../../api/realms';
 import { getErrorMessage } from '../../utils/getErrorMessage';

--- a/admin-ui/src/pages/realms/RealmDetailPage.tsx
+++ b/admin-ui/src/pages/realms/RealmDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, type FormEvent } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getRealmByName, updateRealm, deleteRealm, exportRealm, getThemes } from '../../api/realms';
 import type { ThemeInfo } from '../../api/realms';

--- a/admin-ui/src/pages/realms/RealmListPage.tsx
+++ b/admin-ui/src/pages/realms/RealmListPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { getAllRealms, importRealm } from '../../api/realms';
 import { getErrorMessage } from '../../utils/getErrorMessage';
 

--- a/admin-ui/src/pages/registration/PendingRegistrationsPage.tsx
+++ b/admin-ui/src/pages/registration/PendingRegistrationsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getPendingRegistrations, approveRegistration, rejectRegistration } from '../../api/registration';
 import ConfirmDialog from '../../components/ConfirmDialog';

--- a/admin-ui/src/pages/registration/PublicRegistrationPage.tsx
+++ b/admin-ui/src/pages/registration/PublicRegistrationPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { Realm } from '../../types';
 import { getRealmByName } from '../../api/realms';
 import { getPublicRegistrationFields } from '../../api/registration';

--- a/admin-ui/src/pages/registration/RegistrationFieldsPage.tsx
+++ b/admin-ui/src/pages/registration/RegistrationFieldsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getRegistrationFields,

--- a/admin-ui/src/pages/registration/RegistrationSettingsPage.tsx
+++ b/admin-ui/src/pages/registration/RegistrationSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getRealmByName, updateRealm } from '../../api/realms';
 import type { Realm } from '../../types';

--- a/admin-ui/src/pages/roles/RoleListPage.tsx
+++ b/admin-ui/src/pages/roles/RoleListPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getRealmRoles, createRealmRole, deleteRealmRole } from '../../api/roles';
 import ConfirmDialog from '../../components/ConfirmDialog';

--- a/admin-ui/src/pages/saml/SamlSpCreatePage.tsx
+++ b/admin-ui/src/pages/saml/SamlSpCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createSamlSp } from '../../api/samlServiceProviders';
 

--- a/admin-ui/src/pages/saml/SamlSpDetailPage.tsx
+++ b/admin-ui/src/pages/saml/SamlSpDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getSamlSp,

--- a/admin-ui/src/pages/saml/SamlSpListPage.tsx
+++ b/admin-ui/src/pages/saml/SamlSpListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getSamlSps } from '../../api/samlServiceProviders';
 

--- a/admin-ui/src/pages/scim/ScimConfigPage.tsx
+++ b/admin-ui/src/pages/scim/ScimConfigPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getScimStatus,

--- a/admin-ui/src/pages/service-accounts/ServiceAccountCreatePage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createServiceAccount } from '../../api/serviceAccounts';
 

--- a/admin-ui/src/pages/service-accounts/ServiceAccountDetailPage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getServiceAccount,

--- a/admin-ui/src/pages/service-accounts/ServiceAccountListPage.tsx
+++ b/admin-ui/src/pages/service-accounts/ServiceAccountListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getServiceAccounts } from '../../api/serviceAccounts';
 

--- a/admin-ui/src/pages/sessions/SessionListPage.tsx
+++ b/admin-ui/src/pages/sessions/SessionListPage.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getRealmSessions, revokeSession } from '../../api/sessions';
 

--- a/admin-ui/src/pages/setup-wizard/steps/TestAuthStep.tsx
+++ b/admin-ui/src/pages/setup-wizard/steps/TestAuthStep.tsx
@@ -10,7 +10,7 @@
 
 import { useState, type FormEvent } from 'react';
 import { useMutation } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { completeWizard } from '../../../api/wizard';
 import { useWizard } from '../../../context/WizardContext';
 import { getErrorMessage } from '../../../utils/getErrorMessage';

--- a/admin-ui/src/pages/theme-builder/ThemeBuilderPage.tsx
+++ b/admin-ui/src/pages/theme-builder/ThemeBuilderPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type {
   ThemeStyles,
   ThemeComponent,

--- a/admin-ui/src/pages/upgrade/MigrationHistoryPage.tsx
+++ b/admin-ui/src/pages/upgrade/MigrationHistoryPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getUpgradeAudit, type UpgradeAuditEntry } from '../../api/upgrade';
 

--- a/admin-ui/src/pages/upgrade/StartUpgradePage.tsx
+++ b/admin-ui/src/pages/upgrade/StartUpgradePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import ConfirmDialog from '../../components/ConfirmDialog';
 import {

--- a/admin-ui/src/pages/upgrade/UpgradeStatusPage.tsx
+++ b/admin-ui/src/pages/upgrade/UpgradeStatusPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getUpgradeStatus,

--- a/admin-ui/src/pages/upgrade/__tests__/StartUpgradePage.test.tsx
+++ b/admin-ui/src/pages/upgrade/__tests__/StartUpgradePage.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router';
 import { render } from '../../../test/utils';
 import { server } from '../../../test/mocks/server';
 import StartUpgradePage from '../StartUpgradePage';

--- a/admin-ui/src/pages/user-federation/FederationCreatePage.tsx
+++ b/admin-ui/src/pages/user-federation/FederationCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFederation } from '../../api/userFederation';
 import PasswordInput from '../../components/PasswordInput';

--- a/admin-ui/src/pages/user-federation/FederationDetailPage.tsx
+++ b/admin-ui/src/pages/user-federation/FederationDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getFederation,

--- a/admin-ui/src/pages/user-federation/FederationListPage.tsx
+++ b/admin-ui/src/pages/user-federation/FederationListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getFederations } from '../../api/userFederation';
 

--- a/admin-ui/src/pages/users/UserCreatePage.tsx
+++ b/admin-ui/src/pages/users/UserCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createUser } from '../../api/users';
 import { getErrorMessage } from '../../utils/getErrorMessage';

--- a/admin-ui/src/pages/users/UserDetailPage.tsx
+++ b/admin-ui/src/pages/users/UserDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getUserById, updateUser, deleteUser, resetPassword, getMfaStatus, resetMfa, getOfflineSessions, revokeOfflineSession, impersonateUser, type ImpersonationResult } from '../../api/users';
 import {

--- a/admin-ui/src/pages/users/UserListPage.tsx
+++ b/admin-ui/src/pages/users/UserListPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { getUsers } from '../../api/users';
 import { getErrorMessage } from '../../utils/getErrorMessage';
 

--- a/admin-ui/src/pages/webhooks/WebhookCreatePage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createWebhook } from '../../api/webhooks';
 import PasswordInput from '../../components/PasswordInput';

--- a/admin-ui/src/pages/webhooks/WebhookDetailPage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   getWebhook,

--- a/admin-ui/src/pages/webhooks/WebhookListPage.tsx
+++ b/admin-ui/src/pages/webhooks/WebhookListPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 import { getWebhooks } from '../../api/webhooks';
 

--- a/admin-ui/src/test/utils.tsx
+++ b/admin-ui/src/test/utils.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '../context/AuthContext';
 

--- a/admin-ui/vite.config.ts
+++ b/admin-ui/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
         // framework deps in a single `vendor` chunk for stable cache headers.
         manualChunks(id) {
           if (
-            /[\\/]node_modules[\\/](react|react-dom|react-router-dom|@tanstack[\\/]react-query)[\\/]/.test(
+            /[\\/]node_modules[\\/](react|react-dom|react-router|@tanstack[\\/]react-query)[\\/]/.test(
               id,
             )
           ) {


### PR DESCRIPTION
The open advisory is patched in **react-router 8.3.0**, and admin-ui was pinned to 7.18.1 through `react-router-dom`.

## Why this is a package swap, not a version bump

There is **no `react-router-dom` v8** — v8 removes the package outright. In v7 everything DOM-specific had already collapsed into `react-router/dom`, and `react-router-dom` survived only as a compatibility shim so v6-era imports kept working. v8 drops the shim.

So the upgrade *is* the swap: `react-router-dom@^7.18.0` → `react-router@^8.3.0`, and the import specifier rewritten in **74 files**.

## Nothing else changed

Every import was already a named brace import — no default or namespace imports anywhere. All eleven imported symbols live in `react-router` in v8:

`useParams` (59) · `useNavigate` (45) · `Link` (19) · `Routes` (4) · `Route` (4) · `useLocation` (3) · `Outlet` (2) · `MemoryRouter` (2) · `Navigate` · `NavLink` · `BrowserRouter`

Diff check: **76 lines removed** mentioning `react-router-dom`, **0 added**.

## Breaking changes, checked against the changelog

| v8 change | applies here? |
|---|---|
| `RouterProvider`/`HydratedRouter` must come from `react-router/dom` | **No** — declarative mode only; no `RouterProvider`, `HydratedRouter`, or `createBrowserRouter` anywhere |
| Trailing-slash-aware data requests now default | No — Data Mode |
| Middleware always enabled, `context` is `RouterContextProvider` | No — Data Mode |
| `meta` `data` → `loaderData` rename | No — Data Mode |
| Internal `hasErrorBoundary` removed | No — Data Mode |
| Packages now ESM-only | Fine — Vite and vitest are ESM-native |
| React >= 19.2.7 | ✅ already `^19.2.8` |
| Node >= 22.22.0 | ✅ CI pins `node-version: 22` → latest 22.x |

## Also

`vite.config.ts`'s `manualChunks` matcher named `react-router-dom` explicitly. Left alone it would have **silently dropped the router out of the vendor chunk** — no error, just worse caching. Updated.

The Node floor was implicit either way, so it's now declared in `engines` rather than left for whoever first runs an older 22.x locally.

## Verification

- `tsc --noEmit` — clean
- `npm run build` — clean
- `npm test` — **353 pass**, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)