### PR TITLE
Promote dev to main: MCP publish infra, password a11y fix, impersonation idempotency

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-03-05 - Keyboard Accessibility on Password Toggles
+**Learning:** Excluding password visibility toggle buttons from keyboard navigation (using `tabIndex={-1}`) is a major accessibility barrier. Keyboard-only users are unable to reveal or hide their password inputs to verify them. Removing `tabIndex={-1}` and adding proper `focus-visible` styling allows all users to interact with these elements seamlessly.
+**Action:** Always ensure interactive elements (including eye/toggle buttons) are fully focusable with visible indicators, without using `-1` tabIndex unless there's an alternative keyboard command.

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,9 +1,10 @@
-name: Publish @idenplane/mcp
+name: Publish idenplane-mcp
 
-# Publishes packages/idenplane-mcp to npm as @idenplane/mcp, so the README's
-# documented `npx -y @idenplane/mcp` actually resolves (idenplane#1243 —
-# package.json was already fully configured for publishing: name, bin,
-# files, publishConfig.access — but nothing ever published it).
+# Publishes packages/idenplane-mcp to npm as idenplane-mcp (unscoped — the
+# @idenplane npm organization doesn't exist, and creating one is a manual
+# account/billing action on npmjs.com, not something a publish token can do;
+# publishing unscoped avoids that dependency entirely), so the README's
+# documented `npx -y idenplane-mcp` actually resolves (idenplane#1243).
 #
 #   - every mcp-v* git tag -> publishes, after checking the tag version
 #     matches packages/idenplane-mcp/package.json (same safety check
@@ -14,8 +15,8 @@ name: Publish @idenplane/mcp
 #
 # Requires one repo secret:
 #   NPM_TOKEN - an npm access token (Automation type recommended so it
-#               isn't tied to 2FA prompts) with publish rights to the
-#               @idenplane org/scope.
+#               isn't tied to 2FA prompts) with publish rights for this
+#               package under the token owner's npm account.
 on:
   push:
     tags: ['mcp-v*']
