### PR TITLE
tech-debt(admin-ui): extract shared provider-form scaffolding

### DIFF
--- a/admin-ui/src/components/email/EmailProviderForm.tsx
+++ b/admin-ui/src/components/email/EmailProviderForm.tsx
@@ -4,6 +4,12 @@ import type { Realm, EmailProviderType, EmailProviderConfig } from '../../types'
 import { updateRealm, sendTestEmail, testRealmSmtp } from '../../api/realms';
 import PasswordInput from '../PasswordInput';
 import { getErrorMessage } from '../../utils/getErrorMessage';
+import {
+  Icons,
+  ProviderSelectorGrid,
+  MutationStatusBanner,
+  type ProviderOption,
+} from '../ui';
 
 type EmailProviderFormProps = {
   realm: Realm;
@@ -73,14 +79,6 @@ function buildProviderConfig(form: EmailFormState): EmailProviderConfig {
 
 // ── Provider option cards ──────────────────────────────────────────────────
 
-type ProviderOption = {
-  value: EmailProviderType;
-  label: string;
-  description: string;
-  badge?: string;
-  icon: React.ReactNode;
-};
-
 function ServerIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
@@ -88,23 +86,6 @@ function ServerIcon({ className }: { className?: string }) {
       <rect x="2" y="14" width="20" height="8" rx="2" />
       <line x1="6" y1="6" x2="6.01" y2="6" />
       <line x1="6" y1="18" x2="6.01" y2="18" />
-    </svg>
-  );
-}
-
-function BanIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="12" r="10" />
-      <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
-    </svg>
-  );
-}
-
-function ZapIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
-      <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
     </svg>
   );
 }
@@ -140,12 +121,12 @@ function StampIcon({ className }: { className?: string }) {
   );
 }
 
-const PROVIDERS: ProviderOption[] = [
+const PROVIDERS: ProviderOption<EmailProviderType>[] = [
   {
     value: 'none',
     label: 'Disabled',
     description: 'Email delivery is turned off for this realm.',
-    icon: <BanIcon className="h-5 w-5" />,
+    icon: <Icons.Ban className="h-5 w-5" />,
   },
   {
     value: 'smtp',
@@ -158,7 +139,7 @@ const PROVIDERS: ProviderOption[] = [
     label: 'Resend',
     description: 'Modern email API built for developers.',
     badge: 'Popular',
-    icon: <ZapIcon className="h-5 w-5" />,
+    icon: <Icons.Zap className="h-5 w-5" />,
   },
   {
     value: 'sendgrid',
@@ -480,48 +461,11 @@ export default function EmailProviderForm({ realm }: EmailProviderFormProps) {
         </div>
 
         {/* Provider grid */}
-        <div className="grid grid-cols-3 gap-3">
-          {PROVIDERS.map((p) => {
-            const selected = form.emailProvider === p.value;
-            return (
-              <button
-                key={p.value}
-                type="button"
-                onClick={() => setForm((f) => ({ ...f, emailProvider: p.value }))}
-                className={[
-                  'relative flex flex-col gap-1.5 rounded-lg border-2 p-4 text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-accent',
-                  selected
-                    ? 'border-accent bg-accent-soft'
-                    : 'border-line bg-surface hover:border-line-strong hover:bg-hover',
-                ].join(' ')}
-                aria-pressed={selected}
-              >
-                {p.badge && (
-                  <span className="absolute right-2 top-2 rounded-full bg-accent-soft px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
-                    {p.badge}
-                  </span>
-                )}
-                <span
-                  className={[
-                    'flex h-8 w-8 items-center justify-center rounded-md',
-                    selected ? 'bg-accent text-white' : 'bg-sunken text-subtle',
-                  ].join(' ')}
-                >
-                  {p.icon}
-                </span>
-                <span
-                  className={[
-                    'text-sm font-semibold',
-                    selected ? 'text-accent' : 'text-fg',
-                  ].join(' ')}
-                >
-                  {p.label}
-                </span>
-                <span className="text-xs leading-snug text-subtle">{p.description}</span>
-              </button>
-            );
-          })}
-        </div>
+        <ProviderSelectorGrid
+          options={PROVIDERS}
+          value={form.emailProvider}
+          onChange={(v) => setForm((f) => ({ ...f, emailProvider: v }))}
+        />
 
         {/* Provider-specific fields */}
         {hasConfig && (
@@ -533,17 +477,12 @@ export default function EmailProviderForm({ realm }: EmailProviderFormProps) {
           </div>
         )}
 
-        {/* Status banners */}
-        {updateMutation.isSuccess && (
-          <div role="status" className="rounded-md bg-success-soft p-3 text-sm text-success-fg">
-            Email settings saved successfully.
-          </div>
-        )}
-        {updateMutation.isError && (
-          <div role="alert" className="rounded-md bg-danger-soft p-3 text-sm text-danger-fg">
-            {getErrorMessage(updateMutation.error, 'Failed to save email settings.')}
-          </div>
-        )}
+        {/* Status banner */}
+        <MutationStatusBanner
+          mutation={updateMutation}
+          successMessage="Email settings saved successfully."
+          errorFallback="Failed to save email settings."
+        />
 
         <div className="flex justify-end border-t border-line pt-4">
           <button

--- a/admin-ui/src/components/sms/SmsProviderForm.tsx
+++ b/admin-ui/src/components/sms/SmsProviderForm.tsx
@@ -3,8 +3,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Realm, SmsProviderType, SmsProviderConfig } from '../../types';
 import { updateRealm } from '../../api/realms';
 import PasswordInput from '../PasswordInput';
-import { getErrorMessage } from '../../utils/getErrorMessage';
 import { formatDuration } from '../../utils/formatDuration';
+import {
+  Icons,
+  ProviderSelectorGrid,
+  MutationStatusBanner,
+  type ProviderOption,
+} from '../ui';
 
 type SmsProviderFormProps = {
   realm: Realm;
@@ -76,15 +81,6 @@ function buildProviderConfig(form: SmsFormState): SmsProviderConfig {
 
 // ── Icons ──────────────────────────────────────────────────────────────────
 
-function BanIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
-      <circle cx="12" cy="12" r="10" />
-      <line x1="4.93" y1="4.93" x2="19.07" y2="19.07" />
-    </svg>
-  );
-}
-
 function PhoneIcon({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
@@ -111,30 +107,14 @@ function GlobeIcon({ className }: { className?: string }) {
   );
 }
 
-function ZapIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
-      <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z" />
-    </svg>
-  );
-}
-
 // ── Provider options ───────────────────────────────────────────────────────
 
-type ProviderOption = {
-  value: SmsProviderType;
-  label: string;
-  description: string;
-  badge?: string;
-  icon: React.ReactNode;
-};
-
-const PROVIDERS: ProviderOption[] = [
+const PROVIDERS: ProviderOption<SmsProviderType>[] = [
   {
     value: 'none',
     label: 'Disabled',
     description: 'SMS delivery is turned off for this realm.',
-    icon: <BanIcon className="h-5 w-5" />,
+    icon: <Icons.Ban className="h-5 w-5" />,
   },
   {
     value: 'twilio',
@@ -147,7 +127,7 @@ const PROVIDERS: ProviderOption[] = [
     value: 'vonage',
     label: 'Vonage',
     description: 'Reliable SMS API (formerly Nexmo).',
-    icon: <ZapIcon className="h-5 w-5" />,
+    icon: <Icons.Zap className="h-5 w-5" />,
   },
   {
     value: 'aws-sns',
@@ -443,48 +423,12 @@ export default function SmsProviderForm({ realm }: SmsProviderFormProps) {
           </p>
         </div>
 
-        <div className="grid grid-cols-3 gap-3 sm:grid-cols-5">
-          {PROVIDERS.map((p) => {
-            const selected = form.smsProvider === p.value;
-            return (
-              <button
-                key={p.value}
-                type="button"
-                onClick={() => setForm((f) => ({ ...f, smsProvider: p.value }))}
-                className={[
-                  'relative flex flex-col gap-1.5 rounded-lg border-2 p-4 text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-accent',
-                  selected
-                    ? 'border-accent bg-accent-soft'
-                    : 'border-line bg-surface hover:border-line-strong hover:bg-hover',
-                ].join(' ')}
-                aria-pressed={selected}
-              >
-                {p.badge && (
-                  <span className="absolute right-2 top-2 rounded-full bg-accent-soft px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
-                    {p.badge}
-                  </span>
-                )}
-                <span
-                  className={[
-                    'flex h-8 w-8 items-center justify-center rounded-md',
-                    selected ? 'bg-accent text-white' : 'bg-sunken text-subtle',
-                  ].join(' ')}
-                >
-                  {p.icon}
-                </span>
-                <span
-                  className={[
-                    'text-sm font-semibold',
-                    selected ? 'text-accent' : 'text-fg',
-                  ].join(' ')}
-                >
-                  {p.label}
-                </span>
-                <span className="text-xs leading-snug text-subtle">{p.description}</span>
-              </button>
-            );
-          })}
-        </div>
+        <ProviderSelectorGrid
+          options={PROVIDERS}
+          value={form.smsProvider}
+          onChange={(v) => setForm((f) => ({ ...f, smsProvider: v }))}
+          columnsClassName="grid-cols-3 sm:grid-cols-5"
+        />
 
         {/* Sender / provider fields */}
         {hasProvider && (
@@ -600,17 +544,12 @@ export default function SmsProviderForm({ realm }: SmsProviderFormProps) {
         </div>
       )}
 
-      {/* Status banners */}
-      {updateMutation.isSuccess && (
-        <div role="status" className="rounded-md bg-success-soft p-3 text-sm text-success-fg">
-          SMS settings saved successfully.
-        </div>
-      )}
-      {updateMutation.isError && (
-        <div role="alert" className="rounded-md bg-danger-soft p-3 text-sm text-danger-fg">
-          {getErrorMessage(updateMutation.error, 'Failed to save SMS settings.')}
-        </div>
-      )}
+      {/* Status banner */}
+      <MutationStatusBanner
+        mutation={updateMutation}
+        successMessage="SMS settings saved successfully."
+        errorFallback="Failed to save SMS settings."
+      />
 
       <div className="flex justify-end">
         <button

--- a/admin-ui/src/components/ui/MutationStatusBanner.tsx
+++ b/admin-ui/src/components/ui/MutationStatusBanner.tsx
@@ -1,0 +1,32 @@
+import { Alert } from './Alert';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+export interface MutationStatusBannerProps {
+  mutation: { isSuccess: boolean; isError: boolean; error: unknown };
+  successMessage: string;
+  errorFallback: string;
+}
+
+/**
+ * Success/error banner for a form's save mutation, built on the shared
+ * `Alert` component. Replaces the hand-rolled
+ * `rounded-md bg-success-soft p-3 text-sm text-success-fg` / danger pair
+ * that EmailProviderForm and SmsProviderForm each repeated verbatim.
+ */
+export function MutationStatusBanner({
+  mutation,
+  successMessage,
+  errorFallback,
+}: MutationStatusBannerProps) {
+  if (mutation.isSuccess) {
+    return (
+      <Alert variant="success" role="status">
+        {successMessage}
+      </Alert>
+    );
+  }
+  if (mutation.isError) {
+    return <Alert variant="danger">{getErrorMessage(mutation.error, errorFallback)}</Alert>;
+  }
+  return null;
+}

--- a/admin-ui/src/components/ui/ProviderSelectorGrid.tsx
+++ b/admin-ui/src/components/ui/ProviderSelectorGrid.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react';
+import { cn } from './cn';
+
+export interface ProviderOption<T extends string> {
+  value: T;
+  label: string;
+  description: string;
+  badge?: string;
+  icon: ReactNode;
+}
+
+export interface ProviderSelectorGridProps<T extends string> {
+  options: ProviderOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  /** Grid column classes, e.g. `grid-cols-3` or `grid-cols-3 sm:grid-cols-5`. */
+  columnsClassName?: string;
+}
+
+/**
+ * Card-grid provider picker shared by EmailProviderForm and SmsProviderForm
+ * (previously two near-identical copies of this exact markup).
+ */
+export function ProviderSelectorGrid<T extends string>({
+  options,
+  value,
+  onChange,
+  columnsClassName = 'grid-cols-3',
+}: ProviderSelectorGridProps<T>) {
+  return (
+    <div className={cn('grid gap-3', columnsClassName)}>
+      {options.map((option) => {
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={cn(
+              'relative flex flex-col gap-1.5 rounded-lg border-2 p-4 text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-accent',
+              selected
+                ? 'border-accent bg-accent-soft'
+                : 'border-line bg-surface hover:border-line-strong hover:bg-hover',
+            )}
+            aria-pressed={selected}
+          >
+            {option.badge && (
+              <span className="absolute right-2 top-2 rounded-full bg-accent-soft px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-accent">
+                {option.badge}
+              </span>
+            )}
+            <span
+              className={cn(
+                'flex h-8 w-8 items-center justify-center rounded-md',
+                selected ? 'bg-accent text-white' : 'bg-sunken text-subtle',
+              )}
+            >
+              {option.icon}
+            </span>
+            <span className={cn('text-sm font-semibold', selected ? 'text-accent' : 'text-fg')}>
+              {option.label}
+            </span>
+            <span className="text-xs leading-snug text-subtle">{option.description}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/admin-ui/src/components/ui/__tests__/MutationStatusBanner.test.tsx
+++ b/admin-ui/src/components/ui/__tests__/MutationStatusBanner.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MutationStatusBanner } from '../MutationStatusBanner';
+
+describe('MutationStatusBanner', () => {
+  it('renders nothing when the mutation is idle', () => {
+    const { container } = render(
+      <MutationStatusBanner
+        mutation={{ isSuccess: false, isError: false, error: null }}
+        successMessage="Saved!"
+        errorFallback="Failed."
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the success message with role="status" on success', () => {
+    render(
+      <MutationStatusBanner
+        mutation={{ isSuccess: true, isError: false, error: null }}
+        successMessage="Settings saved successfully."
+        errorFallback="Failed to save."
+      />,
+    );
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Settings saved successfully.');
+  });
+
+  it('renders the error fallback with role="alert" when the error has no message', () => {
+    render(
+      <MutationStatusBanner
+        mutation={{ isSuccess: false, isError: true, error: null }}
+        successMessage="Saved!"
+        errorFallback="Failed to save settings."
+      />,
+    );
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveTextContent('Failed to save settings.');
+  });
+
+  it("prefers the error's own message over the fallback", () => {
+    render(
+      <MutationStatusBanner
+        mutation={{ isSuccess: false, isError: true, error: new Error('Specific failure') }}
+        successMessage="Saved!"
+        errorFallback="Generic fallback."
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('Specific failure');
+  });
+});

--- a/admin-ui/src/components/ui/__tests__/ProviderSelectorGrid.test.tsx
+++ b/admin-ui/src/components/ui/__tests__/ProviderSelectorGrid.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProviderSelectorGrid } from '../ProviderSelectorGrid';
+import type { ProviderOption } from '../ProviderSelectorGrid';
+
+type TestProvider = 'none' | 'a' | 'b';
+
+const OPTIONS: ProviderOption<TestProvider>[] = [
+  { value: 'none', label: 'Disabled', description: 'Turned off.', icon: <span>x</span> },
+  { value: 'a', label: 'Provider A', description: 'First provider.', badge: 'Popular', icon: <span>a</span> },
+  { value: 'b', label: 'Provider B', description: 'Second provider.', icon: <span>b</span> },
+];
+
+describe('ProviderSelectorGrid', () => {
+  it('renders a button for each option with its label and description', () => {
+    render(<ProviderSelectorGrid options={OPTIONS} value="none" onChange={() => {}} />);
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.getByText('Provider A')).toBeInTheDocument();
+    expect(screen.getByText('First provider.')).toBeInTheDocument();
+    expect(screen.getByText('Provider B')).toBeInTheDocument();
+  });
+
+  it('marks the selected option as pressed and others as not', () => {
+    render(<ProviderSelectorGrid options={OPTIONS} value="a" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: /provider a/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /disabled/i })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: /provider b/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders a badge when present', () => {
+    render(<ProviderSelectorGrid options={OPTIONS} value="none" onChange={() => {}} />);
+    expect(screen.getByText('Popular')).toBeInTheDocument();
+  });
+
+  it('calls onChange with the clicked option value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<ProviderSelectorGrid options={OPTIONS} value="none" onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: /provider b/i }));
+
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('defaults to a 3-column grid when columnsClassName is not provided', () => {
+    const { container } = render(
+      <ProviderSelectorGrid options={OPTIONS} value="none" onChange={() => {}} />,
+    );
+    expect(container.firstElementChild?.className).toContain('grid-cols-3');
+  });
+
+  it('applies a custom columnsClassName', () => {
+    const { container } = render(
+      <ProviderSelectorGrid
+        options={OPTIONS}
+        value="none"
+        onChange={() => {}}
+        columnsClassName="grid-cols-3 sm:grid-cols-5"
+      />,
+    );
+    expect(container.firstElementChild?.className).toContain('sm:grid-cols-5');
+  });
+});

--- a/admin-ui/src/components/ui/icons.tsx
+++ b/admin-ui/src/components/ui/icons.tsx
@@ -105,6 +105,8 @@ export const Icons = {
   CheckCircle: makeIcon(['M22 11.08V12a10 10 0 1 1-5.93-9.14', 'm22 4-10 10.01-3-3']),
   X: makeIcon(['M18 6 6 18', 'm6 6 12 12']),
   XCircle: makeIcon(['M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z', 'M15 9 9 15', 'M9 9l6 6']),
+  // Circle-slash "disabled/none" glyph — distinct from XCircle (an X mark).
+  Ban: makeIcon(['M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z', 'M4.93 4.93l14.14 14.14']),
   Info: makeIcon(['M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z', 'M12 16v-4', 'M12 8h.01']),
   Alert: makeIcon(['M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z', 'M12 9v4', 'M12 17h.01']),
   Shield: makeIcon('M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z'),

--- a/admin-ui/src/components/ui/index.ts
+++ b/admin-ui/src/components/ui/index.ts
@@ -29,3 +29,7 @@ export { Sparkline } from './Sparkline';
 export type { SparklineProps } from './Sparkline';
 export { Tooltip } from './Tooltip';
 export type { TooltipProps } from './Tooltip';
+export { ProviderSelectorGrid } from './ProviderSelectorGrid';
+export type { ProviderSelectorGridProps, ProviderOption } from './ProviderSelectorGrid';
+export { MutationStatusBanner } from './MutationStatusBanner';
+export type { MutationStatusBannerProps } from './MutationStatusBanner';


### PR DESCRIPTION
## Summary

Closes #1261. `EmailProviderForm.tsx` (635 lines) and `SmsProviderForm.tsx` (626 lines) duplicated their provider-selection card grid UI almost verbatim, both hand-rolled the same mutation success/error banner markup, and both defined a byte-identical `ZapIcon` (already present in the shared registry as `Icons.Zap`).

- **New `ProviderSelectorGrid`** (`src/components/ui/ProviderSelectorGrid.tsx`) — parameterized by a generic `ProviderOption<T>[]` list, `value`, `onChange`, and an optional `columnsClassName` (Email uses the default `grid-cols-3`; SMS passes `grid-cols-3 sm:grid-cols-5`, matching each form's original grid). Both forms now render this instead of ~40 lines of duplicated card-grid markup each.
- **New `MutationStatusBanner`** (`src/components/ui/MutationStatusBanner.tsx`) — built on the *existing* `Alert` component rather than a new hand-rolled div. This is a small extra win beyond what the issue's literal duplication complaint asked for: `Alert`'s own doc comment says it already "replaces the hand-rolled `rounded-md bg-red-50 p-4 text-sm text-red-700` pattern... duplicated across ~36 pages" — Email/SMS provider forms just hadn't been migrated to it yet, so their banners were both duplicated *and* visually inconsistent with the rest of the app (no icon, different padding, no border). Fixed both at once.
- **Added `Icons.Ban`** to the icon registry — a circle-slash "disabled" glyph, expressed as path data (two path strings) to match the registry's path-only `makeIcon` convention. Deliberately not reusing `Icons.XCircle`, which is a genuinely different icon (an X/cross mark, not a circle-slash) — the issue explicitly said to add a proper equivalent if nothing already fit, rather than force a visually-wrong icon in for the sake of reuse.
- Both forms now use `Icons.Ban`/`Icons.Zap` instead of their local `BanIcon`/`ZapIcon` copies (email's `ServerIcon`/`GridIcon`/`SendIcon`/`StampIcon` and SMS's `PhoneIcon`/`CloudIcon`/`GlobeIcon` are untouched — provider-specific, not duplicated, and not called out by the issue).

**Deliberately left alone**: `seedFromRealm()`/`buildProviderConfig()`. The issue notes both forms define a pair "with the same shape," but the actual fields are entirely different domains (SMTP/Resend/SendGrid/Mailgun/Postmark config vs. Twilio/Vonage/AWS SNS/Webhook config) — merging them into one generic function would require a field-mapping config layer that costs more readability than the duplication it removes. The issue's concrete suggested-fix list doesn't include this one; I read the "same shape" line as an observation supporting the general duplication complaint, not an instruction to force these together.

## Test plan
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] Full admin-ui suite: `npx vitest run` — 45 files / 403 tests passing (2 pre-existing skips, unrelated)
- [x] New: `ProviderSelectorGrid.test.tsx` (6 tests — renders options, `aria-pressed` state, badge, `onChange` wiring, default vs. custom column classes) and `MutationStatusBanner.test.tsx` (4 tests — idle/success/error states, error message precedence over fallback)
- [x] `npx eslint .` — no new errors; one pre-existing error in `ScimConfigPage.tsx` (confirmed via `git diff --stat dev -- ...` — zero diff, untouched by this branch, already present on `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW