### PR TITLE
feat(idenplane-python): add Role and Group admin services

### DIFF
--- a/packages/idenplane-python/idenplane/__init__.py
+++ b/packages/idenplane-python/idenplane/__init__.py
@@ -1,7 +1,8 @@
 """Idenplane Python SDK.
 
-Server-side Python SDK for the Idenplane admin API: OIDC discovery and
-user management. Mirrors the Go SDK (``idenplane-go``) feature-for-feature.
+Server-side Python SDK for the Idenplane admin API: OIDC discovery, user
+management, role management, and group management. Mirrors the Go SDK
+(``idenplane-go``) feature-for-feature.
 
 Quick start::
 
@@ -25,6 +26,8 @@ from idenplane.exceptions import (
     RateLimitError,
     ServerError,
 )
+from idenplane.groups import CreateGroupRequest, Group, GroupService, UpdateGroupRequest
+from idenplane.roles import CreateRoleRequest, Role, RoleService, UpdateRoleRequest
 from idenplane.users import (
     CreateUserRequest,
     ListUsersOptions,
@@ -40,16 +43,24 @@ __all__ = [
     "AuthError",
     "Client",
     "Config",
+    "CreateGroupRequest",
+    "CreateRoleRequest",
     "CreateUserRequest",
     "DiscoveryCache",
     "DiscoveryService",
+    "Group",
+    "GroupService",
     "IdenplaneError",
     "ListUsersOptions",
     "ListUsersResult",
     "NotFoundError",
     "OpenIDConfiguration",
     "RateLimitError",
+    "Role",
+    "RoleService",
     "ServerError",
+    "UpdateGroupRequest",
+    "UpdateRoleRequest",
     "UpdateUserRequest",
     "User",
     "UserService",

--- a/packages/idenplane-python/idenplane/client.py
+++ b/packages/idenplane-python/idenplane/client.py
@@ -2,7 +2,7 @@
 
 The :class:`Client` is the entry point. It holds an immutable :class:`Config`
 and a single ``requests.Session`` that is reused across services for
-keep-alive performance. Service objects (``users``, ``discovery``) are
+keep-alive performance. Service objects (``users``, ``discovery``, ``roles``, ``groups``) are
 lazily instantiated on first access.
 """
 
@@ -12,13 +12,17 @@ import ipaddress
 import os
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import urlparse
 
 import requests
 
+from idenplane.exceptions import IdenplaneError, _raise_for_status
+
 if TYPE_CHECKING:
     from idenplane.discovery import DiscoveryService
+    from idenplane.groups import GroupService
+    from idenplane.roles import RoleService
     from idenplane.users import UserService
 
 _USER_AGENT = "idenplane-python/0.3.0"
@@ -142,6 +146,8 @@ class Client:
         self._session = session if session is not None else requests.Session()
         self._users: Optional[UserService] = None
         self._discovery: Optional[DiscoveryService] = None
+        self._roles: Optional[RoleService] = None
+        self._groups: Optional[GroupService] = None
         self._closed = False
 
     @property
@@ -172,6 +178,24 @@ class Client:
             self._discovery = DiscoveryService(self)
         return self._discovery
 
+    @property
+    def roles(self) -> RoleService:
+        """Return the lazily-instantiated :class:`RoleService`."""
+        if self._roles is None:
+            from idenplane.roles import RoleService
+
+            self._roles = RoleService(self)
+        return self._roles
+
+    @property
+    def groups(self) -> GroupService:
+        """Return the lazily-instantiated :class:`GroupService`."""
+        if self._groups is None:
+            from idenplane.groups import GroupService
+
+            self._groups = GroupService(self)
+        return self._groups
+
     def auth_header(self) -> str:
         """Return the ``Authorization`` header value.
 
@@ -193,6 +217,46 @@ class Client:
         if self._config.extra_headers:
             headers.update(self._config.extra_headers)
         return headers
+
+    def _do_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: Optional[Any] = None,
+        params: Optional[dict[str, str]] = None,
+    ) -> requests.Response:
+        """Build, authenticate, and dispatch an admin API request.
+
+        Shared by every service (``users``, ``roles``, ``groups``, ...) so
+        the header/auth/timeout/error-mapping logic lives in exactly one
+        place. Always attaches ``Accept`` and ``User-Agent``. Adds
+        ``Content-Type: application/json`` when a body is supplied. Attaches
+        ``Authorization`` when the client has an admin token configured.
+        Non-2xx responses raise the appropriate :class:`IdenplaneError`
+        subclass.
+        """
+        headers = self.default_headers()
+        if json is not None:
+            headers["Content-Type"] = "application/json"
+        auth = self.auth_header()
+        if auth:
+            headers["Authorization"] = auth
+
+        try:
+            resp = self._session.request(
+                method=method,
+                url=url,
+                json=json,
+                params=params,
+                headers=headers,
+                timeout=self._config.timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise IdenplaneError(f"HTTP request failed: {exc}") from exc
+
+        _raise_for_status(resp)
+        return resp
 
     def close(self) -> None:
         """Close the underlying HTTP session.

--- a/packages/idenplane-python/idenplane/groups.py
+++ b/packages/idenplane-python/idenplane/groups.py
@@ -1,0 +1,233 @@
+"""Group admin service.
+
+Wraps the realm-management groups endpoints with typed inputs. Groups are
+addressed by ID (unlike roles, which are addressed by name) and support
+nesting via ``parentId``. Mirrors the Go SDK's ``GroupService``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import quote
+
+import requests
+from typing_extensions import NotRequired, TypedDict
+
+from idenplane.exceptions import IdenplaneError
+
+if TYPE_CHECKING:
+    from idenplane.client import Client
+
+
+class Group(TypedDict, total=False):
+    """Group record returned by the admin API.
+
+    ``parentId`` is absent/``None`` for top-level groups and set to the
+    parent group's ID for nested groups.
+
+    ``path`` is accepted on create/update requests but, as of the current
+    server implementation, is never persisted: the Prisma ``Group`` model
+    has no ``path`` column, and ``GroupsService.create``/``update`` never
+    write ``dto.path`` into the database. It is kept on this TypedDict for
+    forward compatibility in case the server starts returning it, but
+    callers should not expect it to be populated.
+
+    ``createdAt`` and ``updatedAt`` are ISO 8601 timestamp strings because
+    Prisma serializes ``DateTime`` columns to ISO strings on the wire.
+
+    The live API's list/get responses also include a ``_count`` object
+    (member/role-mapping counts); it is intentionally not modeled here.
+    """
+
+    id: str
+    realmId: str
+    name: str
+    description: str
+    parentId: str
+    path: str
+    createdAt: str
+    updatedAt: str
+
+
+class CreateGroupRequest(TypedDict, total=False):
+    """Payload for creating a group via the admin API.
+
+    ``path`` is accepted by the backend's ``CreateGroupDto`` but is not
+    persisted (see the caveat on :class:`Group`); it is included here only
+    because the wire contract currently accepts it as input.
+    """
+
+    name: str
+    description: NotRequired[str]
+    parentId: NotRequired[str]
+    path: NotRequired[str]
+
+
+class UpdateGroupRequest(TypedDict, total=False):
+    """Partial-update payload. All fields are optional.
+
+    See the ``path`` caveat on :class:`CreateGroupRequest`.
+    """
+
+    name: NotRequired[str]
+    description: NotRequired[str]
+    parentId: NotRequired[str]
+    path: NotRequired[str]
+
+
+class GroupService:
+    """Admin operations on the realm's groups endpoint.
+
+    Groups are addressed by ID and support nesting via ``parentId``. Every
+    method goes through :meth:`_do_request`, which delegates to
+    :meth:`idenplane.client.Client._do_request` so the header/auth/
+    error-mapping logic lives in one place shared with ``UserService`` and
+    ``RoleService``.
+    """
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------ URLs
+
+    def _groups_url(self) -> str:
+        return (
+            f"{self._client.config.base_url_normalized()}"
+            f"/admin/realms/{self._client.config.realm}/groups"
+        )
+
+    def _group_url(self, group_id: str) -> str:
+        return f"{self._groups_url()}/{quote(group_id, safe='')}"
+
+    # -------------------------------------------------------------- helpers
+
+    def _do_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: Optional[Any] = None,
+        params: Optional[dict[str, str]] = None,
+    ) -> requests.Response:
+        """Build, authenticate, and dispatch an admin API request.
+
+        See :meth:`idenplane.client.Client._do_request` for the full
+        contract (headers, auth, error mapping).
+        """
+        return self._client._do_request(method, url, json=json, params=params)
+
+    @staticmethod
+    def _parse_group_body(resp: requests.Response) -> Optional[Group]:
+        """Decode a JSON group body or return ``None`` if absent/invalid."""
+        if not resp.content:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        return data  # type: ignore[return-value]
+
+    # --------------------------------------------------------------- public
+
+    def create(self, req: CreateGroupRequest) -> Group:
+        """Create a group and return the resulting record.
+
+        Unlike ``UserService.create``, the admin API returns the full group
+        record directly in the response body on 201, so no follow-up
+        ``GET`` is needed.
+        """
+        if not req.get("name"):
+            raise ValueError("CreateGroupRequest.name is required")
+
+        resp = self._do_request("POST", self._groups_url(), json=dict(req))
+        body = self._parse_group_body(resp)
+        if body is None:
+            raise IdenplaneError(
+                "create group: response body was empty or invalid JSON",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+        return body
+
+    def get(self, group_id: str) -> Group:
+        """Fetch a single group by ID.
+
+        Raises:
+            NotFoundError: If no group with ``group_id`` exists in the realm.
+        """
+        if not group_id:
+            raise ValueError("group_id is required")
+        resp = self._do_request("GET", self._group_url(group_id))
+        body = self._parse_group_body(resp)
+        if body is None:
+            raise IdenplaneError(
+                "get group: response body was empty or invalid JSON",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+        return body
+
+    def list(self) -> list[Group]:
+        """List all groups in the realm.
+
+        The admin API returns a plain JSON array with no pagination
+        parameters, so this returns a plain ``list`` rather than a result
+        wrapper (unlike ``UserService.list``).
+        """
+        resp = self._do_request("GET", self._groups_url())
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise IdenplaneError(
+                f"list groups: response was not valid JSON: {exc}",
+                status_code=resp.status_code,
+                body=resp.text,
+            ) from exc
+
+        if not isinstance(data, list):
+            raise IdenplaneError(
+                "list groups: response was not a JSON array",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+
+        groups: list[Group] = []
+        for item in data:
+            if isinstance(item, dict):
+                groups.append(item)  # type: ignore[arg-type]
+        return groups
+
+    def update(self, group_id: str, req: UpdateGroupRequest) -> Group:
+        """Apply a partial update to the group with the given ID.
+
+        Unlike ``UserService.update``, the admin API returns the updated
+        record directly in the response body on 200, so no follow-up
+        ``GET`` is needed.
+
+        Raises:
+            NotFoundError: If no group with ``group_id`` exists in the realm.
+        """
+        if not group_id:
+            raise ValueError("group_id is required")
+        resp = self._do_request("PUT", self._group_url(group_id), json=dict(req))
+        body = self._parse_group_body(resp)
+        if body is None:
+            raise IdenplaneError(
+                "update group: response body was empty or invalid JSON",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+        return body
+
+    def delete(self, group_id: str) -> None:
+        """Delete the group with the given ID.
+
+        Raises:
+            NotFoundError: If no group with ``group_id`` exists in the realm.
+        """
+        if not group_id:
+            raise ValueError("group_id is required")
+        self._do_request("DELETE", self._group_url(group_id))

--- a/packages/idenplane-python/idenplane/roles.py
+++ b/packages/idenplane-python/idenplane/roles.py
@@ -1,0 +1,214 @@
+"""Role admin service.
+
+Wraps the realm-management realm-roles endpoints with typed inputs. Unlike
+users and groups, roles are addressed by **name**, not by ID (see
+``RolesController``/``RolesService`` in the NestJS backend). Mirrors the Go
+SDK's ``RoleService``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+from urllib.parse import quote
+
+import requests
+from typing_extensions import NotRequired, TypedDict
+
+from idenplane.exceptions import IdenplaneError
+
+if TYPE_CHECKING:
+    from idenplane.client import Client
+
+
+class Role(TypedDict, total=False):
+    """Realm role record returned by the admin API.
+
+    ``clientId`` is only populated for client roles. The endpoints wrapped
+    by this SDK (``/admin/realms/{realm}/roles``) only address realm roles,
+    so ``clientId`` is typically absent, but the field is kept on the read
+    model in case the server ever returns a client role through the same
+    shape.
+
+    ``createdAt`` and ``updatedAt`` are ISO 8601 timestamp strings because
+    Prisma serializes ``DateTime`` columns to ISO strings on the wire.
+    """
+
+    id: str
+    realmId: str
+    clientId: str
+    name: str
+    description: str
+    createdAt: str
+    updatedAt: str
+
+
+class CreateRoleRequest(TypedDict, total=False):
+    """Payload for creating a realm role via the admin API."""
+
+    name: str
+    description: NotRequired[str]
+
+
+class UpdateRoleRequest(TypedDict, total=False):
+    """Partial-update payload. All fields are optional."""
+
+    name: NotRequired[str]
+    description: NotRequired[str]
+
+
+class RoleService:
+    """Admin operations on the realm's roles endpoint.
+
+    Roles are addressed by name rather than by ID. Every method goes
+    through :meth:`_do_request`, which delegates to
+    :meth:`idenplane.client.Client._do_request` so the header/auth/
+    error-mapping logic lives in one place shared with ``UserService`` and
+    ``GroupService``.
+    """
+
+    def __init__(self, client: Client) -> None:
+        self._client = client
+
+    # ------------------------------------------------------------------ URLs
+
+    def _roles_url(self) -> str:
+        return (
+            f"{self._client.config.base_url_normalized()}"
+            f"/admin/realms/{self._client.config.realm}/roles"
+        )
+
+    def _role_url(self, name: str) -> str:
+        return f"{self._roles_url()}/{quote(name, safe='')}"
+
+    # -------------------------------------------------------------- helpers
+
+    def _do_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json: Optional[Any] = None,
+        params: Optional[dict[str, str]] = None,
+    ) -> requests.Response:
+        """Build, authenticate, and dispatch an admin API request.
+
+        See :meth:`idenplane.client.Client._do_request` for the full
+        contract (headers, auth, error mapping).
+        """
+        return self._client._do_request(method, url, json=json, params=params)
+
+    @staticmethod
+    def _parse_role_body(resp: requests.Response) -> Optional[Role]:
+        """Decode a JSON role body or return ``None`` if absent/invalid."""
+        if not resp.content:
+            return None
+        try:
+            data = resp.json()
+        except ValueError:
+            return None
+        if not isinstance(data, dict):
+            return None
+        return data  # type: ignore[return-value]
+
+    # --------------------------------------------------------------- public
+
+    def create(self, req: CreateRoleRequest) -> Role:
+        """Create a realm role and return the resulting record.
+
+        Unlike ``UserService.create``, the admin API returns the full role
+        record directly in the response body on 201, so no follow-up
+        ``GET`` is needed.
+        """
+        if not req.get("name"):
+            raise ValueError("CreateRoleRequest.name is required")
+
+        resp = self._do_request("POST", self._roles_url(), json=dict(req))
+        body = self._parse_role_body(resp)
+        if body is None:
+            raise IdenplaneError(
+                "create role: response body was empty or invalid JSON",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+        return body
+
+    def get(self, name: str) -> Role:
+        """Fetch a single realm role by name.
+
+        Raises:
+            NotFoundError: If no role with ``name`` exists in the realm.
+        """
+        if not name:
+            raise ValueError("name is required")
+        resp = self._do_request("GET", self._role_url(name))
+        body = self._parse_role_body(resp)
+        if body is None:
+            raise IdenplaneError(
+                "get role: response body was empty or invalid JSON",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+        return body
+
+    def list(self) -> list[Role]:
+        """List all realm roles.
+
+        The admin API returns a plain JSON array with no pagination
+        parameters, so this returns a plain ``list`` rather than a result
+        wrapper (unlike ``UserService.list``).
+        """
+        resp = self._do_request("GET", self._roles_url())
+
+        try:
+            data = resp.json()
+        except ValueError as exc:
+            raise IdenplaneError(
+                f"list roles: response was not valid JSON: {exc}",
+                status_code=resp.status_code,
+                body=resp.text,
+            ) from exc
+
+        if not isinstance(data, list):
+            raise IdenplaneError(
+                "list roles: response was not a JSON array",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+
+        roles: list[Role] = []
+        for item in data:
+            if isinstance(item, dict):
+                roles.append(item)  # type: ignore[arg-type]
+        return roles
+
+    def update(self, name: str, req: UpdateRoleRequest) -> Role:
+        """Apply a partial update to the role named ``name``.
+
+        Unlike ``UserService.update``, the admin API returns the updated
+        record directly in the response body on 200, so no follow-up
+        ``GET`` is needed.
+
+        Raises:
+            NotFoundError: If no role with ``name`` exists in the realm.
+        """
+        if not name:
+            raise ValueError("name is required")
+        resp = self._do_request("PUT", self._role_url(name), json=dict(req))
+        body = self._parse_role_body(resp)
+        if body is None:
+            raise IdenplaneError(
+                "update role: response body was empty or invalid JSON",
+                status_code=resp.status_code,
+                body=resp.text,
+            )
+        return body
+
+    def delete(self, name: str) -> None:
+        """Delete the realm role named ``name``.
+
+        Raises:
+            NotFoundError: If no role with ``name`` exists in the realm.
+        """
+        if not name:
+            raise ValueError("name is required")
+        self._do_request("DELETE", self._role_url(name))

--- a/packages/idenplane-python/idenplane/users.py
+++ b/packages/idenplane-python/idenplane/users.py
@@ -15,7 +15,7 @@ from urllib.parse import quote
 import requests
 from typing_extensions import NotRequired, TypedDict
 
-from idenplane.exceptions import IdenplaneError, _raise_for_status
+from idenplane.exceptions import IdenplaneError
 
 if TYPE_CHECKING:
     from idenplane.client import Client
@@ -150,33 +150,17 @@ class UserService:
     ) -> requests.Response:
         """Build, authenticate, and dispatch an admin API request.
 
-        Always attaches ``Accept`` and ``User-Agent``. Adds
-        ``Content-Type: application/json`` when a body is supplied. Attaches
-        ``Authorization`` when the client has an admin token configured.
-        Non-2xx responses raise the appropriate :class:`IdenplaneError`
-        subclass.
+        Delegates to :meth:`Client._do_request`, which sets ``Accept`` and
+        ``User-Agent`` on every call, adds ``Content-Type: application/json``
+        when a body is supplied, attaches ``Authorization`` when the client
+        has an admin token configured, and raises the appropriate
+        :class:`IdenplaneError` subclass for non-2xx responses. Kept as a
+        method here (rather than calling ``self._client._do_request``
+        directly at each call site) so ``RoleService``/``GroupService`` and
+        this class share one implementation while every service still reads
+        ``self._do_request(...)``.
         """
-        headers = self._client.default_headers()
-        if json is not None:
-            headers["Content-Type"] = "application/json"
-        auth = self._client.auth_header()
-        if auth:
-            headers["Authorization"] = auth
-
-        try:
-            resp = self._client.session.request(
-                method=method,
-                url=url,
-                json=json,
-                params=params,
-                headers=headers,
-                timeout=self._client.config.timeout_seconds,
-            )
-        except requests.RequestException as exc:
-            raise IdenplaneError(f"HTTP request failed: {exc}") from exc
-
-        _raise_for_status(resp)
-        return resp
+        return self._client._do_request(method, url, json=json, params=params)
 
     @staticmethod
     def _extract_id_from_location(location: str) -> str:

--- a/packages/idenplane-python/tests/test_client.py
+++ b/packages/idenplane-python/tests/test_client.py
@@ -133,6 +133,24 @@ class TestClient:
         finally:
             client.close()
 
+    def test_roles_property_is_lazy_and_cached(self) -> None:
+        client = Client(Config(base_url="https://a", realm="r"))
+        try:
+            first = client.roles
+            second = client.roles
+            assert first is second
+        finally:
+            client.close()
+
+    def test_groups_property_is_lazy_and_cached(self) -> None:
+        client = Client(Config(base_url="https://a", realm="r"))
+        try:
+            first = client.groups
+            second = client.groups
+            assert first is second
+        finally:
+            client.close()
+
     def test_close_is_idempotent(self) -> None:
         client = Client(Config(base_url="https://a", realm="r"))
         client.close()

--- a/packages/idenplane-python/tests/test_groups.py
+++ b/packages/idenplane-python/tests/test_groups.py
@@ -1,0 +1,331 @@
+"""Tests for :mod:`idenplane.groups`."""
+
+from __future__ import annotations
+
+import pytest
+import responses
+from responses import matchers
+
+from idenplane import Client, Config, IdenplaneError
+from idenplane.exceptions import AuthError, NotFoundError, RateLimitError, ServerError
+
+BASE = "https://auth.example.com"
+REALM = "test-realm"
+GROUPS_URL = f"{BASE}/admin/realms/{REALM}/groups"
+
+
+def _client(*, token: str | None = "admin-tok") -> Client:
+    return Client(Config(base_url=BASE, realm=REALM, admin_token=token))
+
+
+class TestCreate:
+    @responses.activate
+    def test_returns_created_group_directly(self) -> None:
+        """Unlike users, groups return the full record synchronously on 201."""
+        responses.add(
+            responses.POST,
+            GROUPS_URL,
+            json={
+                "id": "g-1",
+                "realmId": "realm-1",
+                "name": "engineering",
+                "description": "Engineering team",
+                "parentId": None,
+                "createdAt": "2026-05-22T08:30:00.000Z",
+                "updatedAt": "2026-05-22T08:30:00.000Z",
+            },
+            status=201,
+        )
+
+        with _client() as client:
+            group = client.groups.create({"name": "engineering", "description": "Engineering team"})
+
+        assert group["id"] == "g-1"
+        assert group["name"] == "engineering"
+        assert len(responses.calls) == 1  # no follow-up GET, unlike UserService.create
+
+    @responses.activate
+    def test_supports_parent_id_for_nested_groups(self) -> None:
+        responses.add(
+            responses.POST,
+            GROUPS_URL,
+            json={"id": "g-2", "name": "backend", "parentId": "g-1"},
+            status=201,
+            match=[matchers.json_params_matcher({"name": "backend", "parentId": "g-1"})],
+        )
+
+        with _client() as client:
+            group = client.groups.create({"name": "backend", "parentId": "g-1"})
+
+        assert group["parentId"] == "g-1"
+
+    @responses.activate
+    def test_path_is_sent_but_not_echoed_back(self) -> None:
+        """Documents the known backend quirk: CreateGroupDto accepts `path`,
+        but GroupsService.create never persists dto.path (no `path` column
+        on the Prisma Group model), so the server never echoes it back.
+        """
+        responses.add(
+            responses.POST,
+            GROUPS_URL,
+            json={"id": "g-1", "name": "engineering"},  # server drops `path` silently
+            status=201,
+            match=[matchers.json_params_matcher({"name": "engineering", "path": "/eng"})],
+        )
+
+        with _client() as client:
+            group = client.groups.create({"name": "engineering", "path": "/eng"})
+
+        assert "path" not in group
+
+    @responses.activate
+    def test_sets_authorization_header(self) -> None:
+        responses.add(
+            responses.POST,
+            GROUPS_URL,
+            json={"id": "g-1", "name": "engineering"},
+            status=201,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.groups.create({"name": "engineering"})
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_omits_authorization_when_no_token(self) -> None:
+        responses.add(
+            responses.POST,
+            GROUPS_URL,
+            json={"id": "g-1", "name": "engineering"},
+            status=201,
+        )
+
+        with _client(token=None) as client:
+            client.groups.create({"name": "engineering"})
+
+        sent_headers = responses.calls[0].request.headers
+        assert "Authorization" not in sent_headers
+
+    def test_missing_name_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="name"):
+            client.groups.create({})  # type: ignore[typeddict-item]
+
+    @responses.activate
+    def test_empty_body_raises(self) -> None:
+        responses.add(responses.POST, GROUPS_URL, status=201, body="")
+        with _client() as client, pytest.raises(IdenplaneError, match="empty or invalid JSON"):
+            client.groups.create({"name": "engineering"})
+
+    @responses.activate
+    def test_500_raises_server_error(self) -> None:
+        responses.add(responses.POST, GROUPS_URL, status=500, body="boom")
+        with _client() as client, pytest.raises(ServerError):
+            client.groups.create({"name": "engineering"})
+
+
+class TestGet:
+    @responses.activate
+    def test_happy_path(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{GROUPS_URL}/g-1",
+            json={
+                "id": "g-1",
+                "realmId": "realm-1",
+                "name": "engineering",
+                "description": "Engineering team",
+                "parentId": None,
+                "createdAt": "2026-05-22T08:30:00.000Z",
+                "updatedAt": "2026-05-22T08:30:00.000Z",
+            },
+            status=200,
+        )
+
+        with _client() as client:
+            group = client.groups.get("g-1")
+
+        assert group["id"] == "g-1"
+        assert group["name"] == "engineering"
+        assert group["createdAt"] == "2026-05-22T08:30:00.000Z"
+
+    @responses.activate
+    def test_404_raises_not_found(self) -> None:
+        responses.add(responses.GET, f"{GROUPS_URL}/missing", status=404, body="nope")
+        with _client() as client, pytest.raises(NotFoundError) as exc_info:
+            client.groups.get("missing")
+        assert exc_info.value.status_code == 404
+
+    @responses.activate
+    def test_401_raises_auth_error(self) -> None:
+        responses.add(responses.GET, f"{GROUPS_URL}/g-1", status=401)
+        with _client() as client, pytest.raises(AuthError):
+            client.groups.get("g-1")
+
+    @responses.activate
+    def test_url_encodes_group_id(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{GROUPS_URL}/foo%2Fbar",
+            json={"id": "foo/bar", "name": "x"},
+            status=200,
+        )
+        with _client() as client:
+            group = client.groups.get("foo/bar")
+        assert group["id"] == "foo/bar"
+
+    def test_empty_group_id_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="group_id"):
+            client.groups.get("")
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{GROUPS_URL}/g-1",
+            json={"id": "g-1", "name": "engineering"},
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.groups.get("g-1")
+        assert len(responses.calls) == 1
+
+
+class TestList:
+    @responses.activate
+    def test_returns_plain_list(self) -> None:
+        """Groups don't paginate: list() returns a plain list, not a wrapper."""
+        responses.add(
+            responses.GET,
+            GROUPS_URL,
+            json=[
+                {"id": "g-1", "name": "engineering"},
+                {"id": "g-2", "name": "backend", "parentId": "g-1"},
+            ],
+            status=200,
+        )
+
+        with _client() as client:
+            groups = client.groups.list()
+
+        assert isinstance(groups, list)
+        assert len(groups) == 2
+        assert groups[0]["id"] == "g-1"
+        assert groups[1]["parentId"] == "g-1"
+
+    @responses.activate
+    def test_empty_list(self) -> None:
+        responses.add(responses.GET, GROUPS_URL, json=[], status=200)
+        with _client() as client:
+            groups = client.groups.list()
+        assert groups == []
+
+    @responses.activate
+    def test_non_array_response_raises(self) -> None:
+        responses.add(responses.GET, GROUPS_URL, json={"oops": True}, status=200)
+        with _client() as client, pytest.raises(IdenplaneError, match="JSON array"):
+            client.groups.list()
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.GET,
+            GROUPS_URL,
+            json=[],
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.groups.list()
+        assert len(responses.calls) == 1
+
+
+class TestUpdate:
+    @responses.activate
+    def test_returns_updated_group_directly(self) -> None:
+        """Unlike users, groups return the updated record synchronously on PUT."""
+        responses.add(
+            responses.PUT,
+            f"{GROUPS_URL}/g-1",
+            json={"id": "g-1", "name": "engineering", "description": "Updated"},
+            status=200,
+        )
+
+        with _client() as client:
+            group = client.groups.update("g-1", {"description": "Updated"})
+
+        assert group["description"] == "Updated"
+        assert len(responses.calls) == 1  # no follow-up GET, unlike UserService.update
+
+    @responses.activate
+    def test_supports_reparenting(self) -> None:
+        responses.add(
+            responses.PUT,
+            f"{GROUPS_URL}/g-2",
+            json={"id": "g-2", "name": "backend", "parentId": "g-3"},
+            status=200,
+            match=[matchers.json_params_matcher({"parentId": "g-3"})],
+        )
+
+        with _client() as client:
+            group = client.groups.update("g-2", {"parentId": "g-3"})
+
+        assert group["parentId"] == "g-3"
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.PUT,
+            f"{GROUPS_URL}/g-1",
+            json={"id": "g-1", "name": "engineering"},
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.groups.update("g-1", {"description": "x"})
+
+    @responses.activate
+    def test_404_raises_not_found(self) -> None:
+        responses.add(responses.PUT, f"{GROUPS_URL}/missing", status=404)
+        with _client() as client, pytest.raises(NotFoundError):
+            client.groups.update("missing", {"description": "x"})
+
+    def test_empty_group_id_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="group_id"):
+            client.groups.update("", {"description": "x"})
+
+
+class TestDelete:
+    @responses.activate
+    def test_happy_path(self) -> None:
+        responses.add(responses.DELETE, f"{GROUPS_URL}/g-1", status=204)
+        with _client() as client:
+            client.groups.delete("g-1")
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_404_raises(self) -> None:
+        responses.add(responses.DELETE, f"{GROUPS_URL}/missing", status=404)
+        with _client() as client, pytest.raises(NotFoundError):
+            client.groups.delete("missing")
+
+    @responses.activate
+    def test_429_raises_rate_limit(self) -> None:
+        responses.add(responses.DELETE, f"{GROUPS_URL}/g-1", status=429, body="slow down")
+        with _client() as client, pytest.raises(RateLimitError):
+            client.groups.delete("g-1")
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.DELETE,
+            f"{GROUPS_URL}/g-1",
+            status=204,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.groups.delete("g-1")
+
+    def test_empty_group_id_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="group_id"):
+            client.groups.delete("")

--- a/packages/idenplane-python/tests/test_roles.py
+++ b/packages/idenplane-python/tests/test_roles.py
@@ -1,0 +1,282 @@
+"""Tests for :mod:`idenplane.roles`."""
+
+from __future__ import annotations
+
+import pytest
+import responses
+from responses import matchers
+
+from idenplane import Client, Config, IdenplaneError
+from idenplane.exceptions import AuthError, NotFoundError, RateLimitError, ServerError
+
+BASE = "https://auth.example.com"
+REALM = "test-realm"
+ROLES_URL = f"{BASE}/admin/realms/{REALM}/roles"
+
+
+def _client(*, token: str | None = "admin-tok") -> Client:
+    return Client(Config(base_url=BASE, realm=REALM, admin_token=token))
+
+
+class TestCreate:
+    @responses.activate
+    def test_returns_created_role_directly(self) -> None:
+        """Unlike users, roles return the full record synchronously on 201."""
+        responses.add(
+            responses.POST,
+            ROLES_URL,
+            json={
+                "id": "r-1",
+                "realmId": "realm-1",
+                "name": "admin",
+                "description": "Administrator role",
+                "createdAt": "2026-05-22T08:30:00.000Z",
+                "updatedAt": "2026-05-22T08:30:00.000Z",
+            },
+            status=201,
+        )
+
+        with _client() as client:
+            role = client.roles.create({"name": "admin", "description": "Administrator role"})
+
+        assert role["id"] == "r-1"
+        assert role["name"] == "admin"
+        assert role["description"] == "Administrator role"
+        assert len(responses.calls) == 1  # no follow-up GET, unlike UserService.create
+
+    @responses.activate
+    def test_sets_authorization_header(self) -> None:
+        responses.add(
+            responses.POST,
+            ROLES_URL,
+            json={"id": "r-1", "name": "admin"},
+            status=201,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+
+        with _client() as client:
+            client.roles.create({"name": "admin"})
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_omits_authorization_when_no_token(self) -> None:
+        responses.add(
+            responses.POST,
+            ROLES_URL,
+            json={"id": "r-1", "name": "admin"},
+            status=201,
+        )
+
+        with _client(token=None) as client:
+            client.roles.create({"name": "admin"})
+
+        sent_headers = responses.calls[0].request.headers
+        assert "Authorization" not in sent_headers
+
+    def test_missing_name_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="name"):
+            client.roles.create({})  # type: ignore[typeddict-item]
+
+    @responses.activate
+    def test_empty_body_raises(self) -> None:
+        responses.add(responses.POST, ROLES_URL, status=201, body="")
+        with _client() as client, pytest.raises(IdenplaneError, match="empty or invalid JSON"):
+            client.roles.create({"name": "admin"})
+
+    @responses.activate
+    def test_500_raises_server_error(self) -> None:
+        responses.add(responses.POST, ROLES_URL, status=500, body="boom")
+        with _client() as client, pytest.raises(ServerError):
+            client.roles.create({"name": "admin"})
+
+
+class TestGet:
+    @responses.activate
+    def test_happy_path(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{ROLES_URL}/admin",
+            json={
+                "id": "r-1",
+                "realmId": "realm-1",
+                "name": "admin",
+                "description": "Administrator role",
+                "createdAt": "2026-05-22T08:30:00.000Z",
+                "updatedAt": "2026-05-22T08:30:00.000Z",
+            },
+            status=200,
+        )
+
+        with _client() as client:
+            role = client.roles.get("admin")
+
+        assert role["id"] == "r-1"
+        assert role["name"] == "admin"
+        assert role["createdAt"] == "2026-05-22T08:30:00.000Z"
+
+    @responses.activate
+    def test_404_raises_not_found(self) -> None:
+        responses.add(responses.GET, f"{ROLES_URL}/missing", status=404, body="nope")
+        with _client() as client, pytest.raises(NotFoundError) as exc_info:
+            client.roles.get("missing")
+        assert exc_info.value.status_code == 404
+
+    @responses.activate
+    def test_401_raises_auth_error(self) -> None:
+        responses.add(responses.GET, f"{ROLES_URL}/admin", status=401)
+        with _client() as client, pytest.raises(AuthError):
+            client.roles.get("admin")
+
+    @responses.activate
+    def test_url_encodes_name(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{ROLES_URL}/foo%2Fbar",
+            json={"id": "r-1", "name": "foo/bar"},
+            status=200,
+        )
+        with _client() as client:
+            role = client.roles.get("foo/bar")
+        assert role["name"] == "foo/bar"
+
+    def test_empty_name_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="name"):
+            client.roles.get("")
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{ROLES_URL}/admin",
+            json={"id": "r-1", "name": "admin"},
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.roles.get("admin")
+        assert len(responses.calls) == 1
+
+
+class TestList:
+    @responses.activate
+    def test_returns_plain_list(self) -> None:
+        """Roles don't paginate: list() returns a plain list, not a wrapper."""
+        responses.add(
+            responses.GET,
+            ROLES_URL,
+            json=[
+                {"id": "r-1", "name": "admin"},
+                {"id": "r-2", "name": "viewer"},
+            ],
+            status=200,
+        )
+
+        with _client() as client:
+            roles = client.roles.list()
+
+        assert isinstance(roles, list)
+        assert len(roles) == 2
+        assert roles[0]["id"] == "r-1"
+        assert roles[1]["name"] == "viewer"
+
+    @responses.activate
+    def test_empty_list(self) -> None:
+        responses.add(responses.GET, ROLES_URL, json=[], status=200)
+        with _client() as client:
+            roles = client.roles.list()
+        assert roles == []
+
+    @responses.activate
+    def test_non_array_response_raises(self) -> None:
+        responses.add(responses.GET, ROLES_URL, json={"oops": True}, status=200)
+        with _client() as client, pytest.raises(IdenplaneError, match="JSON array"):
+            client.roles.list()
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.GET,
+            ROLES_URL,
+            json=[],
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.roles.list()
+        assert len(responses.calls) == 1
+
+
+class TestUpdate:
+    @responses.activate
+    def test_returns_updated_role_directly(self) -> None:
+        """Unlike users, roles return the updated record synchronously on PUT."""
+        responses.add(
+            responses.PUT,
+            f"{ROLES_URL}/admin",
+            json={"id": "r-1", "name": "admin", "description": "Updated"},
+            status=200,
+        )
+
+        with _client() as client:
+            role = client.roles.update("admin", {"description": "Updated"})
+
+        assert role["description"] == "Updated"
+        assert len(responses.calls) == 1  # no follow-up GET, unlike UserService.update
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.PUT,
+            f"{ROLES_URL}/admin",
+            json={"id": "r-1", "name": "admin"},
+            status=200,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.roles.update("admin", {"description": "x"})
+
+    @responses.activate
+    def test_404_raises_not_found(self) -> None:
+        responses.add(responses.PUT, f"{ROLES_URL}/missing", status=404)
+        with _client() as client, pytest.raises(NotFoundError):
+            client.roles.update("missing", {"description": "x"})
+
+    def test_empty_name_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="name"):
+            client.roles.update("", {"description": "x"})
+
+
+class TestDelete:
+    @responses.activate
+    def test_happy_path(self) -> None:
+        responses.add(responses.DELETE, f"{ROLES_URL}/admin", status=204)
+        with _client() as client:
+            client.roles.delete("admin")
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_404_raises(self) -> None:
+        responses.add(responses.DELETE, f"{ROLES_URL}/missing", status=404)
+        with _client() as client, pytest.raises(NotFoundError):
+            client.roles.delete("missing")
+
+    @responses.activate
+    def test_429_raises_rate_limit(self) -> None:
+        responses.add(responses.DELETE, f"{ROLES_URL}/admin", status=429, body="slow down")
+        with _client() as client, pytest.raises(RateLimitError):
+            client.roles.delete("admin")
+
+    @responses.activate
+    def test_sends_authorization_header(self) -> None:
+        responses.add(
+            responses.DELETE,
+            f"{ROLES_URL}/admin",
+            status=204,
+            match=[matchers.header_matcher({"Authorization": "Bearer admin-tok"})],
+        )
+        with _client() as client:
+            client.roles.delete("admin")
+
+    def test_empty_name_raises(self) -> None:
+        with _client() as client, pytest.raises(ValueError, match="name"):
+            client.roles.delete("")


### PR DESCRIPTION
## Summary
- Add `RoleService` (`roles.py`): realm roles, addressed by **name** (matching `roles.controller.ts`), with `create`/`get`/`list`/`update`/`delete`.
- Add `GroupService` (`groups.py`): realm groups, addressed by **ID**, with `parentId` nesting support, same CRUD surface.
- Wire `roles`/`groups` into `Client` as lazy `@property` accessors, mirroring the existing `users`/`discovery` pattern.
- Move the shared HTTP-request plumbing (auth header, JSON encode, error mapping) from `UserService._do_request` into `Client._do_request`, reused by all three services instead of being duplicated a third time. `UserService._do_request` now delegates — no behavior change, `test_users.py` untouched and green.
- `test_roles.py` (responses-mock, create/get/list/update/delete + validation + 404/401/429/500 mapping + auth header) / `test_groups.py` (same, plus parenting and the `path` quirk below).

## Notable detail
`CreateGroupDto`/`UpdateGroupDto` accept a `path` field on the backend, but the Prisma `Group` model has no `path` column and `groups.service.ts` silently drops it (pre-existing backend inconsistency, same one documented in the Go SDK's equivalent PR #1293). Kept `path` on the request/response TypedDicts since the API does accept it as input, documented the caveat in docstrings, and added a test asserting the SDK sends `path` but the returned record omits it.

## Verification
- `pytest` → 126 passed, `mypy idenplane` → clean, `ruff check idenplane tests` → clean, from a fresh venv in `packages/idenplane-python/`.

Closes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)