### PR TITLE
fix(security): redact realm-config secrets from logs and audit events

### DIFF
--- a/src/common/logging/logger.config.spec.ts
+++ b/src/common/logging/logger.config.spec.ts
@@ -1,0 +1,37 @@
+import { createLoggerConfig } from './logger.config.js';
+import { SENSITIVE_BODY_FIELDS } from '../security/sensitive-body-fields.js';
+
+describe('createLoggerConfig', () => {
+  function getRedactPaths(): string[] {
+    const config = createLoggerConfig();
+    return (config.pinoHttp as { redact: { paths: string[] } }).redact.paths;
+  }
+
+  it('should redact the authorization and admin API key headers', () => {
+    const paths = getRedactPaths();
+    expect(paths).toContain('req.headers.authorization');
+    expect(paths).toContain('req.headers["x-admin-api-key"]');
+  });
+
+  it('should redact every field in the canonical sensitive-body-fields list', () => {
+    const paths = getRedactPaths();
+    for (const field of SENSITIVE_BODY_FIELDS) {
+      expect(paths).toContain(`req.body.${field}`);
+    }
+  });
+
+  it('should redact the realm-config secrets covered by this fix', () => {
+    const paths = getRedactPaths();
+    expect(paths).toContain('req.body.recaptchaSecretKey');
+    expect(paths).toContain('req.body.hcaptchaSecretKey');
+    expect(paths).toContain('req.body.emailProviderConfig');
+    expect(paths).toContain('req.body.smsProviderConfig');
+  });
+
+  it('should censor redacted values with [REDACTED]', () => {
+    const config = createLoggerConfig();
+    expect(
+      (config.pinoHttp as { redact: { censor: string } }).redact.censor,
+    ).toBe('[REDACTED]');
+  });
+});

--- a/src/common/logging/logger.config.ts
+++ b/src/common/logging/logger.config.ts
@@ -1,5 +1,6 @@
 import type { Params } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
+import { SENSITIVE_BODY_FIELDS } from '../security/sensitive-body-fields.js';
 
 export function createLoggerConfig(): Params {
   const isProduction = process.env['NODE_ENV'] === 'production';
@@ -19,12 +20,7 @@ export function createLoggerConfig(): Params {
         paths: [
           'req.headers.authorization',
           'req.headers["x-admin-api-key"]',
-          'req.body.password',
-          'req.body.client_secret',
-          'req.body.smtpPassword',
-          'req.body.currentPassword',
-          'req.body.newPassword',
-          'req.body.confirmPassword',
+          ...SENSITIVE_BODY_FIELDS.map((field) => `req.body.${field}`),
         ],
         censor: '[REDACTED]',
       },

--- a/src/common/security/sensitive-body-fields.spec.ts
+++ b/src/common/security/sensitive-body-fields.spec.ts
@@ -1,0 +1,21 @@
+import { SENSITIVE_BODY_FIELDS } from './sensitive-body-fields.js';
+
+describe('SENSITIVE_BODY_FIELDS', () => {
+  it('should have no duplicate entries', () => {
+    expect(new Set(SENSITIVE_BODY_FIELDS).size).toBe(
+      SENSITIVE_BODY_FIELDS.length,
+    );
+  });
+
+  it('should include the realm-config secrets this fix adds', () => {
+    expect(SENSITIVE_BODY_FIELDS).toEqual(
+      expect.arrayContaining([
+        'recaptchaSecretKey',
+        'hcaptchaSecretKey',
+        'emailProviderConfig',
+        'smsProviderConfig',
+        'confirmPassword',
+      ]),
+    );
+  });
+});

--- a/src/common/security/sensitive-body-fields.ts
+++ b/src/common/security/sensitive-body-fields.ts
@@ -1,0 +1,26 @@
+/**
+ * Canonical list of top-level request-body field names that must never
+ * reach logs or the admin audit trail verbatim. Shared by the pino HTTP
+ * logger (src/common/logging/logger.config.ts) and AdminEventInterceptor
+ * (src/events/admin-event.interceptor.ts) so the two redaction points can't
+ * drift out of sync with each other.
+ *
+ * `emailProviderConfig` and `smsProviderConfig` are redacted wholesale
+ * (the whole nested object, not just specific sub-keys) because the secret
+ * lives at a different path per provider (e.g. `resend.apiKey` vs.
+ * `postmark.serverToken`), and both redaction mechanisms here only match on
+ * top-level key name.
+ */
+export const SENSITIVE_BODY_FIELDS = [
+  'password',
+  'clientSecret',
+  'client_secret',
+  'smtpPassword',
+  'currentPassword',
+  'newPassword',
+  'confirmPassword',
+  'recaptchaSecretKey',
+  'hcaptchaSecretKey',
+  'emailProviderConfig',
+  'smsProviderConfig',
+] as const;

--- a/src/events/admin-event.interceptor.spec.ts
+++ b/src/events/admin-event.interceptor.spec.ts
@@ -303,6 +303,36 @@ describe('AdminEventInterceptor', () => {
       });
     });
 
