### PR TITLE
perf(sdk): cache parsed JWT claims and use TextDecoder in idenplane-js

### DIFF
--- a/packages/idenplane-js/src/__tests__/client.test.ts
+++ b/packages/idenplane-js/src/__tests__/client.test.ts
@@ -315,6 +315,27 @@ describe('IdenplaneClient', () => {
       expect(claims?.sub).toBe('user-123');
       expect(claims?.email).toBe('test@example.com');
     });
+
+    it('reuses the parsed claims object across calls for the same token', () => {
+      const client = new IdenplaneClient(BASE_CONFIG);
+      (client as any).storage.set('access_token', makeValidAccessToken());
+      const first = client.getTokenClaims();
+      const second = client.getTokenClaims();
+      // Same reference => the second call hit the cache instead of re-parsing.
+      expect(second).toBe(first);
+    });
+
+    it('re-parses when the access token in storage changes', () => {
+      const client = new IdenplaneClient(BASE_CONFIG);
+      (client as any).storage.set('access_token', makeValidAccessToken());
+      const first = client.getTokenClaims();
+
+      (client as any).storage.set('access_token', makeValidAccessToken({ sub: 'user-456' }));
+      const second = client.getTokenClaims();
+
+      expect(second).not.toBe(first);
+      expect(second?.sub).toBe('user-456');
+    });
   });
 
   // ── Role helpers ──────────────────────────────────────────────

--- a/packages/idenplane-js/src/client.ts
+++ b/packages/idenplane-js/src/client.ts
@@ -117,6 +117,10 @@ export class IdenplaneClient {
   private static readonly DISCOVERY_TTL_MS = 60 * 60 * 1000; // 1 hour
   private refreshTimer: ReturnType<typeof setTimeout> | null = null;
   private cachedUserInfo: UserInfo | null = null;
+  // Keyed by the raw token string, so a token change (refresh, login, logout)
+  // naturally invalidates the cache without needing to hook into every
+  // storage mutation site.
+  private cachedTokenClaims: { token: string; claims: TokenClaims } | null = null;
   private initialized = false;
   // Bug #4 fix: guard against concurrent calls to init() (e.g. React StrictMode
   // double-mount, multiple components calling init simultaneously).
@@ -415,8 +419,14 @@ export class IdenplaneClient {
     const token = this.storage.get('access_token');
     if (!token) return null;
 
+    if (this.cachedTokenClaims?.token === token) {
+      return this.cachedTokenClaims.claims;
+    }
+
     try {
-      return parseJwt(token);
+      const claims = parseJwt(token);
+      this.cachedTokenClaims = { token, claims };
+      return claims;
     } catch {
       return null;
     }

--- a/packages/idenplane-js/src/token.ts
+++ b/packages/idenplane-js/src/token.ts
@@ -10,13 +10,9 @@ export function parseJwt(token: string): TokenClaims {
     throw new Error('Invalid JWT format');
   }
   const payload = parts[1];
-  const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
-  const json = decodeURIComponent(
-    atob(padded)
-      .split('')
-      .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-      .join(''),
-  );
+  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+  const json = new TextDecoder().decode(bytes);
   return JSON.parse(json);
 }
 


### PR DESCRIPTION
## Summary
- `parseJwt` decoded the JWT payload via a char-by-char `atob().split('').map(charCodeAt→toString(16))...join('')` loop instead of the simpler/faster `TextDecoder`-based decode.
- Worse, `getTokenClaims()` re-parsed the token from storage on every call with no memoization, and is called from `hasRealmRole`, `hasClientRole`, `getRealmRoles`, and `getClientRoles` — so a single `hasPermission()` call triggers up to 2 independent full JWT parses. In UIs that call these role-check helpers per-render or per-menu-item, this compounds quickly.
- Switched `parseJwt` to build a `Uint8Array` and decode it with `TextDecoder`, and cached the parsed claims in `getTokenClaims()` keyed by the raw token string, so a token change (refresh, login, logout) naturally invalidates the cache without needing to hook into every storage mutation site.

Closes #1254

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 111/111 passing (2 new tests: same-token calls return the identical cached claims object by reference; a token change in storage produces a fresh, different object)
- [x] Existing unicode-payload test (`parseJwt` with Arabic text in a claim) still passes, covering the `TextDecoder` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW