### PR TITLE
fix(mcp): publish as unscoped idenplane-mcp instead of @idenplane/mcp

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,9 +1,10 @@
-name: Publish @idenplane/mcp
+name: Publish idenplane-mcp
 
-# Publishes packages/idenplane-mcp to npm as @idenplane/mcp, so the README's
-# documented `npx -y @idenplane/mcp` actually resolves (idenplane#1243 —
-# package.json was already fully configured for publishing: name, bin,
-# files, publishConfig.access — but nothing ever published it).
+# Publishes packages/idenplane-mcp to npm as idenplane-mcp (unscoped — the
+# @idenplane npm organization doesn't exist, and creating one is a manual
+# account/billing action on npmjs.com, not something a publish token can do;
+# publishing unscoped avoids that dependency entirely), so the README's
+# documented `npx -y idenplane-mcp` actually resolves (idenplane#1243).
 #
 #   - every mcp-v* git tag -> publishes, after checking the tag version
 #     matches packages/idenplane-mcp/package.json (same safety check
@@ -14,8 +15,8 @@ name: Publish @idenplane/mcp
 #
 # Requires one repo secret:
 #   NPM_TOKEN - an npm access token (Automation type recommended so it
-#               isn't tied to 2FA prompts) with publish rights to the
-#               @idenplane org/scope.
+#               isn't tied to 2FA prompts) with publish rights for this
+#               package under the token owner's npm account.
 on:
   push:
     tags: ['mcp-v*']
@@ -86,6 +87,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/idenplane-mcp
-        run: npm publish --access public
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For full per-commit detail, see the [GitHub Releases](https://github.com/idenpla
 ## [Unreleased]
 
 ### Added
-- `@idenplane/mcp` — first-party stdio MCP server for AI agent integration
+- `idenplane-mcp` — first-party stdio MCP server for AI agent integration
 - Multi-provider email abstraction (Resend, SendGrid, Mailgun, Postmark, SMTP)
 - SMS provider configuration UI with card-grid selector
 - Admin UI: webhooks, service accounts, organizations, custom attributes, SCIM, authorization policies, plugins, impersonation, and risk-assessment routing pages

--- a/packages/idenplane-mcp/README.md
+++ b/packages/idenplane-mcp/README.md
@@ -1,4 +1,4 @@
-# @idenplane/mcp
+# idenplane-mcp
 
 First-party MCP (Model Context Protocol) server for [Idenplane](https://idenplane.com) — manage identity in natural language from Claude Desktop, Claude Code, or Cursor.
 
@@ -44,7 +44,7 @@ Add this to `~/Library/Application Support/Claude/claude_desktop_config.json` (m
   "mcpServers": {
     "idenplane": {
       "command": "npx",
-      "args": ["-y", "@idenplane/mcp"],
+      "args": ["-y", "idenplane-mcp"],
       "env": {
         "IDENPLANE_URL": "http://localhost:3000",
         "IDENPLANE_ADMIN_TOKEN": "your-admin-api-key"
@@ -62,7 +62,7 @@ Run once to register the server for this project:
 claude mcp add idenplane \
   -e IDENPLANE_URL=http://localhost:3000 \
   -e IDENPLANE_ADMIN_TOKEN=your-admin-api-key \
-  -- npx -y @idenplane/mcp
+  -- npx -y idenplane-mcp
 ```
 
 Or add it globally (available in all projects):
@@ -71,7 +71,7 @@ Or add it globally (available in all projects):
 claude mcp add --scope user idenplane \
   -e IDENPLANE_URL=http://localhost:3000 \
   -e IDENPLANE_ADMIN_TOKEN=your-admin-api-key \
-  -- npx -y @idenplane/mcp
+  -- npx -y idenplane-mcp
 ```
 
 ## Cursor
@@ -83,7 +83,7 @@ Add to `.cursor/mcp.json` in your project root:
   "mcpServers": {
     "idenplane": {
       "command": "npx",
-      "args": ["-y", "@idenplane/mcp"],
+      "args": ["-y", "idenplane-mcp"],
       "env": {
         "IDENPLANE_URL": "http://localhost:3000",
         "IDENPLANE_ADMIN_TOKEN": "your-admin-api-key"

--- a/packages/idenplane-mcp/package-lock.json
+++ b/packages/idenplane-mcp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@idenplane/mcp",
+  "name": "idenplane-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@idenplane/mcp",
+      "name": "idenplane-mcp",
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/packages/idenplane-mcp/package.json
+++ b/packages/idenplane-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@idenplane/mcp",
+  "name": "idenplane-mcp",
   "version": "0.1.0",
   "description": "MCP server for Idenplane IAM — manage identities in natural language",
   "type": "module",
@@ -51,8 +51,5 @@
     "type": "git",
     "url": "git+https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-mcp"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/idenplane-mcp/src/index.ts
+++ b/packages/idenplane-mcp/src/index.ts
@@ -13,7 +13,7 @@ async function main(): Promise<void> {
   const apiClient = new IdenplaneClient(config);
 
   const server = new McpServer({
-    name: '@idenplane/mcp',
+    name: 'idenplane-mcp',
     version: '0.1.0',
   });
 

--- a/packages/idenplane-mcp/tests/integration.mjs
+++ b/packages/idenplane-mcp/tests/integration.mjs
@@ -1,5 +1,5 @@
 /**
- * Integration tests for @idenplane/mcp — exercises all tool calls over the MCP protocol.
+ * Integration tests for idenplane-mcp — exercises all tool calls over the MCP protocol.
  *
  * Prerequisites:
  *   docker compose up db -d && npm run start:dev   (from repo root)

--- a/packages/idenplane-mcp/tsup.config.ts
+++ b/packages/idenplane-mcp/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   target: 'node18',
   // @idenplane/http-internal is an unpublished, monorepo-local package —
   // inline it into the bundle rather than leaving a require/import that
-  // wouldn't resolve for a real npm install of @idenplane/mcp.
+  // wouldn't resolve for a real npm install of idenplane-mcp.
   noExternal: ['@idenplane/http-internal'],
   banner: {
     js: '#!/usr/bin/env node',


### PR DESCRIPTION
## Summary

Follow-up to #1281 (which added the publish workflow for #1243). Its first real run failed: `npm publish` returned

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@idenplane%2fmcp - Scope not found
```

The `@idenplane` npm organization doesn't exist. Creating an npm org is a manual, account/billing-level action on npmjs.com — there's no API or token-based way to do it, and it's not something to decide unilaterally on someone else's npm account. Went with publishing **unscoped** instead: renamed the package to `idenplane-mcp` (confirmed available — `npm view idenplane-mcp` → 404 Not Found before this change).

## Changes
- `package.json`: `name` → `idenplane-mcp`; dropped `publishConfig.access` (only meaningful for scoped packages, a no-op now)
- `src/index.ts`: the `McpServer`'s reported `name` (shown to MCP clients on `initialize`) → `idenplane-mcp`
- `tsup.config.ts` / `tests/integration.mjs`: comment references updated
- `README.md`: title + all three `npx -y .../claude mcp add` examples updated
- Root `CHANGELOG.md`: the `idenplane-mcp` bullet under `[Unreleased]`
- `.github/workflows/publish-mcp.yml`: name/comments updated, dropped `npm publish --access public` (scoped-package-only flag, no-op here)
- `package-lock.json` regenerated via `npm install` to pick up the new root package name

## Test plan
- [x] `npm install` (regenerated lockfile), `npm run build`, `npm run typecheck` — all clean
- [x] `npm run test:all` — 17/17 pass (integration test correctly self-skips without a live Idenplane instance, same as before)
- [x] `npm pack --dry-run` — same 4 files as before (`README.md`, `dist/index.js`, `dist/index.d.ts`, `package.json`), now under `idenplane-mcp@0.1.0`
- [x] Repo-wide grep for `@idenplane/mcp` / `@idenplane%2fmcp` — zero remaining references
- [x] Grepped the built `dist/index.js` bundle directly — zero occurrences of the old name, new name present

## Next step after merge
Delete the stale `mcp-v0.1.0` tag (it points at the pre-rename commit that failed to publish) and re-tag `mcp-v0.1.0` against this fix once it's on `dev`, to trigger a fresh publish attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)