### PR TITLE
ci: cover the docs site and the Go SDK, and stop double-running admin-ui tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,30 @@ jobs:
       - name: Test
         run: npm run ${{ matrix.package == 'idenplane-mcp' && 'test:all' || 'test' }}
 
+  docs-build:
+    # The docs site had been failing to build and nothing noticed, because no
+    # job ever built it. Its dependency tree is separate from the root one, so
+    # a bad resolution there is invisible to every other job here.
+    name: Docs Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install docs dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run build
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,9 @@ jobs:
       - name: Install admin-ui dependencies
         run: npm ci
 
-      - name: Run admin-ui tests
-        run: npm test
-
+      # `test` is `vitest run` and `test:coverage` is the same run with
+      # --coverage, so running both executed every test twice for no extra
+      # signal. Only the coverage variant is kept.
       - name: Run admin-ui tests with coverage
         run: npm run test:coverage
 
@@ -191,6 +191,32 @@ jobs:
       # smoke test. The other four expose a single `test`.
       - name: Test
         run: npm run ${{ matrix.package == 'idenplane-mcp' && 'test:all' || 'test' }}
+
+  go-sdk:
+    # 35 tests in packages/idenplane-go had never run — no job in this
+    # workflow touched Go at all. The module declares no external
+    # dependencies, so there is no go.sum to restore and nothing to cache.
+    name: Go SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/idenplane-go
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: '1.24'
+          cache: false
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
 
   docs-build:
     # The docs site had been failing to build and nothing noticed, because no


### PR DESCRIPTION
Three gaps in CI coverage, all the same shape: code that ships but that nothing builds or tests.

## Docs build

The docs site had been failing to build and **nothing noticed**, because no job ever built it. Its dependency tree is entirely separate from the root one, so a bad resolution there stays invisible to every other job here — which is how an unbounded `@babel/core` override pulled in Babel 8 and broke the build without a single red square.

Verified the job would have caught it: forcing `@babel/core` to `^8` makes `npm run build` in `docs/` exit non-zero.

> Noted for later: `onBrokenLinks` and `onBrokenMarkdownLinks` are both `'warn'` and the site currently has broken links. Turning either to `'throw'` would fail this job immediately, so that's a separate change once the existing links are fixed.

## Go SDK

**No job in this workflow touched Go at all**, so the **35 tests** in `packages/idenplane-go` had never run. Adds a job that builds, vets and tests it.

The module declares no external dependencies, so there's no `go.sum` to restore — caching is explicitly disabled rather than left to look for one. *(The absence of `go.sum` there is correct, not an oversight — a Go module with no external requires legitimately has none.)*

⚠️ Go isn't installed on the machine this was written on, so **this job is the first thing to actually exercise that code**. If it turns up failures they're pre-existing, exactly like the three the SDK matrix surfaced last time.

## admin-ui ran its tests twice

```yaml
- run: npm test              # vitest run
- run: npm run test:coverage # vitest run --coverage
```

Verified both execute an identical **34 files / 353 tests** — so every test ran twice for no extra signal. Only the coverage variant is kept.

## Still uncovered, deliberately

`providers/pulumi-provider-idenplane/provider` requires `github.com/idenplane/terraform-provider-idenplane v0.0.0` with **no `replace` directive**, so it can't resolve and has no `go.sum`. Nothing references it. That's a separate call about whether it should exist at all, not something to paper over with a CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)