### PR TITLE
fix(docs): patch brace-expansion DoS vulnerability (Dependabot #326)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -4278,9 +4278,9 @@
       }
     },
     "node_modules/@easyops-cn/docusaurus-search-local": {
-      "version": "0.55.2",
-      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.2.tgz",
-      "integrity": "sha512-dI/riu+MbDxkAjAHAdc0uahjXRaWKvbIPe9IAmA6AGcUfnVb9xd8s2I/6wEPTOXsAd6eFqn4Yis3WBWh3KUd3g==",
+      "version": "0.55.3",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.3.tgz",
+      "integrity": "sha512-PlMKmxuonvZ1C+/zJS1hJaF1xaxD1TsUvOMzpP6DdQMtZqmTaYjcLGM12ePzl0m1rp3AgfTBeDbFNHQhwnH/dA==",
       "license": "MIT",
       "dependencies": {
         "@docusaurus/plugin-content-docs": "^2 || ^3",
@@ -6945,9 +6945,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
## Summary
- Bumps `brace-expansion` from `1.1.16` to `1.1.18` in `docs/package-lock.json`, patching GHSA-mh99-v99m-4gvg (CVE-2026-14257), a high-severity DoS via unbounded expansion length.
- Resolves Dependabot alert [#326](https://github.com/idenplane/idenplane/security/dependabot/326).
- Mirrors the same fix already applied to the root lockfile in #1284.
- Side-effect patch bump of `@easyops-cn/docusaurus-search-local` 0.55.2 → 0.55.3 (within its declared `^0.55.2` range in package.json, pulled in by npm's re-resolution).

## Test plan
- [x] `npm audit fix` in `docs/`, confirmed `brace-expansion` no longer appears in `npm audit` output
- [x] `npm run build` in `docs/` completes successfully