### PR TITLE
refactor(docker,sms): clean install in prod stage, lazy-load Twilio SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,20 +61,28 @@ RUN apk add --no-cache "postgresql${PG_MAJOR}-client" \
     && pg_dump --version \
     && pg_restore --version
 
-COPY --from=build /app/node_modules ./node_modules
-COPY --from=build /app/dist ./dist
-COPY --from=build /app/prisma ./prisma
-COPY --from=build /app/themes ./themes
+# Manifests + prisma schema/config first, so `npm ci`'s postinstall
+# (`prisma generate`) has what it needs; then a clean production-only
+# install directly in this stage, rather than copying the build stage's
+# full node_modules (including devDependencies) and pruning afterward —
+# simpler, and doesn't depend on npm's prune graph-pruning being exactly
+# right.
 COPY --from=build /app/package.json ./package.json
 COPY --from=build /app/package-lock.json ./package-lock.json
+COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+COPY --from=build /app/prisma ./prisma
+RUN npm ci --omit=dev
 
-# prisma.config.ts is TypeScript and cannot be executed directly by Node in the
-# production image (no compiler present).  migrate deploy only needs the schema
-# file, which is already present under ./prisma/schema.prisma — the --schema flag
-# is passed explicitly in docker-entrypoint.sh instead.
+# prisma.config.ts is TypeScript and cannot be executed directly by Node in
+# this image (no compiler present) — it was only needed above, for
+# `prisma generate` during the npm ci postinstall step. `migrate deploy`
+# only needs the schema file (already present under ./prisma/schema.prisma —
+# the --schema flag is passed explicitly in docker-entrypoint.sh instead),
+# so drop it rather than ship a file nothing here can run.
+RUN rm prisma.config.ts
 
-# Remove dev dependencies in production stage (not build stage)
-RUN npm prune --omit=dev
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/themes ./themes
 
 # Use the existing 'node' user (UID 1000, GID 1000) from the base image
 # instead of creating a new group/user that conflicts with the pre-existing GID

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,16 @@ module.exports = {
   rootDir: 'src',
   testRegex: '.*\\.spec\\.ts$',
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    // Override the project tsconfig's "module": "nodenext" to plain
+    // "commonjs" for this transform only. Under nodenext, TypeScript
+    // preserves a literal `await import(...)` expression verbatim (correct
+    // for real Node, which supports dynamic import from CJS natively) — but
+    // Jest's default CJS test environment can't execute that syntax without
+    // --experimental-vm-modules. Plain "commonjs" makes TypeScript downlevel
+    // it to a require()-based Promise instead, which Jest runs fine. This
+    // only affects how ts-jest compiles for tests; the real build
+    // (nest build / tsconfig.build.json) is untouched.
+    '^.+\\.(t|j)s$': ['ts-jest', { tsconfig: { module: 'commonjs' } }],
   },
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',

--- a/src/sms/sms.service.spec.ts
+++ b/src/sms/sms.service.spec.ts
@@ -1,0 +1,116 @@
+import { SmsService } from './sms.service.js';
+import {
+  createMockPrismaService,
+  MockPrismaService,
+} from '../prisma/prisma.mock.js';
+import { TwilioSmsProvider } from './providers/twilio.provider.js';
+import { VonageSmsProvider } from './providers/vonage.provider.js';
+import { AwsSnsProvider } from './providers/aws-sns.provider.js';
+import { WebhookSmsProvider } from './providers/webhook.provider.js';
+
+describe('SmsService', () => {
+  let service: SmsService;
+  let prisma: MockPrismaService;
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+    service = new SmsService(prisma as any);
+  });
+
+  describe('isConfigured', () => {
+    it('should return true when a provider is set', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'twilio' });
+      expect(await service.isConfigured('my-realm')).toBe(true);
+    });
+
+    it('should return false when smsProvider is "none"', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'none' });
+      expect(await service.isConfigured('my-realm')).toBe(false);
+    });
+
+    it('should return false when the realm has no smsProvider', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: null });
+      expect(await service.isConfigured('my-realm')).toBe(false);
+    });
+  });
+
+  describe('getProvider', () => {
+    it('should return null and log a warning when smsProvider is "none"', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'none' });
+      expect(await service.getProvider('my-realm')).toBeNull();
+    });
+
+    it('should return null when the realm is not found', async () => {
+      prisma.realm.findUnique.mockResolvedValue(null);
+      expect(await service.getProvider('missing')).toBeNull();
+    });
+
+    it('should lazily construct a TwilioSmsProvider via dynamic import', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'twilio' });
+      const provider = await service.getProvider('my-realm');
+      expect(provider).toBeInstanceOf(TwilioSmsProvider);
+    });
+
+    it('should construct a VonageSmsProvider', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'vonage' });
+      const provider = await service.getProvider('my-realm');
+      expect(provider).toBeInstanceOf(VonageSmsProvider);
+    });
+
+    it('should construct an AwsSnsProvider', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'aws-sns' });
+      const provider = await service.getProvider('my-realm');
+      expect(provider).toBeInstanceOf(AwsSnsProvider);
+    });
+
+    it('should construct a WebhookSmsProvider', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'webhook' });
+      const provider = await service.getProvider('my-realm');
+      expect(provider).toBeInstanceOf(WebhookSmsProvider);
+    });
+
+    it('should return null for an unrecognized provider type', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'bogus' });
+      expect(await service.getProvider('my-realm')).toBeNull();
+    });
+  });
+
+  describe('sendSms', () => {
+    it('should skip sending when smsProvider is "none"', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'none' });
+      await expect(
+        service.sendSms('my-realm', '+15550100', 'hello'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should skip sending when the realm is not found', async () => {
+      prisma.realm.findUnique.mockResolvedValue(null);
+      await expect(
+        service.sendSms('missing', '+15550100', 'hello'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw when the provider cannot be instantiated', async () => {
+      prisma.realm.findUnique.mockResolvedValue({ smsProvider: 'bogus' });
+      await expect(
+        service.sendSms('my-realm', '+15550100', 'hello'),
+      ).rejects.toThrow('could not be instantiated');
+    });
+
+    it('should send via the Twilio provider resolved through the dynamic import', async () => {
+      prisma.realm.findUnique.mockResolvedValue({
+        smsProvider: 'twilio',
+        smsProviderConfig: null,
+        smsFrom: null,
+      });
+      const sendSmsSpy = jest
+        .spyOn(TwilioSmsProvider.prototype, 'sendSms')
+        .mockResolvedValue(undefined);
+
+      await service.sendSms('my-realm', '+15550100', 'hello');
+
+      expect(sendSmsSpy).toHaveBeenCalledWith('+15550100', 'hello');
+      sendSmsSpy.mockRestore();
+    });
+  });
+});

--- a/src/sms/sms.service.ts
+++ b/src/sms/sms.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { SmsProvider } from './providers/sms-provider.interface.js';
-import { TwilioSmsProvider } from './providers/twilio.provider.js';
 import { VonageSmsProvider } from './providers/vonage.provider.js';
 import { AwsSnsProvider } from './providers/aws-sns.provider.js';
 import { WebhookSmsProvider } from './providers/webhook.provider.js';
@@ -35,17 +34,31 @@ export class SmsService {
       return null;
     }
 
-    const provider = this.createProvider(realm.smsProvider as SmsProviderType);
+    const provider = await this.createProvider(
+      realm.smsProvider as SmsProviderType,
+    );
     this.logger.debug(
       `SMS provider "${realm.smsProvider}" requested for realm "${realmName}"`,
     );
     return provider;
   }
 
-  private createProvider(providerType: SmsProviderType): SmsProvider | null {
+  /**
+   * The `twilio` SDK is a large (~40MB) dependency that only realms actually
+   * using Twilio need. SmsModule is registered globally, so a static import
+   * would load it into every server process at startup regardless of
+   * config — imported dynamically here so it's only pulled in when a realm
+   * is actually configured for Twilio.
+   */
+  private async createProvider(
+    providerType: SmsProviderType,
+  ): Promise<SmsProvider | null> {
     switch (providerType) {
-      case SmsProviderType.TWILIO:
+      case SmsProviderType.TWILIO: {
+        const { TwilioSmsProvider } =
+          await import('./providers/twilio.provider.js');
         return new TwilioSmsProvider();
+      }
       case SmsProviderType.VONAGE:
         return new VonageSmsProvider();
       case SmsProviderType.AWS_SNS:
@@ -75,7 +88,9 @@ export class SmsService {
       return;
     }
 
-    const provider = this.createProvider(realm.smsProvider as SmsProviderType);
+    const provider = await this.createProvider(
+      realm.smsProvider as SmsProviderType,
+    );
     if (!provider) {
       this.logger.error(
         `Failed to create SMS provider for realm "${realmName}"`,


### PR DESCRIPTION
## Summary

Closes #1256.

**Docker production stage.** It copied the entire build-stage `node_modules` (including devDependencies) and ran `npm prune --omit=dev` afterward, rather than a clean `npm ci --omit=dev` directly against the production stage — simpler, and doesn't depend on npm's prune graph-pruning being exactly right.

Now: manifests (`package.json`/`package-lock.json`) plus `prisma.config.ts` and `prisma/` are copied in first, so `npm ci`'s `postinstall` (`prisma generate`) has what it needs, then `npm ci --omit=dev` runs directly. `prisma.config.ts` is then removed — it's TypeScript and unusable without a compiler in this image, and was only needed for the postinstall step above (`migrate deploy` already gets `--schema` passed explicitly in `docker-entrypoint.sh` rather than relying on config-file discovery, per the existing comment this preserves).

I caught a real bug in my first pass at this: a `\`-continued `RUN npm ci --omit=dev \` with an explanatory `#` comment on a following continuation line, followed by `&& rm prisma.config.ts`. I verified empirically (reproduced the exact byte sequence in a real shell script) that Docker's line-continuation joins lines the same way a literal shell `\`-continuation does — the comment terminates that logical statement, and the next line starting with `&&` is a **syntax error**, which would have failed the entire `docker build`. Fixed by moving the comment to its own Dockerfile-level line before a separate `RUN rm prisma.config.ts` instruction (Dockerfile comments before an instruction never reach the shell; comments *inside* a `\`-joined shell command do, and end the statement they're on).

Since I don't have Docker available to build locally in this environment, I'm relying on CI's `Docker Build` job (which builds the real image via `docker/build-push-action`) as the authoritative check — watching it closely.

**Lazy Twilio SDK.** `sms.service.ts` statically imported `TwilioSmsProvider`, which statically imports the ~40MB `twilio` npm package. Since `SmsModule` is registered globally (`@Global()`), every server process loaded Twilio at startup regardless of whether any realm actually uses it.

`createProvider()` is now `async` and dynamically imports `twilio.provider.js` only in the Twilio branch. Confirmed via grep that nothing else in `src/` imports `twilio.provider.js`, so this dynamic import is the only load path — the SDK now only loads when a realm is actually configured for Twilio.

Making this testable required one more fix: TypeScript under this project's `"module": "nodenext"` preserves a literal `await import(...)` expression verbatim (correct for real Node, which runs it natively even from a CJS file — confirmed the compiled `dist/sms/sms.service.js` output keeps it as-is). But Jest's default CJS test environment can't execute that syntax without `--experimental-vm-modules`. I overrode ts-jest's `module` compiler option to plain `commonjs` for the test transform only (`jest.config.ts`) — TypeScript downlevels dynamic import to a `require()`-based Promise under that setting, which Jest runs fine. This doesn't touch the real build (`tsconfig.build.json`, still `nodenext`) and I ran the full suite after the change to confirm nothing else was affected.

## Test plan
- [x] `npm run build` — clean; verified `dist/sms/sms.service.js` still contains the literal `await import(...)` (production behavior unchanged, still genuinely lazy at runtime)
- [x] Full backend suite: `npx jest` — 128 suites / 2146 tests passing (jest.config.ts transform change didn't break anything else)
- [x] New: `sms.service.spec.ts` (didn't exist before) covering `getProvider`/`sendSms` for all four provider types including a real assertion that the Twilio branch resolves via the dynamic import to an actual `TwilioSmsProvider` instance, plus the not-configured/unknown-type/not-found paths
- [x] `npx eslint` / `npx prettier --check` clean on all changed files
- [ ] CI's `Docker Build` job — the real verification for the Dockerfile change, watching before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW