### PR TITLE
perf: RealmGuard uses the realm cache instead of a Postgres hit per request

### DIFF
--- a/src/cache/cache.module.ts
+++ b/src/cache/cache.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { CacheService } from './cache.service.js';
 
+@Global()
 @Module({
   providers: [CacheService],
   exports: [CacheService],

--- a/src/common/guards/realm.guard.spec.ts
+++ b/src/common/guards/realm.guard.spec.ts
@@ -18,13 +18,23 @@ function createMockExecutionContext(
   } as any;
 }
 
+function createMockCacheService() {
+  return {
+    getCachedRealmByName: jest.fn().mockResolvedValue(null),
+    cacheRealmByName: jest.fn().mockResolvedValue(undefined),
+    cacheRealmConfig: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe('RealmGuard', () => {
   let guard: RealmGuard;
   let prisma: MockPrismaService;
+  let cache: ReturnType<typeof createMockCacheService>;
 
   beforeEach(() => {
     prisma = createMockPrismaService();
-    guard = new RealmGuard(prisma as any);
+    cache = createMockCacheService();
+    guard = new RealmGuard(prisma as any, cache as any);
   });
 
   it('should pass through when no realm param is present', async () => {
@@ -144,5 +154,50 @@ describe('RealmGuard', () => {
     expect(result).toBe(true);
     const request = ctx.switchToHttp().getRequest();
     expect(request.realm).toEqual(disabledRealm);
+  });
+
+  describe('caching', () => {
+    it('should use the cached realm and skip the Postgres lookup on a cache hit', async () => {
+      const cachedRealm = { id: '1', name: 'my-realm', enabled: true };
+      cache.getCachedRealmByName.mockResolvedValue(cachedRealm);
+      const ctx = createMockExecutionContext({ realmName: 'my-realm' });
+
+      const result = await guard.canActivate(ctx);
+
+      expect(result).toBe(true);
+      expect(cache.getCachedRealmByName).toHaveBeenCalledWith('my-realm');
+      expect(prisma.realm.findUnique).not.toHaveBeenCalled();
+      const request = ctx.switchToHttp().getRequest();
+      expect(request.realm).toEqual(cachedRealm);
+    });
+
+    it('should populate the cache after a Postgres lookup on a cache miss', async () => {
+      const fakeRealm = { id: '1', name: 'my-realm', enabled: true };
+      cache.getCachedRealmByName.mockResolvedValue(null);
+      prisma.realm.findUnique.mockResolvedValue(fakeRealm);
+      const ctx = createMockExecutionContext({ realmName: 'my-realm' });
+
+      await guard.canActivate(ctx);
+
+      expect(prisma.realm.findUnique).toHaveBeenCalledWith({
+        where: { name: 'my-realm' },
+      });
+      expect(cache.cacheRealmByName).toHaveBeenCalledWith(
+        'my-realm',
+        fakeRealm,
+      );
+      expect(cache.cacheRealmConfig).toHaveBeenCalledWith('1', fakeRealm);
+    });
+
+    it('should not populate the cache when the realm does not exist', async () => {
+      cache.getCachedRealmByName.mockResolvedValue(null);
+      prisma.realm.findUnique.mockResolvedValue(null);
+      const ctx = createMockExecutionContext({ realmName: 'nonexistent' });
+
+      await expect(guard.canActivate(ctx)).rejects.toThrow(NotFoundException);
+
+      expect(cache.cacheRealmByName).not.toHaveBeenCalled();
+      expect(cache.cacheRealmConfig).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/common/guards/realm.guard.ts
+++ b/src/common/guards/realm.guard.ts
@@ -6,11 +6,16 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import type { Request } from 'express';
+import type { Realm } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service.js';
+import { CacheService } from '../../cache/cache.service.js';
 
 @Injectable()
 export class RealmGuard implements CanActivate {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cache: CacheService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
@@ -20,9 +25,7 @@ export class RealmGuard implements CanActivate {
 
     const realmName = Array.isArray(rawName) ? rawName[0] : rawName;
 
-    const realm = await this.prisma.realm.findUnique({
-      where: { name: realmName },
-    });
+    const realm = await this.findRealmByName(realmName);
 
     if (!realm) {
       throw new NotFoundException(`Realm '${realmName}' not found`);
@@ -35,5 +38,26 @@ export class RealmGuard implements CanActivate {
 
     (request as Request & { realm: typeof realm }).realm = realm;
     return true;
+  }
+
+  /**
+   * Cache-aside lookup mirroring RealmsService.findByNameRaw: this guard
+   * runs on almost every request (~35+ controllers), so a cache hit avoids
+   * a Postgres round-trip per request. Cache invalidation on realm
+   * update/delete already goes through CacheService.invalidateRealmCache.
+   */
+  private async findRealmByName(name: string): Promise<Realm | null> {
+    const cached = await this.cache.getCachedRealmByName<Realm | null>(name);
+    if (cached) return cached;
+
+    const realm = await this.prisma.realm.findUnique({ where: { name } });
+    if (!realm) return null;
+
+    await Promise.all([
+      this.cache.cacheRealmByName(name, realm),
+      this.cache.cacheRealmConfig(realm.id, realm),
+    ]);
+
+    return realm;
   }
 }


### PR DESCRIPTION
## Summary

Closes #1252. `RealmGuard.canActivate` ran `prisma.realm.findUnique()` on every request carrying a `realmName`/`realm` route param, with zero cache interaction. This guard is attached via `@UseGuards(RealmGuard, ...)` to ~35+ controllers (auth, oauth, users, clients, sessions, webhooks, saml, scim, etc.), making it a DB round-trip on almost every incoming request.

`RealmsService.findByNameRaw` already implements the exact caching pattern needed (Redis-backed cache-aside via `CacheService.getCachedRealmByName`/`cacheRealmByName`, 300s TTL) for the identical query.

- `RealmGuard` now runs the same cache-aside lookup (check cache → fall back to Prisma → populate cache) directly, instead of calling `RealmsService.findByNameRaw`. I chose not to inject `RealmsService` itself because `RealmsModule` pulls in `ThemeModule`/`CacheModule`/`CryptoModule` and isn't `@Global()` — wiring that into ~35+ controller modules is a bigger footprint than this fix needs. `CacheService` alone is enough.
- Marked `CacheModule` `@Global()` (matching the existing precedent of `PrismaModule`/`CryptoModule`/`EmailModule` in this codebase), so the guard's new `CacheService` dependency resolves everywhere without touching any of the ~35+ controller modules that use `@UseGuards(RealmGuard)`.
- Cache invalidation on realm update/delete already goes through `CacheService.invalidateRealmCache`, so no new invalidation path is needed.

### Risk check I did before writing this

A cached realm object round-trips through `JSON.stringify`/`parse` in Redis, so `Date`-typed fields (`createdAt`/`updatedAt`) come back as ISO strings instead of `Date` instances — the one shape change this introduces. I grepped all ~299 usages of `@CurrentRealm()` across the codebase and confirmed none of them read `.createdAt`/`.updatedAt` as a `Date` (no `.getTime()`/`.toISOString()`/date arithmetic on those fields anywhere outside `src/realms/`, which queries Prisma directly and isn't affected). Every other `Realm` field is a plain JSON-compatible type (string/number/boolean/JSON), so this round-trips exactly.

## Test plan
- [x] `npm run build` — clean (confirms the guard's new `CacheService` dependency resolves through Nest's DI without needing per-module imports)
- [x] Full backend suite: `npx jest` — 125 suites / 2121 tests passing
- [x] `realm.guard.spec.ts`: existing tests unchanged (mock cache defaults to a miss, so the fallback-to-Prisma path is exercised exactly as before); added cases for cache-hit (skips Prisma), cache-miss (populates cache after the DB fetch), and not-found (cache is never populated)
- [x] `npx eslint` / `npx prettier --check` clean on all changed files
- [ ] CI's `E2E Tests` job (which runs against a real Postgres+Redis) is the actual runtime confirmation that Nest resolves `RealmGuard`'s new `CacheService` dependency correctly across all the controller modules that use this guard — watching CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW