### PR TITLE
refactor: extract a shared HTTP client for idenplane-cli and idenplane-mcp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,16 @@ jobs:
           npm ci
           npm run build
 
+      # mcp consumes @idenplane/http-internal through
+      # `file:../idenplane-http-internal`, and its dist/ is gitignored — so on
+      # a fresh checkout it has no compiled output to resolve. Build it first.
+      - name: Build the local idenplane-http-internal dependency
+        if: matrix.package == 'idenplane-mcp'
+        working-directory: packages/idenplane-http-internal
+        run: |
+          npm ci
+          npm run build
+
       - name: Install dependencies
         run: npm ci
 

--- a/packages/idenplane-cli/package.json
+++ b/packages/idenplane-cli/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",
-    "@types/node": "^22.10.7"
+    "@types/node": "^22.10.7",
+    "@idenplane/http-internal": "file:../idenplane-http-internal"
   },
   "files": [
     "dist",

--- a/packages/idenplane-cli/src/http.ts
+++ b/packages/idenplane-cli/src/http.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { buildUrlWithQuery, extractErrorMessage, rawRequest } from '@idenplane/http-internal';
 import { requireAuth } from './config.js';
 import type { CliConfig } from './types.js';
 
@@ -7,76 +8,42 @@ export class HttpClient {
   private headers: Record<string, string>;
 
   constructor(config?: { serverUrl: string; headers?: Record<string, string> }) {
-    if (config) {
-      this.serverUrl = config.serverUrl.replace(/\/$/, '');
-      this.headers = {
-        'Content-Type': 'application/json',
-        ...config.headers,
-      };
-    } else {
-      const auth = requireAuth();
-      this.serverUrl = auth.serverUrl.replace(/\/$/, '');
-      this.headers = {
-        'Content-Type': 'application/json',
-        ...auth.headers,
-      };
-    }
-  }
-
-  private url(path: string): string {
-    return `${this.serverUrl}${path}`;
+    const { serverUrl, headers } = config ?? requireAuth();
+    this.serverUrl = serverUrl.replace(/\/$/, '');
+    this.headers = {
+      'Content-Type': 'application/json',
+      ...headers,
+    };
   }
 
   async get<T>(path: string, query?: Record<string, string>): Promise<T> {
-    const url = new URL(this.url(path));
-    if (query) {
-      for (const [k, v] of Object.entries(query)) {
-        if (v !== undefined) url.searchParams.set(k, v);
-      }
-    }
-    return this.request<T>('GET', url.toString());
+    return this.request<T>('GET', buildUrlWithQuery(this.serverUrl, path, query));
   }
 
   async post<T>(path: string, body?: unknown, query?: Record<string, string>): Promise<T> {
-    let fullUrl = this.url(path);
-    if (query) {
-      const url = new URL(fullUrl);
-      for (const [k, v] of Object.entries(query)) {
-        if (v !== undefined) url.searchParams.set(k, v);
-      }
-      fullUrl = url.toString();
-    }
-    return this.request<T>('POST', fullUrl, body);
+    return this.request<T>('POST', buildUrlWithQuery(this.serverUrl, path, query), body);
   }
 
   async put<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('PUT', this.url(path), body);
+    return this.request<T>('PUT', buildUrlWithQuery(this.serverUrl, path), body);
   }
 
   async delete<T>(path: string, body?: unknown): Promise<T | void> {
-    return this.request<T>('DELETE', this.url(path), body);
+    return this.request<T>('DELETE', buildUrlWithQuery(this.serverUrl, path), body);
   }
 
   private async request<T>(method: string, url: string, body?: unknown): Promise<T> {
-    const res = await fetch(url, {
-      method,
-      headers: this.headers,
-      body: body ? JSON.stringify(body) : undefined,
-    });
+    const response = await rawRequest({ method, url, headers: this.headers, body });
 
-    if (res.status === 204) return undefined as T;
+    if (response.status === 204) return undefined as T;
 
-    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-
-    if (!res.ok) {
-      const msg = (json?.message ?? json?.error ?? res.statusText) as unknown;
-      const display = Array.isArray(msg) ? msg.join(', ') : msg;
-      const error = new Error(`Error ${res.status}: ${display}`);
+    if (!response.ok) {
+      const error = new Error(`Error ${response.status}: ${extractErrorMessage(response)}`);
       error.message = chalk.red(error.message);
       throw error;
     }
 
-    return json as T;
+    return response.json as T;
   }
 }
 

--- a/packages/idenplane-cli/tests/http.test.ts
+++ b/packages/idenplane-cli/tests/http.test.ts
@@ -1,0 +1,71 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { HttpClient } from '../src/http.js';
+
+function withMockedFetch(handler: typeof fetch, fn: () => Promise<void>): Promise<void> {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+test('HttpClient.get: builds the URL with query params and returns the parsed body', async () => {
+  let capturedUrl = '';
+  await withMockedFetch(
+    (async (url: string | URL) => {
+      capturedUrl = url.toString();
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch,
+    async () => {
+      const client = new HttpClient({ serverUrl: 'http://x.local/', headers: {} });
+      const result = await client.get<{ ok: boolean }>('/admin/realms', { search: 'a', skip: undefined as never });
+      assert.equal(result.ok, true);
+      assert.equal(capturedUrl, 'http://x.local/admin/realms?search=a');
+    },
+  );
+});
+
+test('HttpClient: returns undefined for a 204 response', async () => {
+  await withMockedFetch(
+    (async () => new Response(null, { status: 204 })) as typeof fetch,
+    async () => {
+      const client = new HttpClient({ serverUrl: 'http://x.local', headers: {} });
+      const result = await client.delete('/admin/realms/r');
+      assert.equal(result, undefined);
+    },
+  );
+});
+
+test('HttpClient: throws a chalk-colored error with the parsed message on a non-2xx response', async () => {
+  await withMockedFetch(
+    (async () =>
+      new Response(JSON.stringify({ message: 'realm not found' }), {
+        status: 404,
+        statusText: 'Not Found',
+      })) as typeof fetch,
+    async () => {
+      const client = new HttpClient({ serverUrl: 'http://x.local', headers: {} });
+      await assert.rejects(client.get('/admin/realms/missing'), (err: unknown) => {
+        assert.ok(err instanceof Error);
+        assert.match(err.message, /Error 404: realm not found/);
+        return true;
+      });
+    },
+  );
+});
+
+test('HttpClient: strips a trailing slash from serverUrl', async () => {
+  let capturedUrl = '';
+  await withMockedFetch(
+    (async (url: string | URL) => {
+      capturedUrl = url.toString();
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch,
+    async () => {
+      const client = new HttpClient({ serverUrl: 'http://x.local/', headers: {} });
+      await client.get('/admin/realms');
+      assert.equal(capturedUrl, 'http://x.local/admin/realms');
+    },
+  );
+});

--- a/packages/idenplane-cli/tsup.config.ts
+++ b/packages/idenplane-cli/tsup.config.ts
@@ -7,6 +7,10 @@ export default defineConfig([
     dts: true,
     clean: true,
     target: 'node18',
+    // @idenplane/http-internal is an unpublished, monorepo-local package —
+    // inline it into the bundle rather than leaving a require/import that
+    // wouldn't resolve for a real npm install of idenplane-cli.
+    noExternal: ['@idenplane/http-internal'],
     banner: {
       js: '#!/usr/bin/env node',
     },
@@ -19,5 +23,6 @@ export default defineConfig([
     clean: false,
     target: 'node18',
     sourcemap: true,
+    noExternal: ['@idenplane/http-internal'],
   },
 ]);

--- a/packages/idenplane-http-internal/package-lock.json
+++ b/packages/idenplane-http-internal/package-lock.json
@@ -1,34 +1,12 @@
 {
-  "name": "idenplane-cli",
-  "version": "1.0.1",
+  "name": "@idenplane/http-internal",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "idenplane-cli",
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.4.0",
-        "commander": "^13.0.0"
-      },
-      "bin": {
-        "idenplane": "dist/index.js"
-      },
-      "devDependencies": {
-        "@idenplane/http-internal": "file:../idenplane-http-internal",
-        "@types/node": "^22.10.7",
-        "tsup": "^8.4.0",
-        "typescript": "^5.7.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "../idenplane-http-internal": {
       "name": "@idenplane/http-internal",
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.7",
@@ -481,10 +459,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@idenplane/http-internal": {
-      "resolved": "../idenplane-http-internal",
-      "link": true
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -525,9 +499,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
-      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
       "cpu": [
         "arm"
       ],
@@ -539,9 +513,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
-      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
       "cpu": [
         "arm64"
       ],
@@ -553,9 +527,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
-      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
       "cpu": [
         "arm64"
       ],
@@ -567,9 +541,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
-      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
       "cpu": [
         "x64"
       ],
@@ -581,9 +555,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
-      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
       "cpu": [
         "arm64"
       ],
@@ -595,9 +569,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
-      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
       "cpu": [
         "x64"
       ],
@@ -609,9 +583,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
-      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
       "cpu": [
         "arm"
       ],
@@ -626,9 +600,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
-      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
       "cpu": [
         "arm"
       ],
@@ -643,9 +617,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
-      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
       "cpu": [
         "arm64"
       ],
@@ -660,9 +634,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
-      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
       "cpu": [
         "arm64"
       ],
@@ -677,9 +651,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
-      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
       "cpu": [
         "loong64"
       ],
@@ -694,9 +668,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
-      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
       "cpu": [
         "loong64"
       ],
@@ -711,9 +685,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
-      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
       "cpu": [
         "ppc64"
       ],
@@ -728,9 +702,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
-      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
       "cpu": [
         "ppc64"
       ],
@@ -745,9 +719,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
-      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
       "cpu": [
         "riscv64"
       ],
@@ -762,9 +736,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
-      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
       "cpu": [
         "riscv64"
       ],
@@ -779,9 +753,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
-      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
       "cpu": [
         "s390x"
       ],
@@ -796,9 +770,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
       "cpu": [
         "x64"
       ],
@@ -813,9 +787,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
-      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
       "cpu": [
         "x64"
       ],
@@ -830,9 +804,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
-      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
       "cpu": [
         "x64"
       ],
@@ -844,9 +818,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
-      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
       "cpu": [
         "arm64"
       ],
@@ -858,9 +832,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
-      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
       "cpu": [
         "arm64"
       ],
@@ -872,9 +846,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
-      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
       "cpu": [
         "ia32"
       ],
@@ -886,9 +860,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
-      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
       "cpu": [
         "x64"
       ],
@@ -900,9 +874,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
-      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
       "cpu": [
         "x64"
       ],
@@ -914,16 +888,16 @@
       ]
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -931,9 +905,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -976,18 +950,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1005,12 +967,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 6"
       }
     },
     "node_modules/confbox": {
@@ -1186,16 +1149,16 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
-      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "pathe": "^2.0.3",
         "pkg-types": "^1.3.1",
-        "ufo": "^1.6.1"
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/ms": {
@@ -1242,9 +1205,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1344,13 +1307,13 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
-      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -1360,31 +1323,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.4",
-        "@rollup/rollup-android-arm64": "4.60.4",
-        "@rollup/rollup-darwin-arm64": "4.60.4",
-        "@rollup/rollup-darwin-x64": "4.60.4",
-        "@rollup/rollup-freebsd-arm64": "4.60.4",
-        "@rollup/rollup-freebsd-x64": "4.60.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
-        "@rollup/rollup-linux-arm64-musl": "4.60.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
-        "@rollup/rollup-linux-loong64-musl": "4.60.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-gnu": "4.60.4",
-        "@rollup/rollup-linux-x64-musl": "4.60.4",
-        "@rollup/rollup-openbsd-x64": "4.60.4",
-        "@rollup/rollup-openharmony-arm64": "4.60.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
-        "@rollup/rollup-win32-x64-gnu": "4.60.4",
-        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -1421,16 +1384,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -1462,14 +1415,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1563,9 +1516,9 @@
       }
     },
     "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/idenplane-http-internal/package.json
+++ b/packages/idenplane-http-internal/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@idenplane/http-internal",
+  "version": "0.1.0",
+  "description": "Shared fetch-wrapper internals for idenplane-cli and idenplane-mcp (not published standalone)",
+  "type": "module",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup && node scripts/fix-node-imports.mjs",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test dist/tests/*.test.js"
+  },
+  "devDependencies": {
+    "tsup": "^8.4.0",
+    "typescript": "^5.7.0",
+    "@types/node": "^22.10.7"
+  },
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "overrides": {
+    "esbuild": "^0.28.1"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/idenplane/idenplane.git",
+    "directory": "packages/idenplane-http-internal"
+  }
+}

--- a/packages/idenplane-http-internal/scripts/fix-node-imports.mjs
+++ b/packages/idenplane-http-internal/scripts/fix-node-imports.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Post-build script: restore the `node:` prefix for built-in modules
+ * that esbuild strips during compilation of test files.
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const testDir = join(__dirname, '..', 'dist', 'tests');
+
+// These are built-in module names that esbuild strips the `node:` prefix from.
+const BARE_BUILTINS = [
+  'test',
+  'assert',
+  'assert/strict',
+  'fs',
+  'path',
+  'os',
+  'readline',
+  'module',
+  'url',
+  'crypto',
+  'events',
+  'stream',
+  'util',
+];
+
+let patchedFiles = 0;
+let patchedImports = 0;
+
+for (const file of readdirSync(testDir)) {
+  if (!file.endsWith('.js')) continue;
+  const filePath = join(testDir, file);
+  let src = readFileSync(filePath, 'utf-8');
+  let changed = false;
+
+  for (const mod of BARE_BUILTINS) {
+    // Match: from "mod" or from 'mod'  (but NOT from "node:mod" already)
+    const dq = new RegExp(`from "${mod}"`, 'g');
+    const sq = new RegExp(`from '${mod}'`, 'g');
+    if (dq.test(src)) {
+      src = src.replace(dq, `from "node:${mod}"`);
+      patchedImports++;
+      changed = true;
+    }
+    if (sq.test(src)) {
+      src = src.replace(sq, `from 'node:${mod}'`);
+      patchedImports++;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    writeFileSync(filePath, src, 'utf-8');
+    patchedFiles++;
+  }
+}
+
+console.log(`Patched ${patchedImports} import(s) in ${patchedFiles} file(s).`);

--- a/packages/idenplane-http-internal/src/index.ts
+++ b/packages/idenplane-http-internal/src/index.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared fetch-wrapper internals for idenplane-cli and idenplane-mcp. Both
+ * clients need the same request plumbing (URL-with-query-params
+ * construction, the 204→no-body short-circuit, the `message`/`error`/
+ * statusText fallback chain for extracting an error message) but want to
+ * throw their own error type (CLI: a chalk-formatted `Error`; MCP: `ApiError`)
+ * so that stays in each package.
+ */
+
+export interface RequestOptions {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body?: unknown;
+}
+
+export interface RawResponse {
+  status: number;
+  statusText: string;
+  ok: boolean;
+  /** Parsed JSON body, or `null` for a 204 response or an unparseable body. */
+  json: Record<string, unknown> | null;
+}
+
+/**
+ * Performs the fetch and parses the body as JSON. Never throws on a non-2xx
+ * status — inspect `RawResponse.ok`/`status` and call `extractErrorMessage`
+ * to build a caller-specific error.
+ */
+export async function rawRequest(options: RequestOptions): Promise<RawResponse> {
+  const res = await fetch(options.url, {
+    method: options.method,
+    headers: options.headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (res.status === 204) {
+    return { status: res.status, statusText: res.statusText, ok: res.ok, json: null };
+  }
+
+  const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+  return { status: res.status, statusText: res.statusText, ok: res.ok, json };
+}
+
+/**
+ * Extracts a human-readable error message from a JSON error body, falling
+ * back to the HTTP status text when the body has neither `message` nor
+ * `error`.
+ */
+export function extractErrorMessage(response: Pick<RawResponse, 'json' | 'statusText'>): string {
+  const msg = response.json?.['message'] ?? response.json?.['error'] ?? response.statusText;
+  return Array.isArray(msg) ? msg.join(', ') : String(msg);
+}
+
+/** Joins `baseUrl` + `path` and appends `query` as URL search params, skipping `undefined` values. */
+export function buildUrlWithQuery(
+  baseUrl: string,
+  path: string,
+  query?: Record<string, string | undefined>,
+): string {
+  const url = new URL(`${baseUrl}${path}`);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== undefined) url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}

--- a/packages/idenplane-http-internal/tests/index.test.ts
+++ b/packages/idenplane-http-internal/tests/index.test.ts
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildUrlWithQuery, extractErrorMessage, rawRequest } from '../src/index.js';
+
+test('buildUrlWithQuery: joins base + path with no query', () => {
+  assert.equal(buildUrlWithQuery('http://x.local', '/admin/realms'), 'http://x.local/admin/realms');
+});
+
+test('buildUrlWithQuery: appends query params, skipping undefined values', () => {
+  const url = buildUrlWithQuery('http://x.local', '/admin/realms/r/users', {
+    limit: '50',
+    skip: undefined,
+    search: 'alice',
+  });
+  const parsed = new URL(url);
+  assert.equal(parsed.searchParams.get('limit'), '50');
+  assert.equal(parsed.searchParams.has('skip'), false);
+  assert.equal(parsed.searchParams.get('search'), 'alice');
+});
+
+test('extractErrorMessage: prefers `message` over `error` over statusText', () => {
+  assert.equal(
+    extractErrorMessage({ json: { message: 'bad request' }, statusText: 'Bad Request' }),
+    'bad request',
+  );
+  assert.equal(
+    extractErrorMessage({ json: { error: 'nope' }, statusText: 'Bad Request' }),
+    'nope',
+  );
+  assert.equal(extractErrorMessage({ json: null, statusText: 'Not Found' }), 'Not Found');
+});
+
+test('extractErrorMessage: joins array messages', () => {
+  assert.equal(
+    extractErrorMessage({ json: { message: ['field a is required', 'field b is required'] }, statusText: '' }),
+    'field a is required, field b is required',
+  );
+});
+
+test('rawRequest: returns a null json body and ok=true for a 204', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(null, { status: 204 })) as typeof fetch;
+  try {
+    const response = await rawRequest({ method: 'DELETE', url: 'http://x.local/thing', headers: {} });
+    assert.equal(response.status, 204);
+    assert.equal(response.ok, true);
+    assert.equal(response.json, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('rawRequest: parses a JSON body and reports non-2xx as not ok', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ message: 'realm not found' }), {
+      status: 404,
+      statusText: 'Not Found',
+      headers: { 'Content-Type': 'application/json' },
+    })) as typeof fetch;
+  try {
+    const response = await rawRequest({ method: 'GET', url: 'http://x.local/thing', headers: {} });
+    assert.equal(response.status, 404);
+    assert.equal(response.ok, false);
+    assert.deepEqual(response.json, { message: 'realm not found' });
+    assert.equal(extractErrorMessage(response), 'realm not found');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('rawRequest: sends a JSON body only when one is provided', async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: Array<RequestInit | undefined> = [];
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    calls.push(init);
+    return new Response(null, { status: 204 });
+  }) as typeof fetch;
+  try {
+    await rawRequest({ method: 'POST', url: 'http://x.local/thing', headers: {}, body: { a: 1 } });
+    await rawRequest({ method: 'DELETE', url: 'http://x.local/thing', headers: {} });
+    assert.equal(calls[0]?.body, JSON.stringify({ a: 1 }));
+    assert.equal(calls[1]?.body, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/idenplane-http-internal/tsconfig.json
+++ b/packages/idenplane-http-internal/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2022"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/idenplane-http-internal/tsup.config.ts
+++ b/packages/idenplane-http-internal/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig([
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    target: 'node18',
+  },
+  {
+    entry: ['tests/*.test.ts'],
+    outDir: 'dist/tests',
+    format: ['esm'],
+    dts: false,
+    clean: false,
+    target: 'node18',
+    sourcemap: true,
+  },
+]);

--- a/packages/idenplane-mcp/package-lock.json
+++ b/packages/idenplane-mcp/package-lock.json
@@ -16,6 +16,21 @@
         "idenplane-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@idenplane/http-internal": "file:../idenplane-http-internal",
+        "@types/node": "^22.10.7",
+        "tsup": "^8.4.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "../idenplane-http-internal": {
+      "name": "@idenplane/http-internal",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
         "@types/node": "^22.10.7",
         "tsup": "^8.4.0",
         "typescript": "^5.7.0"
@@ -477,6 +492,10 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@idenplane/http-internal": {
+      "resolved": "../idenplane-http-internal",
+      "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/packages/idenplane-mcp/package.json
+++ b/packages/idenplane-mcp/package.json
@@ -23,7 +23,8 @@
   "devDependencies": {
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",
-    "@types/node": "^22.10.7"
+    "@types/node": "^22.10.7",
+    "@idenplane/http-internal": "file:../idenplane-http-internal"
   },
   "overrides": {
     "esbuild": "^0.28.1",

--- a/packages/idenplane-mcp/src/client.ts
+++ b/packages/idenplane-mcp/src/client.ts
@@ -1,3 +1,5 @@
+import { buildUrlWithQuery, extractErrorMessage, rawRequest } from '@idenplane/http-internal';
+
 export interface ClientConfig {
   serverUrl: string;
   adminToken: string;
@@ -30,41 +32,27 @@ export class IdenplaneClient {
   }
 
   async get<T>(path: string, query?: Record<string, string | undefined>): Promise<T> {
-    const url = new URL(`${this.baseUrl}${path}`);
-    if (query) {
-      for (const [k, v] of Object.entries(query)) {
-        if (v !== undefined) url.searchParams.set(k, v);
-      }
-    }
-    return this.request<T>('GET', url.toString());
+    return this.request<T>('GET', buildUrlWithQuery(this.baseUrl, path, query));
   }
 
   async post<T>(path: string, body?: unknown): Promise<T> {
-    return this.request<T>('POST', `${this.baseUrl}${path}`, body);
+    return this.request<T>('POST', buildUrlWithQuery(this.baseUrl, path), body);
   }
 
   async delete<T>(path: string, body?: unknown): Promise<T | undefined> {
-    return this.request<T>('DELETE', `${this.baseUrl}${path}`, body);
+    return this.request<T>('DELETE', buildUrlWithQuery(this.baseUrl, path), body);
   }
 
   private async request<T>(method: string, url: string, body?: unknown): Promise<T> {
-    const res = await fetch(url, {
-      method,
-      headers: this.headers,
-      body: body !== undefined ? JSON.stringify(body) : undefined,
-    });
+    const response = await rawRequest({ method, url, headers: this.headers, body });
 
-    if (res.status === 204) return undefined as T;
+    if (response.status === 204) return undefined as T;
 
-    const json = (await res.json().catch(() => null)) as Record<string, unknown> | null;
-
-    if (!res.ok) {
-      const msg = json?.['message'] ?? json?.['error'] ?? res.statusText;
-      const display = Array.isArray(msg) ? (msg as unknown[]).join(', ') : String(msg);
-      throw new ApiError(res.status, display);
+    if (!response.ok) {
+      throw new ApiError(response.status, extractErrorMessage(response));
     }
 
-    return json as T;
+    return response.json as T;
   }
 }
 

--- a/packages/idenplane-mcp/tsup.config.ts
+++ b/packages/idenplane-mcp/tsup.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
   dts: true,
   clean: true,
   target: 'node18',
+  // @idenplane/http-internal is an unpublished, monorepo-local package —
+  // inline it into the bundle rather than leaving a require/import that
+  // wouldn't resolve for a real npm install of @idenplane/mcp.
+  noExternal: ['@idenplane/http-internal'],
   banner: {
     js: '#!/usr/bin/env node',
   },


### PR DESCRIPTION
## Summary
- `idenplane-cli/src/http.ts` and `idenplane-mcp/src/client.ts` each implemented their own thin fetch wrapper with nearly identical request/response handling: the same URL-with-query-params construction, the same `message`/`error`/statusText fallback chain for extracting an error message, the same 204→no-body short-circuit, and the same unchecked JSON cast. Any correctness fix had to be made twice and would drift.
- Added a new private, unpublished `packages/idenplane-http-internal` with a single parameterized `rawRequest()`/`extractErrorMessage()`/`buildUrlWithQuery()` implementation. Both `idenplane-cli`'s `HttpClient` and `idenplane-mcp`'s `IdenplaneClient` now wrap it with their own auth-header construction and error type (a chalk-formatted `Error` vs `ApiError`), which is the only part that actually differed between them.
- Since the shared package is monorepo-internal and never published, each consumer depends on it via a `devDependency` `file:` link and inlines it at build time (`tsup` `noExternal`) so the published npm packages stay self-contained — neither `idenplane-cli` nor `@idenplane/mcp` gains a new runtime dependency a real `npm install` would need to resolve.
- CI now builds the shared package before `idenplane-mcp`'s job, mirroring the existing `idenplane-js` prebuild step already used for vue/angular/nextjs.

Closes #1257

## Test plan
- [x] `idenplane-http-internal`: `npm run typecheck` and `npm run test` — 7/7 passing (new package, new tests for `rawRequest`/`extractErrorMessage`/`buildUrlWithQuery`)
- [x] `idenplane-cli`: `npm run typecheck` and `npm run test` — 38/38 passing (4 new tests for `HttpClient`, which had no prior test coverage)
- [x] `idenplane-mcp`: `npm run typecheck` and `npm run test:all` — 17/17 passing (existing smoke + path-traversal + integration suites, unaffected by the refactor)
- [x] Verified `grep -c "@idenplane/http-internal" dist/index.js` is `0` for both `idenplane-cli` and `idenplane-mcp` builds — confirms the shared package is fully inlined, not left as an unresolved import in the published bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW