### PR TITLE
feat(idenplane-go): add Role and Group admin services

### DIFF
--- a/packages/idenplane-go/groups.go
+++ b/packages/idenplane-go/groups.go
@@ -1,0 +1,171 @@
+package idenplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// CreateGroupRequest is the payload for creating a realm group via the admin API.
+//
+// Path is accepted by the backend's CreateGroupDto but, as of the current
+// server implementation, is not persisted (the Prisma Group model has no
+// path column) and will not be echoed back on the resulting Group. It is
+// included here to match the request shape the API currently accepts.
+type CreateGroupRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	ParentID    string `json:"parentId,omitempty"`
+	Path        string `json:"path,omitempty"`
+}
+
+// UpdateGroupRequest is the payload for partial group updates. All fields
+// are optional. See the Path caveat on CreateGroupRequest.
+type UpdateGroupRequest struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	ParentID    *string `json:"parentId,omitempty"`
+	Path        *string `json:"path,omitempty"`
+}
+
+// Group is the wire representation of a realm group from the admin API.
+// CreatedAt and UpdatedAt are ISO 8601 strings; Prisma serializes DateTime
+// columns to ISO strings rather than Unix-epoch integers.
+//
+// ParentID is empty for top-level groups and set to the parent group's ID
+// for nested groups.
+//
+// Path is always empty in practice: the backend accepts it on create/update
+// requests but never stores or returns it (no path column on the Group
+// model). It is kept on this struct for forward compatibility in case the
+// server starts returning it.
+type Group struct {
+	ID          string `json:"id"`
+	RealmID     string `json:"realmId"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	ParentID    string `json:"parentId,omitempty"`
+	Path        string `json:"path,omitempty"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+// GroupService exposes admin operations on the realm's groups endpoint.
+// Groups are addressed by ID and support nesting via ParentID.
+type GroupService struct {
+	client *Client
+}
+
+func (gs *GroupService) groupsURL() string {
+	return fmt.Sprintf("%s/admin/realms/%s/groups", strings.TrimSuffix(gs.client.config.ServerURL, "/"), gs.client.config.Realm)
+}
+
+func (gs *GroupService) groupURL(id string) string {
+	return gs.groupsURL() + "/" + url.PathEscape(id)
+}
+
+// Create creates a realm group and returns the resulting record.
+func (gs *GroupService) Create(ctx context.Context, req CreateGroupRequest) (*Group, error) {
+	if req.Name == "" {
+		return nil, ErrInvalidConfig("Name is required")
+	}
+	resp, err := gs.client.doRequest(ctx, http.MethodPost, gs.groupsURL(), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("create group: status %d", resp.StatusCode))
+	}
+
+	var group Group
+	if err := json.NewDecoder(resp.Body).Decode(&group); err != nil {
+		return nil, ErrServerError("invalid group payload: " + err.Error())
+	}
+	return &group, nil
+}
+
+// Get fetches a single realm group by ID.
+func (gs *GroupService) Get(ctx context.Context, id string) (*Group, error) {
+	resp, err := gs.client.doRequest(ctx, http.MethodGet, gs.groupURL(id), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrGroupNotFound(id)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("get group: status %d", resp.StatusCode))
+	}
+
+	var group Group
+	if err := json.NewDecoder(resp.Body).Decode(&group); err != nil {
+		return nil, ErrServerError("invalid group payload: " + err.Error())
+	}
+	return &group, nil
+}
+
+// List returns all realm groups.
+func (gs *GroupService) List(ctx context.Context) ([]*Group, error) {
+	resp, err := gs.client.doRequest(ctx, http.MethodGet, gs.groupsURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("list groups: status %d", resp.StatusCode))
+	}
+
+	var groups []*Group
+	if err := json.NewDecoder(resp.Body).Decode(&groups); err != nil {
+		return nil, ErrServerError("invalid list payload: " + err.Error())
+	}
+	return groups, nil
+}
+
+// Update applies a partial update to the group with the given ID and
+// returns the updated record.
+func (gs *GroupService) Update(ctx context.Context, id string, req UpdateGroupRequest) (*Group, error) {
+	resp, err := gs.client.doRequest(ctx, http.MethodPut, gs.groupURL(id), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrGroupNotFound(id)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("update group: status %d", resp.StatusCode))
+	}
+
+	var group Group
+	if err := json.NewDecoder(resp.Body).Decode(&group); err != nil {
+		return nil, ErrServerError("invalid group payload: " + err.Error())
+	}
+	return &group, nil
+}
+
+// Delete removes the group with the given ID.
+func (gs *GroupService) Delete(ctx context.Context, id string) error {
+	resp, err := gs.client.doRequest(ctx, http.MethodDelete, gs.groupURL(id), nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrGroupNotFound(id)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ErrServerError(fmt.Sprintf("delete group: status %d", resp.StatusCode))
+	}
+	return nil
+}

--- a/packages/idenplane-go/groups_test.go
+++ b/packages/idenplane-go/groups_test.go
@@ -1,0 +1,429 @@
+package idenplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockGroupsServer creates a mock groups API server for testing.
+func mockGroupsServer(handlers map[string]func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if handler, ok := handlers[key]; ok {
+			handler(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+// TestGroupServiceCreate tests creating a new realm group.
+func TestGroupServiceCreate(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"POST /admin/realms/test-realm/groups": func(w http.ResponseWriter, r *http.Request) {
+			var req CreateGroupRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if req.Name == "" {
+				http.Error(w, "Name required", http.StatusBadRequest)
+				return
+			}
+			if req.Path != "/engineering" {
+				t.Errorf("Expected path '/engineering' in request, got '%s'", req.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "group-123",
+				"realmId":     "realm-1",
+				"name":        req.Name,
+				"description": req.Description,
+				"createdAt":   "2026-05-22T08:30:00.000Z",
+				"updatedAt":   "2026-05-22T08:30:00.000Z",
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	group, err := client.Groups.Create(context.Background(), CreateGroupRequest{
+		Name:        "engineering",
+		Description: "Engineering team",
+		Path:        "/engineering",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if group == nil {
+		t.Fatal("Expected group to be returned")
+	}
+	if group.Name != "engineering" {
+		t.Errorf("Expected name 'engineering', got '%s'", group.Name)
+	}
+	if group.ID != "group-123" {
+		t.Errorf("Expected ID 'group-123', got '%s'", group.ID)
+	}
+}
+
+// TestGroupServiceCreateSendsPath tests that Path is included in the create
+// request body. The live backend currently accepts but does not persist or
+// echo back Path (no path column on the Group model), so this test only
+// asserts what the SDK sends, not what comes back.
+func TestGroupServiceCreateSendsPath(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"POST /admin/realms/test-realm/groups": func(w http.ResponseWriter, r *http.Request) {
+			var req CreateGroupRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if req.Path != "/engineering" {
+				t.Errorf("Expected path '/engineering', got '%s'", req.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":      "group-789",
+				"realmId": "realm-1",
+				"name":    req.Name,
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Groups.Create(context.Background(), CreateGroupRequest{
+		Name: "engineering",
+		Path: "/engineering",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+}
+
+// TestGroupServiceCreateWithParent tests creating a nested group with a parentId.
+func TestGroupServiceCreateWithParent(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"POST /admin/realms/test-realm/groups": func(w http.ResponseWriter, r *http.Request) {
+			var req CreateGroupRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if req.ParentID != "group-parent" {
+				t.Errorf("Expected parentId 'group-parent', got '%s'", req.ParentID)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":       "group-456",
+				"realmId":  "realm-1",
+				"name":     req.Name,
+				"parentId": req.ParentID,
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	group, err := client.Groups.Create(context.Background(), CreateGroupRequest{
+		Name:     "subteam",
+		ParentID: "group-parent",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if group.ParentID != "group-parent" {
+		t.Errorf("Expected parentId 'group-parent', got '%s'", group.ParentID)
+	}
+}
+
+// TestGroupServiceCreateValidation tests client-side validation of an empty name.
+func TestGroupServiceCreateValidation(t *testing.T) {
+	client := NewClient(Config{
+		ServerURL:    "https://example.com",
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Groups.Create(context.Background(), CreateGroupRequest{})
+	if err == nil {
+		t.Error("Expected error for empty group name")
+	}
+}
+
+// TestGroupServiceCreateError tests error handling during group creation.
+func TestGroupServiceCreateError(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"POST /admin/realms/test-realm/groups": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Invalid request", http.StatusBadRequest)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Groups.Create(context.Background(), CreateGroupRequest{Name: "engineering"})
+	if err == nil {
+		t.Error("Expected error for bad request")
+	}
+}
+
+// TestGroupServiceGet tests retrieving a group by ID.
+func TestGroupServiceGet(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/groups/group-123": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "group-123",
+				"realmId":     "realm-1",
+				"name":        "engineering",
+				"description": "Engineering team",
+				"createdAt":   "2026-05-22T08:30:00.000Z",
+				"updatedAt":   "2026-05-22T08:30:00.000Z",
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	group, err := client.Groups.Get(context.Background(), "group-123")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if group == nil {
+		t.Fatal("Expected group to be returned")
+	}
+	if group.Name != "engineering" {
+		t.Errorf("Expected name 'engineering', got '%s'", group.Name)
+	}
+}
+
+// TestGroupServiceGetNotFound tests handling of a non-existent group.
+func TestGroupServiceGetNotFound(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/groups/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Group not found", http.StatusNotFound)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Groups.Get(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent group")
+	}
+	var idenplaneErr *Error
+	if !errors.As(err, &idenplaneErr) {
+		t.Fatalf("Expected *Error, got %T", err)
+	}
+	if idenplaneErr.Code != ErrCodeGroupNotFound {
+		t.Errorf("Expected code %q, got %q", ErrCodeGroupNotFound, idenplaneErr.Code)
+	}
+}
+
+// TestGroupServiceList tests listing realm groups.
+func TestGroupServiceList(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/groups": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "group-1", "realmId": "realm-1", "name": "engineering"},
+				{"id": "group-2", "realmId": "realm-1", "name": "sales"},
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	groups, err := client.Groups.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(groups) != 2 {
+		t.Errorf("Expected 2 groups, got %d", len(groups))
+	}
+}
+
+// TestGroupServiceListServerError tests handling of server errors during list.
+func TestGroupServiceListServerError(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/groups": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Groups.List(context.Background())
+	if err == nil {
+		t.Error("Expected error for server error")
+	}
+}
+
+// TestGroupServiceUpdate tests updating a group.
+func TestGroupServiceUpdate(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"PUT /admin/realms/test-realm/groups/group-123": func(w http.ResponseWriter, r *http.Request) {
+			var req UpdateGroupRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if req.Description == nil || *req.Description != "Updated description" {
+				t.Errorf("Expected description 'Updated description', got %v", req.Description)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "group-123",
+				"realmId":     "realm-1",
+				"name":        "engineering",
+				"description": "Updated description",
+				"createdAt":   "2026-05-22T08:30:00.000Z",
+				"updatedAt":   "2026-05-22T09:00:00.000Z",
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	desc := "Updated description"
+	group, err := client.Groups.Update(context.Background(), "group-123", UpdateGroupRequest{Description: &desc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if group.Description != "Updated description" {
+		t.Errorf("Expected description 'Updated description', got '%s'", group.Description)
+	}
+}
+
+// TestGroupServiceUpdateNotFound tests handling of a non-existent group during update.
+func TestGroupServiceUpdateNotFound(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"PUT /admin/realms/test-realm/groups/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Group not found", http.StatusNotFound)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Groups.Update(context.Background(), "nonexistent", UpdateGroupRequest{})
+	if err == nil {
+		t.Error("Expected error for non-existent group")
+	}
+}
+
+// TestGroupServiceDelete tests deleting a group.
+func TestGroupServiceDelete(t *testing.T) {
+	deleteCalled := false
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"DELETE /admin/realms/test-realm/groups/group-123": func(w http.ResponseWriter, r *http.Request) {
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	err := client.Groups.Delete(context.Background(), "group-123")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if !deleteCalled {
+		t.Error("Delete was not called")
+	}
+}
+
+// TestGroupServiceDeleteNotFound tests handling of a non-existent group during delete.
+func TestGroupServiceDeleteNotFound(t *testing.T) {
+	server := mockGroupsServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"DELETE /admin/realms/test-realm/groups/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Group not found", http.StatusNotFound)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	err := client.Groups.Delete(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent group")
+	}
+}

--- a/packages/idenplane-go/idenplane.go
+++ b/packages/idenplane-go/idenplane.go
@@ -3,8 +3,12 @@
 package idenplane
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -174,6 +178,10 @@ type Client struct {
 	config Config
 	// Users exposes admin-API user management.
 	Users *UserService
+	// Roles exposes admin-API realm role management.
+	Roles *RoleService
+	// Groups exposes admin-API realm group management.
+	Groups *GroupService
 }
 
 // NewClient creates a new Idenplane client with the given configuration.
@@ -183,6 +191,8 @@ type Client struct {
 func NewClient(config Config) *Client {
 	c := &Client{config: config}
 	c.Users = &UserService{client: c}
+	c.Roles = &RoleService{client: c}
+	c.Groups = &GroupService{client: c}
 	return c
 }
 
@@ -212,6 +222,40 @@ func (c *Client) authHeader() string {
 	return "Bearer " + c.config.AdminToken
 }
 
+// doRequest builds, authenticates, and dispatches an admin API request.
+// When body is non-nil it is JSON-encoded and the Content-Type header set.
+// When the client has an AdminToken configured, the Authorization header is
+// attached so admin endpoints don't return 401.
+//
+// This is shared by UserService, RoleService, and GroupService, all of which
+// speak the same admin-API conventions (JSON in/out, bearer auth).
+func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		raw, err := json.Marshal(body)
+		if err != nil {
+			return nil, ErrServerError("marshal request body: " + err.Error())
+		}
+		reader = bytes.NewReader(raw)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, path, reader)
+	if err != nil {
+		return nil, ErrNetworkError("build request", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	if auth := c.authHeader(); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+	resp, err := c.config.httpClient().Do(req)
+	if err != nil {
+		return nil, ErrNetworkError("request failed", err)
+	}
+	return resp, nil
+}
+
 // Error is the base error type for Idenplane errors.
 type Error struct {
 	// Code is the error code.
@@ -227,7 +271,7 @@ type ErrorCode string
 
 // Error codes.
 const (
-	ErrCodeInvalidConfig     ErrorCode = "invalid_config"
+	ErrCodeInvalidConfig    ErrorCode = "invalid_config"
 	ErrCodeNotAuthenticated ErrorCode = "not_authenticated"
 	ErrCodeTokenExpired     ErrorCode = "token_expired"
 	ErrCodeServerError      ErrorCode = "server_error"
@@ -236,6 +280,8 @@ const (
 	ErrCodeJWTError         ErrorCode = "jwt_error"
 	ErrCodeUserNotFound     ErrorCode = "user_not_found"
 	ErrCodeInvalidToken     ErrorCode = "invalid_token"
+	ErrCodeRoleNotFound     ErrorCode = "role_not_found"
+	ErrCodeGroupNotFound    ErrorCode = "group_not_found"
 )
 
 // Error returns the error message.
@@ -302,6 +348,16 @@ func ErrUserNotFound(userID string) *Error {
 // ErrInvalidToken creates an invalid token error.
 func ErrInvalidToken(message string) *Error {
 	return &Error{Code: ErrCodeInvalidToken, Message: message}
+}
+
+// ErrRoleNotFound creates a role not found error.
+func ErrRoleNotFound(name string) *Error {
+	return &Error{Code: ErrCodeRoleNotFound, Message: fmt.Sprintf("Role not found: %s", name)}
+}
+
+// ErrGroupNotFound creates a group not found error.
+func ErrGroupNotFound(id string) *Error {
+	return &Error{Code: ErrCodeGroupNotFound, Message: fmt.Sprintf("Group not found: %s", id)}
 }
 
 // IsRetryable returns true if the error is retryable (network error or server error).

--- a/packages/idenplane-go/roles.go
+++ b/packages/idenplane-go/roles.go
@@ -1,0 +1,157 @@
+package idenplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// CreateRoleRequest is the payload for creating a realm role via the admin API.
+type CreateRoleRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// UpdateRoleRequest is the payload for partial role updates. All fields are optional.
+type UpdateRoleRequest struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+// Role is the wire representation of a realm role from the admin API.
+// CreatedAt and UpdatedAt are ISO 8601 strings; Prisma serializes DateTime
+// columns to ISO strings rather than Unix-epoch integers.
+//
+// ClientID is only populated for client roles. The admin API's list/get
+// endpoints used by this SDK only address realm roles, so it is typically
+// empty, but the field is kept on the read model in case the server ever
+// returns a client role through the same shape.
+type Role struct {
+	ID          string `json:"id"`
+	RealmID     string `json:"realmId"`
+	ClientID    string `json:"clientId,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	CreatedAt   string `json:"createdAt"`
+	UpdatedAt   string `json:"updatedAt"`
+}
+
+// RoleService exposes admin operations on the realm's roles endpoint. Unlike
+// users and groups, roles are addressed by name rather than by ID.
+type RoleService struct {
+	client *Client
+}
+
+func (rs *RoleService) rolesURL() string {
+	return fmt.Sprintf("%s/admin/realms/%s/roles", strings.TrimSuffix(rs.client.config.ServerURL, "/"), rs.client.config.Realm)
+}
+
+func (rs *RoleService) roleURL(name string) string {
+	return rs.rolesURL() + "/" + url.PathEscape(name)
+}
+
+// Create creates a realm role and returns the resulting record.
+func (rs *RoleService) Create(ctx context.Context, req CreateRoleRequest) (*Role, error) {
+	if req.Name == "" {
+		return nil, ErrInvalidConfig("Name is required")
+	}
+	resp, err := rs.client.doRequest(ctx, http.MethodPost, rs.rolesURL(), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("create role: status %d", resp.StatusCode))
+	}
+
+	var role Role
+	if err := json.NewDecoder(resp.Body).Decode(&role); err != nil {
+		return nil, ErrServerError("invalid role payload: " + err.Error())
+	}
+	return &role, nil
+}
+
+// Get fetches a single realm role by name.
+func (rs *RoleService) Get(ctx context.Context, name string) (*Role, error) {
+	resp, err := rs.client.doRequest(ctx, http.MethodGet, rs.roleURL(name), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrRoleNotFound(name)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("get role: status %d", resp.StatusCode))
+	}
+
+	var role Role
+	if err := json.NewDecoder(resp.Body).Decode(&role); err != nil {
+		return nil, ErrServerError("invalid role payload: " + err.Error())
+	}
+	return &role, nil
+}
+
+// List returns all realm roles. Client roles are excluded by the backend.
+func (rs *RoleService) List(ctx context.Context) ([]*Role, error) {
+	resp, err := rs.client.doRequest(ctx, http.MethodGet, rs.rolesURL(), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("list roles: status %d", resp.StatusCode))
+	}
+
+	var roles []*Role
+	if err := json.NewDecoder(resp.Body).Decode(&roles); err != nil {
+		return nil, ErrServerError("invalid list payload: " + err.Error())
+	}
+	return roles, nil
+}
+
+// Update applies a partial update to the role with the given name and
+// returns the updated record.
+func (rs *RoleService) Update(ctx context.Context, name string, req UpdateRoleRequest) (*Role, error) {
+	resp, err := rs.client.doRequest(ctx, http.MethodPut, rs.roleURL(name), req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrRoleNotFound(name)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, ErrServerError(fmt.Sprintf("update role: status %d", resp.StatusCode))
+	}
+
+	var role Role
+	if err := json.NewDecoder(resp.Body).Decode(&role); err != nil {
+		return nil, ErrServerError("invalid role payload: " + err.Error())
+	}
+	return &role, nil
+}
+
+// Delete removes the role with the given name.
+func (rs *RoleService) Delete(ctx context.Context, name string) error {
+	resp, err := rs.client.doRequest(ctx, http.MethodDelete, rs.roleURL(name), nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ErrRoleNotFound(name)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return ErrServerError(fmt.Sprintf("delete role: status %d", resp.StatusCode))
+	}
+	return nil
+}

--- a/packages/idenplane-go/roles_test.go
+++ b/packages/idenplane-go/roles_test.go
@@ -1,0 +1,346 @@
+package idenplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// mockRolesServer creates a mock roles API server for testing.
+func mockRolesServer(handlers map[string]func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if handler, ok := handlers[key]; ok {
+			handler(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+// TestRoleServiceCreate tests creating a new realm role.
+func TestRoleServiceCreate(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"POST /admin/realms/test-realm/roles": func(w http.ResponseWriter, r *http.Request) {
+			var req CreateRoleRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if req.Name == "" {
+				http.Error(w, "Name required", http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "role-123",
+				"realmId":     "realm-1",
+				"name":        req.Name,
+				"description": req.Description,
+				"createdAt":   "2026-05-22T08:30:00.000Z",
+				"updatedAt":   "2026-05-22T08:30:00.000Z",
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	role, err := client.Roles.Create(context.Background(), CreateRoleRequest{
+		Name:        "admin",
+		Description: "Administrator role",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if role == nil {
+		t.Fatal("Expected role to be returned")
+	}
+	if role.Name != "admin" {
+		t.Errorf("Expected name 'admin', got '%s'", role.Name)
+	}
+	if role.Description != "Administrator role" {
+		t.Errorf("Expected description 'Administrator role', got '%s'", role.Description)
+	}
+	if role.ID != "role-123" {
+		t.Errorf("Expected ID 'role-123', got '%s'", role.ID)
+	}
+}
+
+// TestRoleServiceCreateValidation tests client-side validation of an empty name.
+func TestRoleServiceCreateValidation(t *testing.T) {
+	client := NewClient(Config{
+		ServerURL:    "https://example.com",
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Roles.Create(context.Background(), CreateRoleRequest{})
+	if err == nil {
+		t.Error("Expected error for empty role name")
+	}
+}
+
+// TestRoleServiceCreateError tests error handling during role creation.
+func TestRoleServiceCreateError(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"POST /admin/realms/test-realm/roles": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Invalid request", http.StatusBadRequest)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Roles.Create(context.Background(), CreateRoleRequest{Name: "admin"})
+	if err == nil {
+		t.Error("Expected error for bad request")
+	}
+}
+
+// TestRoleServiceGet tests retrieving a role by name.
+func TestRoleServiceGet(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/roles/admin": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "role-123",
+				"realmId":     "realm-1",
+				"name":        "admin",
+				"description": "Administrator role",
+				"createdAt":   "2026-05-22T08:30:00.000Z",
+				"updatedAt":   "2026-05-22T08:30:00.000Z",
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	role, err := client.Roles.Get(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if role == nil {
+		t.Fatal("Expected role to be returned")
+	}
+	if role.Name != "admin" {
+		t.Errorf("Expected name 'admin', got '%s'", role.Name)
+	}
+	if role.CreatedAt != "2026-05-22T08:30:00.000Z" {
+		t.Errorf("Expected CreatedAt '2026-05-22T08:30:00.000Z', got '%s'", role.CreatedAt)
+	}
+}
+
+// TestRoleServiceGetNotFound tests handling of a non-existent role.
+func TestRoleServiceGetNotFound(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/roles/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Role not found", http.StatusNotFound)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Roles.Get(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent role")
+	}
+	var idenplaneErr *Error
+	if !errors.As(err, &idenplaneErr) {
+		t.Fatalf("Expected *Error, got %T", err)
+	}
+	if idenplaneErr.Code != ErrCodeRoleNotFound {
+		t.Errorf("Expected code %q, got %q", ErrCodeRoleNotFound, idenplaneErr.Code)
+	}
+}
+
+// TestRoleServiceList tests listing realm roles.
+func TestRoleServiceList(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/roles": func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "role-1", "realmId": "realm-1", "name": "admin"},
+				{"id": "role-2", "realmId": "realm-1", "name": "member"},
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	roles, err := client.Roles.List(context.Background())
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(roles) != 2 {
+		t.Errorf("Expected 2 roles, got %d", len(roles))
+	}
+}
+
+// TestRoleServiceListServerError tests handling of server errors during list.
+func TestRoleServiceListServerError(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"GET /admin/realms/test-realm/roles": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Roles.List(context.Background())
+	if err == nil {
+		t.Error("Expected error for server error")
+	}
+}
+
+// TestRoleServiceUpdate tests updating a role.
+func TestRoleServiceUpdate(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"PUT /admin/realms/test-realm/roles/admin": func(w http.ResponseWriter, r *http.Request) {
+			var req UpdateRoleRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "Invalid JSON", http.StatusBadRequest)
+				return
+			}
+			if req.Description == nil || *req.Description != "Updated description" {
+				t.Errorf("Expected description 'Updated description', got %v", req.Description)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":          "role-123",
+				"realmId":     "realm-1",
+				"name":        "admin",
+				"description": "Updated description",
+				"createdAt":   "2026-05-22T08:30:00.000Z",
+				"updatedAt":   "2026-05-22T09:00:00.000Z",
+			})
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	desc := "Updated description"
+	role, err := client.Roles.Update(context.Background(), "admin", UpdateRoleRequest{Description: &desc})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+	if role.Description != "Updated description" {
+		t.Errorf("Expected description 'Updated description', got '%s'", role.Description)
+	}
+}
+
+// TestRoleServiceUpdateNotFound tests handling of a non-existent role during update.
+func TestRoleServiceUpdateNotFound(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"PUT /admin/realms/test-realm/roles/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Role not found", http.StatusNotFound)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	_, err := client.Roles.Update(context.Background(), "nonexistent", UpdateRoleRequest{})
+	if err == nil {
+		t.Error("Expected error for non-existent role")
+	}
+}
+
+// TestRoleServiceDelete tests deleting a role.
+func TestRoleServiceDelete(t *testing.T) {
+	deleteCalled := false
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"DELETE /admin/realms/test-realm/roles/admin": func(w http.ResponseWriter, r *http.Request) {
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	err := client.Roles.Delete(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if !deleteCalled {
+		t.Error("Delete was not called")
+	}
+}
+
+// TestRoleServiceDeleteNotFound tests handling of a non-existent role during delete.
+func TestRoleServiceDeleteNotFound(t *testing.T) {
+	server := mockRolesServer(map[string]func(w http.ResponseWriter, r *http.Request){
+		"DELETE /admin/realms/test-realm/roles/nonexistent": func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Role not found", http.StatusNotFound)
+		},
+	})
+	defer server.Close()
+
+	client := NewClient(Config{
+		ServerURL:    server.URL,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+	})
+
+	err := client.Roles.Delete(context.Background(), "nonexistent")
+	if err == nil {
+		t.Error("Expected error for non-existent role")
+	}
+}

--- a/packages/idenplane-go/users.go
+++ b/packages/idenplane-go/users.go
@@ -1,7 +1,6 @@
 package idenplane
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -106,31 +105,11 @@ func (us *UserService) usersURL() string {
 // When body is non-nil it is JSON-encoded and the Content-Type header set.
 // When the client has an AdminToken configured, the Authorization header is
 // attached so admin endpoints don't return 401.
+//
+// This delegates to Client.doRequest, which is shared across UserService,
+// RoleService, and GroupService.
 func (us *UserService) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
-	var reader io.Reader
-	if body != nil {
-		raw, err := json.Marshal(body)
-		if err != nil {
-			return nil, ErrServerError("marshal request body: " + err.Error())
-		}
-		reader = bytes.NewReader(raw)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, path, reader)
-	if err != nil {
-		return nil, ErrNetworkError("build request", err)
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	req.Header.Set("Accept", "application/json")
-	if auth := us.client.authHeader(); auth != "" {
-		req.Header.Set("Authorization", auth)
-	}
-	resp, err := us.client.config.httpClient().Do(req)
-	if err != nil {
-		return nil, ErrNetworkError("request failed", err)
-	}
-	return resp, nil
+	return us.client.doRequest(ctx, method, path, body)
 }
 
 // Create creates a user and returns the resulting record. Idenplane's admin


### PR DESCRIPTION
## Summary
- Add `RoleService` (`roles.go`): realm roles, addressed by **name** (`GetRoleName` matches the backend's `roles.controller.ts`, not by ID), with `Create`/`Get`/`List`/`Update`/`Delete`.
- Add `GroupService` (`groups.go`): realm groups, addressed by **ID**, with `ParentID` nesting support, same CRUD surface.
- Wire `Roles`/`Groups` into `Client`/`NewClient`, following the existing `Users` pattern.
- Extract `Client.doRequest` from `UserService.doRequest` (same auth/JSON/Content-Type plumbing, now shared by all three services instead of being duplicated a third time). `UserService.doRequest` delegates to it in one line — no behavior change, `users_test.go` untouched.
- Add `ErrRoleNotFound`/`ErrGroupNotFound` (mirroring `ErrUserNotFound`) so a 404 isn't misclassified as a retryable `ErrServerError` by `IsRetryable`.
- `roles_test.go` (11 tests) / `groups_test.go` (13 tests) follow `users_test.go`'s `httptest` mock-server pattern.

## Notable finding
The backend's `CreateGroupDto`/`UpdateGroupDto` accept a `path` field, but the Prisma `Group` model has no `path` column and the service silently drops it (pre-existing backend inconsistency, not introduced or fixed here). Kept `Path` on the Go SDK's request/response types since the API does accept it as input, documented the caveat in doc comments, and added a test asserting what the SDK actually sends rather than asserting a wire contract the server doesn't have.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./... -count=1` all pass in `packages/idenplane-go/`.

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)