@@ -86,6 +87,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: packages/idenplane-mcp
-        run: npm publish --access public
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,91 @@
+name: Publish @idenplane/mcp
+
+# Publishes packages/idenplane-mcp to npm as @idenplane/mcp, so the README's
+# documented `npx -y @idenplane/mcp` actually resolves (idenplane#1243 —
+# package.json was already fully configured for publishing: name, bin,
+# files, publishConfig.access — but nothing ever published it).
+#
+#   - every mcp-v* git tag -> publishes, after checking the tag version
+#     matches packages/idenplane-mcp/package.json (same safety check
+#     release-version-check.yml does for root v* tags, scoped to this
+#     package instead)
+#   - manual dispatch       -> on demand, e.g. for the very first release,
+#     since there's no mcp-v* tag history yet to trigger off of
+#
+# Requires one repo secret:
+#   NPM_TOKEN - an npm access token (Automation type recommended so it
+#               isn't tied to 2FA prompts) with publish rights to the
+#               @idenplane org/scope.
+on:
+  push:
+    tags: ['mcp-v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-mcp-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build & publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: packages/idenplane-mcp/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      # idenplane-mcp consumes @idenplane/http-internal through
+      # `file:../idenplane-http-internal`, and its dist/ is gitignored — so on
+      # a fresh checkout it has no compiled output to resolve. Build it first
+      # (mirrors the identical step in ci.yml's SDK matrix job).
+      - name: Build the local idenplane-http-internal dependency
+        working-directory: packages/idenplane-http-internal
+        run: |
+          npm ci
+          npm run build
+
+      - name: Verify tag matches package.json version
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: packages/idenplane-mcp
+        run: |
+          set -e
+          TAG_VERSION="${GITHUB_REF_NAME#mcp-v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+
+          echo "Tag:          ${GITHUB_REF_NAME} (${TAG_VERSION})"
+          echo "package.json: ${PKG_VERSION}"
+
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match packages/idenplane-mcp/package.json version (${PKG_VERSION})"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: packages/idenplane-mcp
+        run: npm ci
+
+      - name: Build
+        working-directory: packages/idenplane-mcp
+        run: npm run build
+
+      - name: Test
+        working-directory: packages/idenplane-mcp
+        run: npm run test:all
+
+      - name: Verify package contents
+        working-directory: packages/idenplane-mcp
+        run: npm pack --dry-run
+
+      - name: Publish to npm
+        working-directory: packages/idenplane-mcp
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2026-08-01 - Idempotency in Impersonation Session Termination
+**Vulnerability:** The impersonation session termination endpoint (`/admin/realms/:realmName/impersonation/end`) previously threw a `BadRequestException` when requested to end a session that was already inactive. This lack of idempotency exposed an error message and status code (400) when the endpoint was called on a closed session, which could leak state or create unnecessary operational noise/errors for client integrations.
+**Learning:** Security APIs that modify session state (such as revocation or termination) should behave idempotently. Returning success (e.g. 204 No Content or 200 OK) for an already-inactive resource prevents timing side-channels and state-leakage while minimizing operational integration errors.
+**Prevention:** Always design session/credential destruction, revocation, and termination endpoints to be idempotent. If the target state is already reached, return successfully rather than throwing a bad request error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ For full per-commit detail, see the [GitHub Releases](https://github.com/idenpla
 ## [Unreleased]
 
 ### Added
-- `@idenplane/mcp` — first-party stdio MCP server for AI agent integration
+- `idenplane-mcp` — first-party stdio MCP server for AI agent integration
 - Multi-provider email abstraction (Resend, SendGrid, Mailgun, Postmark, SMTP)
 - SMS provider configuration UI with card-grid selector
 - Admin UI: webhooks, service accounts, organizations, custom attributes, SCIM, authorization policies, plugins, impersonation, and risk-assessment routing pages

--- a/admin-ui/src/components/PasswordInput.tsx
+++ b/admin-ui/src/components/PasswordInput.tsx
@@ -10,9 +10,8 @@ export default function PasswordInput(props: PasswordInputProps) {
       <input {...props} type={visible ? 'text' : 'password'} className={`${props.className ?? ''} pr-10`} />
       <button
         type="button"
-        tabIndex={-1}
         onClick={() => setVisible(!visible)}
-        className="absolute inset-y-0 right-0 flex items-center pr-3 text-subtle hover:text-muted"
+        className="absolute right-2 top-1/2 -translate-y-1/2 flex h-7 w-7 items-center justify-center rounded-md text-subtle hover:text-muted focus-visible:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent transition-all duration-150"
         aria-label={visible ? 'Hide password' : 'Show password'}
       >
         {visible ? (

--- a/admin-ui/src/components/__tests__/PasswordInput.test.tsx
+++ b/admin-ui/src/components/__tests__/PasswordInput.test.tsx
@@ -82,9 +82,9 @@ describe('PasswordInput', () => {
     expect(input.className).toContain('pr-10');
   });
 
-  it('the toggle button has tabIndex -1 so it is skipped during keyboard navigation', () => {
+  it('the toggle button does not have tabIndex -1 so it is reachable during keyboard navigation', () => {
     render(<PasswordInput />);
     const toggleBtn = screen.getByRole('button', { name: /show password/i });
-    expect(toggleBtn).toHaveAttribute('tabIndex', '-1');
+    expect(toggleBtn).not.toHaveAttribute('tabIndex', '-1');
   });
 });

--- a/admin-ui/src/components/magic-link/MagicLinkSettingsForm.tsx
+++ b/admin-ui/src/components/magic-link/MagicLinkSettingsForm.tsx
@@ -9,31 +9,28 @@ type MagicLinkSettingsFormProps = {
   realm: Realm;
 };
 
+function seedFromRealm(realm: Realm): MagicLinkSettings {
+  return {
+    enabled: realm.magicLinkEnabled ?? false,
+    expirySeconds: realm.magicLinkExpirySeconds ?? 300,
+    rateLimitPerEmail: realm.magicLinkRateLimitPerEmail ?? 3,
+    rateLimitWindowSeconds: realm.magicLinkRateLimitWindowSeconds ?? 900,
+    emailSubject: realm.magicLinkEmailSubject ?? null,
+    emailTemplate: realm.magicLinkEmailTemplate ?? null,
+  };
+}
+
 export default function MagicLinkSettingsForm({ realm }: MagicLinkSettingsFormProps) {
   const queryClient = useQueryClient();
 
-  const [form, setForm] = useState<MagicLinkSettings>({
-    enabled: false,
-    expirySeconds: 300,
-    rateLimitPerEmail: 3,
-    rateLimitWindowSeconds: 900,
-    emailSubject: null,
-    emailTemplate: null,
-  });
+  const [form, setForm] = useState<MagicLinkSettings>(() => seedFromRealm(realm));
 
-  // Seed the editable form from the realm prop when it changes.
+  // Reseed the editable form when the realm prop changes (e.g. after a refetch).
   // Adjusting state during render (vs. an effect) avoids an extra render pass.
   const [seededRealm, setSeededRealm] = useState(realm);
   if (realm !== seededRealm) {
     setSeededRealm(realm);
-    setForm({
-      enabled: realm.magicLinkEnabled ?? false,
-      expirySeconds: realm.magicLinkExpirySeconds ?? 300,
-      rateLimitPerEmail: realm.magicLinkRateLimitPerEmail ?? 3,
-      rateLimitWindowSeconds: realm.magicLinkRateLimitWindowSeconds ?? 900,
-      emailSubject: realm.magicLinkEmailSubject ?? null,
-      emailTemplate: realm.magicLinkEmailTemplate ?? null,
-    });
+    setForm(seedFromRealm(realm));
   }
 
   const updateMutation = useMutation({

--- a/admin-ui/src/components/magic-link/__tests__/MagicLinkSettingsForm.test.tsx
+++ b/admin-ui/src/components/magic-link/__tests__/MagicLinkSettingsForm.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test/mocks/server';
+import { render } from '../../../test/utils';
+import { makeRealm } from '../../../test/mocks/data';
+import MagicLinkSettingsForm from '../MagicLinkSettingsForm';
+
+describe('MagicLinkSettingsForm', () => {
+  it('seeds fields from the realm prop on first render (regression: was showing hardcoded defaults)', () => {
+    render(
+      <MagicLinkSettingsForm
+        realm={makeRealm({
+          magicLinkEnabled: true,
+          magicLinkExpirySeconds: 600,
+          magicLinkRateLimitPerEmail: 7,
+          magicLinkRateLimitWindowSeconds: 1800,
+          magicLinkEmailSubject: 'Your custom sign-in link',
+        })}
+      />,
+    );
+
+    expect(screen.getByLabelText(/enable magic link authentication/i)).toBeChecked();
+    expect(screen.getByDisplayValue('600')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('7')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('1800')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Your custom sign-in link')).toBeInTheDocument();
+  });
+
+  it('submits only the magic-link fields and shows a success banner', async () => {
+    let capturedBody: Record<string, unknown> | null = null;
+    server.use(
+      http.put('/admin/realms/:name', async ({ request }) => {
+        capturedBody = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(makeRealm(capturedBody));
+      }),
+    );
+
+    const user = userEvent.setup();
+    render(
+      <MagicLinkSettingsForm
+        realm={makeRealm({
+          name: 'my-realm',
+          magicLinkEnabled: true,
+          magicLinkExpirySeconds: 600,
+          magicLinkRateLimitPerEmail: 7,
+          magicLinkRateLimitWindowSeconds: 1800,
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    expect(await screen.findByText('Magic link settings updated successfully.')).toBeInTheDocument();
+    expect(capturedBody).toEqual({
+      magicLinkEnabled: true,
+      magicLinkExpirySeconds: 600,
+      magicLinkRateLimitPerEmail: 7,
+      magicLinkRateLimitWindowSeconds: 1800,
+      magicLinkEmailSubject: null,
+      magicLinkEmailTemplate: null,
+    });
+  });
+});

--- a/admin-ui/src/pages/scim/ScimConfigPage.tsx
+++ b/admin-ui/src/pages/scim/ScimConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useParams } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -53,13 +53,13 @@ export default function ScimConfigPage() {
     enabled: !!name,
   });
 
-  useEffect(() => {
-    if (realm !== undefined) {
-      setScimEnabledToggle(realm.scimEnabled ?? false);
-      setScimUserAutocreate(realm.scimUserAutocreate ?? true);
-      setScimGroupSyncEnabled(realm.scimGroupSyncEnabled ?? true);
-    }
-  }, [realm]);
+  const [prevRealm, setPrevRealm] = useState<typeof realm | null>(null);
+  if (realm && realm !== prevRealm) {
+    setPrevRealm(realm);
+    setScimEnabledToggle(realm.scimEnabled ?? false);
+    setScimUserAutocreate(realm.scimUserAutocreate ?? true);
+    setScimGroupSyncEnabled(realm.scimGroupSyncEnabled ?? true);
+  }
 
   const updateRealmMutation = useMutation({
     mutationFn: (payload: { scimEnabled: boolean; scimUserAutocreate: boolean; scimGroupSyncEnabled: boolean }) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2378,9 +2378,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6264,9 +6264,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9744,9 +9744,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10124,9 +10124,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/idenplane-mcp/README.md
+++ b/packages/idenplane-mcp/README.md
@@ -1,4 +1,4 @@
-# @idenplane/mcp
+# idenplane-mcp
 
 First-party MCP (Model Context Protocol) server for [Idenplane](https://idenplane.com) — manage identity in natural language from Claude Desktop, Claude Code, or Cursor.
 
@@ -44,7 +44,7 @@ Add this to `~/Library/Application Support/Claude/claude_desktop_config.json` (m
   "mcpServers": {
     "idenplane": {
       "command": "npx",
-      "args": ["-y", "@idenplane/mcp"],
+      "args": ["-y", "idenplane-mcp"],
       "env": {
         "IDENPLANE_URL": "http://localhost:3000",
         "IDENPLANE_ADMIN_TOKEN": "your-admin-api-key"
@@ -62,7 +62,7 @@ Run once to register the server for this project:
 claude mcp add idenplane \
   -e IDENPLANE_URL=http://localhost:3000 \
   -e IDENPLANE_ADMIN_TOKEN=your-admin-api-key \
-  -- npx -y @idenplane/mcp
+  -- npx -y idenplane-mcp
 ```
 
 Or add it globally (available in all projects):
@@ -71,7 +71,7 @@ Or add it globally (available in all projects):
 claude mcp add --scope user idenplane \
   -e IDENPLANE_URL=http://localhost:3000 \
   -e IDENPLANE_ADMIN_TOKEN=your-admin-api-key \
-  -- npx -y @idenplane/mcp
+  -- npx -y idenplane-mcp
 ```
 
 ## Cursor
@@ -83,7 +83,7 @@ Add to `.cursor/mcp.json` in your project root:
   "mcpServers": {
     "idenplane": {
       "command": "npx",
-      "args": ["-y", "@idenplane/mcp"],
+      "args": ["-y", "idenplane-mcp"],
       "env": {
         "IDENPLANE_URL": "http://localhost:3000",
         "IDENPLANE_ADMIN_TOKEN": "your-admin-api-key"

--- a/packages/idenplane-mcp/package-lock.json
+++ b/packages/idenplane-mcp/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@idenplane/mcp",
+  "name": "idenplane-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@idenplane/mcp",
+      "name": "idenplane-mcp",
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/packages/idenplane-mcp/package.json
+++ b/packages/idenplane-mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@idenplane/mcp",
+  "name": "idenplane-mcp",
   "version": "0.1.0",
   "description": "MCP server for Idenplane IAM — manage identities in natural language",
   "type": "module",
@@ -51,8 +51,5 @@
     "type": "git",
     "url": "git+https://github.com/idenplane/idenplane.git",
     "directory": "packages/idenplane-mcp"
-  },
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/packages/idenplane-mcp/src/index.ts
+++ b/packages/idenplane-mcp/src/index.ts
@@ -13,7 +13,7 @@ async function main(): Promise<void> {
   const apiClient = new IdenplaneClient(config);
 
   const server = new McpServer({
-    name: '@idenplane/mcp',
+    name: 'idenplane-mcp',
     version: '0.1.0',
   });
 

--- a/packages/idenplane-mcp/tests/integration.mjs
+++ b/packages/idenplane-mcp/tests/integration.mjs
@@ -1,5 +1,5 @@
 /**
- * Integration tests for @idenplane/mcp — exercises all tool calls over the MCP protocol.
+ * Integration tests for idenplane-mcp — exercises all tool calls over the MCP protocol.
  *
  * Prerequisites:
  *   docker compose up db -d && npm run start:dev   (from repo root)

--- a/packages/idenplane-mcp/tsup.config.ts
+++ b/packages/idenplane-mcp/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   target: 'node18',
   // @idenplane/http-internal is an unpublished, monorepo-local package —
   // inline it into the bundle rather than leaving a require/import that
-  // wouldn't resolve for a real npm install of @idenplane/mcp.
+  // wouldn't resolve for a real npm install of idenplane-mcp.
   noExternal: ['@idenplane/http-internal'],
   banner: {
     js: '#!/usr/bin/env node',

--- a/src/impersonation/impersonation.service.spec.ts
+++ b/src/impersonation/impersonation.service.spec.ts
@@ -312,7 +312,7 @@ describe('ImpersonationService', () => {
       ).rejects.toThrow(ForbiddenException);
     });
 
-    it('throws BadRequestException when session is already ended', async () => {
+    it('returns successfully and does nothing when session is already ended', async () => {
       (prisma as any).impersonationSession.findUnique.mockResolvedValue({
         ...impersonationSession,
         active: false,
@@ -320,7 +320,7 @@ describe('ImpersonationService', () => {
 
       await expect(
         service.endImpersonation(realm, 'imp-session-1', 'admin-1'),
-      ).rejects.toThrow(BadRequestException);
+      ).resolves.toBeUndefined();
     });
 
     it('records IMPERSONATION_END login event', async () => {

--- a/src/impersonation/impersonation.service.ts
+++ b/src/impersonation/impersonation.service.ts
@@ -197,7 +197,7 @@ export class ImpersonationService {
     }
 
     if (!impSession.active) {
-      throw new BadRequestException('Impersonation session is already ended');
+      return;
     }
 
     // Revoke all refresh tokens for the underlying OAuth session


### PR DESCRIPTION
## Summary

Promotes \`dev\` → \`main\`. Contains 5 commits since the last promotion:

- #1280 — fix: MagicLinkSettingsForm now seeds from the realm prop on first render (was showing hardcoded defaults)
- #1281 / #1282 — feat/fix: adds an npm publish workflow for the MCP server package, published as unscoped \`idenplane-mcp\` (the \`@idenplane\` npm org doesn't exist, so the originally-planned scoped name isn't publishable without a manual org-creation step on npmjs.com)
- #1283 — palette: PasswordInput's show/hide toggle button is now keyboard-focusable (removed `tabIndex={-1}`) with a visible focus ring, plus a fix for a pre-existing `react-hooks/set-state-in-effect` lint error in ScimConfigPage.tsx
- #1284 — sentinel: `endImpersonation` is now idempotent (returns successfully instead of throwing 400 when the session is already ended — reviewed the full method to confirm the existence/ownership checks still run first, so this doesn't skip any authorization), plus a `brace-expansion` devDependency bump for a ReDoS advisory (Jest-only transitive dep, no production impact)

## Test plan
- [x] Every commit above already went through its own PR into \`dev\` with full CI (build, lint, unit/E2E tests, CodeQL) passing
- [x] This promotion PR's own CI: all checks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)