### PR TITLE
feat(ci): add npm publish workflow for @idenplane/mcp

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,91 @@
+name: Publish @idenplane/mcp
+
+# Publishes packages/idenplane-mcp to npm as @idenplane/mcp, so the README's
+# documented `npx -y @idenplane/mcp` actually resolves (idenplane#1243 —
+# package.json was already fully configured for publishing: name, bin,
+# files, publishConfig.access — but nothing ever published it).
+#
+#   - every mcp-v* git tag -> publishes, after checking the tag version
+#     matches packages/idenplane-mcp/package.json (same safety check
+#     release-version-check.yml does for root v* tags, scoped to this
+#     package instead)
+#   - manual dispatch       -> on demand, e.g. for the very first release,
+#     since there's no mcp-v* tag history yet to trigger off of
+#
+# Requires one repo secret:
+#   NPM_TOKEN - an npm access token (Automation type recommended so it
+#               isn't tied to 2FA prompts) with publish rights to the
+#               @idenplane org/scope.
+on:
+  push:
+    tags: ['mcp-v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-mcp-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build & publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: packages/idenplane-mcp/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      # idenplane-mcp consumes @idenplane/http-internal through
+      # `file:../idenplane-http-internal`, and its dist/ is gitignored — so on
+      # a fresh checkout it has no compiled output to resolve. Build it first
+      # (mirrors the identical step in ci.yml's SDK matrix job).
+      - name: Build the local idenplane-http-internal dependency
+        working-directory: packages/idenplane-http-internal
+        run: |
+          npm ci
+          npm run build
+
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: packages/idenplane-mcp
+        run: |
+          set -e
+          TAG_VERSION="${GITHUB_REF_NAME#mcp-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+
+          echo "Tag:          ${GITHUB_REF_NAME} (${TAG_VERSION})"
+          echo "package.json: ${PKG_VERSION}"
+
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match packages/idenplane-mcp/package.json version (${PKG_VERSION})"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: packages/idenplane-mcp
+        run: npm ci
+
+      - name: Build
+        working-directory: packages/idenplane-mcp
+        run: npm run build
+
+      - name: Test
+        working-directory: packages/idenplane-mcp
+        run: npm run test:all
+
+      - name: Verify package contents
+        working-directory: packages/idenplane-mcp
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        working-directory: packages/idenplane-mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Closes #1243. `packages/idenplane-mcp/package.json` was already fully configured for publishing — `name: "@idenplane/mcp"`, `bin`, `files: ["dist", "README.md"]`, `publishConfig.access: "public"` — but nothing ever actually published it, so the README's documented `npx -y @idenplane/mcp` fails with `E404` for anyone following the Claude Desktop / Claude Code / Cursor setup instructions.

Went with the issue's preferred fix (option 1: publish, rather than option 2: rewrite the docs to a build-from-source workaround).

Also worth noting from my investigation: **none of the SDK packages in this repo are actually published to npm yet** (checked `@idenplane/js` too — same 404), and there was no npm-publish CI at all before this (only Docker publish + a root-app release-version-check). This PR only sets up publishing for `idenplane-mcp`, matching the issue's scope — the other 9 SDK packages being unpublished is a separate, pre-existing situation I didn't try to fix here.

### What this adds

`.github/workflows/publish-mcp.yml`:
- Triggers on `mcp-v*` tags (checked against `packages/idenplane-mcp/package.json`'s version first, mirroring `release-version-check.yml`'s tag-vs-package.json check but scoped to this package) or manual `workflow_dispatch` — dispatch is needed for the very first release, since there's no `mcp-v*` tag history yet.
- Builds the local `@idenplane/http-internal` `file:` dependency first (this package's `dist/` is gitignored, so a fresh checkout has nothing to resolve otherwise) — mirrors the identical step already in `ci.yml`'s SDK matrix job for this exact package.
- Runs the package's own build, its full test suite (`test:all`), and `npm pack --dry-run` to confirm contents before publishing.
- Publishes via `npm publish --access public` using `NODE_AUTH_TOKEN` from a `NPM_TOKEN` repo secret (via `actions/setup-node`'s `registry-url` integration) — not a value passed directly in any step.

Root `v*` tags are reserved for the main app (checked against the *root* `package.json`/`CHANGELOG.md`), so this uses a separate `mcp-v*` tag namespace deliberately, to avoid colliding with that.

## Verified locally before writing the workflow
- `npm ci && npm run build` — clean
- `npm run test:smoke` — all 17 tests pass (path-traversal validation across 3 tools × 5 payloads, plus the 14-tool listing) against the actual built output
- `npm pack --dry-run` — exactly 4 files in the tarball: `README.md`, `dist/index.js`, `dist/index.d.ts`, `package.json`. No source `.ts`, no tests, no secrets.
- Workflow YAML parses cleanly (checked with `js-yaml`)

## Test plan
- [x] Everything above
- [ ] After merge: set the `NPM_TOKEN` repo secret and trigger the first publish via `workflow_dispatch`, then confirm `npm view @idenplane/mcp version` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)