### PR TITLE
perf(admin-ui): memoize dashboard event aggregation

### DIFF
--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 import { getAllRealms } from '../api/realms';
@@ -111,28 +112,32 @@ function RealmStatsSection({ realmName }: { realmName: string }) {
     staleTime: 60_000,
   });
 
-  const recentEvents = [
-    ...(loginEvents ?? []).map((e) => ({
-      id: e.id,
-      kind: 'login' as const,
-      type: e.type,
-      detail: e.userId ? `User: ${e.userId}` : e.clientId ? `Client: ${e.clientId}` : '—',
-      ip: e.ipAddress,
-      error: e.error,
-      createdAt: e.createdAt,
-    })),
-    ...(adminEvents ?? []).map((e) => ({
-      id: e.id,
-      kind: 'admin' as const,
-      type: `${e.operationType} ${e.resourceType}`,
-      detail: e.resourcePath,
-      ip: e.ipAddress,
-      error: null,
-      createdAt: e.createdAt,
-    })),
-  ]
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    .slice(0, 20);
+  const recentEvents = useMemo(
+    () =>
+      [
+        ...(loginEvents ?? []).map((e) => ({
+          id: e.id,
+          kind: 'login' as const,
+          type: e.type,
+          detail: e.userId ? `User: ${e.userId}` : e.clientId ? `Client: ${e.clientId}` : '—',
+          ip: e.ipAddress,
+          error: e.error,
+          createdAt: e.createdAt,
+        })),
+        ...(adminEvents ?? []).map((e) => ({
+          id: e.id,
+          kind: 'admin' as const,
+          type: `${e.operationType} ${e.resourceType}`,
+          detail: e.resourcePath,
+          ip: e.ipAddress,
+          error: null,
+          createdAt: e.createdAt,
+        })),
+      ]
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .slice(0, 20),
+    [loginEvents, adminEvents],
+  );
 
   const totalRate = (stats?.loginSuccessCount ?? 0) + (stats?.loginFailureCount ?? 0);
   const successRate =
@@ -213,7 +218,7 @@ function RealmStatsSection({ realmName }: { realmName: string }) {
         <div className="mb-3 flex items-center justify-between">
           <h2 className="text-base font-semibold text-fg">Recent Events</h2>
           <span className="text-xs text-subtle" aria-live="polite" aria-atomic="true">
-            Auto-refreshes every 30s
+            Auto-refreshes every 60s
           </span>
         </div>
         {eventsLoading ? (

--- a/admin-ui/src/pages/__tests__/DashboardPage.test.tsx
+++ b/admin-ui/src/pages/__tests__/DashboardPage.test.tsx
@@ -104,6 +104,11 @@ describe('DashboardPage', () => {
     });
   });
 
+  it('shows the correct auto-refresh interval for the events feed (matches the 60s refetchInterval)', async () => {
+    renderDashboard();
+    expect(await screen.findByText('Auto-refreshes every 60s')).toBeInTheDocument();
+  });
+
   it('renders quick action buttons', async () => {
     renderDashboard();
     expect(await screen.findByText('Create User')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Addresses #1253's first half. `RealmStatsSection` in `DashboardPage.tsx` recomputed `recentEvents` (merge two arrays + `O(n log n)` sort + slice) on every render with no memoization, so any parent re-render — including the two 60s polling queries feeding it — redid the work even when `loginEvents`/`adminEvents` hadn't changed.

- Wrapped `recentEvents` in `useMemo` keyed on `[loginEvents, adminEvents]`. With `structuralSharing` on by default in React Query, an unchanged refetch returns the same array reference, so this correctly skips the recompute rather than just changing when it happens.
- Fixed a bug I found right next to this: the "Auto-refreshes every **30s**" label under Recent Events was wrong — both event queries actually use `refetchInterval: 60_000`. Changed the label to say 60s.

### On the issue's second suggested fix (`refetchIntervalInBackground: false`) — investigated, not applied

The issue states all 13 `useQuery` calls with `refetchInterval` keep polling when the tab is backgrounded because none set `refetchIntervalInBackground: false`. I checked the actual installed library source (`admin-ui` pins `@tanstack/react-query@5.101.2`) before writing any code for this part:

- `node_modules/@tanstack/query-core/build/legacy/queryObserver.js:423`: the interval-refetch tick only fires if `this.options.refetchIntervalInBackground || focusManager.isFocused()`.
- `node_modules/@tanstack/query-core/build/legacy/focusManager.js:69`: `isFocused()` returns `document.visibilityState !== "hidden"`.

Since none of the 13 call sites set `refetchIntervalInBackground` (it's `undefined`, i.e. falsy), the check reduces to `focusManager.isFocused()` — meaning **backgrounded tabs already skip the interval refetch today**, at the version actually installed. Explicitly adding `refetchIntervalInBackground: false` would be a no-op: `false || focusManager.isFocused()` behaves identically to `undefined || focusManager.isFocused()`.

I didn't ship that part, because a "fix" with zero behavioral effect reads as if polling was broken and is now fixed, which it wasn't. Posting this finding as a comment on #1253 for the record. (Note: this is about `visibilityState` specifically — a merely-blurred-but-visible tab still polls, which is TanStack's deliberate v5 behavior and isn't what the issue reported.)

## Test plan
- [x] Full admin-ui suite: `npm run test:coverage` — 35 files / 365 tests passing (2 pre-existing skips, unrelated)
- [x] `npx eslint` clean on both changed files
- [x] `npm run build` (tsc + vite) — clean
- [x] Added a regression test asserting the corrected "Auto-refreshes every 60s" label
- [ ] CI's `Admin UI Tests` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW