### PR TITLE
perf: tune Postgres pool size and bound Argon2 concurrency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,15 @@ DATABASE_URL=postgresql://idenplane:idenplane@localhost:5432/idenplane
 # SQLite (development / CI only — no database server needed):
 # Before switching run: ./scripts/use-sqlite.sh
 # DATABASE_URL=file:./dev.db
+#
+# PostgreSQL connection pool (optional — defaults are tuned to available CPU
+# cores rather than pg's bare default of 10). If running many replicas
+# against the same database, tune DATABASE_POOL_MAX down (or raise
+# Postgres's max_connections), since total connections are roughly
+# replicas * DATABASE_POOL_MAX.
+# DATABASE_POOL_MAX=<2 * cpu cores + 1>
+# DATABASE_POOL_MIN=2
+# DATABASE_POOL_IDLE_TIMEOUT_MS=30000
 
 PORT=3000
 NODE_ENV=development
@@ -40,6 +49,12 @@ WEBHOOK_SECRET_KEY=REPLACE_ME_WITH_A_STRONG_RANDOM_SECRET
 # Same boot rule as above: production refuses to start if unset or default.
 # Changing this value invalidates all previously encrypted webhook secrets.
 WEBHOOK_ENCRYPTION_SALT=REPLACE_ME_WITH_A_UNIQUE_RANDOM_SALT
+#
+# Optional: caps how many Argon2id password hash/verify calls run at once
+# (extra calls queue instead of piling on CPU/memory). Defaults to the
+# number of CPU cores. Lower this in containers with a CPU limit below the
+# host's core count.
+# ARGON2_MAX_CONCURRENCY=<cpu cores>
 THROTTLE_TTL=60000
 THROTTLE_LIMIT=100
 BASE_URL=http://localhost:3000

--- a/src/common/utils/concurrency-limiter.util.spec.ts
+++ b/src/common/utils/concurrency-limiter.util.spec.ts
@@ -1,0 +1,78 @@
+import { createConcurrencyLimiter } from './concurrency-limiter.util.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('createConcurrencyLimiter', () => {
+  it('should throw when concurrency is less than 1', () => {
+    expect(() => createConcurrencyLimiter(0)).toThrow(
+      'concurrency must be at least 1',
+    );
+    expect(() => createConcurrencyLimiter(-1)).toThrow();
+  });
+
+  it('should run a single task and resolve with its result', async () => {
+    const limit = createConcurrencyLimiter(2);
+    const result = await limit(() => Promise.resolve('done'));
+    expect(result).toBe('done');
+  });
+
+  it('should propagate a rejected task', async () => {
+    const limit = createConcurrencyLimiter(2);
+    await expect(
+      limit(() => Promise.reject(new Error('boom'))),
+    ).rejects.toThrow('boom');
+  });
+
+  it('should never run more than `concurrency` tasks at once', async () => {
+    const limit = createConcurrencyLimiter(2);
+    let active = 0;
+    let maxActive = 0;
+    const gates = Array.from({ length: 5 }, () => deferred<void>());
+
+    const runs = gates.map((gate, i) =>
+      limit(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await gate.promise;
+        active--;
+        return i;
+      }),
+    );
+
+    // Let the first batch start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(active).toBe(2);
+    expect(maxActive).toBe(2);
+
+    // Release tasks one at a time; active count should never exceed 2.
+    for (const gate of gates) {
+      gate.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(active).toBeLessThanOrEqual(2);
+    }
+
+    const results = await Promise.all(runs);
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+    expect(maxActive).toBe(2);
+  });
+
+  it('should still run a queued task after an earlier task rejects', async () => {
+    const limit = createConcurrencyLimiter(1);
+
+    const first = limit(() => Promise.reject(new Error('first failed')));
+    const second = limit(() => Promise.resolve('second succeeded'));
+
+    await expect(first).rejects.toThrow('first failed');
+    await expect(second).resolves.toBe('second succeeded');
+  });
+});

--- a/src/common/utils/concurrency-limiter.util.ts
+++ b/src/common/utils/concurrency-limiter.util.ts
@@ -1,0 +1,34 @@
+/**
+ * Caps the number of `fn` calls running at once, queueing the rest until a
+ * slot frees up. Used to bound CPU/memory-heavy work (e.g. Argon2 hashing)
+ * so a burst of concurrent requests can't drive unbounded resource pressure.
+ */
+export function createConcurrencyLimiter(concurrency: number) {
+  if (concurrency < 1) {
+    throw new Error('concurrency must be at least 1');
+  }
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  function next(): void {
+    if (active >= concurrency || queue.length === 0) return;
+    active++;
+    const run = queue.shift()!;
+    run();
+  }
+
+  return function limit<T>(fn: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      queue.push(() => {
+        fn()
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            next();
+          });
+      });
+      next();
+    });
+  };
+}

--- a/src/crypto/crypto.service.spec.ts
+++ b/src/crypto/crypto.service.spec.ts
@@ -1,4 +1,28 @@
+import * as argon2 from 'argon2';
 import { CryptoService } from './crypto.service.js';
+
+// argon2's native bindings export non-configurable properties, so
+// jest.spyOn (which redefines the property) can't wrap them directly.
+// Mocking the module and wrapping each export in jest.fn(actual) keeps the
+// real implementation as the default behavior (so the round-trip tests
+// below are unaffected) while letting specific tests override return
+// values with mockReturnValueOnce.
+jest.mock('argon2', () => {
+  const actual = jest.requireActual('argon2') as typeof argon2;
+  return {
+    ...actual,
+    hash: jest.fn(actual.hash),
+    verify: jest.fn(actual.verify),
+  };
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
 
 describe('CryptoService', () => {
   let service: CryptoService;
@@ -130,6 +154,86 @@ describe('CryptoService', () => {
       expect(service.decryptSecret(null)).toBeNull();
       expect(service.decryptSecret(undefined)).toBeUndefined();
       expect(service.decryptSecret('')).toBe('');
+    });
+  });
+
+  describe('Argon2 concurrency limiting', () => {
+    const originalEnv = process.env['ARGON2_MAX_CONCURRENCY'];
+    const hashMock = argon2.hash as jest.MockedFunction<typeof argon2.hash>;
+    const verifyMock = argon2.verify as jest.MockedFunction<
+      typeof argon2.verify
+    >;
+
+    beforeEach(() => {
+      hashMock.mockClear();
+      verifyMock.mockClear();
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env['ARGON2_MAX_CONCURRENCY'];
+      } else {
+        process.env['ARGON2_MAX_CONCURRENCY'] = originalEnv;
+      }
+    });
+
+    it('should queue a second hashPassword call until the first completes when concurrency is 1', async () => {
+      process.env['ARGON2_MAX_CONCURRENCY'] = '1';
+      const limitedService = new CryptoService();
+
+      const first = deferred<string>();
+      const second = deferred<string>();
+      hashMock
+        .mockReturnValueOnce(first.promise as Promise<string>)
+        .mockReturnValueOnce(second.promise as Promise<string>);
+
+      const call1 = limitedService.hashPassword('password-one');
+      const call2 = limitedService.hashPassword('password-two');
+
+      // Only the first call should have reached argon2.hash so far — the
+      // second is queued behind the concurrency-1 limit.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(hashMock).toHaveBeenCalledTimes(1);
+
+      first.resolve('hash-one');
+      await call1;
+
+      // Releasing the first call lets the queued second call through.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(hashMock).toHaveBeenCalledTimes(2);
+
+      second.resolve('hash-two');
+      expect(await call2).toBe('hash-two');
+    });
+
+    it('should route verifyPassword through the same concurrency limiter', async () => {
+      process.env['ARGON2_MAX_CONCURRENCY'] = '1';
+      const limitedService = new CryptoService();
+
+      const first = deferred<boolean>();
+      const second = deferred<boolean>();
+      verifyMock
+        .mockReturnValueOnce(first.promise as Promise<boolean>)
+        .mockReturnValueOnce(second.promise as Promise<boolean>);
+
+      const call1 = limitedService.verifyPassword('hash-one', 'password-one');
+      const call2 = limitedService.verifyPassword('hash-two', 'password-two');
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(verifyMock).toHaveBeenCalledTimes(1);
+
+      first.resolve(true);
+      await call1;
+
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(verifyMock).toHaveBeenCalledTimes(2);
+
+      second.resolve(false);
+      expect(await call2).toBe(false);
     });
   });
 });

--- a/src/crypto/crypto.service.ts
+++ b/src/crypto/crypto.service.ts
@@ -12,6 +12,8 @@ import {
   createDecipheriv,
   scryptSync,
 } from 'crypto';
+import { cpus } from 'os';
+import { createConcurrencyLimiter } from '../common/utils/concurrency-limiter.util.js';
 
 /** Maximum password length accepted by hashPassword / verifyPassword.
  *  Argon2 has no built-in length limit; feeding it a multi-megabyte string
@@ -19,6 +21,16 @@ import {
  *  limit that covers every legitimate password while bounding hashing time.
  */
 const MAX_PASSWORD_LENGTH = 1024;
+
+/**
+ * Argon2id with memoryCost: 65536 (64 MiB) allocates real memory per call.
+ * With no cap, a burst of concurrent logins/registrations can drive
+ * unbounded memory/CPU pressure. One in-flight hash per CPU core keeps the
+ * server responsive under load; excess calls queue instead of piling on.
+ * Overridable via ARGON2_MAX_CONCURRENCY for environments that need to tune
+ * it (e.g. containers with a CPU limit below the host's core count).
+ */
+const DEFAULT_ARGON2_MAX_CONCURRENCY = cpus().length;
 
 // Algorithm constants for AES-256-GCM symmetric encryption.
 const ALGORITHM = 'aes-256-gcm';
@@ -49,6 +61,15 @@ export class CryptoService implements OnModuleInit {
       process.env['WEBHOOK_ENCRYPTION_SALT'] ?? DEFAULT_WEBHOOK_ENCRYPTION_SALT;
     return scryptSync(raw, salt, 32);
   })();
+
+  /** Bounds concurrent Argon2 hash/verify calls; see DEFAULT_ARGON2_MAX_CONCURRENCY. */
+  private readonly limitArgon2Concurrency = createConcurrencyLimiter(
+    parseInt(
+      process.env['ARGON2_MAX_CONCURRENCY'] ??
+        String(DEFAULT_ARGON2_MAX_CONCURRENCY),
+      10,
+    ),
+  );
 
   onModuleInit(): void {
     const key = process.env['WEBHOOK_SECRET_KEY'];
@@ -97,12 +118,14 @@ export class CryptoService implements OnModuleInit {
         `Password must not exceed ${MAX_PASSWORD_LENGTH} characters.`,
       );
     }