+    it('should redact realm-config secrets (CAPTCHA/SMS/email provider), including nested objects wholesale', (done) => {
+      const context = createContext({
+        method: 'PUT',
+        path: '/admin/realms/test',
+        body: {
+          displayName: 'Test Realm',
+          confirmPassword: 'new',
+          recaptchaSecretKey: 'recaptcha-secret',
+          hcaptchaSecretKey: 'hcaptcha-secret',
+          emailProviderConfig: { resend: { apiKey: 're_live_secret' } },
+          smsProviderConfig: { twilio: { authToken: 'twilio-secret' } },
+        },
+      });
+
+      interceptor.intercept(context as any, nextHandler).subscribe({
+        complete: () => {
+          const call = eventsService.recordAdminEvent.mock.calls[0][0];
+          expect(call.representation).toEqual({
+            displayName: 'Test Realm',
+            confirmPassword: '[REDACTED]',
+            recaptchaSecretKey: '[REDACTED]',
+            hcaptchaSecretKey: '[REDACTED]',
+            emailProviderConfig: '[REDACTED]',
+            smsProviderConfig: '[REDACTED]',
+          });
+          done();
+        },
+      });
+    });
+
     it('should handle null body gracefully', (done) => {
       const context = createContext({
         method: 'POST',

--- a/src/events/admin-event.interceptor.ts
+++ b/src/events/admin-event.interceptor.ts
@@ -9,6 +9,7 @@ import type { Request } from 'express';
 import { EventsService } from './events.service.js';
 import { ResourceType, OperationType } from './event-types.js';
 import type { OperationTypeValue, ResourceTypeValue } from './event-types.js';
+import { SENSITIVE_BODY_FIELDS } from '../common/security/sensitive-body-fields.js';
 
 const RESOURCE_TYPE_MAP: Array<{ pattern: RegExp; type: ResourceTypeValue }> = [
   // More-specific patterns must come before broader ones to avoid mis-classification.
@@ -114,15 +115,7 @@ export class AdminEventInterceptor implements NestInterceptor {
     const redacted: Record<string, unknown> = {
       ...(body as Record<string, unknown>),
     };
-    const sensitiveKeys = [
-      'password',
-      'clientSecret',
-      'smtpPassword',
-      'client_secret',
-      'currentPassword',
-      'newPassword',
-    ];
-    for (const key of sensitiveKeys) {
+    for (const key of SENSITIVE_BODY_FIELDS) {
       if (key in redacted) redacted[key] = '[REDACTED]';
     }
     return redacted;


### PR DESCRIPTION
## Summary

Closes #1248. Follows directly from #1247 (which encrypted these fields at rest) — this closes the parallel exposure through logs and the audit trail.

Neither `logger.config.ts`'s pino `redact.paths` nor `admin-event.interceptor.ts`'s `sensitiveKeys` covered `recaptchaSecretKey`, `hcaptchaSecretKey`, `smsProviderConfig`, or `emailProviderConfig`. A realm update request body containing these was logged in HTTP access logs and stored verbatim in `AdminEvent.representation`. The two lists were also inconsistent with each other — the interceptor list was missing `confirmPassword`, which the pino list already had.

- Added `src/common/security/sensitive-body-fields.ts` exporting a single canonical `SENSITIVE_BODY_FIELDS` list, now used by both `logger.config.ts` and `admin-event.interceptor.ts` (per the issue's own suggested fix) so the two lists can't drift apart again.
- `emailProviderConfig` and `smsProviderConfig` are redacted **wholesale** (the entire nested object replaced with `[REDACTED]`), not by nested sub-key — both redaction mechanisms here only match on top-level key name, and the actual secret lives at a different nested path per provider (`resend.apiKey` vs. `postmark.serverToken` vs. whatever a future SMS provider config field turns out to be named).

## Test plan
- [x] `npm run build` — clean
- [x] Full backend suite: `npx jest` — 125 suites / 2118 tests passing
- [x] New: `logger.config.spec.ts` (didn't exist before) asserting every canonical field is present in the pino redact paths
- [x] New: `sensitive-body-fields.spec.ts` — no duplicate entries, includes the fields this fix adds
- [x] Updated `admin-event.interceptor.spec.ts` with a case covering all five new/changed fields, including the wholesale-redaction behavior for the two nested config objects
- [x] `npx eslint` / `npx prettier --check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW