### PR TITLE
refactor(sdk): split the 851-line IdenplaneClient into focused modules

### DIFF
--- a/packages/idenplane-js/src/__tests__/discovery.test.ts
+++ b/packages/idenplane-js/src/__tests__/discovery.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { DiscoveryClient } from '../discovery.js';
+
+const oidcDiscovery = {
+  issuer: 'http://localhost:3000/realms/test',
+  authorization_endpoint: 'http://localhost:3000/realms/test/protocol/openid-connect/auth',
+  token_endpoint: 'http://localhost:3000/realms/test/protocol/openid-connect/token',
+  userinfo_endpoint: 'http://localhost:3000/realms/test/protocol/openid-connect/userinfo',
+  jwks_uri: 'http://localhost:3000/realms/test/protocol/openid-connect/certs',
+  end_session_endpoint: 'http://localhost:3000/realms/test/protocol/openid-connect/logout',
+  response_types_supported: ['code'],
+  grant_types_supported: ['authorization_code', 'refresh_token'],
+  subject_types_supported: ['public'],
+  id_token_signing_alg_values_supported: ['RS256'],
+  scopes_supported: ['openid', 'profile', 'email'],
+  token_endpoint_auth_methods_supported: ['none'],
+  claims_supported: ['sub', 'name', 'email'],
+};
+
+describe('DiscoveryClient', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the discovery document from the realm well-known URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(oidcDiscovery),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DiscoveryClient('http://localhost:3000', 'test');
+    const config = await client.getConfig();
+
+    expect(config).toEqual(oidcDiscovery);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:3000/realms/test/.well-known/openid-configuration',
+    );
+  });
+
+  it('caches the document across calls instead of re-fetching', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(oidcDiscovery),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DiscoveryClient('http://localhost:3000', 'test');
+    await client.getConfig();
+    await client.getConfig();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws and evicts the cache when the fetch fails', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DiscoveryClient('http://localhost:3000', 'test');
+    await expect(client.getConfig()).rejects.toThrow('Failed to fetch OIDC discovery document');
+
+    // A subsequent call retries rather than serving a poisoned cache.
+    fetchMock.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(oidcDiscovery) });
+    const config = await client.getConfig();
+    expect(config).toEqual(oidcDiscovery);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetchDiscovery() unconditionally re-fetches, bypassing the cache', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(oidcDiscovery),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new DiscoveryClient('http://localhost:3000', 'test');
+    await client.getConfig();
+    await client.fetchDiscovery();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/idenplane-js/src/client.ts
+++ b/packages/idenplane-js/src/client.ts
@@ -7,37 +7,15 @@ import type {
   UserInfo,
 } from './types.js';
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './pkce.js';
-import { getTokenExpiresIn, isTokenExpired, parseJwt } from './token.js';
+import { isTokenExpired, parseJwt } from './token.js';
 import { createStorage, type TokenStorage } from './storage.js';
 import { EventEmitter } from './events.js';
+import { DiscoveryClient } from './discovery.js';
+import { TokenRefresher } from './token-refresh.js';
 
 const DEFAULT_SCOPES = ['openid', 'profile', 'email'];
 const DEFAULT_REFRESH_BUFFER = 30; // seconds before expiry to trigger refresh
-// For "eager" strategy, refresh this much earlier than the normal buffer
-const EAGER_REFRESH_MULTIPLIER = 2;
 
-/**
- * Call this function on the page that serves as the silent-refresh redirect URI.
- *
- * Bug #438-1 fix: the `silentRefresh()` iframe flow requires the redirect-URI
- * page to post an `idenplane:silent_callback` message back to the parent window.
- * Without this, the parent's `message` event listener never fires and every
- * silent refresh times out after 10 seconds.
- *
- * The redirect URI page (e.g. `/silent-callback.html`) must call this helper:
- *
- * ```html
- * <!-- public/silent-callback.html -->
- * <script type="module">
- *   import { handleSilentCallback } from '@idenplane/js';
- *   handleSilentCallback();
- * </script>
- * ```
- *
- * The function reads `code`, `state`, and `error` from the current URL's
- * search params and posts them to the parent window via `postMessage`.
- * It is a no-op outside of a browser iframe context.
- */
 /**
  * Reject non-HTTPS server URLs, since they would send access tokens, refresh
  * tokens, and PKCE verifiers over the wire in plaintext. Loopback hosts
@@ -66,6 +44,28 @@ function assertSecureServerUrl(url: string, allowInsecureHttp: boolean | undefin
   throw new Error(`Idenplane: server URL must use "https://" (got "${parsed.protocol}//" in "${url}")`);
 }
 
+/**
+ * Call this function on the page that serves as the silent-refresh redirect URI.
+ *
+ * Bug #438-1 fix: the `silentRefresh()` iframe flow requires the redirect-URI
+ * page to post an `idenplane:silent_callback` message back to the parent window.
+ * Without this, the parent's `message` event listener never fires and every
+ * silent refresh times out after 10 seconds.
+ *
+ * The redirect URI page (e.g. `/silent-callback.html`) must call this helper:
+ *
+ * ```html
+ * <!-- public/silent-callback.html -->
+ * <script type="module">
+ *   import { handleSilentCallback } from '@idenplane/js';
+ *   handleSilentCallback();
+ * </script>
+ * ```
+ *
+ * The function reads `code`, `state`, and `error` from the current URL's
+ * search params and posts them to the parent window via `postMessage`.
+ * It is a no-op outside of a browser iframe context.
+ */
 export function handleSilentCallback(): void {
   if (typeof window === 'undefined') return;
   // Only act when running inside an iframe
@@ -106,16 +106,8 @@ export class IdenplaneClient {
 
   private storage: TokenStorage;
   private events = new EventEmitter<IdenplaneEventMap>();
-  private oidcConfig: OpenIDConfiguration | null = null;
-  // Bug #438-2 fix: the discovery document was cached forever.  If the IdP
-  // returns an error (e.g. 5xx) and `oidcConfig` somehow already held a stale
-  // value, that stale config would be served indefinitely.  More practically,
-  // key-rotation events (IdP JWKS changes) would go undetected.
-  // Fix: record the fetch timestamp and evict the cache after 1 hour so the
-  // discovery document is periodically re-fetched.
-  private oidcConfigFetchedAt: number | null = null;
-  private static readonly DISCOVERY_TTL_MS = 60 * 60 * 1000; // 1 hour
-  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private discoveryClient: DiscoveryClient;
+  private tokenRefresher: TokenRefresher;
   private cachedUserInfo: UserInfo | null = null;
   // Keyed by the raw token string, so a token change (refresh, login, logout)
   // naturally invalidates the cache without needing to hook into every
@@ -127,7 +119,6 @@ export class IdenplaneClient {
   private _initializing = false;
   private _initPromise: Promise<boolean> | null = null;
   private callbackPromise: Promise<boolean> | null = null;
-  private silentRefreshIframe: HTMLIFrameElement | null = null;
 
   constructor(config: IdenplaneConfig) {
     assertSecureServerUrl(config.url, config.allowInsecureHttp);
@@ -151,6 +142,22 @@ export class IdenplaneClient {
     // sessionStorage/localStorage are accessible to any JS on the page.
     // Users can opt-in to persistent storage if they accept the risk.
     this.storage = createStorage(config.storage ?? 'memory');
+
+    this.discoveryClient = new DiscoveryClient(this.config.url, this.config.realm);
+    this.tokenRefresher = new TokenRefresher({
+      storage: this.storage,
+      events: this.events,
+      getOidcConfig: () => this.discoveryClient.getConfig(),
+      storeTokens: (tokens) => this.storeTokens(tokens),
+      clearTokens: () => this.clearTokens(),
+      clientId: this.config.clientId,
+      scopes: this.config.scopes,
+      redirectUri: this.config.redirectUri,
+      silentRedirectUri: this.config.silentRedirectUri,
+      refreshStrategy: this.config.refreshStrategy,
+      refreshBuffer: this.config.refreshBuffer,
+      autoRefresh: this.config.autoRefresh,
+    });
 
     // Wire up callback-style config options to the event system
     if (config.onLogin) {
@@ -187,14 +194,14 @@ export class IdenplaneClient {
   }
 
   private async _init(): Promise<boolean> {
-    await this.fetchDiscovery();
+    await this.discoveryClient.fetchDiscovery();
 
     const accessToken = this.storage.get('access_token');
     if (accessToken) {
       try {
         const claims = parseJwt(accessToken);
         if (!isTokenExpired(claims)) {
-          this.scheduleRefresh();
+          this.tokenRefresher.scheduleRefresh();
           this.initialized = true;
           this.events.emit('ready', true);
           return true;
@@ -222,7 +229,7 @@ export class IdenplaneClient {
     // Attempt silent auth if strategy is 'silent'
     if (this.config.refreshStrategy === 'silent' && typeof window !== 'undefined') {
       try {
-        const silentSuccess = await this.silentAuthenticate();
+        const silentSuccess = await this.tokenRefresher.silentAuthenticate();
         this.initialized = true;
         this.events.emit('ready', silentSuccess);
         return silentSuccess;
@@ -338,7 +345,7 @@ export class IdenplaneClient {
 
     const tokens: TokenResponse = await response.json();
     this.storeTokens(tokens);
-    this.scheduleRefresh();
+    this.tokenRefresher.scheduleRefresh();
 
     // Clean up PKCE state
     this.storage.remove('pkce_verifier');
@@ -534,223 +541,7 @@ export class IdenplaneClient {
    * This is called automatically when autoRefresh is enabled.
    */
   async refreshTokens(): Promise<TokenResponse> {
-    const strategy = this.config.refreshStrategy;
-
-    if (strategy === 'silent') {
-      return this.silentRefresh();
-    }
-
-    return this.rotationRefresh();
-  }
-
-  /**
-   * Refresh tokens using the rotation (refresh_token grant) strategy.
-   */
-  private async rotationRefresh(): Promise<TokenResponse> {
-    const refreshToken = this.storage.get('refresh_token');
-    if (!refreshToken) {
-      throw new Error('No refresh token available');
-    }
-
-    const config = await this.getOidcConfig();
-    const body = new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-      client_id: this.config.clientId,
-    });
-
-    const response = await fetch(config.token_endpoint, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: body.toString(),
-    });
-
-    if (!response.ok) {
-      const err = await response.json().catch(() => ({ error: 'refresh_failed' }));
-      // Bug #2 fix: only discard stored tokens when the server definitively rejects
-      // the refresh token (4xx — e.g. invalid_grant, token revoked).  On 5xx
-      // (server errors, network hiccups) the tokens may still be valid; clearing
-      // them would silently log the user out due to a transient server problem.
-      if (response.status >= 400 && response.status < 500) {
-        this.clearTokens();
-      }
-      throw new Error(err.error_description ?? err.error);
-    }
-
-    const tokens: TokenResponse = await response.json();
-    this.storeTokens(tokens);
-    this.scheduleRefresh();
-    this.events.emit('tokenRefresh', tokens);
-    // Backward compatibility alias
-    this.events.emit('tokenRefreshed', tokens);
-    return tokens;
-  }
-
-  /**
-   * Attempt silent authentication using a hidden iframe.
-   * The iframe will go through the authorization flow with prompt=none,
-   * which succeeds only if the user has an active session at the IdP.
-   */
-  private async silentAuthenticate(): Promise<boolean> {
-    if (typeof window === 'undefined') return false;
-
-    try {
-      const tokens = await this.silentRefresh();
-      return !!tokens;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Perform a silent token refresh via hidden iframe.
-   * Requires the server to support prompt=none and check_session_iframe.
-   */
-  private silentRefresh(): Promise<TokenResponse> {
-    // Fall back to rotation if not in a browser environment or no session endpoint
-    if (typeof window === 'undefined') {
-      return this.rotationRefresh();
-    }
-
-    return this._silentRefreshAsync();
-  }
-
-  private async _silentRefreshAsync(): Promise<TokenResponse> {
-    const oidcConfig = await this.getOidcConfig();
-    const verifier = generateCodeVerifier();
-    const challenge = await generateCodeChallenge(verifier);
-    const state = generateState();
-    const nonce = generateState();
-
-    // Store PKCE state for callback
-    this.storage.set('silent_pkce_verifier', verifier);
-    this.storage.set('silent_auth_state', state);
-
-    // Resolve the redirect URI for the silent-refresh iframe.  A dedicated
-    // silentRedirectUri (pointing at a page that calls handleSilentCallback)
-    // is strongly recommended.  Falling back to the main redirectUri works
-    // only if that page also posts the idenplane:silent_callback message.
-    let silentRedirectUri: string;
-    if (this.config.silentRedirectUri) {
-      silentRedirectUri = this.config.silentRedirectUri;
-    } else {
-      console.warn(
-        '[idenplane] silentRedirectUri is not set. ' +
-          'Falling back to redirectUri for the silent-refresh iframe. ' +
-          'Set silentRedirectUri to a dedicated page that calls handleSilentCallback().',
-      );
-      silentRedirectUri = this.config.redirectUri;
-    }
-
-    const params = new URLSearchParams({
-      response_type: 'code',
-      client_id: this.config.clientId,
-      redirect_uri: silentRedirectUri,
-      scope: this.config.scopes.join(' '),
-      state,
-      nonce,
-      code_challenge: challenge,
-      code_challenge_method: 'S256',
-      prompt: 'none',
-    });
-
-    const authUrl = `${oidcConfig.authorization_endpoint}?${params.toString()}`;
-
-    // Remove old iframe if present
-    if (this.silentRefreshIframe) {
-      document.body.removeChild(this.silentRefreshIframe);
-      this.silentRefreshIframe = null;
-    }
-
-    const iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    iframe.style.width = '0';
-    iframe.style.height = '0';
-    this.silentRefreshIframe = iframe;
-
-    return new Promise<TokenResponse>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        cleanup();
-        reject(new Error('Silent refresh timed out'));
-      }, 10000);
-
-      const onMessage = async (event: MessageEvent) => {
-        if (event.origin !== window.location.origin) return;
-        if (!event.data?.type || event.data.type !== 'idenplane:silent_callback') return;
-
-        cleanup();
-
-        const { code, state: returnedState, error } = event.data;
-
-        if (error) {
-          reject(new Error(error));
-          return;
-        }
-
-        const storedState = this.storage.get('silent_auth_state');
-        if (!storedState || returnedState !== storedState) {
-          reject(new Error('Silent refresh state mismatch'));
-          return;
-        }
-
-        const storedVerifier = this.storage.get('silent_pkce_verifier');
-        if (!storedVerifier || !code) {
-          reject(new Error('Missing silent refresh PKCE data'));
-          return;
-        }
-
-        this.storage.remove('silent_pkce_verifier');
-        this.storage.remove('silent_auth_state');
-
-        try {
-          const body = new URLSearchParams({
-            grant_type: 'authorization_code',
-            code,
-            redirect_uri: silentRedirectUri,
-            client_id: this.config.clientId,
-            code_verifier: storedVerifier,
-          });
-
-          const response = await fetch(oidcConfig.token_endpoint, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-            body: body.toString(),
-          });
-
-          if (!response.ok) {
-            const err = await response.json().catch(() => ({ error: 'silent_refresh_failed' }));
-            reject(new Error(err.error_description ?? err.error));
-            return;
-          }
-
-          const tokens: TokenResponse = await response.json();
-          this.storeTokens(tokens);
-          this.scheduleRefresh();
-          this.events.emit('tokenRefresh', tokens);
-          this.events.emit('tokenRefreshed', tokens);
-          resolve(tokens);
-        } catch (err) {
-          reject(err);
-        }
-      };
-
-      const cleanup = () => {
-        clearTimeout(timeout);
-        window.removeEventListener('message', onMessage);
-        if (this.silentRefreshIframe) {
-          try {
-            document.body.removeChild(this.silentRefreshIframe);
-          } catch {
-            // Ignore
-          }
-          this.silentRefreshIframe = null;
-        }
-      };
-
-      window.addEventListener('message', onMessage);
-      document.body.appendChild(iframe);
-      iframe.src = authUrl;
-    });
+    return this.tokenRefresher.refresh();
   }
 
   // ── Events ──────────────────────────────────────────────────────
@@ -806,30 +597,8 @@ export class IdenplaneClient {
 
   // ── Internal ────────────────────────────────────────────────────
 
-  private async fetchDiscovery(): Promise<void> {
-    // SSR-safe: skip if no fetch available (edge case)
-    const url = `${this.config.url}/realms/${this.config.realm}/.well-known/openid-configuration`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      // On error, evict any stale cached config so the next call retries.
-      this.oidcConfig = null;
-      this.oidcConfigFetchedAt = null;
-      throw new Error(`Failed to fetch OIDC discovery document from ${url}`);
-    }
-    this.oidcConfig = await response.json();
-    this.oidcConfigFetchedAt = Date.now();
-  }
-
   private async getOidcConfig(): Promise<OpenIDConfiguration> {
-    const now = Date.now();
-    const isExpired =
-      this.oidcConfigFetchedAt === null ||
-      now - this.oidcConfigFetchedAt > IdenplaneClient.DISCOVERY_TTL_MS;
-
-    if (!this.oidcConfig || isExpired) {
-      await this.fetchDiscovery();
-    }
-    return this.oidcConfig!;
+    return this.discoveryClient.getConfig();
   }
 
   private storeTokens(tokens: TokenResponse): void {
@@ -845,46 +614,8 @@ export class IdenplaneClient {
   }
 
   private clearTokens(): void {
-    this.cancelRefreshTimer();
+    this.tokenRefresher.cancelRefreshTimer();
     this.storage.clear();
     this.cachedUserInfo = null;
-  }
-
-  private scheduleRefresh(): void {
-    if (!this.config.autoRefresh) return;
-    this.cancelRefreshTimer();
-
-    const token = this.storage.get('access_token');
-    if (!token) return;
-
-    try {
-      const claims = parseJwt(token);
-      const expiresIn = getTokenExpiresIn(claims);
-
-      // For eager strategy, refresh even sooner (2x the buffer)
-      const buffer =
-        this.config.refreshStrategy === 'eager'
-          ? this.config.refreshBuffer * EAGER_REFRESH_MULTIPLIER
-          : this.config.refreshBuffer;
-
-      const refreshIn = Math.max(0, expiresIn - buffer) * 1000;
-
-      this.refreshTimer = setTimeout(async () => {
-        try {
-          await this.refreshTokens();
-        } catch (err) {
-          this.events.emit('error', err instanceof Error ? err : new Error(String(err)));
-        }
-      }, refreshIn);
-    } catch {
-      // Token parse failure — don't schedule
-    }
-  }
-
-  private cancelRefreshTimer(): void {
-    if (this.refreshTimer) {
-      clearTimeout(this.refreshTimer);
-      this.refreshTimer = null;
-    }
   }
 }

--- a/packages/idenplane-js/src/discovery.ts
+++ b/packages/idenplane-js/src/discovery.ts
@@ -1,0 +1,48 @@
+import type { OpenIDConfiguration } from './types.js';
+
+const DISCOVERY_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+/**
+ * Fetches and caches a realm's OIDC discovery document.
+ *
+ * Bug #438-2 fix: the discovery document was cached forever. If the IdP
+ * returns an error (e.g. 5xx) and the cache somehow already held a stale
+ * value, that stale config would be served indefinitely. More practically,
+ * key-rotation events (IdP JWKS changes) would go undetected. Fix: record
+ * the fetch timestamp and evict the cache after `DISCOVERY_TTL_MS` so the
+ * discovery document is periodically re-fetched.
+ */
+export class DiscoveryClient {
+  private config: OpenIDConfiguration | null = null;
+  private fetchedAt: number | null = null;
+
+  constructor(
+    private readonly serverUrl: string,
+    private readonly realm: string,
+  ) {}
+
+  /** Unconditionally re-fetch the discovery document, replacing any cached value. */
+  async fetchDiscovery(): Promise<void> {
+    const url = `${this.serverUrl}/realms/${this.realm}/.well-known/openid-configuration`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      // On error, evict any stale cached config so the next call retries.
+      this.config = null;
+      this.fetchedAt = null;
+      throw new Error(`Failed to fetch OIDC discovery document from ${url}`);
+    }
+    this.config = await response.json();
+    this.fetchedAt = Date.now();
+  }
+
+  /** Get the discovery document, fetching (or re-fetching an expired one) as needed. */
+  async getConfig(): Promise<OpenIDConfiguration> {
+    const now = Date.now();
+    const isExpired = this.fetchedAt === null || now - this.fetchedAt > DISCOVERY_TTL_MS;
+
+    if (!this.config || isExpired) {
+      await this.fetchDiscovery();
+    }
+    return this.config!;
+  }
+}

--- a/packages/idenplane-js/src/silent-refresh.ts
+++ b/packages/idenplane-js/src/silent-refresh.ts
@@ -1,0 +1,161 @@
+import type { TokenResponse } from './types.js';
+import type { TokenStorage } from './storage.js';
+import { generateCodeChallenge, generateCodeVerifier, generateState } from './pkce.js';
+
+const SILENT_REFRESH_TIMEOUT_MS = 10000;
+
+export interface SilentRefreshDeps {
+  storage: TokenStorage;
+  clientId: string;
+  scopes: string[];
+  redirectUri: string;
+  silentRedirectUri?: string;
+  getOidcConfig: () => Promise<{ authorization_endpoint: string; token_endpoint: string }>;
+}
+
+/**
+ * Perform a silent token refresh via a hidden iframe. Requires the server to
+ * support `prompt=none` and a check-session iframe flow. The redirect-URI
+ * page it targets must call `handleSilentCallback()` to post the
+ * `idenplane:silent_callback` message this function listens for.
+ *
+ * `iframeBox` lets the caller track the current iframe across calls so a
+ * stale one (from a silent refresh that didn't finish) gets torn down before
+ * a new one starts.
+ */
+export async function performSilentRefresh(
+  deps: SilentRefreshDeps,
+  iframeBox: { current: HTMLIFrameElement | null },
+): Promise<TokenResponse> {
+  const oidcConfig = await deps.getOidcConfig();
+  const verifier = generateCodeVerifier();
+  const challenge = await generateCodeChallenge(verifier);
+  const state = generateState();
+  const nonce = generateState();
+
+  // Store PKCE state for callback
+  deps.storage.set('silent_pkce_verifier', verifier);
+  deps.storage.set('silent_auth_state', state);
+
+  // Resolve the redirect URI for the silent-refresh iframe. A dedicated
+  // silentRedirectUri (pointing at a page that calls handleSilentCallback)
+  // is strongly recommended. Falling back to the main redirectUri works
+  // only if that page also posts the idenplane:silent_callback message.
+  let silentRedirectUri: string;
+  if (deps.silentRedirectUri) {
+    silentRedirectUri = deps.silentRedirectUri;
+  } else {
+    console.warn(
+      '[idenplane] silentRedirectUri is not set. ' +
+        'Falling back to redirectUri for the silent-refresh iframe. ' +
+        'Set silentRedirectUri to a dedicated page that calls handleSilentCallback().',
+    );
+    silentRedirectUri = deps.redirectUri;
+  }
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: deps.clientId,
+    redirect_uri: silentRedirectUri,
+    scope: deps.scopes.join(' '),
+    state,
+    nonce,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    prompt: 'none',
+  });
+
+  const authUrl = `${oidcConfig.authorization_endpoint}?${params.toString()}`;
+
+  // Remove old iframe if present
+  if (iframeBox.current) {
+    document.body.removeChild(iframeBox.current);
+    iframeBox.current = null;
+  }
+
+  const iframe = document.createElement('iframe');
+  iframe.style.display = 'none';
+  iframe.style.width = '0';
+  iframe.style.height = '0';
+  iframeBox.current = iframe;
+
+  return new Promise<TokenResponse>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error('Silent refresh timed out'));
+    }, SILENT_REFRESH_TIMEOUT_MS);
+
+    const onMessage = async (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      if (!event.data?.type || event.data.type !== 'idenplane:silent_callback') return;
+
+      cleanup();
+
+      const { code, state: returnedState, error } = event.data;
+
+      if (error) {
+        reject(new Error(error));
+        return;
+      }
+
+      const storedState = deps.storage.get('silent_auth_state');
+      if (!storedState || returnedState !== storedState) {
+        reject(new Error('Silent refresh state mismatch'));
+        return;
+      }
+
+      const storedVerifier = deps.storage.get('silent_pkce_verifier');
+      if (!storedVerifier || !code) {
+        reject(new Error('Missing silent refresh PKCE data'));
+        return;
+      }
+
+      deps.storage.remove('silent_pkce_verifier');
+      deps.storage.remove('silent_auth_state');
+
+      try {
+        const body = new URLSearchParams({
+          grant_type: 'authorization_code',
+          code,
+          redirect_uri: silentRedirectUri,
+          client_id: deps.clientId,
+          code_verifier: storedVerifier,
+        });
+
+        const response = await fetch(oidcConfig.token_endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: body.toString(),
+        });
+
+        if (!response.ok) {
+          const err = await response.json().catch(() => ({ error: 'silent_refresh_failed' }));
+          reject(new Error(err.error_description ?? err.error));
+          return;
+        }
+
+        const tokens: TokenResponse = await response.json();
+        resolve(tokens);
+      } catch (err) {
+        reject(err);
+      }
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      window.removeEventListener('message', onMessage);
+      if (iframeBox.current) {
+        try {
+          document.body.removeChild(iframeBox.current);
+        } catch {
+          // Ignore
+        }
+        iframeBox.current = null;
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    document.body.appendChild(iframe);
+    iframe.src = authUrl;
+  });
+}

--- a/packages/idenplane-js/src/token-refresh.ts
+++ b/packages/idenplane-js/src/token-refresh.ts
@@ -1,0 +1,157 @@
+import type { TokenResponse } from './types.js';
+import type { TokenStorage } from './storage.js';
+import type { EventEmitter } from './events.js';
+import type { IdenplaneEventMap } from './types.js';
+import { getTokenExpiresIn, parseJwt } from './token.js';
+import { performSilentRefresh } from './silent-refresh.js';
+
+// For "eager" strategy, refresh this much earlier than the normal buffer
+const EAGER_REFRESH_MULTIPLIER = 2;
+
+export interface TokenRefresherDeps {
+  storage: TokenStorage;
+  events: EventEmitter<IdenplaneEventMap>;
+  getOidcConfig: () => Promise<{ authorization_endpoint: string; token_endpoint: string }>;
+  /** Persists newly-obtained tokens (and invalidates any caches keyed on them). */
+  storeTokens: (tokens: TokenResponse) => void;
+  /** Discards all stored tokens, e.g. after the server definitively rejects a refresh. */
+  clearTokens: () => void;
+  clientId: string;
+  scopes: string[];
+  redirectUri: string;
+  silentRedirectUri?: string;
+  refreshStrategy: 'silent' | 'rotation' | 'eager';
+  refreshBuffer: number;
+  autoRefresh: boolean;
+}
+
+/**
+ * Owns the token-refresh lifecycle: dispatching to the configured strategy
+ * (rotation grant, or a silent-iframe re-authentication), and scheduling the
+ * next automatic refresh before the current access token expires.
+ */
+export class TokenRefresher {
+  private refreshTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly silentRefreshIframeBox: { current: HTMLIFrameElement | null } = { current: null };
+
+  constructor(private readonly deps: TokenRefresherDeps) {}
+
+  /** Refresh using the configured strategy. */
+  async refresh(): Promise<TokenResponse> {
+    if (this.deps.refreshStrategy === 'silent') {
+      return this.silentRefresh();
+    }
+    return this.rotationRefresh();
+  }
+
+  /** Refresh tokens using the rotation (refresh_token grant) strategy. */
+  async rotationRefresh(): Promise<TokenResponse> {
+    const refreshToken = this.deps.storage.get('refresh_token');
+    if (!refreshToken) {
+      throw new Error('No refresh token available');
+    }
+
+    const config = await this.deps.getOidcConfig();
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+      client_id: this.deps.clientId,
+    });
+
+    const response = await fetch(config.token_endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: 'refresh_failed' }));
+      // Bug #2 fix: only discard stored tokens when the server definitively rejects
+      // the refresh token (4xx — e.g. invalid_grant, token revoked). On 5xx
+      // (server errors, network hiccups) the tokens may still be valid; clearing
+      // them would silently log the user out due to a transient server problem.
+      if (response.status >= 400 && response.status < 500) {
+        this.deps.clearTokens();
+      }
+      throw new Error(err.error_description ?? err.error);
+    }
+
+    const tokens: TokenResponse = await response.json();
+    this.finishRefresh(tokens);
+    return tokens;
+  }
+
+  /**
+   * Attempt silent authentication using a hidden iframe. The iframe goes
+   * through the authorization flow with prompt=none, which succeeds only if
+   * the user has an active session at the IdP.
+   */
+  async silentAuthenticate(): Promise<boolean> {
+    if (typeof window === 'undefined') return false;
+
+    try {
+      await this.silentRefresh();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Perform a silent token refresh via hidden iframe (falls back to rotation off-browser). */
+  private async silentRefresh(): Promise<TokenResponse> {
+    if (typeof window === 'undefined') {
+      return this.rotationRefresh();
+    }
+
+    const tokens = await performSilentRefresh(this.deps, this.silentRefreshIframeBox);
+    this.finishRefresh(tokens);
+    return tokens;
+  }
+
+  private finishRefresh(tokens: TokenResponse): void {
+    this.deps.storeTokens(tokens);
+    this.scheduleRefresh();
+    this.deps.events.emit('tokenRefresh', tokens);
+    // Backward compatibility alias
+    this.deps.events.emit('tokenRefreshed', tokens);
+  }
+
+  /** Schedule the next automatic refresh before the current access token expires. */
+  scheduleRefresh(): void {
+    if (!this.deps.autoRefresh) return;
+    this.cancelRefreshTimer();
+
+    const token = this.deps.storage.get('access_token');
+    if (!token) return;
+
+    try {
+      const claims = parseJwt(token);
+      const expiresIn = getTokenExpiresIn(claims);
+
+      // For eager strategy, refresh even sooner (2x the buffer)
+      const buffer =
+        this.deps.refreshStrategy === 'eager'
+          ? this.deps.refreshBuffer * EAGER_REFRESH_MULTIPLIER
+          : this.deps.refreshBuffer;
+
+      const refreshIn = Math.max(0, expiresIn - buffer) * 1000;
+
+      this.refreshTimer = setTimeout(async () => {
+        try {
+          await this.refresh();
+        } catch (err) {
+          this.deps.events.emit('error', err instanceof Error ? err : new Error(String(err)));
+        }
+      }, refreshIn);
+    } catch {
+      // Token parse failure — don't schedule
+    }
+  }
+
+  cancelRefreshTimer(): void {
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
`IdenplaneClient` was a single class responsible for OIDC discovery/caching, PKCE authorization-code flow, callback handling, three distinct token-refresh strategies (rotation, silent-iframe, eager), user-info caching, role/permission checks, event emission, and logout. The silent-refresh iframe logic alone was 137 lines of DOM/postMessage management with nothing to do with, e.g., role checking, and testing any one concern meant mocking `window`/`document`/`fetch` all at once.

Split into composable units, matching the issue's suggested shape:
- **`discovery.ts`** — `DiscoveryClient` owns OIDC discovery document fetching and its 1-hour TTL cache, independent of the rest of the client.
- **`silent-refresh.ts`** — `performSilentRefresh()` is a standalone function that takes its dependencies (storage, config values, a `getOidcConfig` callback) as an explicit argument, not `this` — so it's actually decoupled from `IdenplaneClient`, not just relocated.
- **`token-refresh.ts`** — `TokenRefresher` dispatches rotation vs. silent refresh, owns the refresh timer and iframe-tracking state, and schedules the next automatic refresh.
- **`client.ts`** — now a thin facade that composes the above, plus the PKCE login/callback/logout flow, token/claims access, user info, role helpers, and events: the concerns that are genuinely the client's own identity.

`IdenplaneClient` still owns `storage`/`events`/`config` as direct instance properties (the existing test file pokes at these via `(client as any)`), and the public API is unchanged.

**Drive-by:** fixed `handleSilentCallback`'s JSDoc, which the #1249 PR had accidentally orphaned above an unrelated function when `assertSecureServerUrl` was inserted between the comment and the function it documented.

`client.ts`: 851 → 621 lines.

Closes #1260

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — **111/111 existing tests passing with zero test-file changes** (the regression safety net the issue itself called out), plus 4 new tests
- [x] Added `discovery.test.ts` — 4 new tests for `DiscoveryClient` in isolation, demonstrating the actual payoff: no `window`/`document`/`fetch`-juggling needed to test discovery caching on its own
- [x] Verified `idenplane-nextjs` still typechecks against the rebuilt `idenplane-js` dist (unchanged public API surface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW