### PR TITLE
fix(admin-ui): MagicLinkSettingsForm seeds from realm on first render

### DIFF
--- a/admin-ui/src/components/magic-link/MagicLinkSettingsForm.tsx
+++ b/admin-ui/src/components/magic-link/MagicLinkSettingsForm.tsx
@@ -9,31 +9,28 @@ type MagicLinkSettingsFormProps = {
   realm: Realm;
 };
 
+function seedFromRealm(realm: Realm): MagicLinkSettings {
+  return {
+    enabled: realm.magicLinkEnabled ?? false,
+    expirySeconds: realm.magicLinkExpirySeconds ?? 300,
+    rateLimitPerEmail: realm.magicLinkRateLimitPerEmail ?? 3,
+    rateLimitWindowSeconds: realm.magicLinkRateLimitWindowSeconds ?? 900,
+    emailSubject: realm.magicLinkEmailSubject ?? null,
+    emailTemplate: realm.magicLinkEmailTemplate ?? null,
+  };
+}
+
 export default function MagicLinkSettingsForm({ realm }: MagicLinkSettingsFormProps) {
   const queryClient = useQueryClient();
 
-  const [form, setForm] = useState<MagicLinkSettings>({
-    enabled: false,
-    expirySeconds: 300,
-    rateLimitPerEmail: 3,
-    rateLimitWindowSeconds: 900,
-    emailSubject: null,
-    emailTemplate: null,
-  });
+  const [form, setForm] = useState<MagicLinkSettings>(() => seedFromRealm(realm));
 
-  // Seed the editable form from the realm prop when it changes.
+  // Reseed the editable form when the realm prop changes (e.g. after a refetch).
   // Adjusting state during render (vs. an effect) avoids an extra render pass.
   const [seededRealm, setSeededRealm] = useState(realm);
   if (realm !== seededRealm) {
     setSeededRealm(realm);
-    setForm({
-      enabled: realm.magicLinkEnabled ?? false,
-      expirySeconds: realm.magicLinkExpirySeconds ?? 300,
-      rateLimitPerEmail: realm.magicLinkRateLimitPerEmail ?? 3,
-      rateLimitWindowSeconds: realm.magicLinkRateLimitWindowSeconds ?? 900,
-      emailSubject: realm.magicLinkEmailSubject ?? null,
-      emailTemplate: realm.magicLinkEmailTemplate ?? null,
-    });
+    setForm(seedFromRealm(realm));
   }
 
   const updateMutation = useMutation({

--- a/admin-ui/src/components/magic-link/__tests__/MagicLinkSettingsForm.test.tsx
+++ b/admin-ui/src/components/magic-link/__tests__/MagicLinkSettingsForm.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test/mocks/server';
+import { render } from '../../../test/utils';
+import { makeRealm } from '../../../test/mocks/data';
+import MagicLinkSettingsForm from '../MagicLinkSettingsForm';
+
+describe('MagicLinkSettingsForm', () => {
+  it('seeds fields from the realm prop on first render (regression: was showing hardcoded defaults)', () => {
+    render(
+      <MagicLinkSettingsForm
+        realm={makeRealm({
+          magicLinkEnabled: true,
+          magicLinkExpirySeconds: 600,
+          magicLinkRateLimitPerEmail: 7,
+          magicLinkRateLimitWindowSeconds: 1800,
+          magicLinkEmailSubject: 'Your custom sign-in link',
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText(/enable magic link authentication/i)).toBeChecked();
+    expect(screen.getByDisplayValue('600')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('7')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1800')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Your custom sign-in link')).toBeInTheDocument();
+  });
+
+  it('submits only the magic-link fields and shows a success banner', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.put('/admin/realms/:name', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(makeRealm(capturedBody));
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <MagicLinkSettingsForm
+        realm={makeRealm({
+          name: 'my-realm',
+          magicLinkEnabled: true,
+          magicLinkExpirySeconds: 600,
+          magicLinkRateLimitPerEmail: 7,
+          magicLinkRateLimitWindowSeconds: 1800,
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(await screen.findByText('Magic link settings updated successfully.')).toBeInTheDocument();
+    expect(capturedBody).toEqual({
+      magicLinkEnabled: true,
+      magicLinkExpirySeconds: 600,
+      magicLinkRateLimitPerEmail: 7,
+      magicLinkRateLimitWindowSeconds: 1800,
+      magicLinkEmailSubject: null,
+      magicLinkEmailTemplate: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1275 (filed as a follow-up while working on #1258/#1274).

`MagicLinkSettingsForm.tsx` initialized its form state with hardcoded defaults, and only reseeded from the `realm` prop inside `if (realm !== seededRealm)` — a check that's always `false` on first mount, since `seededRealm`'s own initial value is the same `realm` reference passed in. Opening the Magic Link tab for a realm with custom settings (e.g. `expirySeconds: 600`) silently showed the hardcoded defaults (`300`) instead of the realm's actual saved values, until something else caused a re-render with a new `realm` object reference (e.g. a query refetch).

Fixed with the same `seedFromRealm()` + lazy `useState` initializer pattern already used by `EmailProviderForm`/`SmsProviderForm` and the realm settings-tab forms extracted in #1258/#1274: `useState(() => seedFromRealm(realm))` seeds correctly on mount; the `seededRealm` diff-check now only needs to handle later prop-reference changes.

## Test plan
- [x] New regression test: renders the form with a realm carrying non-default magic-link settings and asserts the *first* render shows those values (not the hardcoded defaults) — this test would have failed before the fix
- [x] Existing-behavior test: submitting only sends the magic-link fields and shows the success banner
- [x] `npx vitest run` — 46 files / 405 tests passing (2 pre-existing skips, unrelated)
- [x] `npm run build` (`tsc -b && vite build`) — clean
- [x] `npx eslint` — clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)