### PR TITLE
docs: point internal links at the paths the pages actually have

### DIFF
--- a/docs/docs/configuration/environment-variables.md
+++ b/docs/docs/configuration/environment-variables.md
@@ -321,13 +321,13 @@ openssl rand -hex 16
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Configuration Guide**](/docs/getting-started/configuration)
+[**Configuration Guide**](/getting-started/configuration)
 Configure Idenplane for your environment
 
-[**Installation**](/docs/getting-started/installation)
+[**Installation**](/getting-started/installation)
 Detailed installation instructions
 
-[**Deployment**](/docs/deployment/docker)
+[**Deployment**](/deployment/docker)
 Deploy to production with Docker
 
 </div>

--- a/docs/docs/configuration/options.md
+++ b/docs/docs/configuration/options.md
@@ -877,13 +877,13 @@ await client.realms.update('my-realm', {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Environment Variables**](/docs/configuration/environment-variables)
+[**Environment Variables**](/configuration/environment-variables)
 Environment-based configuration reference
 
-[**Admin API**](/docs/api/realms)
+[**Admin API**](/api/realms)
 Manage realms programmatically
 
-[**Deployment**](/docs/deployment/docker)
+[**Deployment**](/deployment/docker)
 Deploy with Docker Compose
 
 </div>

--- a/docs/docs/deployment/bare-metal.mdx
+++ b/docs/docs/deployment/bare-metal.mdx
@@ -679,16 +679,16 @@ sudo systemctl start fail2ban
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Environment Variables**](/docs/configuration/environment-variables)
+[**Environment Variables**](/configuration/environment-variables)
 Complete list of all configuration options
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Detailed configuration guide
 
-[**Docker Compose**](/docs/deployment/docker)
+[**Docker Compose**](/deployment/docker)
 Deploy using Docker Compose
 
-[**Kubernetes**](/docs/deployment/kubernetes)
+[**Kubernetes**](/deployment/kubernetes)
 Deploy on Kubernetes
 
 </div>

--- a/docs/docs/deployment/docker.mdx
+++ b/docs/docs/deployment/docker.mdx
@@ -419,13 +419,13 @@ docker compose up -d
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Kubernetes**](/docs/deployment/kubernetes)
+[**Kubernetes**](/deployment/kubernetes)
 Deploy Idenplane on Kubernetes with Helm charts
 
-[**Environment Variables**](/docs/configuration/environment-variables)
+[**Environment Variables**](/configuration/environment-variables)
 Complete list of all configuration options
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Detailed configuration guide
 
 </div>

--- a/docs/docs/deployment/kubernetes.mdx
+++ b/docs/docs/deployment/kubernetes.mdx
@@ -532,13 +532,13 @@ kubectl port-forward -n idenplane svc/idenplane 3000:3000
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Environment Variables**](/docs/configuration/environment-variables)
+[**Environment Variables**](/configuration/environment-variables)
 Complete list of all configuration options
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Detailed configuration guide
 
-[**Docker Compose**](/docs/deployment/docker)
+[**Docker Compose**](/deployment/docker)
 Deploy using Docker Compose
 
 </div>

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -251,13 +251,13 @@ Most settings can also be configured through the Admin Console at `/console`:
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Deployment**](/docs/deployment/docker)
+[**Deployment**](/deployment/docker)
 Deploy Idenplane to production with Docker
 
-[**First Application**](/docs/guides/first-app)
+[**First Application**](/guides/first-app)
 Register your first OAuth client
 
-[**SDK Guides**](/docs/guides/sdks/react)
+[**SDK Guides**](/guides/sdks/react-sdk)
 Integrate Idenplane with your application
 
 </div>

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -275,13 +275,13 @@ After starting Idenplane, verify the installation:
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options and environment variables
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Get started with Idenplane authentication in your first application
 
-[**Admin Console**](/docs/getting-started/admin-console)
+[**Admin Console**](/getting-started/admin-console)
 Configure realms, users, and clients
 
 </div>

--- a/docs/docs/guides/authentication.mdx
+++ b/docs/docs/guides/authentication.mdx
@@ -895,16 +895,16 @@ function parseCallback(): { code?: string; error?: string; state?: string } {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Authorization Guide**](/docs/guides/authorization)
+[**Authorization Guide**](/guides/authorization)
 Learn about RBAC, permissions, and access control policies
 
-[**MFA Setup**](/docs/guides/mfa)
+[**MFA Setup**](/guides/mfa)
 Configure multi-factor authentication for your users
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation with examples
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 Integrate Idenplane into your React application
 
 </div>

--- a/docs/docs/guides/authorization.mdx
+++ b/docs/docs/guides/authorization.mdx
@@ -794,16 +794,16 @@ Always set DENY policies with higher priority than ALLOW policies to ensure expl
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Authentication Guide**](/docs/guides/authentication)
+[**Authentication Guide**](/guides/authentication)
 Learn about OAuth 2.0 and OpenID Connect flows
 
-[**MFA Setup**](/docs/guides/mfa)
+[**MFA Setup**](/guides/mfa)
 Configure multi-factor authentication
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 Integrate Idenplane into your React application
 
 </div>

--- a/docs/docs/guides/mfa.mdx
+++ b/docs/docs/guides/mfa.mdx
@@ -575,16 +575,16 @@ async function checkMfaActivity(accessToken: string) {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Authentication Guide**](/docs/guides/authentication)
+[**Authentication Guide**](/guides/authentication)
 Learn about OAuth 2.0 and OIDC authentication flows
 
-[**Authorization Guide**](/docs/guides/authorization)
+[**Authorization Guide**](/guides/authorization)
 Understand RBAC and access control policies
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation with examples
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 Integrate Idenplane into your React application
 
 </div>

--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -380,16 +380,16 @@ class AuthViewModel(private val authMe: IdenplaneClient) : ViewModel() {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Set up Idenplane and create your first authenticated app
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
-[**JavaScript SDK**](/docs/guides/sdks/vanilla)
+[**JavaScript SDK**](/guides/sdks/vanilla)
 Core SDK for non-React applications
 
 </div>

--- a/docs/docs/guides/sdks/angular.mdx
+++ b/docs/docs/guides/sdks/angular.mdx
@@ -507,16 +507,16 @@ constructor(public auth: AuthService) {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Set up Idenplane and create your first authenticated app
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
-[**JavaScript SDK**](/docs/guides/sdks/vanilla)
+[**JavaScript SDK**](/guides/sdks/vanilla)
 Core SDK for non-framework applications
 
 </div>

--- a/docs/docs/guides/sdks/ios.mdx
+++ b/docs/docs/guides/sdks/ios.mdx
@@ -319,16 +319,16 @@ struct ContentView: View {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Set up Idenplane and create your first authenticated app
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
-[**Android SDK**](/docs/guides/sdks/android)
+[**Android SDK**](/guides/sdks/android-sdk)
 Idenplane SDK for Android with Kotlin
 
 </div>

--- a/docs/docs/guides/sdks/nextjs.mdx
+++ b/docs/docs/guides/sdks/nextjs.mdx
@@ -703,16 +703,16 @@ import { useAuth, useUser, usePermissions } from '@idenplane/nextjs';
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Set up Idenplane and create your first authenticated Next.js app
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 React-specific hooks and components
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
 </div>

--- a/docs/docs/guides/sdks/react.mdx
+++ b/docs/docs/guides/sdks/react.mdx
@@ -589,16 +589,16 @@ function MyComponent() {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Set up Idenplane and create your first authenticated app
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
-[**JavaScript SDK**](/docs/guides/sdks/vanilla)
+[**JavaScript SDK**](/guides/sdks/vanilla)
 Core SDK for non-React applications
 
 </div>

--- a/docs/docs/guides/sdks/vue.mdx
+++ b/docs/docs/guides/sdks/vue.mdx
@@ -668,16 +668,16 @@ function MyComponent() {
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Set up Idenplane and create your first authenticated Vue app
 
-[**Configuration**](/docs/getting-started/configuration)
+[**Configuration**](/getting-started/configuration)
 Learn about all configuration options
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 React-specific hooks and components
 
 </div>

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -170,16 +170,16 @@ Idenplane is ideal when you need:
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Quickstart**](/docs/quickstart)
+[**Quickstart**](/quickstart)
 Get up and running in 30 seconds with Docker
 
-[**Installation**](/docs/getting-started/installation)
+[**Installation**](/getting-started/installation)
 Detailed installation instructions for all platforms
 
-[**SDK Guides**](/docs/guides/sdks/react)
+[**SDK Guides**](/guides/sdks/react-sdk)
 Integrate Idenplane with your application
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation
 
 </div>

--- a/docs/docs/migration/auth0.mdx
+++ b/docs/docs/migration/auth0.mdx
@@ -15,7 +15,7 @@ This guide covers migrating users, clients, roles, and connections from Auth0 to
 
 Before starting the migration:
 
-- [Idenplane installed](/docs/getting-started/installation) and running
+- [Idenplane installed](/getting-started/installation) and running
 - Admin API key configured
 - Auth0 Management API export file
 - Sufficient database storage for migrated data
@@ -325,7 +325,7 @@ Auth0 role permissions are **not** migrated. These need to be recreated using Id
 }
 ```
 
-See [Authorization Guide](/docs/guides/authorization) for policy creation.
+See [Authorization Guide](/guides/authorization) for policy creation.
 
 ---
 
@@ -379,7 +379,7 @@ Auth0 Organizations are **not** automatically migrated:
 }
 ```
 
-Recreate organizations manually in Idenplane. See [Multi-Tenancy Documentation](/docs/guides/authorization) for organization setup.
+Recreate organizations manually in Idenplane. See [Multi-Tenancy Documentation](/guides/authorization) for organization setup.
 
 ---
 
@@ -611,16 +611,16 @@ Import data from Auth0 Management API export.
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Authentication Guide**](/docs/guides/authentication)
+[**Authentication Guide**](/guides/authentication)
 Learn about OAuth 2.0 and OIDC authentication flows
 
-[**Authorization Guide**](/docs/guides/authorization)
+[**Authorization Guide**](/guides/authorization)
 Understand RBAC and access control policies
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation with examples
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 Integrate Idenplane into your React application
 
 </div>

--- a/docs/docs/migration/keycloak.mdx
+++ b/docs/docs/migration/keycloak.mdx
@@ -15,7 +15,7 @@ This guide covers migrating users, clients, and realm configuration from Keycloa
 
 Before starting the migration:
 
-- [Idenplane installed](/docs/getting-started/installation) and running
+- [Idenplane installed](/getting-started/installation) and running
 - Admin API key configured
 - Keycloak realm export JSON file
 - Sufficient database storage for migrated data
@@ -418,7 +418,7 @@ Update applications to use Idenplane endpoints:
 
 ### 4. Migrate Identity Providers
 
-Social and enterprise identity providers require manual reconfiguration. See [Identity Provider Configuration](/docs/guides/authentication#identity-providers) for supported providers.
+Social and enterprise identity providers require manual reconfiguration. See [Identity Provider Configuration](/guides/authentication#identity-providers) for supported providers.
 
 ### 5. Notify Users
 
@@ -495,16 +495,16 @@ Import realm from Keycloak export.
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Authentication Guide**](/docs/guides/authentication)
+[**Authentication Guide**](/guides/authentication)
 Learn about OAuth 2.0 and OIDC authentication flows
 
-[**Authorization Guide**](/docs/guides/authorization)
+[**Authorization Guide**](/guides/authorization)
 Understand RBAC and access control policies
 
-[**API Reference**](/docs/api)
+[**API Reference**](/api)
 Complete REST API documentation with examples
 
-[**React SDK**](/docs/guides/sdks/react)
+[**React SDK**](/guides/sdks/react-sdk)
 Integrate Idenplane into your React application
 
 </div>

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -48,13 +48,13 @@ After starting Idenplane, you can access the Admin Console with these default cr
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
 
-[**Installation Guide**](/docs/getting-started/installation)
+[**Installation Guide**](/getting-started/installation)
 Detailed installation instructions for Docker, Kubernetes, and bare metal
 
-[**Admin Console**](/docs/getting-started/admin-console)
+[**Admin Console**](/getting-started/admin-console)
 Learn how to configure realms, users, and clients
 
-[**First Application**](/docs/guides/first-app)
+[**First Application**](/guides/first-app)
 Register your first OAuth client and integrate with your app
 
 </div>


### PR DESCRIPTION
## One mistake, repeated 78 times

Every internal link was written with a `/docs/` prefix — but the site serves docs at the **root**:

```ts
baseUrl: '/',
routeBasePath: '/',
```

So `/docs/quickstart` was never a page. `/quickstart` is. 78 links across 20 files.

Two SDK guides had a second problem on top: `android.mdx` and `react.mdx` declare `id: android-sdk` / `id: react-sdk`, so their URLs carry an `-sdk` suffix that ten links didn't have.

## Result

| | before | after |
|---|---|---|
| broken link **instances** | 72 | **8** |
| broken link **targets** | 17 | **4** |

## Safety

- **Every changed line is a link path** — verified: zero non-link lines in the diff
- The two external URLs containing `/docs/` are **untouched** — `https://www.postgresql.org/docs/latest/installation.html` and an `error_uri` in a JSON sample. The replacement matched `](/docs/`; those begin `](h`.

## What's left — and why it isn't in this PR

The four remaining are **not path errors**. They point at content that was never written:

- `/getting-started/admin-console`
- `/guides/first-app`
- `/guides/sdks/vanilla`
- `/guides/authentication#identity-providers` — the page exists, the section doesn't

These are gaps in the docs rather than typos: **a reader following the getting-started flow reaches a dead end.** They need pages written or links dropped — a content decision, not a mechanical one.

`onBrokenLinks` stays `'warn'` until they're resolved; flipping it to `'throw'` now would fail the docs build job on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)