### PR TITLE
feat(idenplane-mcp): add Group management tools

### DIFF
--- a/packages/idenplane-mcp/src/client.ts
+++ b/packages/idenplane-mcp/src/client.ts
@@ -39,6 +39,10 @@ export class IdenplaneClient {
     return this.request<T>('POST', buildUrlWithQuery(this.baseUrl, path), body);
   }
 
+  async put<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('PUT', buildUrlWithQuery(this.baseUrl, path), body);
+  }
+
   async delete<T>(path: string, body?: unknown): Promise<T | undefined> {
     return this.request<T>('DELETE', buildUrlWithQuery(this.baseUrl, path), body);
   }

--- a/packages/idenplane-mcp/src/index.ts
+++ b/packages/idenplane-mcp/src/index.ts
@@ -5,6 +5,7 @@ import { registerRealmTools } from './tools/realms.js';
 import { registerClientTools } from './tools/clients.js';
 import { registerUserTools } from './tools/users.js';
 import { registerRoleTools } from './tools/roles.js';
+import { registerGroupTools } from './tools/groups.js';
 import { registerSessionTools } from './tools/sessions.js';
 import { registerAuditTools } from './tools/audit.js';
 
@@ -21,6 +22,7 @@ async function main(): Promise<void> {
   registerClientTools(server, apiClient);
   registerUserTools(server, apiClient);
   registerRoleTools(server, apiClient);
+  registerGroupTools(server, apiClient);
   registerSessionTools(server, apiClient);
   registerAuditTools(server, apiClient);
 

--- a/packages/idenplane-mcp/src/tools/groups.ts
+++ b/packages/idenplane-mcp/src/tools/groups.ts
@@ -1,0 +1,154 @@
+import { z } from 'zod';
+import type { IdenplaneClient } from '../client.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { pathSegment } from '../schemas.js';
+
+const GroupSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().optional(),
+  parentId: z.string().optional(),
+});
+
+export type Group = z.infer<typeof GroupSchema>;
+
+export function registerGroupTools(server: McpServer, client: IdenplaneClient): void {
+  server.registerTool(
+    'list_groups',
+    {
+      description: 'List all groups defined in a realm.',
+      inputSchema: {
+        realmName: pathSegment('Realm to list groups from'),
+      },
+    },
+    async ({ realmName }) => {
+      const groups = await client.get<Group[]>(`/admin/realms/${realmName}/groups`);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(groups, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'get_group',
+    {
+      description: 'Get full details for a specific group by its ID.',
+      inputSchema: {
+        realmName: pathSegment('Realm the group belongs to'),
+        groupId: pathSegment('Group ID (UUID)'),
+      },
+    },
+    async ({ realmName, groupId }) => {
+      const group = await client.get<Group>(`/admin/realms/${realmName}/groups/${groupId}`);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(group, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'create_group',
+    {
+      description:
+        '[WRITE] Create a new group in a realm. Name is required. Pass parentId to nest the group under an existing group.',
+      inputSchema: {
+        realmName: pathSegment('Realm to create the group in'),
+        name: z.string().describe('Unique group name within the realm'),
+        description: z.string().optional().describe('Group description'),
+        parentId: z.string().optional().describe('Parent group ID (UUID) to nest this group under'),
+      },
+    },
+    async ({ realmName, name, description, parentId }) => {
+      const body: Record<string, unknown> = { name };
+      if (description !== undefined) body['description'] = description;
+      if (parentId !== undefined) body['parentId'] = parentId;
+      const group = await client.post<Group>(`/admin/realms/${realmName}/groups`, body);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(group, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'update_group',
+    {
+      description:
+        '[WRITE] Update a group. Only the provided fields are changed; omitted fields are left as-is.',
+      inputSchema: {
+        realmName: pathSegment('Realm the group belongs to'),
+        groupId: pathSegment('Group ID (UUID)'),
+        name: z.string().optional().describe('New group name'),
+        description: z.string().optional().describe('New group description'),
+        parentId: z.string().optional().describe('New parent group ID (UUID)'),
+      },
+    },
+    async ({ realmName, groupId, name, description, parentId }) => {
+      const body: Record<string, unknown> = {};
+      if (name !== undefined) body['name'] = name;
+      if (description !== undefined) body['description'] = description;
+      if (parentId !== undefined) body['parentId'] = parentId;
+      const group = await client.put<Group>(
+        `/admin/realms/${realmName}/groups/${groupId}`,
+        body,
+      );
+      return {
+        content: [{ type: 'text', text: JSON.stringify(group, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'delete_group',
+    {
+      description: '[WRITE] Delete a group from a realm. This cannot be undone.',
+      inputSchema: {
+        realmName: pathSegment('Realm the group belongs to'),
+        groupId: pathSegment('Group ID (UUID) to delete'),
+      },
+    },
+    async ({ realmName, groupId }) => {
+      await client.delete(`/admin/realms/${realmName}/groups/${groupId}`);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ deleted: true, groupId }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'add_group_member',
+    {
+      description: '[WRITE] Add a user to a group.',
+      inputSchema: {
+        realmName: pathSegment('Realm the user and group belong to'),
+        userId: pathSegment('User ID (UUID) to add'),
+        groupId: pathSegment('Group ID (UUID) to add the user to'),
+      },
+    },
+    async ({ realmName, userId, groupId }) => {
+      await client.post(`/admin/realms/${realmName}/users/${userId}/groups/${groupId}`);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ added: true, userId, groupId }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'remove_group_member',
+    {
+      description: '[WRITE] Remove a user from a group.',
+      inputSchema: {
+        realmName: pathSegment('Realm the user and group belong to'),
+        userId: pathSegment('User ID (UUID) to remove'),
+        groupId: pathSegment('Group ID (UUID) to remove the user from'),
+      },
+    },
+    async ({ realmName, userId, groupId }) => {
+      await client.delete(`/admin/realms/${realmName}/users/${userId}/groups/${groupId}`);
+      return {
+        content: [
+          { type: 'text', text: JSON.stringify({ removed: true, userId, groupId }, null, 2) },
+        ],
+      };
+    },
+  );
+}

--- a/packages/idenplane-mcp/tests/smoke.mjs
+++ b/packages/idenplane-mcp/tests/smoke.mjs
@@ -1,5 +1,5 @@
 /**
- * Smoke test: spawns the MCP server and verifies all 14 tools are listed.
+ * Smoke test: spawns the MCP server and verifies all 21 tools are listed.
  * Does NOT require a running Idenplane instance — uses dummy env vars.
  * tools/list does not invoke handlers, so no network calls are made.
  *
@@ -28,13 +28,20 @@ const EXPECTED_TOOLS = [
   'set_user_roles',
   'list_roles',
   'assign_role',
+  'list_groups',
+  'get_group',
+  'create_group',
+  'update_group',
+  'delete_group',
+  'add_group_member',
+  'remove_group_member',
   'list_active_sessions',
   'revoke_session',
   'query_audit_events',
 ];
 
 describe('MCP server smoke test', () => {
-  it('lists all 14 expected tools without a live Idenplane instance', async () => {
+  it('lists all 21 expected tools without a live Idenplane instance', async () => {
     const transport = new StdioClientTransport({
       command: 'node',
       args: [serverPath],


### PR DESCRIPTION
## Summary
- Add `tools/groups.ts`: `list_groups`, `get_group`, `create_group` [WRITE], `update_group` [WRITE], `delete_group` [WRITE], `add_group_member` [WRITE], `remove_group_member` [WRITE] — following the `registerRoleTools`/`registerUserTools` pattern (Zod schemas, `pathSegment` validation for every path-interpolated ID).
- Register `registerGroupTools(server, apiClient)` in `index.ts`.
- Add `IdenplaneClient.put()` — the backend's group-update endpoint (`PUT /admin/realms/{realm}/groups/{groupId}`) is PUT-only, and no existing MCP tool previously needed anything beyond `get`/`post`/`delete`, so the client had no `put` method at all.
- Update the smoke test's expected tool list from 14 → 21 tools.

## Verification
- `npm run build`, `npm run typecheck`, `npm run test:all` all pass in `packages/idenplane-mcp/` (17/17 tests, including the updated smoke test confirming all 21 tools register).

Closes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)