-    return argon2.hash(password, {
-      type: argon2.argon2id,
-      memoryCost: 65536,
-      timeCost: 3,
-      parallelism: 4,
-    });
+    return this.limitArgon2Concurrency(() =>
+      argon2.hash(password, {
+        type: argon2.argon2id,
+        memoryCost: 65536,
+        timeCost: 3,
+        parallelism: 4,
+      }),
+    );
   }
 
   async verifyPassword(hash: string, password: string): Promise<boolean> {
@@ -113,7 +136,7 @@ export class CryptoService implements OnModuleInit {
       // beyond the normal "invalid credentials" response).
       return false;
     }
-    return argon2.verify(hash, password);
+    return this.limitArgon2Concurrency(() => argon2.verify(hash, password));
   }
 
   generateSecret(bytes = 32): string {

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -7,6 +7,7 @@ import {
 import { PrismaClient } from '@prisma/client';
 import type { SqlDriverAdapterFactory } from '@prisma/driver-adapter-utils';
 import { DatabaseProvider, detectProvider } from './database-provider.js';
+import { getPgPoolConfig } from './pg-pool-config.js';
 
 /**
  * DatabaseService wraps PrismaClient and adds provider-aware initialisation.
@@ -41,11 +42,13 @@ export class DatabaseService
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { PrismaPg } = require('@prisma/adapter-pg') as {
         PrismaPg: {
-          new (config: { connectionString: string }): SqlDriverAdapterFactory;
+          new (
+            config: ReturnType<typeof getPgPoolConfig>,
+          ): SqlDriverAdapterFactory;
         };
       };
 
-      const adapter = new PrismaPg({ connectionString: url });
+      const adapter = new PrismaPg(getPgPoolConfig(url));
       super({ adapter });
     } else {
       // MySQL and SQLite use Prisma's built-in drivers — no adapter needed.

--- a/src/database/pg-pool-config.spec.ts
+++ b/src/database/pg-pool-config.spec.ts
@@ -1,0 +1,58 @@
+import { cpus } from 'os';
+import { getPgPoolConfig } from './pg-pool-config.js';
+
+describe('getPgPoolConfig', () => {
+  const ENV_KEYS = [
+    'DATABASE_POOL_MAX',
+    'DATABASE_POOL_MIN',
+    'DATABASE_POOL_IDLE_TIMEOUT_MS',
+  ] as const;
+  const originalEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      originalEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalEnv[key];
+      }
+    }
+  });
+
+  it('should carry through the connection string unchanged', () => {
+    const config = getPgPoolConfig('postgresql://user:pass@localhost:5432/db');
+    expect(config.connectionString).toBe(
+      'postgresql://user:pass@localhost:5432/db',
+    );
+  });
+
+  it('should default max to 2x CPU cores + 1, not the pg default of 10', () => {
+    const config = getPgPoolConfig('postgresql://localhost/db');
+    expect(config.max).toBe(cpus().length * 2 + 1);
+  });
+
+  it('should default min to 2 and idleTimeoutMillis to 30s', () => {
+    const config = getPgPoolConfig('postgresql://localhost/db');
+    expect(config.min).toBe(2);
+    expect(config.idleTimeoutMillis).toBe(30_000);
+  });
+
+  it('should honor DATABASE_POOL_MAX/MIN/IDLE_TIMEOUT_MS overrides', () => {
+    process.env['DATABASE_POOL_MAX'] = '50';
+    process.env['DATABASE_POOL_MIN'] = '5';
+    process.env['DATABASE_POOL_IDLE_TIMEOUT_MS'] = '10000';
+
+    const config = getPgPoolConfig('postgresql://localhost/db');
+
+    expect(config.max).toBe(50);
+    expect(config.min).toBe(5);
+    expect(config.idleTimeoutMillis).toBe(10_000);
+  });
+});

--- a/src/database/pg-pool-config.ts
+++ b/src/database/pg-pool-config.ts
@@ -1,0 +1,40 @@
+import { cpus } from 'os';
+
+/**
+ * `pg`'s own default pool size is 10 connections regardless of instance
+ * size, which is too small for typical production concurrency. Sizing to
+ * available CPU cores is a common heuristic for connection-pool capacity.
+ *
+ * Caveat for multi-instance deployments: this sizes the pool per process.
+ * With N replicas, total connections against Postgres are roughly
+ * N * DATABASE_POOL_MAX — tune DATABASE_POOL_MAX down (or raise Postgres's
+ * max_connections) if running many replicas on multi-core hosts.
+ */
+const DEFAULT_POOL_MAX = cpus().length * 2 + 1;
+const DEFAULT_POOL_MIN = 2;
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
+
+/**
+ * Builds a pool config for `PrismaPg` (structurally a `pg.PoolConfig`),
+ * with pool size explicitly tuned (rather than left at `pg`'s bare
+ * default) and overridable via env vars so operators can adjust for their
+ * instance size / replica count.
+ */
+export function getPgPoolConfig(connectionString: string | undefined) {
+  return {
+    connectionString,
+    max: parseInt(
+      process.env['DATABASE_POOL_MAX'] ?? String(DEFAULT_POOL_MAX),
+      10,
+    ),
+    min: parseInt(
+      process.env['DATABASE_POOL_MIN'] ?? String(DEFAULT_POOL_MIN),
+      10,
+    ),
+    idleTimeoutMillis: parseInt(
+      process.env['DATABASE_POOL_IDLE_TIMEOUT_MS'] ??
+        String(DEFAULT_IDLE_TIMEOUT_MS),
+      10,
+    ),
+  };
+}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
+import { getPgPoolConfig } from '../database/pg-pool-config.js';
 
 @Injectable()
 export class PrismaService
@@ -8,9 +9,7 @@ export class PrismaService
   implements OnModuleInit, OnModuleDestroy
 {
   constructor() {
-    const adapter = new PrismaPg({
-      connectionString: process.env['DATABASE_URL'],
-    });
+    const adapter = new PrismaPg(getPgPoolConfig(process.env['DATABASE_URL']));
     super({ adapter });
   }
 


### PR DESCRIPTION
## Summary

Closes #1255.

**Postgres pool size.** Both Prisma clients constructed `PrismaPg` with only `connectionString`, leaving pool size at `pg`'s driver default of 10 connections regardless of instance size:
- `src/prisma/prisma.service.ts` — the client actually wired into `app.module.ts` via `PrismaModule`.
- `src/database/database.service.ts` — a secondary/provider-aware client.

Added `getPgPoolConfig()` (`src/database/pg-pool-config.ts`), a shared helper both clients now use, defaulting `max` to `2 * cpu cores + 1`, `min` to `2`, and `idleTimeoutMillis` to `30s` — all overridable via `DATABASE_POOL_MAX`/`DATABASE_POOL_MIN`/`DATABASE_POOL_IDLE_TIMEOUT_MS`, documented in `.env.example` including the multi-replica connection-budget caveat (total connections against Postgres are roughly `replicas * DATABASE_POOL_MAX`).

Worth noting: `DatabaseService`/`DatabaseModule` aren't currently imported into `app.module.ts` — I verified with a repo-wide grep that nothing references either outside `src/database/` itself. So the `DatabaseService` half of this fix has no effect on the running app today; I applied it anyway for consistency in case it gets wired in later, matching the issue's literal scope (it names both files).

**Argon2 concurrency.** `CryptoService.hashPassword`/`verifyPassword` call Argon2id with `memoryCost: 65536` (64 MiB) and `parallelism: 4`, with nothing capping in-flight operations — a burst of concurrent logins/registrations could drive unbounded memory/CPU pressure.

Added `createConcurrencyLimiter()` (`src/common/utils/concurrency-limiter.util.ts`) — a small, dependency-free FIFO queue capping how many `fn` calls run at once. I did not add `p-limit` as the issue suggests: it's already present as a transitive *dev* dependency (via eslint/jest), and its v4+ releases are ESM-only, which wouldn't load under this backend's CommonJS build (`module: nodenext`, no `"type": "module"` in `package.json`) without pinning to the older v3 — a self-contained ~20-line limiter avoids that whole version-compatibility question for something this simple.

Both `hashPassword` and `verifyPassword` share one limiter instance, defaulting to one in-flight Argon2 call per CPU core, overridable via `ARGON2_MAX_CONCURRENCY` (documented in `.env.example`).

## Test plan
- [x] `npm run build` — clean
- [x] Full backend suite: `npx jest` — 127 suites / 2132 tests passing
- [x] New: `concurrency-limiter.util.spec.ts` — enforces the concurrency cap under real async interleaving (deferred promises, not fake timers), propagates results/errors, continues after a queued task's predecessor rejects
- [x] New: `pg-pool-config.spec.ts` — default sizing (`2 * cpus + 1`), env-var overrides, connection-string passthrough
- [x] New tests in `crypto.service.spec.ts`: verifies `hashPassword`/`verifyPassword` actually route through the limiter (second call queues behind a concurrency-1 limit, using a module mock that wraps the *real* argon2 implementation by default — argon2's native bindings can't be `jest.spyOn`'d directly since their properties are non-configurable, so I mocked the whole module and wrapped each export in `jest.fn(actual)` to keep every pre-existing hash/verify test's behavior unchanged)
- [x] `npx eslint` / `npx prettier --check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW