### PR TITLE
docs: document the core SDK, retarget dead links, and fail the build on new ones

### DIFF
--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -254,8 +254,8 @@ Most settings can also be configured through the Admin Console at `/console`:
 [**Deployment**](/deployment/docker)
 Deploy Idenplane to production with Docker
 
-[**First Application**](/guides/first-app)
-Register your first OAuth client
+[**Authentication**](/guides/authentication)
+OAuth 2.0 flows and how clients authenticate
 
 [**SDK Guides**](/guides/sdks/react-sdk)
 Integrate Idenplane with your application

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -281,8 +281,8 @@ Learn about all configuration options and environment variables
 [**Quickstart**](/quickstart)
 Get started with Idenplane authentication in your first application
 
-[**Admin Console**](/getting-started/admin-console)
-Configure realms, users, and clients
+[**API Reference**](/api)
+Manage realms, users, and clients over the REST API
 
 </div>
 

--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -389,7 +389,7 @@ Learn about all configuration options
 [**API Reference**](/api)
 Complete REST API documentation
 
-[**JavaScript SDK**](/guides/sdks/vanilla)
+[**JavaScript SDK**](/guides/sdks/javascript-sdk)
 Core SDK for non-React applications
 
 </div>

--- a/docs/docs/guides/sdks/angular.mdx
+++ b/docs/docs/guides/sdks/angular.mdx
@@ -516,7 +516,7 @@ Learn about all configuration options
 [**API Reference**](/api)
 Complete REST API documentation
 
-[**JavaScript SDK**](/guides/sdks/vanilla)
+[**JavaScript SDK**](/guides/sdks/javascript-sdk)
 Core SDK for non-framework applications
 
 </div>

--- a/docs/docs/guides/sdks/javascript.mdx
+++ b/docs/docs/guides/sdks/javascript.mdx
@@ -1,0 +1,264 @@
+---
+id: javascript-sdk
+title: JavaScript SDK
+description: Integrate Idenplane authentication into any JavaScript or TypeScript application using the core browser SDK
+---
+
+# JavaScript SDK
+
+`idenplane-sdk` is the core browser SDK. Every framework package — React, Next.js, Angular, Vue — wraps this one, so anything documented here is available through them too. Use it directly in plain JavaScript or TypeScript applications, or in any framework without a dedicated Idenplane package.
+
+It implements the OAuth 2.0 Authorization Code flow with PKCE against a public client, and handles token storage, refresh, and role checks for you.
+
+## Installation
+
+```bash
+npm install idenplane-sdk
+```
+
+---
+
+## Quick Start
+
+### 1. Create a client
+
+```typescript
+import { IdenplaneClient } from 'idenplane-sdk';
+
+const client = new IdenplaneClient({
+  url: 'http://localhost:3000',
+  realm: 'my-realm',
+  clientId: 'my-app',
+  redirectUri: `${window.location.origin}/callback`,
+});
+```
+
+The `clientId` must be registered in Idenplane as a **public** client, and `redirectUri` must be one of its allowed redirect URIs.
+
+### 2. Initialise on page load
+
+`init()` restores an existing session if there is one, and returns whether the user ended up authenticated.
+
+```typescript
+const isAuthenticated = await client.init();
+
+if (isAuthenticated) {
+  const user = client.getUserInfo();
+  console.log(`Signed in as ${user?.preferred_username}`);
+} else {
+  await client.login();
+}
+```
+
+### 3. Handle the callback
+
+On the page you registered as `redirectUri`:
+
+```typescript
+import { IdenplaneClient } from 'idenplane-sdk';
+
+const client = new IdenplaneClient({ /* same config */ });
+
+const success = await client.handleCallback();
+if (success) {
+  window.location.replace('/');
+}
+```
+
+---
+
+## Configuration
+
+`IdenplaneConfig` is passed to the constructor.
+
+### Required
+
+| Option | Type | Description |
+|---|---|---|
+| `url` | `string` | Base URL of the Idenplane server, e.g. `http://localhost:3000` |
+| `realm` | `string` | Realm to authenticate against |
+| `clientId` | `string` | OAuth 2.0 client ID — must be registered as a **public** client |
+| `redirectUri` | `string` | URL to return to after login |
+
+### Optional
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `scopes` | `string[]` | `['openid', 'profile', 'email']` | Scopes to request |
+| `storage` | `'memory' \| 'sessionStorage' \| 'localStorage'` | `'memory'` | Where tokens are kept |
+| `autoRefresh` | `boolean` | `true` | Refresh tokens before they expire |
+| `refreshBuffer` | `number` | `30` | Seconds before expiry to trigger a refresh |
+| `refreshStrategy` | `'rotation' \| 'silent' \| 'eager'` | `'rotation'` | How refreshes are performed |
+| `silentRedirectUri` | `string` | falls back to `redirectUri` | Redirect target for the silent-refresh iframe |
+| `postLogoutRedirectUri` | `string` | — | Where to send the browser after logout |
+
+### Choosing a storage type
+
+`memory` is the default because it is the safest: tokens never leave the JavaScript heap, so nothing survives a reload or is readable by other scripts. The cost is that every page load starts a fresh silent re-authentication.
+
+`sessionStorage` persists tokens for the life of the tab, and `localStorage` across tabs and restarts. Both put tokens somewhere any script on the origin can read them, so they trade XSS resistance for convenience — prefer them only when a full re-authentication on every load is genuinely not workable.
+
+### Refresh strategies
+
+- **`rotation`** — exchanges the refresh token for a new access token. The standard choice.
+- **`silent`** — re-authenticates through a hidden iframe. Use when the server does not issue refresh tokens to public clients. Requires `silentRedirectUri` to point at a page that calls `handleSilentCallback()`.
+- **`eager`** — rotation, but checks earlier than `refreshBuffer` so a slow network cannot leave a request holding an expired token.
+
+---
+
+## Silent refresh
+
+If you use `refreshStrategy: 'silent'`, serve a minimal page at `silentRedirectUri` that does nothing but complete the handshake:
+
+```typescript
+// /silent-callback.html
+import { handleSilentCallback } from 'idenplane-sdk';
+
+handleSilentCallback();
+```
+
+`handleSilentCallback()` returns immediately when the page is not inside an iframe, so it is safe to ship on a route that might also be opened directly.
+
+---
+
+## Authentication
+
+### `init()`
+
+```typescript
+const isAuthenticated: boolean = await client.init();
+```
+
+Discovers the realm's OpenID configuration, restores any stored session, and starts the refresh timer. Call it once, before anything else.
+
+### `login(options?)`
+
+```typescript
+await client.login();
+
+// request extra scopes, or round-trip your own state
+await client.login({ scope: ['openid', 'profile', 'offline_access'] });
+await client.login({ state: '/dashboard' });
+```
+
+Redirects the browser to the authorization endpoint. Nothing after this call runs.
+
+### `handleCallback(url?)`
+
+```typescript
+const success: boolean = await client.handleCallback();
+```
+
+Exchanges the authorization code for tokens. Defaults to reading the current URL; pass one explicitly if your router has already consumed it.
+
+### `logout()`
+
+```typescript
+await client.logout();
+```
+
+Clears stored tokens and redirects to the realm's end-session endpoint.
+
+---
+
+## Tokens
+
+```typescript
+client.getAccessToken();      // string | null
+client.getTokenClaims();      // TokenClaims | null — decoded access token
+client.getIdTokenClaims();    // TokenClaims | null — decoded ID token
+client.isAuthenticated();     // boolean
+await client.refreshTokens(); // TokenResponse — force a refresh now
+```
+
+Standalone helpers are exported for working with tokens you hold yourself:
+
+```typescript
+import { parseJwt, isTokenExpired, getTokenExpiresIn } from 'idenplane-sdk';
+
+const claims = parseJwt(someToken);
+const expired = isTokenExpired(someToken);
+const seconds = getTokenExpiresIn(someToken);
+```
+
+:::note
+`parseJwt` decodes a token; it does not verify its signature. Treat anything it returns as untrusted input — signature verification belongs on the server.
+:::
+
+---
+
+## User info
+
+```typescript
+await client.fetchUserInfo(); // UserInfo | null — calls the userinfo endpoint
+client.getUserInfo();         // UserInfo | null — cached, no network call
+```
+
+---
+
+## Roles and permissions
+
+```typescript
+client.hasRealmRole('admin');                  // boolean
+client.hasClientRole('my-app', 'editor');      // boolean
+client.getRealmRoles();                        // string[]
+client.getClientRoles('my-app');               // string[]
+client.hasPermission('users:read');            // boolean
+```
+
+:::warning
+These read the claims in the token the browser holds, so they are only suitable for deciding what to show. Every protected operation must be authorised again on the server — a token's claims are visible and editable by anyone who can open developer tools.
+:::
+
+---
+
+## Events
+
+```typescript
+client.on('login', (tokens) => { /* TokenResponse */ });
+client.on('logout', () => {});
+client.on('tokenRefresh', (tokens) => { /* TokenResponse */ });
+client.on('error', (error) => { /* Error */ });
+client.on('ready', (isAuthenticated) => { /* boolean */ });
+```
+
+`off()` removes a listener with the same arguments:
+
+```typescript
+const onLogin = (tokens) => console.log(tokens);
+client.on('login', onLogin);
+client.off('login', onLogin);
+```
+
+`authenticated` and `tokenRefreshed` are kept as aliases for `login` and `tokenRefresh`; prefer the shorter names in new code.
+
+The `onLogin`, `onLogout`, `onError` and `onTokenRefresh` config callbacks fire alongside the matching events — use whichever suits the call site.
+
+---
+
+## Continuous verification
+
+For deployments using continuous verification, the SDK exposes a client for reporting device posture and behavioural signals:
+
+```typescript
+import { ContinuousVerification } from 'idenplane-sdk';
+```
+
+See the [Authentication Guide](/guides/authentication) for how these signals are evaluated.
+
+---
+
+## Next steps
+
+<div className="row">
+
+[**Authentication Guide**](/guides/authentication)
+OAuth 2.0 flows in depth
+
+[**Authorization Guide**](/guides/authorization)
+Roles, scopes and permissions
+
+[**API Reference**](/api)
+Complete REST API documentation
+
+</div>

--- a/docs/docs/guides/sdks/react.mdx
+++ b/docs/docs/guides/sdks/react.mdx
@@ -598,7 +598,7 @@ Learn about all configuration options
 [**API Reference**](/api)
 Complete REST API documentation
 
-[**JavaScript SDK**](/guides/sdks/vanilla)
+[**JavaScript SDK**](/guides/sdks/javascript-sdk)
 Core SDK for non-React applications
 
 </div>

--- a/docs/docs/migration/keycloak.mdx
+++ b/docs/docs/migration/keycloak.mdx
@@ -418,7 +418,7 @@ Update applications to use Idenplane endpoints:
 
 ### 4. Migrate Identity Providers
 
-Social and enterprise identity providers require manual reconfiguration. See [Identity Provider Configuration](/guides/authentication#identity-providers) for supported providers.
+Social and enterprise identity providers require manual reconfiguration; they are not carried over by the export.
 
 ### 5. Notify Users
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -51,11 +51,11 @@ After starting Idenplane, you can access the Admin Console with these default cr
 [**Installation Guide**](/getting-started/installation)
 Detailed installation instructions for Docker, Kubernetes, and bare metal
 
-[**Admin Console**](/getting-started/admin-console)
-Learn how to configure realms, users, and clients
+[**Configuration**](/getting-started/configuration)
+Environment variables, realms, and server options
 
-[**First Application**](/guides/first-app)
-Register your first OAuth client and integrate with your app
+[**JavaScript SDK**](/guides/sdks/javascript-sdk)
+Register a public client and integrate it with your app
 
 </div>
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -18,8 +18,12 @@ const config: Config = {
   organizationName: 'idenplane-project',
   projectName: 'idenplane-docs',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  // Fail the build rather than warn. Warnings scrolled past unread for long
+  // enough that 72 internal links pointed at a /docs/ prefix the site does not
+  // use, and three "next steps" cards led to pages nobody had written.
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   i18n: {
     defaultLocale: 'en',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -71,6 +71,11 @@ const sidebars: SidebarsConfig = {
       items: [
         {
           type: 'doc',
+          id: 'guides/sdks/javascript-sdk',
+          label: 'JavaScript',
+        },
+        {
+          type: 'doc',
           id: 'guides/sdks/react-sdk',
           label: 'React',
         },


### PR DESCRIPTION
Eight links still pointed at pages nobody had written. **All three targets name real, shipped features** — so deleting the links would have hidden genuine gaps rather than fixed anything.

## The biggest gap, closed

`packages/idenplane-js` is the core SDK that React, Next.js, Angular and Vue all wrap — and it was **the only one without a page**. Three SDK guides linked to a "JavaScript SDK" that didn't exist.

New page: `docs/guides/sdks/javascript.mdx` — configuration, the login/callback round-trip, tokens, user info, roles, events, silent refresh. Written from `src/client.ts` and `src/types.ts` rather than inferred from the wrappers, and it carries the two warnings the API invites:

- role checks read browser-held claims and **cannot authorise anything**
- `parseJwt` decodes **without verifying**

## The other two, retargeted honestly

`admin-console` and `first-app` need product knowledge that isn't in the source — what the console screens look like, what the intended first-application path is. Writing those badly would be worse than not writing them, so the cards now point at pages that genuinely answer the same question:

| page | was | now |
|---|---|---|
| `quickstart` | Admin Console | Configuration |
| `quickstart` | First Application | JavaScript SDK |
| `installation` | Admin Console | API Reference |
| `configuration` | First Application | Authentication |

The gaps are filed as #1229, #1230 and #1231 rather than quietly dropped.

The Keycloak migration guide linked to a `#identity-providers` anchor that exists nowhere. The sentence reads correctly without it, so it now states plainly that providers aren't carried over by the export.

## The guard

```ts
onBrokenLinks: 'throw',
onBrokenMarkdownLinks: 'throw',
onBrokenAnchors: 'throw',
```

Warnings scrolled past unread long enough for **72 links** to point at a `/docs/` prefix the site doesn't use, and for three "next steps" cards to lead nowhere.

**Verified the guard works**: reintroducing a single bad link fails the build.

## Result

Broken links: **72 → 0**, and the docs-build job added in #1226 now enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)