### PR TITLE
fix(packages): repair the three broken SDK packages and cover them in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       # vue, angular and nextjs consume idenplane-js through `file:../idenplane-js`,
       # and its dist/ is gitignored — so on a fresh checkout `idenplane-sdk` has no
       # type declarations to resolve and all three fail to typecheck. Build it first.
-      - name: Build idenplane-js (local file: dependency)
+      - name: Build the local idenplane-js dependency
         if: matrix.package != 'idenplane-js' && matrix.package != 'idenplane-mcp'
         working-directory: packages/idenplane-js
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,59 @@ jobs:
           path: admin-ui/coverage/
           retention-days: 14
 
+  sdk-packages:
+    # Nothing built or tested these until now, so breakage sat unnoticed:
+    # idenplane-angular had not compiled since Angular went ESM-only, and a
+    # vue guard test asserted behaviour the guard had deliberately stopped
+    # having. One job per package so a red square names the culprit.
+    name: SDK — ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - idenplane-js
+          - idenplane-vue
+          - idenplane-angular
+          - idenplane-nextjs
+          - idenplane-mcp
+    defaults:
+      run:
+        working-directory: packages/${{ matrix.package }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: packages/${{ matrix.package }}/package-lock.json
+
+      # vue, angular and nextjs consume idenplane-js through `file:../idenplane-js`,
+      # and its dist/ is gitignored — so on a fresh checkout `idenplane-sdk` has no
+      # type declarations to resolve and all three fail to typecheck. Build it first.
+      - name: Build idenplane-js (local file: dependency)
+        if: matrix.package != 'idenplane-js' && matrix.package != 'idenplane-mcp'
+        working-directory: packages/idenplane-js
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      # idenplane-mcp splits its suites: `test` is the integration suite, which
+      # skips itself without a live Idenplane instance, and `test:all` adds the
+      # smoke test. The other four expose a single `test`.
+      - name: Test
+        run: npm run ${{ matrix.package == 'idenplane-mcp' && 'test:all' || 'test' }}
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/packages/idenplane-angular/package.json
+++ b/packages/idenplane-angular/package.json
@@ -2,12 +2,12 @@
   "name": "idenplane-angular",
   "version": "1.0.1",
   "description": "Angular SDK for Idenplane Identity and Access Management Server",
-  "type": "commonjs",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "require": {
+      "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
@@ -57,5 +57,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "module": "./dist/index.js"
 }

--- a/packages/idenplane-angular/tsconfig.json
+++ b/packages/idenplane-angular/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "declaration": true,

--- a/packages/idenplane-mcp/tests/integration.mjs
+++ b/packages/idenplane-mcp/tests/integration.mjs
@@ -28,6 +28,25 @@ const TEST_REALM = `mcp-test-${Date.now()}`;
 
 let mcpClient;
 
+/**
+ * These tests drive the MCP server against a real Idenplane instance, so they
+ * are only meaningful when one is running. Probe for it up front and skip the
+ * suite when it is absent — otherwise every run without a server reports five
+ * failures that say nothing about the code, which is exactly what kept this
+ * package out of CI.
+ */
+async function skipReason() {
+  try {
+    const res = await fetch(`${IDENPLANE_URL}/health`, {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (res.ok) return false;
+    return `Idenplane at ${IDENPLANE_URL} answered /health with ${res.status}`;
+  } catch {
+    return `no Idenplane instance reachable at ${IDENPLANE_URL} — start one with \`docker compose up db -d && npm run start:dev\` from the repo root`;
+  }
+}
+
 /** Call a tool and return the first text content string. */
 async function callTool(name, args) {
   const result = await mcpClient.callTool({ name, arguments: args ?? {} });
@@ -37,7 +56,7 @@ async function callTool(name, args) {
   return JSON.parse(text);
 }
 
-describe('Idenplane MCP integration (over protocol)', () => {
+describe('Idenplane MCP integration (over protocol)', { skip: await skipReason() }, () => {
   before(async () => {
     const transport = new StdioClientTransport({
       command: 'node',

--- a/packages/idenplane-nextjs/package-lock.json
+++ b/packages/idenplane-nextjs/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
+        "@types/node": "^22.10.7",
         "@types/react": "^19.0.0",
         "idenplane-sdk": "file:../idenplane-js",
         "next": "^15.0.0",
@@ -2028,6 +2029,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -3452,6 +3463,13 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/idenplane-nextjs/package.json
+++ b/packages/idenplane-nextjs/package.json
@@ -69,6 +69,7 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@types/node": "^22.10.7",
     "@types/react": "^19.0.0",
     "idenplane-sdk": "file:../idenplane-js",
     "next": "^15.0.0",

--- a/packages/idenplane-vue/src/__tests__/guard.test.ts
+++ b/packages/idenplane-vue/src/__tests__/guard.test.ts
@@ -120,7 +120,7 @@ describe('createAuthGuard', () => {
     expect(client.init).toHaveBeenCalled();
   });
 
-  it('warns and fails-open when no client is available', async () => {
+  it('warns and fails closed when no client is available', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const guard = createAuthGuard(); // no client override, no inject context
 
@@ -128,7 +128,14 @@ describe('createAuthGuard', () => {
     const from = makeRoute({ path: '/' });
     const result = await guard(to, from, vi.fn() as never);
 
-    expect(result).toBe(true); // fail-open
+    // No client means identity cannot be verified. Letting navigation through
+    // would hand out a protected route to an unauthenticated visitor, so the
+    // guard redirects instead — and carries `next` so the user lands back on
+    // the route they asked for once they have signed in.
+    expect(result).toEqual({
+      path: '/login',
+      query: { next: '/dashboard' },
+    });
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
   });


### PR DESCRIPTION
No CI job ever built or tested `packages/*`, so three failures had been sitting there unnoticed. Fixing them is most of this change; the job that stops it recurring is the rest.

## `idenplane-angular` — had not compiled since Angular went ESM-only

The package was configured as CommonJS with `moduleResolution: "node"`, so tsc couldn't resolve `@angular/common/http` at all. Switching resolution to `Node16` only surfaced the real cause:

```
TS1479: The current file is a CommonJS module whose imports will produce
'require' calls; however, the referenced file is an ECMAScript module
```

Converted to ESM — `type: module`, an import-only `exports` condition, `module: ESNext` and `moduleResolution: bundler` to match the three sibling SDKs.

**It keeps building with `tsc` rather than moving to the siblings' tsup setup, and that difference is deliberate.** `auth.interceptor.ts` and `auth.guard.ts` use Angular constructor injection with implicit parameter types:

```ts
constructor(private readonly auth: AuthService) {}
```

That needs `emitDecoratorMetadata`. **esbuild — which tsup builds on — does not implement it**, so the code would compile and then fail to resolve its dependencies at runtime. Verified the emitted files still carry `design:paramtypes`.

## `idenplane-vue` — a test asserting behaviour the guard deliberately stopped having

The guard redirects to the login route when no client is available, with an explicit comment:

```ts
// Fail closed: no client means we cannot verify identity, so block
// navigation and redirect to the login route.
```

The test still asserted `toBe(true) // fail-open`. **Fail-open in an auth guard hands a protected route to an unauthenticated visitor**, so the implementation is right and the test was the stale side. It now asserts the redirect — and confirmed it fails if the guard is reverted to fail-open.

## `idenplane-mcp` — integration suite failing instead of skipping

`npm test` ran the integration suite, which needs a live Idenplane instance — so it reported **five failures on every machine that didn't have one**. It now probes `/health` first and skips with a message naming the command that starts a server.

Confirmed the skip is **conditional, not permanent**: pointed `IDENPLANE_URL` at a stub that answers `/health` and the five tests ran.

## The CI job

`sdk-packages` builds, typechecks and tests all five — one matrix entry each, `fail-fast: false`, so a red square names the package.

One non-obvious step: vue, angular and nextjs consume `idenplane-js` via `file:../idenplane-js`, and **its `dist/` is gitignored**. Without building it first, all three fail to resolve `idenplane-sdk`'s types on a fresh checkout. Verified by deleting `dist/` locally — all three went red immediately.

## Verification

All **fifteen** build/typecheck/test steps pass locally:

| package | build | typecheck | test |
|---|---|---|---|
| `idenplane-js` | ✅ | ✅ | ✅ |
| `idenplane-vue` | ✅ | ✅ | ✅ 19 |
| `idenplane-angular` | ✅ | ✅ | ✅ 11 |
| `idenplane-nextjs` | ✅ | ✅ | ✅ 15 |
| `idenplane-mcp` | ✅ | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)