### PR TITLE
fix(sdk): enforce https scheme in SDK server-URL constructors

### DIFF
--- a/packages/idenplane-go/idenplane.go
+++ b/packages/idenplane-go/idenplane.go
@@ -5,7 +5,9 @@ package idenplane
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -91,6 +93,14 @@ type Config struct {
 
 	// HTTPTimeout is the timeout for HTTP requests. Default: 30 seconds.
 	HTTPTimeout time.Duration
+
+	// AllowInsecureHTTP permits ServerURL to use "http://" for a non-loopback
+	// host (default: false). Loopback hosts (localhost, 127.0.0.1, ::1) are
+	// always permitted over "http://" since local development has no TLS to
+	// offer. Anywhere else, plaintext HTTP would send the admin token and
+	// discovery responses over the wire unencrypted, so Validate rejects it
+	// unless this is set.
+	AllowInsecureHTTP bool
 }
 
 // Validate checks that the config has all required fields and returns an error if not.
@@ -105,7 +115,41 @@ func (c Config) Validate() error {
 	if c.ClientID == "" {
 		return ErrInvalidConfig("ClientID is required")
 	}
+	if err := validateServerURLScheme(c.ServerURL, c.AllowInsecureHTTP); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateServerURLScheme rejects non-HTTPS server URLs unless the host is a
+// loopback address or the caller has explicitly opted into insecure HTTP.
+func validateServerURLScheme(serverURL string, allowInsecureHTTP bool) error {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return ErrInvalidConfig(fmt.Sprintf("ServerURL is invalid: %v", err))
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if allowInsecureHTTP || isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return ErrInvalidConfig(
+			`ServerURL uses insecure "http://"; use "https://" or set AllowInsecureHTTP if this is intentional`,
+		)
+	default:
+		return ErrInvalidConfig(fmt.Sprintf(`ServerURL must use "https://" (got %q)`, u.Scheme))
+	}
+}
+
+// isLoopbackHost reports whether host is localhost or a loopback IP literal.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // discoveryURL returns the OIDC discovery URL for this configuration.

--- a/packages/idenplane-go/idenplane_test.go
+++ b/packages/idenplane-go/idenplane_test.go
@@ -1,0 +1,56 @@
+package idenplane
+
+import "testing"
+
+func TestConfigValidateURLScheme(t *testing.T) {
+	base := Config{Realm: "test", ClientID: "test-client"}
+
+	t.Run("accepts https", func(t *testing.T) {
+		c := base
+		c.ServerURL = "https://auth.example.com"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("allows http for localhost", func(t *testing.T) {
+		c := base
+		c.ServerURL = "http://localhost:3000"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("allows http for loopback IP", func(t *testing.T) {
+		c := base
+		c.ServerURL = "http://127.0.0.1:3000"
+		if err := c.Validate(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("rejects http for a non-loopback host", func(t *testing.T) {
+		c := base
+		c.ServerURL = "http://auth.example.com"
+		if err := c.Validate(); err == nil {
+			t.Fatal("expected an error for insecure http://, got nil")
+		}
+	})
+
+	t.Run("allows http for a non-loopback host with AllowInsecureHTTP", func(t *testing.T) {
+		c := base
+		c.ServerURL = "http://auth.example.com"
+		c.AllowInsecureHTTP = true
+		if err := c.Validate(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("rejects a non-http(s) scheme", func(t *testing.T) {
+		c := base
+		c.ServerURL = "ftp://auth.example.com"
+		if err := c.Validate(); err == nil {
+			t.Fatal("expected an error for a non-http(s) scheme, got nil")
+		}
+	})
+}

--- a/packages/idenplane-js/src/__tests__/client.test.ts
+++ b/packages/idenplane-js/src/__tests__/client.test.ts
@@ -122,6 +122,31 @@ describe('IdenplaneClient', () => {
       expect(client).toBeDefined();
     });
 
+    it('allows http:// for loopback hosts without an opt-out', () => {
+      expect(() => new IdenplaneClient({ ...BASE_CONFIG, url: 'http://localhost:3000' })).not.toThrow();
+      expect(() => new IdenplaneClient({ ...BASE_CONFIG, url: 'http://127.0.0.1:3000' })).not.toThrow();
+    });
+
+    it('accepts https:// URLs', () => {
+      expect(() => new IdenplaneClient({ ...BASE_CONFIG, url: 'https://auth.example.com' })).not.toThrow();
+    });
+
+    it('rejects http:// for a non-loopback host', () => {
+      expect(() => new IdenplaneClient({ ...BASE_CONFIG, url: 'http://auth.example.com' })).toThrow(
+        /insecure/i,
+      );
+    });
+
+    it('allows http:// for a non-loopback host with allowInsecureHttp: true', () => {
+      expect(
+        () => new IdenplaneClient({ ...BASE_CONFIG, url: 'http://auth.example.com', allowInsecureHttp: true }),
+      ).not.toThrow();
+    });
+
+    it('rejects an unparsable server URL', () => {
+      expect(() => new IdenplaneClient({ ...BASE_CONFIG, url: 'not-a-url' })).toThrow(/invalid server url/i);
+    });
+
     it('accepts refreshStrategy option', () => {
       const client = new IdenplaneClient({ ...BASE_CONFIG, refreshStrategy: 'eager' });
       expect(client).toBeDefined();

--- a/packages/idenplane-js/src/client.ts
+++ b/packages/idenplane-js/src/client.ts
@@ -38,6 +38,34 @@ const EAGER_REFRESH_MULTIPLIER = 2;
  * search params and posts them to the parent window via `postMessage`.
  * It is a no-op outside of a browser iframe context.
  */
+/**
+ * Reject non-HTTPS server URLs, since they would send access tokens, refresh
+ * tokens, and PKCE verifiers over the wire in plaintext. Loopback hosts
+ * (localhost, 127.0.0.1, ::1) are always exempt because local development
+ * has no TLS to offer; anywhere else, opt in explicitly with
+ * `allowInsecureHttp: true` if plaintext HTTP is genuinely intended (e.g. an
+ * internal network).
+ */
+function assertSecureServerUrl(url: string, allowInsecureHttp: boolean | undefined): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Idenplane: invalid server URL "${url}"`);
+  }
+  if (parsed.protocol === 'https:') return;
+  if (parsed.protocol === 'http:') {
+    const isLoopback =
+      parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+    if (isLoopback || allowInsecureHttp) return;
+    throw new Error(
+      `Idenplane: refusing insecure "http://" server URL "${url}". ` +
+        `Use "https://", or pass allowInsecureHttp: true if this is intentional.`,
+    );
+  }
+  throw new Error(`Idenplane: server URL must use "https://" (got "${parsed.protocol}//" in "${url}")`);
+}
+
 export function handleSilentCallback(): void {
   if (typeof window === 'undefined') return;
   // Only act when running inside an iframe
@@ -98,6 +126,7 @@ export class IdenplaneClient {
   private silentRefreshIframe: HTMLIFrameElement | null = null;
 
   constructor(config: IdenplaneConfig) {
+    assertSecureServerUrl(config.url, config.allowInsecureHttp);
     this.config = {
       url: config.url.replace(/\/$/, ''),
       realm: config.realm,

--- a/packages/idenplane-js/src/types.ts
+++ b/packages/idenplane-js/src/types.ts
@@ -1,7 +1,16 @@
 /** Configuration for creating an IdenplaneClient instance. */
 export interface IdenplaneConfig {
-  /** Base URL of the Idenplane server (e.g. "http://localhost:3000") */
+  /** Base URL of the Idenplane server (e.g. "https://auth.example.com") */
   url: string;
+  /**
+   * Allow `url` to use `http://` for a non-loopback host (default: false).
+   * Loopback hosts (localhost, 127.0.0.1, ::1) are always permitted over
+   * `http://` since local development has no TLS to offer. Anywhere else,
+   * plaintext HTTP would send access tokens, refresh tokens, and PKCE
+   * verifiers over the wire unencrypted, so the constructor throws unless
+   * this is explicitly set.
+   */
+  allowInsecureHttp?: boolean;
   /** Realm name to authenticate against */
   realm: string;
   /** OAuth2 client ID (must be registered in Idenplane as a PUBLIC client) */

--- a/packages/idenplane-nextjs/src/__tests__/api.test.ts
+++ b/packages/idenplane-nextjs/src/__tests__/api.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { withAuth, withAuthHandler } from '../api.js';
+
+describe('withAuth / withAuthHandler config validation', () => {
+  const base = { realm: 'test' };
+  const handler = () => {};
+  const appRouterHandler = () => Response.json({});
+
+  it('allows http:// for localhost', () => {
+    expect(() => withAuth({ ...base, serverUrl: 'http://localhost:3000' }, handler)).not.toThrow();
+    expect(() =>
+      withAuthHandler({ ...base, serverUrl: 'http://localhost:3000' }, appRouterHandler),
+    ).not.toThrow();
+  });
+
+  it('accepts https:// URLs', () => {
+    expect(() => withAuth({ ...base, serverUrl: 'https://auth.example.com' }, handler)).not.toThrow();
+  });
+
+  it('rejects http:// for a non-loopback host', () => {
+    expect(() => withAuth({ ...base, serverUrl: 'http://auth.example.com' }, handler)).toThrow(/insecure/i);
+    expect(() =>
+      withAuthHandler({ ...base, serverUrl: 'http://auth.example.com' }, appRouterHandler),
+    ).toThrow(/insecure/i);
+  });
+
+  it('allows http:// for a non-loopback host with allowInsecureHttp: true', () => {
+    expect(() =>
+      withAuth({ ...base, serverUrl: 'http://auth.example.com', allowInsecureHttp: true }, handler),
+    ).not.toThrow();
+  });
+});

--- a/packages/idenplane-nextjs/src/__tests__/middleware.test.ts
+++ b/packages/idenplane-nextjs/src/__tests__/middleware.test.ts
@@ -62,6 +62,28 @@ function makeNextResponse() {
 
 // ── Tests ─────────────────────────────────────────────────────────
 
+describe('createAuthMiddleware config validation', () => {
+  const base = { realm: 'test', clientId: 'test-app' };
+
+  it('allows http:// for localhost', () => {
+    expect(() => createAuthMiddleware({ ...base, serverUrl: 'http://localhost:3000' })).not.toThrow();
+  });
+
+  it('accepts https:// URLs', () => {
+    expect(() => createAuthMiddleware({ ...base, serverUrl: 'https://auth.example.com' })).not.toThrow();
+  });
+
+  it('rejects http:// for a non-loopback host', () => {
+    expect(() => createAuthMiddleware({ ...base, serverUrl: 'http://auth.example.com' })).toThrow(/insecure/i);
+  });
+
+  it('allows http:// for a non-loopback host with allowInsecureHttp: true', () => {
+    expect(() =>
+      createAuthMiddleware({ ...base, serverUrl: 'http://auth.example.com', allowInsecureHttp: true }),
+    ).not.toThrow();
+  });
+});
+
 describe('createAuthMiddleware', () => {
   const config = {
     serverUrl: 'http://localhost:3000',

--- a/packages/idenplane-nextjs/src/api.ts
+++ b/packages/idenplane-nextjs/src/api.ts
@@ -7,7 +7,7 @@
  * import { withAuth } from '@idenplane/nextjs/api';
  *
  * export default withAuth(
- *   { serverUrl: 'http://localhost:3000', realm: 'my-realm' },
+ *   { serverUrl: 'https://auth.example.com', realm: 'my-realm' },
  *   (req, res) => {
  *     res.json({ user: req.authUser });
  *   },
@@ -20,13 +20,14 @@
  * import { withAuthHandler } from '@idenplane/nextjs/api';
  *
  * export const GET = withAuthHandler(
- *   { serverUrl: 'http://localhost:3000', realm: 'my-realm' },
+ *   { serverUrl: 'https://auth.example.com', realm: 'my-realm' },
  *   (req, user) => Response.json({ user }),
  * );
  * ```
  */
 
 import type { TokenPayload } from './server.js';
+import { assertSecureServerUrl } from './internal/url-validation.js';
 
 // ── Shared types ─────────────────────────────────────────────────
 
@@ -37,6 +38,11 @@ export interface ApiAuthConfig {
   realm: string;
   /** Required realm roles (user must have ALL of them) */
   requiredRoles?: string[];
+  /**
+   * Allow `serverUrl` to use `http://` for a non-loopback host (default: false).
+   * See {@link assertSecureServerUrl}.
+   */
+  allowInsecureHttp?: boolean;
 }
 
 // ── Pages Router ─────────────────────────────────────────────────
@@ -95,6 +101,8 @@ export function withAuth(
   config: ApiAuthConfig,
   handler: AuthenticatedHandler,
 ): NextApiHandler {
+  assertSecureServerUrl(config.serverUrl, config.allowInsecureHttp);
+
   return async (req, res) => {
     const token = extractBearer(req.headers);
 
@@ -137,6 +145,8 @@ export function withAuthHandler(
   config: ApiAuthConfig,
   handler: AppRouterHandler,
 ): (req: Request) => Promise<Response> {
+  assertSecureServerUrl(config.serverUrl, config.allowInsecureHttp);
+
   return async (req: Request) => {
     const authHeader = req.headers.get('authorization');
     const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;

--- a/packages/idenplane-nextjs/src/internal/url-validation.ts
+++ b/packages/idenplane-nextjs/src/internal/url-validation.ts
@@ -1,0 +1,26 @@
+/**
+ * Reject non-HTTPS Idenplane server URLs, since they would send bearer
+ * tokens and JWKS responses over the wire in plaintext. Loopback hosts
+ * (localhost, 127.0.0.1, ::1) are always exempt because local development
+ * has no TLS to offer; anywhere else, opt in explicitly with
+ * `allowInsecureHttp: true` if plaintext HTTP is genuinely intended.
+ */
+export function assertSecureServerUrl(serverUrl: string, allowInsecureHttp: boolean | undefined): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(serverUrl);
+  } catch {
+    throw new Error(`Idenplane: invalid server URL "${serverUrl}"`);
+  }
+  if (parsed.protocol === 'https:') return;
+  if (parsed.protocol === 'http:') {
+    const isLoopback =
+      parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+    if (isLoopback || allowInsecureHttp) return;
+    throw new Error(
+      `Idenplane: refusing insecure "http://" server URL "${serverUrl}". ` +
+        `Use "https://", or pass allowInsecureHttp: true if this is intentional.`,
+    );
+  }
+  throw new Error(`Idenplane: server URL must use "https://" (got "${parsed.protocol}//" in "${serverUrl}")`);
+}

--- a/packages/idenplane-nextjs/src/middleware.ts
+++ b/packages/idenplane-nextjs/src/middleware.ts
@@ -11,7 +11,7 @@
  * import { createAuthMiddleware } from '@idenplane/nextjs/middleware';
  *
  * const authMiddleware = createAuthMiddleware({
- *   serverUrl: 'http://localhost:3000',
+ *   serverUrl: 'https://auth.example.com',
  *   realm: 'my-realm',
  *   clientId: 'my-app',
  *   protectedPaths: ['/dashboard', '/api/protected'],
@@ -28,8 +28,10 @@
  * ```
  */
 
+import { assertSecureServerUrl } from './internal/url-validation.js';
+
 export interface AuthMiddlewareConfig {
-  /** Idenplane server base URL (e.g. "http://localhost:3000") */
+  /** Idenplane server base URL (e.g. "https://auth.example.com") */
   serverUrl: string;
   /** Realm name */
   realm: string;
@@ -41,6 +43,11 @@ export interface AuthMiddlewareConfig {
   loginPath?: string;
   /** Cookie name that holds the access token (default: "idenplane_access_token") */
   cookieName?: string;
+  /**
+   * Allow `serverUrl` to use `http://` for a non-loopback host (default: false).
+   * See {@link assertSecureServerUrl}.
+   */
+  allowInsecureHttp?: boolean;
 }
 
 /**
@@ -110,6 +117,8 @@ function isTokenExpiredLocally(token: string): boolean {
  * when the user is not authenticated.
  */
 export function createAuthMiddleware(config: AuthMiddlewareConfig) {
+  assertSecureServerUrl(config.serverUrl, config.allowInsecureHttp);
+
   const {
     protectedPaths = [],
     loginPath = '/login',

--- a/packages/idenplane-python/idenplane/client.py
+++ b/packages/idenplane-python/idenplane/client.py
@@ -8,10 +8,12 @@ lazily instantiated on first access.
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from dataclasses import dataclass, field
 from types import TracebackType
 from typing import TYPE_CHECKING, Optional
+from urllib.parse import urlparse
 
 import requests
 
@@ -21,6 +23,18 @@ if TYPE_CHECKING:
 
 _USER_AGENT = "idenplane-python/0.3.0"
 _DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+def _is_loopback_host(host: Optional[str]) -> bool:
+    """Return whether host is localhost or a loopback IP literal."""
+    if host is None:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 @dataclass(frozen=True)
@@ -35,6 +49,12 @@ class Config:
             ``Authorization`` header is omitted (useful for public discovery).
         timeout_seconds: HTTP request timeout in seconds. Defaults to 30s.
         user_agent: Value sent in the ``User-Agent`` header.
+        allow_insecure_http: Allow ``base_url`` to use ``http://`` for a
+            non-loopback host (default: ``False``). Loopback hosts
+            (``localhost``, ``127.0.0.1``, ``::1``) are always permitted over
+            ``http://`` since local development has no TLS to offer.
+            Anywhere else, plaintext HTTP would send the admin token over the
+            wire unencrypted, so construction fails unless this is set.
     """
 
     base_url: str
@@ -43,6 +63,7 @@ class Config:
     timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS
     user_agent: str = _USER_AGENT
     extra_headers: dict[str, str] = field(default_factory=dict)
+    allow_insecure_http: bool = False
 
     def __post_init__(self) -> None:
         if not self.base_url:
@@ -51,6 +72,22 @@ class Config:
             raise ValueError("Config.realm is required")
         if self.timeout_seconds <= 0:
             raise ValueError("Config.timeout_seconds must be positive")
+        self._validate_url_scheme()
+
+    def _validate_url_scheme(self) -> None:
+        parsed = urlparse(self.base_url)
+        if parsed.scheme == "https":
+            return
+        if parsed.scheme == "http":
+            if self.allow_insecure_http or _is_loopback_host(parsed.hostname):
+                return
+            raise ValueError(
+                'Config.base_url uses insecure "http://"; use "https://" or '
+                "set allow_insecure_http=True if this is intentional"
+            )
+        raise ValueError(
+            f'Config.base_url must use "https://" (got "{parsed.scheme}://" in {self.base_url!r})'
+        )
 
     @classmethod
     def from_env(cls) -> Config:

--- a/packages/idenplane-python/tests/test_client.py
+++ b/packages/idenplane-python/tests/test_client.py
@@ -36,6 +36,26 @@ class TestConfig:
         with pytest.raises(ValueError, match="timeout"):
             Config(base_url="https://a", realm="r", timeout_seconds=0)
 
+    def test_allows_http_for_localhost(self) -> None:
+        cfg = Config(base_url="http://localhost:3000", realm="r")
+        assert cfg.base_url == "http://localhost:3000"
+
+    def test_allows_http_for_loopback_ip(self) -> None:
+        cfg = Config(base_url="http://127.0.0.1:3000", realm="r")
+        assert cfg.base_url == "http://127.0.0.1:3000"
+
+    def test_rejects_http_for_non_loopback_host(self) -> None:
+        with pytest.raises(ValueError, match="insecure"):
+            Config(base_url="http://auth.example.com", realm="r")
+
+    def test_allows_http_for_non_loopback_host_with_opt_out(self) -> None:
+        cfg = Config(base_url="http://auth.example.com", realm="r", allow_insecure_http=True)
+        assert cfg.base_url == "http://auth.example.com"
+
+    def test_rejects_non_http_scheme(self) -> None:
+        with pytest.raises(ValueError, match="https"):
+            Config(base_url="ftp://auth.example.com", realm="r")
+
     def test_base_url_normalized_strips_trailing_slash(self) -> None:
         cfg = Config(base_url="https://auth.example.com/", realm="r")
         assert cfg.base_url_normalized() == "https://auth.example.com"


### PR DESCRIPTION
## Summary
- None of the SDK constructors validated that the server URL used `https://`, so a misconfigured deployment (or MITM downgrade) could send access tokens, refresh tokens, and PKCE verifiers over plaintext HTTP with no warning.
- Reject `http://` by default in `idenplane-js` (`IdenplaneClient`), `idenplane-go` (`Config.Validate`), `idenplane-python` (`Config`), and `idenplane-nextjs` (`createAuthMiddleware`, `withAuth`, `withAuthHandler`).
- Loopback hosts (`localhost`, `127.0.0.1`, `::1`) stay permitted over `http://` since local development has no TLS to offer; any other host requires an explicit `allowInsecureHttp` / `allow_insecure_http` / `AllowInsecureHTTP` opt-out.

Closes #1249

## Test plan
- [x] `idenplane-js`: `npm run typecheck` and `vitest run` — 109/109 passing (5 new)
- [x] `idenplane-go`: `go vet ./...`, `go build ./...`, `go test ./...` — all passing (new `idenplane_test.go`)
- [x] `idenplane-python`: `pytest`, `mypy`, `ruff check` — 71/71 passing (5 new), no type/lint issues
- [x] `idenplane-nextjs`: `tsc --noEmit` and `vitest run` — 23/23 passing (new `api.test.ts` + additions to `middleware.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW