### PR TITLE
docs: add the Admin Console and first-application guides, and document identity providers

### DIFF
--- a/docs/docs/getting-started/admin-console.md
+++ b/docs/docs/getting-started/admin-console.md
@@ -1,0 +1,138 @@
+---
+id: admin-console
+title: Admin Console
+sidebar_position: 3
+description: Tour of the Idenplane admin console — signing in, realms, and where each setting lives
+---
+
+# Admin Console
+
+The admin console is served by the same process as the API, at **`/console`**. Everything it does goes through the Admin API, so anything here can also be scripted — see the [API Reference](/api).
+
+---
+
+## Signing in
+
+Go to `http://localhost:3000/console`. The login page offers two modes:
+
+**Admin credentials** — the username and password of an admin account. This is the normal way in. The initial account comes from `ADMIN_USER` and `ADMIN_PASSWORD`, which default to `admin` / `admin`.
+
+**API key** — the value of `ADMIN_API_KEY`. Useful when you have not created an admin account yet, or for a break-glass login.
+
+:::warning
+Change the default `admin` / `admin` credentials before exposing an instance to anything. See [Configuration](/getting-started/configuration#api-authentication).
+:::
+
+### First run
+
+On a fresh install, `/setup` runs a six-step wizard that takes you from an empty database to a working login. Start there rather than with the console — see [Your First Application](/guides/first-app).
+
+---
+
+## Layout
+
+The console has two levels of navigation.
+
+**Global**, always visible:
+
+| Section | What it's for |
+|---|---|
+| **Dashboard** | Instance overview |
+| **Realms** | List of realms, and the entry point to everything below |
+| **Plugins** | Installed plugins, enable and disable |
+| **System Status** | Health of the server and its dependencies |
+| **Upgrade** | Version upgrades — see [Upgrading](/deployment/upgrading) |
+
+**Per-realm**, once you pick a realm. Almost all configuration lives here, because almost everything in Idenplane is scoped to a realm.
+
+---
+
+## Inside a realm
+
+### Identity
+
+| Section | What you manage |
+|---|---|
+| **Users** | Accounts, credentials, attributes, role assignments |
+| **Groups** | Group hierarchy and group-level role mappings |
+| **Roles** | Realm roles and client roles |
+| **Service Accounts** | Machine identities for client-credentials flows |
+| **Non-Human Identity** | Workload identities, with their own analytics view |
+| **Organizations** | Multi-tenant grouping of users within a realm |
+
+### Applications
+
+| Section | What you manage |
+|---|---|
+| **Clients** | OAuth 2.0 clients — redirect URIs, flows, secrets |
+| **Client Scopes** | Reusable scope definitions mapped onto clients |
+| **Authorization** | Fine-grained authorization policies |
+| **Custom Attributes** | Extra user fields, and how they surface in tokens |
+| **SCIM** | SCIM 2.0 provisioning endpoints |
+
+### External identity
+
+| Section | What you manage |
+|---|---|
+| **Identity Providers** | OIDC providers for social and enterprise login |
+| **SAML Providers** | SAML identity providers |
+| **User Federation** | External user stores |
+
+### Sign-in behaviour
+
+| Section | What you manage |
+|---|---|
+| **Auth Flows** | The steps a user goes through when authenticating |
+| **Registration Settings** | Whether self-registration is open, and on what terms |
+| **Registration Fields** | Which fields the registration form collects |
+| **Registration Approvals** | Queue of sign-ups awaiting an admin decision |
+| **Consent Categories** | Consent grouping, plus a statistics view |
+
+### Operations
+
+| Section | What you manage |
+|---|---|
+| **Sessions** | Active sessions, with the ability to revoke |
+| **Events** | Authentication events |
+| **Admin Events** | Administrative actions, separately from user events |
+| **Risk Dashboard** | Continuous-verification signals and risk scoring |
+| **Risk Policies** | What the risk engine does about them |
+| **Webhooks** | Outbound event delivery |
+| **Theme Builder** | Per-realm branding for login, consent, account and email pages |
+
+---
+
+## Realm settings
+
+The realm **Overview** page holds the settings that apply to the realm as a whole, grouped into tabs:
+
+| Tab | Covers |
+|---|---|
+| **General** | Name, display name, enabled state |
+| **Tokens** | Access and refresh token lifespans, session timeouts |
+| **Email** | SMTP configuration and templates |
+| **SMS** | SMS provider configuration |
+| **Security** | Password policy, brute-force protection, MFA requirements |
+| **Events** | Which events are recorded, and for how long |
+| **Theme** | Theme selection |
+| **Magic Link** | Passwordless email sign-in |
+| **Locale** | Default locale |
+
+Most of these have an environment-variable equivalent listed in [Configuration](/getting-started/configuration). Realm settings win where both exist, since they are per-realm and the variables are per-instance.
+
+---
+
+## Next steps
+
+<div className="row">
+
+[**Your First Application**](/guides/first-app)
+Register a client and sign a user in
+
+[**Configuration**](/getting-started/configuration)
+Environment variables and server options
+
+[**API Reference**](/api)
+Everything the console does, over HTTP
+
+</div>

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -254,8 +254,8 @@ Most settings can also be configured through the Admin Console at `/console`:
 [**Deployment**](/deployment/docker)
 Deploy Idenplane to production with Docker
 
-[**Authentication**](/guides/authentication)
-OAuth 2.0 flows and how clients authenticate
+[**First Application**](/guides/first-app)
+Register your first OAuth client
 
 [**SDK Guides**](/guides/sdks/react-sdk)
 Integrate Idenplane with your application

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -281,8 +281,8 @@ Learn about all configuration options and environment variables
 [**Quickstart**](/quickstart)
 Get started with Idenplane authentication in your first application
 
-[**API Reference**](/api)
-Manage realms, users, and clients over the REST API
+[**Admin Console**](/getting-started/admin-console)
+Configure realms, users, and clients
 
 </div>
 

--- a/docs/docs/guides/authentication.mdx
+++ b/docs/docs/guides/authentication.mdx
@@ -891,6 +891,54 @@ function parseCallback(): { code?: string; error?: string; state?: string } {
 
 ---
 
+## Identity Providers
+
+Idenplane can delegate authentication to an external provider, so users sign in with an account they already have. Providers are configured per realm, under **Identity Providers** in the admin console.
+
+### What this covers
+
+These endpoints handle **OpenID Connect** providers — Okta, Auth0, Microsoft Entra, Google, another Keycloak or Idenplane, anything that speaks OIDC. `providerType` defaults to `oidc` and is the only type this module has behaviour for.
+
+Two neighbouring features are managed separately:
+
+- **SAML 2.0** providers have their own module and their own console section, **SAML Providers**
+- **LDAP** and other external user stores live under **User Federation**, which synchronises users rather than delegating the login
+
+### Configuring one
+
+```bash
+curl -X POST http://localhost:3000/admin/realms/my-realm/identity-providers   -H "x-admin-api-key: $ADMIN_API_KEY"   -H "Content-Type: application/json"   -d '{
+    "alias": "okta",
+    "displayName": "Okta",
+    "providerType": "oidc",
+    "clientId": "0oa...",
+    "clientSecret": "...",
+    "issuer": "https://your-org.okta.com",
+    "authorizationUrl": "https://your-org.okta.com/oauth2/v1/authorize",
+    "tokenUrl": "https://your-org.okta.com/oauth2/v1/token",
+    "userinfoUrl": "https://your-org.okta.com/oauth2/v1/userinfo",
+    "jwksUrl": "https://your-org.okta.com/oauth2/v1/keys",
+    "defaultScopes": "openid profile email",
+    "enabled": true
+  }'
+```
+
+`alias` identifies the provider within the realm and appears in its callback URL, so pick it once and keep it.
+
+### Options that change behaviour
+
+| Field | Effect |
+|---|---|
+| `trustEmail` | Accept the provider's email as verified, skipping your own verification step |
+| `linkOnly` | Allow linking to existing accounts but do not create new ones from this provider |
+| `syncUserProfile` | Refresh name and email from the provider on each login |
+
+:::warning
+`trustEmail` makes the provider authoritative for email addresses. Only enable it for a provider that verifies them — otherwise someone can claim an address they do not own and, if an account already exists for it, be linked to that account.
+:::
+
+---
+
 ## Next Steps
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>

--- a/docs/docs/guides/first-app.mdx
+++ b/docs/docs/guides/first-app.mdx
@@ -1,0 +1,186 @@
+---
+id: first-app
+title: Your First Application
+description: Register an OAuth client in Idenplane and sign a user in from your own app
+---
+
+# Your First Application
+
+This is the step between having Idenplane running and having it actually authenticate someone. By the end you will have a realm, a registered client, and a page that signs a user in and reads their claims.
+
+If you have not installed Idenplane yet, start with [Installation](/getting-started/installation).
+
+---
+
+## The fast path: the setup wizard
+
+A fresh instance serves a six-step wizard at **`/setup`** that does all of this for you:
+
+| Step | What it does |
+|---|---|
+| 1. Create Admin Account | Replaces the default `admin` / `admin` |
+| 2. Configure Realm Settings | Names the realm and sets its basics |
+| 3. Setup SMTP | Optional — skip it if you are not sending email yet |
+| 4. Create First Client | Registers a public OAuth client |
+| 5. SDK Integration | Shows the snippet for your framework |
+| 6. Test Authentication | Runs a login against what you just built |
+
+Step 6 is the part worth not skipping: it proves the whole chain works before you write any of your own code.
+
+The rest of this page is the same thing done by hand — useful if the wizard has already been completed, or if you are scripting a new environment.
+
+---
+
+## 1. Create a realm
+
+A realm is an isolated set of users, clients and roles. Applications that should not share accounts belong in different realms.
+
+In the console at `/console/realms`, click **Create Realm**. Or over the API:
+
+```bash
+curl -X POST http://localhost:3000/admin/realms \
+  -H "x-admin-api-key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-realm","displayName":"My Realm","enabled":true}'
+```
+
+---
+
+## 2. Register a client
+
+A **client** is one application. Browser and mobile apps are **public** clients — they cannot keep a secret, so they authenticate with PKCE instead.
+
+In the console, open your realm and go to **Clients → Create**. The fields that matter:
+
+| Field | Value for a browser app |
+|---|---|
+| Client ID | Anything stable, e.g. `my-web-app` |
+| Public client | **Yes** — a browser cannot hold a secret |
+| Standard flow | **Enabled** — this is Authorization Code + PKCE |
+| Redirect URIs | Exactly where Idenplane may send users back, e.g. `http://localhost:5173/callback` |
+| Web origins | Your app's origin, for CORS |
+
+:::warning
+Redirect URIs are matched exactly, and they are a security boundary — anything listed here can receive an authorization code. Do not add wildcards or origins you do not control.
+:::
+
+Over the API:
+
+```bash
+curl -X POST http://localhost:3000/admin/realms/my-realm/clients \
+  -H "x-admin-api-key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "my-web-app",
+    "name": "My Web App",
+    "publicClient": true,
+    "standardFlow": true,
+    "redirectUris": ["http://localhost:5173/callback"],
+    "webOrigins": ["http://localhost:5173"]
+  }'
+```
+
+---
+
+## 3. Create a user
+
+**Users → Create** in the console, or:
+
+```bash
+curl -X POST http://localhost:3000/admin/realms/my-realm/users \
+  -H "x-admin-api-key: $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"username":"alice","email":"alice@example.com","enabled":true}'
+```
+
+Set a password from the user's detail page, or via the credentials endpoint.
+
+---
+
+## 4. Wire it into your app
+
+Install the SDK:
+
+```bash
+npm install idenplane-sdk
+```
+
+Point it at the client you just registered:
+
+```typescript
+import { IdenplaneClient } from 'idenplane-sdk';
+
+export const auth = new IdenplaneClient({
+  url: 'http://localhost:3000',
+  realm: 'my-realm',
+  clientId: 'my-web-app',
+  redirectUri: `${window.location.origin}/callback`,
+});
+```
+
+On startup, restore any existing session and send the user to log in if there isn't one:
+
+```typescript
+const isAuthenticated = await auth.init();
+if (!isAuthenticated) {
+  await auth.login();
+}
+```
+
+On the `/callback` route — the URL you registered above — finish the exchange:
+
+```typescript
+const success = await auth.handleCallback();
+if (success) {
+  window.location.replace('/');
+}
+```
+
+Using React, Vue, Angular or Next.js? The framework packages wrap the same client — see the [SDK guides](/guides/sdks/javascript-sdk).
+
+---
+
+## 5. Confirm it worked
+
+Once `init()` returns `true`:
+
+```typescript
+const user = auth.getUserInfo();
+console.log(user?.preferred_username);   // alice
+
+const claims = auth.getTokenClaims();
+console.log(claims?.sub, claims?.exp);
+```
+
+If you get that far, the realm, the client, the redirect URI and the token exchange are all correct.
+
+---
+
+## When it doesn't work
+
+| Symptom | Usual cause |
+|---|---|
+| `invalid_redirect_uri` | The `redirectUri` in your config is not listed on the client, character for character |
+| CORS error in the console | Your app's origin is missing from the client's **Web origins** |
+| `unauthorized_client` | The client is not public, or standard flow is disabled |
+| Login succeeds, `init()` still returns false | `storage` is `memory` (the default) and you reloaded — expected, see [Choosing a storage type](/guides/sdks/javascript-sdk#choosing-a-storage-type) |
+| `invalid_client` | The `clientId` does not exist in the realm you named |
+
+Realm **Events** in the console records failed authentication attempts with a reason, which is usually faster than guessing.
+
+---
+
+## Next steps
+
+<div className="row">
+
+[**JavaScript SDK**](/guides/sdks/javascript-sdk)
+The full client API
+
+[**Authentication**](/guides/authentication)
+OAuth 2.0 flows in depth
+
+[**Authorization**](/guides/authorization)
+Roles, scopes and permissions
+
+</div>

--- a/docs/docs/migration/keycloak.mdx
+++ b/docs/docs/migration/keycloak.mdx
@@ -418,7 +418,7 @@ Update applications to use Idenplane endpoints:
 
 ### 4. Migrate Identity Providers
 
-Social and enterprise identity providers require manual reconfiguration; they are not carried over by the export.
+Social and enterprise identity providers require manual reconfiguration; they are not carried over by the export. See [Identity Providers](/guides/authentication#identity-providers) for the supported types and how to configure one.
 
 ### 5. Notify Users
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -51,11 +51,11 @@ After starting Idenplane, you can access the Admin Console with these default cr
 [**Installation Guide**](/getting-started/installation)
 Detailed installation instructions for Docker, Kubernetes, and bare metal
 
-[**Configuration**](/getting-started/configuration)
-Environment variables, realms, and server options
+[**Admin Console**](/getting-started/admin-console)
+Learn how to configure realms, users, and clients
 
-[**JavaScript SDK**](/guides/sdks/javascript-sdk)
-Register a public client and integrate it with your app
+[**First Application**](/guides/first-app)
+Register your first OAuth client and integrate with your app
 
 </div>
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -26,6 +26,11 @@ const sidebars: SidebarsConfig = {
           id: 'getting-started/configuration',
           label: 'Configuration',
         },
+        {
+          type: 'doc',
+          id: 'getting-started/admin-console',
+          label: 'Admin Console',
+        },
       ],
     },
     {
@@ -110,6 +115,11 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Guides',
       items: [
+        {
+          type: 'doc',
+          id: 'guides/first-app',
+          label: 'Your First Application',
+        },
         {
           type: 'doc',
           id: 'guides/authentication',


### PR DESCRIPTION
Closes #1229, #1230 and #1231. All three named features that **ship in the product**, so these are written from the source rather than from the outside.

## Admin Console — #1229

Maps what an operator actually sees:

- both login modes, from `LoginPage.tsx`
- the five global nav entries and ~30 per-realm sections, from `Layout.tsx`
- the nine realm-settings tabs, from `RealmDetailPage.tsx`

Sections are grouped by **what they're for** — identity, applications, external identity, sign-in behaviour, operations — rather than in nav order. Thirty entries in source order is a list, not a guide.

## Your First Application — #1230

This one had an answer already in the product: **`/setup` runs a six-step wizard** that goes from an empty database to a working login, ending on a step that tests the login it just configured.

```
1. Create Admin Account   4. Create First Client
2. Realm Settings         5. SDK Integration
3. SMTP (optional)        6. Test Authentication
```

The page leads with that, then documents the same thing by hand for instances where the wizard has already run. It ends with a symptom table for the five ways this usually fails — mismatched redirect URI, missing web origin, non-public client, memory storage after a reload, wrong realm.

## Identity Providers — #1231

Now a section in the authentication guide, which is where the Keycloak migration guide had been pointing all along. **That link is restored and the anchor exists.**

## Two claims didn't survive checking

Caught and corrected before this landed:

1. I drafted a table listing `google` and `saml` as `providerType` values. **Only `oidc` appears in the service** — `providerType` is an unvalidated string defaulting to it, and SAML is a separate module (`src/saml`) with its own console section. The section now says that plainly and points at where SAML and LDAP actually live.
2. Verified every other documented field against `create-identity-provider.dto.ts` — `alias`, `trustEmail`, `linkOnly`, `syncUserProfile`, `issuer`, `jwksUrl`, `defaultScopes`, `authorizationUrl`, `tokenUrl`, `userinfoUrl` all confirmed present.

## Links restored

The four links retargeted in #1232 point back at these pages now that they exist. `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'throw'` are on, so the build proves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)