### PR TITLE
ci: build the Docker image and render the Helm chart on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,70 @@ jobs:
       - name: Build docs
         run: npm run build
 
+  docker-build:
+    # The publish workflow only runs after a merge to main, so until now a
+    # Dockerfile change was never built while it could still be rejected — it
+    # broke the published image instead. This builds the same Dockerfile on the
+    # PR, without pushing anything.
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # amd64 only: the publish workflow also does arm64 through QEMU, which
+      # roughly triples the build and is not worth it for a pre-merge check.
+      - name: Build image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false
+          load: true
+          tags: idenplane:ci
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # The upgrade feature shells out to these. They are installed in the
+      # Dockerfile and their --version is asserted there, but that only proves
+      # they existed at build time in that layer; this proves they are in the
+      # final image and on PATH for the entrypoint.
+      - name: Backup tooling present in the image
+        run: |
+          docker run --rm --entrypoint pg_dump idenplane:ci --version
+          docker run --rm --entrypoint pg_restore idenplane:ci --version
+
+  helm-chart:
+    # 16 files that ship to anyone deploying on Kubernetes, and nothing had
+    # ever linted or rendered them. values.schema.json in particular was being
+    # validated against nothing at all.
+    name: Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: azure/setup-helm@v5
+
+      # postgresql and redis are declared as dependencies. Their conditions
+      # control whether they get installed, not whether helm needs them
+      # present — without this, lint warns and template refuses outright.
+      - name: Fetch chart dependencies
+        run: helm dependency build helm/idenplane
+
+      - name: Lint
+        run: helm lint helm/idenplane
+
+      # Rendering is what catches a template that only fails on a value it has
+      # never been given. Both value files go through it, and helm validates
+      # each against values.schema.json on the way.
+      - name: Render with default values
+        run: helm template idenplane helm/idenplane > /dev/null
+
+      - name: Render with production values
+        run: helm template idenplane helm/idenplane -f helm/idenplane/values.production.yaml > /dev/null
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ admin-ui/.redesign-screens/
 # Database backups written by the upgrade flow (BACKUP_DIR, default ./backups).
 # These are full production dumps — they must never be committed.
 backups/
+
+# Helm pulls these in with `helm dependency build`; they are not ours to commit.
+helm/*/charts/
+helm/*/Chart.lock


### PR DESCRIPTION
The last two things this repository ships that **nothing verified before a merge**.

## Docker image — built only after the merge

`docker-publish.yml` runs on `push: branches: [main]`. There is no `pull_request` trigger, so a Dockerfile change could go green through review and only break once it *was* the published image.

Now built on the PR — amd64 only and without pushing. The publish workflow keeps doing arm64 through QEMU; that roughly triples the build and isn't worth it for a pre-merge check.

### And it checks the backup tooling

```bash
docker run --rm --entrypoint pg_dump    idenplane:ci --version
docker run --rm --entrypoint pg_restore idenplane:ci --version
```

The Dockerfile already asserts `--version` during the `apk add` layer — but that only proves they existed **in that layer, at that moment**. Running them against the final image proves they survived into it and are on `PATH`.

The upgrade feature shells out to both and refuses to run without them, so this is what keeps the shipped image able to take a backup.

## Helm chart — no checks at all, and it didn't render

Sixteen files, and a `values.schema.json` that was being validated against nothing.

It also **could not be rendered as committed**:

```
Error: found in Chart.yaml, but missing in charts/ directory: postgresql, redis
```

`postgresql` and `redis` are declared dependencies. Their `condition:` fields govern whether they get *installed* — not whether helm needs them *present*. Anyone cloning the repo and running `helm install ./helm/idenplane` hit that error.

The job fetches them, lints, and renders **both** value files (default and production), which is also what puts `values.schema.json` to work.

## Verification

Done locally with helm 4.2.3:

- `helm dependency build` → pulls postgresql 16.7.27, redis 20.13.4
- `helm lint` → passes
- `helm template` with default values → exit 0
- `helm template` with production values → exit 0
- **appending one undefined value to a template makes the render fail** — the guard works

`charts/` and `Chart.lock` are gitignored; helm fetches those, they aren't ours to commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)