### PR TITLE
tech-debt(terraform-provider): dedup realm field-mapping

### DIFF
--- a/terraform-provider-idenplane/client/realms.go
+++ b/terraform-provider-idenplane/client/realms.go
@@ -78,9 +78,13 @@ type Realm struct {
 	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
-// CreateRealmRequest represents the request body for creating a realm
-type CreateRealmRequest struct {
-	Name                          string                 `json:"name"`
+// RealmRequestFields holds the realm settings shared by CreateRealmRequest
+// and UpdateRealmRequest. The two request bodies have an identical field
+// set (Create has one extra top-level Name field, since a realm's name
+// can't change after creation) -- extracting the shared fields here lets
+// the Terraform resource map a plan onto either request type with a single
+// function instead of keeping two ~215-line copies in lockstep by hand.
+type RealmRequestFields struct {
 	DisplayName                   string                 `json:"displayName,omitempty"`
 	Enabled                       *bool                  `json:"enabled,omitempty"`
 	AccessTokenLifespan           int                    `json:"accessTokenLifespan,omitempty"`
@@ -146,72 +150,18 @@ type CreateRealmRequest struct {
 	AllowedEmailDomains           []string `json:"allowedEmailDomains,omitempty"`
 }
 
-// UpdateRealmRequest represents the request body for updating a realm
-type UpdateRealmRequest struct {
-	DisplayName                   string                 `json:"displayName,omitempty"`
-	Enabled                       *bool                  `json:"enabled,omitempty"`
-	AccessTokenLifespan           int                    `json:"accessTokenLifespan,omitempty"`
-	RefreshTokenLifespan          int                    `json:"refreshTokenLifespan,omitempty"`
-	SMTPHost                      string                 `json:"smtpHost,omitempty"`
-	SMTPPort                      int                    `json:"smtpPort,omitempty"`
-	SMTPUser                      string                 `json:"smtpUser,omitempty"`
-	SMTPPassword                 string                 `json:"smtpPassword,omitempty"`
-	SMTPFrom                      string                 `json:"smtpFrom,omitempty"`
-	SMTPSecure                    *bool                  `json:"smtpSecure,omitempty"`
-	PasswordMinLength             int                    `json:"passwordMinLength,omitempty"`
-	PasswordRequireUppercase      *bool                  `json:"passwordRequireUppercase,omitempty"`
-	PasswordRequireLowercase       *bool                  `json:"passwordRequireLowercase,omitempty"`
-	PasswordRequireDigits          *bool                  `json:"passwordRequireDigits,omitempty"`
-	PasswordRequireSpecialChars    *bool                  `json:"passwordRequireSpecialChars,omitempty"`
-	PasswordHistoryCount           int                    `json:"passwordHistoryCount,omitempty"`
-	PasswordMaxAgeDays             int                    `json:"passwordMaxAgeDays,omitempty"`
-	BruteForceEnabled              *bool                  `json:"bruteForceEnabled,omitempty"`
-	MaxLoginFailures               int                    `json:"maxLoginFailures,omitempty"`
-	LockoutDuration                int                    `json:"lockoutDuration,omitempty"`
-	FailureResetTime               int                    `json:"failureResetTime,omitempty"`
-	PermanentLockoutAfter          int                    `json:"permanentLockoutAfter,omitempty"`
-	RegistrationAllowed           *bool                  `json:"registrationAllowed,omitempty"`
-	RequireEmailVerification       *bool                  `json:"requireEmailVerification,omitempty"`
-	MFARequired                   *bool                  `json:"mfaRequired,omitempty"`
-	OfflineTokenLifespan           int                    `json:"offlineTokenLifespan,omitempty"`
-	EventsEnabled                 *bool                  `json:"eventsEnabled,omitempty"`
-	EventsExpiration               int                    `json:"eventsExpiration,omitempty"`
-	AdminEventsEnabled            *bool                  `json:"adminEventsEnabled,omitempty"`
-	// Rate limiting
-	RateLimitEnabled        *bool `json:"rateLimitEnabled,omitempty"`
-	ClientRateLimitPerMinute int  `json:"clientRateLimitPerMinute,omitempty"`
-	ClientRateLimitPerHour   int  `json:"clientRateLimitPerHour,omitempty"`
-	UserRateLimitPerMinute   int  `json:"userRateLimitPerMinute,omitempty"`
-	UserRateLimitPerHour     int  `json:"userRateLimitPerHour,omitempty"`
-	IPRateLimitPerMinute     int  `json:"ipRateLimitPerMinute,omitempty"`
-	IPRateLimitPerHour       int  `json:"ipRateLimitPerHour,omitempty"`
-	// Session management
-	MaxSessionsPerUser int `json:"maxSessionsPerUser,omitempty"`
-	// Theming
-	ThemeName    string                  `json:"themeName,omitempty"`
-	Theme        map[string]interface{} `json:"theme,omitempty"`
-	LoginTheme   string                  `json:"loginTheme,omitempty"`
-	AccountTheme string                  `json:"accountTheme,omitempty"`
-	EmailTheme   string                  `json:"emailTheme,omitempty"`
-	// Impersonation
-	ImpersonationEnabled    *bool `json:"impersonationEnabled,omitempty"`
-	ImpersonationMaxDuration int  `json:"impersonationMaxDuration,omitempty"`
-	// WebAuthn / passkeys
-	WebAuthnEnabled *bool  `json:"webAuthnEnabled,omitempty"`
-	WebAuthnRpName  string `json:"webAuthnRpName,omitempty"`
-	WebAuthnRpID    string `json:"webAuthnRpId,omitempty"`
-	// Adaptive authentication
-	AdaptiveAuthEnabled *bool `json:"adaptiveAuthEnabled,omitempty"`
-	RiskThresholdStepUp  int   `json:"riskThresholdStepUp,omitempty"`
-	RiskThresholdBlock    int   `json:"riskThresholdBlock,omitempty"`
-	// Localisation
-	DefaultLocale    string   `json:"defaultLocale,omitempty"`
-	SupportedLocales []string `json:"supportedLocales,omitempty"`
-	// Legal / registration controls
-	TermsOfServiceURL             string   `json:"termsOfServiceUrl,omitempty"`
-	RegistrationApprovalRequired *bool    `json:"registrationApprovalRequired,omitempty"`
-	AllowedEmailDomains           []string `json:"allowedEmailDomains,omitempty"`
+// CreateRealmRequest represents the request body for creating a realm
+type CreateRealmRequest struct {
+	Name string `json:"name"`
+	RealmRequestFields
 }
+
+// UpdateRealmRequest represents the request body for updating a realm.
+// An update request has no fields beyond the shared set, so this is a type
+// alias rather than a wrapper -- existing keyed struct literals such as
+// UpdateRealmRequest{DisplayName: "..."} keep working unchanged, since
+// DisplayName is a direct (not promoted) field of RealmRequestFields.
+type UpdateRealmRequest = RealmRequestFields
 
 // Theme represents an available theme
 type Theme struct {

--- a/terraform-provider-idenplane/client/realms_test.go
+++ b/terraform-provider-idenplane/client/realms_test.go
@@ -44,8 +44,10 @@ func TestRealmsClient_CreateRealm(t *testing.T) {
 
 	realmsClient := NewRealmsClient(client)
 	req := CreateRealmRequest{
-		Name:        "test-realm",
-		DisplayName: "Test Realm",
+		Name: "test-realm",
+		RealmRequestFields: RealmRequestFields{
+			DisplayName: "Test Realm",
+		},
 	}
 
 	realm, err := realmsClient.CreateRealm(context.Background(), req)

--- a/terraform-provider-idenplane/provider/resource_realm.go
+++ b/terraform-provider-idenplane/provider/resource_realm.go
@@ -416,11 +416,9 @@ func (r *RealmResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	// Build the create request
 	createReq := client.CreateRealmRequest{
-		Name: plan.Name.ValueString(),
+		Name:               plan.Name.ValueString(),
+		RealmRequestFields: mapRealmPlanToRequestFields(ctx, plan),
 	}
-
-	// Map optional fields from the plan
-	mapRealmPlanToCreateRequest(ctx, plan, &createReq)
 
 	// Create the realms client and call the API
 	realmsClient := client.NewRealmsClient(r.httpClient)
@@ -519,10 +517,7 @@ func (r *RealmResource) Update(ctx context.Context, req resource.UpdateRequest, 
 	realmName := state.Name.ValueString()
 
 	// Build the update request
-	updateReq := client.UpdateRealmRequest{}
-
-	// Map optional fields from the plan
-	mapRealmPlanToUpdateRequest(ctx, plan, &updateReq)
+	updateReq := mapRealmPlanToRequestFields(ctx, plan)
 
 	// Create the realms client and call the API
 	realmsClient := client.NewRealmsClient(r.httpClient)
@@ -632,8 +627,15 @@ func (r *RealmResource) ImportState(ctx context.Context, req resource.ImportStat
 	})
 }
 
-// mapRealmPlanToCreateRequest maps the Terraform plan to the create request
-func mapRealmPlanToCreateRequest(ctx context.Context, plan RealmResourceModel, req *client.CreateRealmRequest) {
+// mapRealmPlanToRequestFields maps the Terraform plan onto the realm
+// settings fields shared by CreateRealmRequest and UpdateRealmRequest.
+// Both request types have an identical field set (Create has one extra
+// top-level Name field, set separately by the caller), so this single
+// function serves both -- replacing what used to be two ~215-line
+// functions that had to be kept in lockstep by hand for every new field.
+func mapRealmPlanToRequestFields(ctx context.Context, plan RealmResourceModel) client.RealmRequestFields {
+	var req client.RealmRequestFields
+
 	if !plan.DisplayName.IsNull() {
 		req.DisplayName = plan.DisplayName.ValueString()
 	}
@@ -847,223 +849,8 @@ func mapRealmPlanToCreateRequest(ctx context.Context, plan RealmResourceModel, r
 		plan.AllowedEmailDomains.ElementsAs(ctx, &domains, false)
 		req.AllowedEmailDomains = domains
 	}
-}
 
-// mapRealmPlanToUpdateRequest maps the Terraform plan to the update request
-func mapRealmPlanToUpdateRequest(ctx context.Context, plan RealmResourceModel, req *client.UpdateRealmRequest) {
-	if !plan.DisplayName.IsNull() {
-		req.DisplayName = plan.DisplayName.ValueString()
-	}
-
-	if !plan.Enabled.IsNull() {
-		enabled := plan.Enabled.ValueBool()
-		req.Enabled = &enabled
-	}
-
-	if !plan.AccessTokenLifespan.IsNull() {
-		req.AccessTokenLifespan = int(plan.AccessTokenLifespan.ValueInt64())
-	}
-
-	if !plan.RefreshTokenLifespan.IsNull() {
-		req.RefreshTokenLifespan = int(plan.RefreshTokenLifespan.ValueInt64())
-	}
-
-	if !plan.OfflineTokenLifespan.IsNull() {
-		req.OfflineTokenLifespan = int(plan.OfflineTokenLifespan.ValueInt64())
-	}
-
-	// SMTP settings
-	if !plan.SMTPHost.IsNull() {
-		req.SMTPHost = plan.SMTPHost.ValueString()
-	}
-	if !plan.SMTPPort.IsNull() {
-		req.SMTPPort = int(plan.SMTPPort.ValueInt64())
-	}
-	if !plan.SMTPUser.IsNull() {
-		req.SMTPUser = plan.SMTPUser.ValueString()
-	}
-	if !plan.SMTPPassword.IsNull() && plan.SMTPPassword.ValueString() != "" {
-		req.SMTPPassword = plan.SMTPPassword.ValueString()
-	}
-	if !plan.SMTPFrom.IsNull() {
-		req.SMTPFrom = plan.SMTPFrom.ValueString()
-	}
-	if !plan.SMTPSecure.IsNull() {
-		secure := plan.SMTPSecure.ValueBool()
-		req.SMTPSecure = &secure
-	}
-
-	// Password settings
-	if !plan.PasswordMinLength.IsNull() {
-		req.PasswordMinLength = int(plan.PasswordMinLength.ValueInt64())
-	}
-	if !plan.PasswordRequireUppercase.IsNull() {
-		val := plan.PasswordRequireUppercase.ValueBool()
-		req.PasswordRequireUppercase = &val
-	}
-	if !plan.PasswordRequireLowercase.IsNull() {
-		val := plan.PasswordRequireLowercase.ValueBool()
-		req.PasswordRequireLowercase = &val
-	}
-	if !plan.PasswordRequireDigits.IsNull() {
-		val := plan.PasswordRequireDigits.ValueBool()
-		req.PasswordRequireDigits = &val
-	}
-	if !plan.PasswordRequireSpecial.IsNull() {
-		val := plan.PasswordRequireSpecial.ValueBool()
-		req.PasswordRequireSpecialChars = &val
-	}
-	if !plan.PasswordHistoryCount.IsNull() {
-		req.PasswordHistoryCount = int(plan.PasswordHistoryCount.ValueInt64())
-	}
-	if !plan.PasswordMaxAgeDays.IsNull() {
-		req.PasswordMaxAgeDays = int(plan.PasswordMaxAgeDays.ValueInt64())
-	}
-
-	// Brute force protection
-	if !plan.BruteForceEnabled.IsNull() {
-		val := plan.BruteForceEnabled.ValueBool()
-		req.BruteForceEnabled = &val
-	}
-	if !plan.MaxLoginFailures.IsNull() {
-		req.MaxLoginFailures = int(plan.MaxLoginFailures.ValueInt64())
-	}
-	if !plan.LockoutDuration.IsNull() {
-		req.LockoutDuration = int(plan.LockoutDuration.ValueInt64())
-	}
-	if !plan.FailureResetTime.IsNull() {
-		req.FailureResetTime = int(plan.FailureResetTime.ValueInt64())
-	}
-	if !plan.PermanentLockoutAfter.IsNull() {
-		req.PermanentLockoutAfter = int(plan.PermanentLockoutAfter.ValueInt64())
-	}
-
-	// Registration settings
-	if !plan.RegistrationAllowed.IsNull() {
-		val := plan.RegistrationAllowed.ValueBool()
-		req.RegistrationAllowed = &val
-	}
-	if !plan.RequireEmailVerification.IsNull() {
-		val := plan.RequireEmailVerification.ValueBool()
-		req.RequireEmailVerification = &val
-	}
-	if !plan.MFARequired.IsNull() {
-		val := plan.MFARequired.ValueBool()
-		req.MFARequired = &val
-	}
-
-	// Event settings
-	if !plan.EventsEnabled.IsNull() {
-		val := plan.EventsEnabled.ValueBool()
-		req.EventsEnabled = &val
-	}
-	if !plan.EventsExpiration.IsNull() {
-		req.EventsExpiration = int(plan.EventsExpiration.ValueInt64())
-	}
-	if !plan.AdminEventsEnabled.IsNull() {
-		val := plan.AdminEventsEnabled.ValueBool()
-		req.AdminEventsEnabled = &val
-	}
-
-	// Rate limiting
-	if !plan.RateLimitEnabled.IsNull() {
-		val := plan.RateLimitEnabled.ValueBool()
-		req.RateLimitEnabled = &val
-	}
-	if !plan.ClientRateLimitPerMinute.IsNull() {
-		req.ClientRateLimitPerMinute = int(plan.ClientRateLimitPerMinute.ValueInt64())
-	}
-	if !plan.ClientRateLimitPerHour.IsNull() {
-		req.ClientRateLimitPerHour = int(plan.ClientRateLimitPerHour.ValueInt64())
-	}
-	if !plan.UserRateLimitPerMinute.IsNull() {
-		req.UserRateLimitPerMinute = int(plan.UserRateLimitPerMinute.ValueInt64())
-	}
-	if !plan.UserRateLimitPerHour.IsNull() {
-		req.UserRateLimitPerHour = int(plan.UserRateLimitPerHour.ValueInt64())
-	}
-	if !plan.IPRateLimitPerMinute.IsNull() {
-		req.IPRateLimitPerMinute = int(plan.IPRateLimitPerMinute.ValueInt64())
-	}
-	if !plan.IPRateLimitPerHour.IsNull() {
-		req.IPRateLimitPerHour = int(plan.IPRateLimitPerHour.ValueInt64())
-	}
-
-	// Session management
-	if !plan.MaxSessionsPerUser.IsNull() {
-		req.MaxSessionsPerUser = int(plan.MaxSessionsPerUser.ValueInt64())
-	}
-
-	// Theme settings
-	if !plan.ThemeName.IsNull() {
-		req.ThemeName = plan.ThemeName.ValueString()
-	}
-	if !plan.LoginTheme.IsNull() {
-		req.LoginTheme = plan.LoginTheme.ValueString()
-	}
-	if !plan.AccountTheme.IsNull() {
-		req.AccountTheme = plan.AccountTheme.ValueString()
-	}
-	if !plan.EmailTheme.IsNull() {
-		req.EmailTheme = plan.EmailTheme.ValueString()
-	}
-
-	// Impersonation
-	if !plan.ImpersonationEnabled.IsNull() {
-		val := plan.ImpersonationEnabled.ValueBool()
-		req.ImpersonationEnabled = &val
-	}
-	if !plan.ImpersonationMaxDuration.IsNull() {
-		req.ImpersonationMaxDuration = int(plan.ImpersonationMaxDuration.ValueInt64())
-	}
-
-	// WebAuthn
-	if !plan.WebAuthnEnabled.IsNull() {
-		val := plan.WebAuthnEnabled.ValueBool()
-		req.WebAuthnEnabled = &val
-	}
-	if !plan.WebAuthnRpName.IsNull() {
-		req.WebAuthnRpName = plan.WebAuthnRpName.ValueString()
-	}
-	if !plan.WebAuthnRpID.IsNull() {
-		req.WebAuthnRpID = plan.WebAuthnRpID.ValueString()
-	}
-
-	// Adaptive auth
-	if !plan.AdaptiveAuthEnabled.IsNull() {
-		val := plan.AdaptiveAuthEnabled.ValueBool()
-		req.AdaptiveAuthEnabled = &val
-	}
-	if !plan.RiskThresholdStepUp.IsNull() {
-		req.RiskThresholdStepUp = int(plan.RiskThresholdStepUp.ValueInt64())
-	}
-	if !plan.RiskThresholdBlock.IsNull() {
-		req.RiskThresholdBlock = int(plan.RiskThresholdBlock.ValueInt64())
-	}
-
-	// Locale settings
-	if !plan.DefaultLocale.IsNull() {
-		req.DefaultLocale = plan.DefaultLocale.ValueString()
-	}
-	if !plan.SupportedLocales.IsNull() {
-		var locales []string
-		plan.SupportedLocales.ElementsAs(ctx, &locales, false)
-		req.SupportedLocales = locales
-	}
-
-	// Legal / registration controls
-	if !plan.TermsOfServiceURL.IsNull() {
-		req.TermsOfServiceURL = plan.TermsOfServiceURL.ValueString()
-	}
-	if !plan.RegistrationApprovalRequired.IsNull() {
-		val := plan.RegistrationApprovalRequired.ValueBool()
-		req.RegistrationApprovalRequired = &val
-	}
-	if !plan.AllowedEmailDomains.IsNull() {
-		var domains []string
-		plan.AllowedEmailDomains.ElementsAs(ctx, &domains, false)
-		req.AllowedEmailDomains = domains
-	}
+	return req
 }
 
 // mapRealmToState maps the API realm response to the Terraform state


### PR DESCRIPTION
## Summary

Closes #1259. `mapRealmPlanToCreateRequest` and `mapRealmPlanToUpdateRequest` in `terraform-provider-idenplane/provider/resource_realm.go` were 215 lines each of field-by-field `IsNull()`/`ValueXxx()` mapping, textually identical apart from the target struct type (`CreateRealmRequest` vs `UpdateRealmRequest`). I also verified the two request structs themselves have an identical field set (`CreateRealmRequest` has one extra top-level `Name` field, since a realm's name can't change after creation).

- Extracted the shared fields into `client.RealmRequestFields` (`client/realms.go`).
- `CreateRealmRequest` now embeds `RealmRequestFields` alongside `Name`.
- `UpdateRealmRequest` becomes a **type alias** to `RealmRequestFields` (`type UpdateRealmRequest = RealmRequestFields`) rather than a wrapper struct — since an update request has no fields beyond the shared set, aliasing means existing keyed struct literals like `UpdateRealmRequest{DisplayName: "..."}` keep working completely unchanged (`DisplayName` is a direct field of `RealmRequestFields`, not promoted through embedding, so nothing about how callers construct an `UpdateRealmRequest` changes).
- `CreateRealmRequest`'s embedding *does* change one thing: a keyed literal that sets both `Name` and a shared field in the same expression now needs the shared fields nested — `CreateRealmRequest{Name: x, RealmRequestFields: RealmRequestFields{DisplayName: y}}` instead of a flat literal. I found and updated the one call site that did this (`client/realms_test.go`'s `TestRealmsClient_CreateRealm`). `resource_realm.go`'s own construction only ever set `Name` directly in the literal (everything else via the mapping function / dot-assignment, which works fine on promoted fields), so it needed no equivalent fix.
- `resource_realm.go`'s two 215-line functions collapse into one, `mapRealmPlanToRequestFields`, called from both `Create()` and `Update()` — cutting ~260 duplicated lines total and centralizing future field additions to one struct, one function.

I did not run `gofmt -w` on these files — confirmed via `git stash` that they (and most of this Go module) already fail `gofmt -l` on `dev` before my change; CI's Go job only runs `go build`/`go vet`/`go test` (no format check), so reformatting here would just add unrelated whitespace noise to the diff.

I didn't add new unit tests for `mapRealmPlanToRequestFields` specifically: there are zero resource-level unit tests anywhere in the `provider` package today (only `examples_test.go`, which tests schema/example consistency), and the merged function's body is a byte-for-byte copy of what was already independently present (and already exercised implicitly) in both original functions — there's no new logic to test, only consolidated logic.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all passing, including `TestRealmsClient_CreateRealm`/`TestRealmsClient_UpdateRealm` (exercise the new struct shapes' JSON serialization end-to-end) and `TestExamplesMatchProviderSchema` (confirms the Terraform-facing schema is unaffected — this is purely an internal Go-side refactor)
- [x] Manually diffed the new `mapRealmPlanToRequestFields` body against both original functions to confirm the mapping logic (which fields get set, in what order, with what nil-guards) is preserved exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCLNGFCJv7rkJ2bxSwNGHW