### PR TITLE
🎨 Palette: Improve password toggle keyboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-03-05 - Keyboard Accessibility on Password Toggles
+**Learning:** Excluding password visibility toggle buttons from keyboard navigation (using `tabIndex={-1}`) is a major accessibility barrier. Keyboard-only users are unable to reveal or hide their password inputs to verify them. Removing `tabIndex={-1}` and adding proper `focus-visible` styling allows all users to interact with these elements seamlessly.
+**Action:** Always ensure interactive elements (including eye/toggle buttons) are fully focusable with visible indicators, without using `-1` tabIndex unless there's an alternative keyboard command.

--- a/admin-ui/src/components/PasswordInput.tsx
+++ b/admin-ui/src/components/PasswordInput.tsx
@@ -10,9 +10,8 @@ export default function PasswordInput(props: PasswordInputProps) {
       <input {...props} type={visible ? 'text' : 'password'} className={`${props.className ?? ''} pr-10`} />
       <button
         type="button"
-        tabIndex={-1}
         onClick={() => setVisible(!visible)}
-        className="absolute inset-y-0 right-0 flex items-center pr-3 text-subtle hover:text-muted"
+        className="absolute right-2 top-1/2 -translate-y-1/2 flex h-7 w-7 items-center justify-center rounded-md text-subtle hover:text-muted focus-visible:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-all duration-150"
         aria-label={visible ? 'Hide password' : 'Show password'}
       >
         {visible ? (

--- a/admin-ui/src/components/__tests__/PasswordInput.test.tsx
+++ b/admin-ui/src/components/__tests__/PasswordInput.test.tsx
@@ -82,9 +82,9 @@ describe('PasswordInput', () => {
     expect(input.className).toContain('pr-10');
   });
 
-  it('the toggle button has tabIndex -1 so it is skipped during keyboard navigation', () => {
+  it('the toggle button does not have tabIndex -1 so it is reachable during keyboard navigation', () => {
     render(<PasswordInput />);
     const toggleBtn = screen.getByRole('button', { name: /show password/i });
-    expect(toggleBtn).toHaveAttribute('tabIndex', '-1');
+    expect(toggleBtn).not.toHaveAttribute('tabIndex', '-1');
   });
 });

--- a/admin-ui/src/pages/scim/ScimConfigPage.tsx
+++ b/admin-ui/src/pages/scim/ScimConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -53,13 +53,13 @@ export default function ScimConfigPage() {
     enabled: !!name,
   });
 
-  useEffect(() => {
-    if (realm !== undefined) {
-      setScimEnabledToggle(realm.scimEnabled ?? false);
-      setScimUserAutocreate(realm.scimUserAutocreate ?? true);
-      setScimGroupSyncEnabled(realm.scimGroupSyncEnabled ?? true);
-    }
-  }, [realm]);
+  const [prevRealm, setPrevRealm] = useState<typeof realm | null>(null);
+  if (realm && realm !== prevRealm) {
+    setPrevRealm(realm);
+    setScimEnabledToggle(realm.scimEnabled ?? false);
+    setScimUserAutocreate(realm.scimUserAutocreate ?? true);
+    setScimGroupSyncEnabled(realm.scimGroupSyncEnabled ?? true);
+  }
 
   const updateRealmMutation = useMutation({
     mutationFn: (payload: { scimEnabled: boolean; scimUserAutocreate: boolean; scimGroupSyncEnabled: boolean }) =>


### PR DESCRIPTION
We have improved the user experience and accessibility of the administration console's PasswordInput component. Specifically, we made the password visibility toggle button accessible to keyboard-only and screen reader users by removing tabIndex={-1}, and added styling for a highly visible and elegant focus-visible ring outline. All frontend unit tests and linter tasks pass successfully, including a clean SCIMConfigPage component.

---
*PR created automatically by Jules for task [17259563462798602445](https://jules.google.com/task/17259563462798602445) started by @Islamawad132*