### PR TITLE
docs(cli,mcp): add JSDoc to exported classes and functions

### DIFF
--- a/packages/idenplane-cli/src/commands/auth.ts
+++ b/packages/idenplane-cli/src/commands/auth.ts
@@ -6,6 +6,12 @@ import { printResult, success } from '../output.js';
 import { HttpClient } from '../http.js';
 import type { LoginResponse } from '../types.js';
 
+/**
+ * Registers the top-level `idenplane login|logout|whoami` commands for
+ * authenticating the CLI against an Idenplane server (username/password or
+ * a static `--api-key`), clearing saved credentials, and inspecting the
+ * currently authenticated identity.
+ */
 export function registerAuthCommands(program: Command): void {
   program
     .command('login')

--- a/packages/idenplane-cli/src/commands/client.ts
+++ b/packages/idenplane-cli/src/commands/client.ts
@@ -3,6 +3,10 @@ import { HttpClient } from '../http.js';
 import { printResult, success } from '../output.js';
 import { confirm } from '../prompt.js';
 
+/**
+ * Registers `idenplane client list|create|get|update|delete|rotate-secret`
+ * subcommands for managing OAuth2/OIDC clients within a realm.
+ */
 export function registerClientCommands(program: Command): void {
   const client = program.command('client').description('Manage clients');
 

--- a/packages/idenplane-cli/src/commands/completion.ts
+++ b/packages/idenplane-cli/src/commands/completion.ts
@@ -156,6 +156,11 @@ const INSTALL_HINTS: Record<string, string> = {
   fish: `# Save to your fish completions directory:\n# idenplane completion fish > ~/.config/fish/completions/idenplane.fish`,
 };
 
+/**
+ * Registers `idenplane completion <shell>`, which prints a shell completion
+ * script for `bash`, `zsh`, or `fish` to stdout (plus an install hint when
+ * run in a TTY).
+ */
 export function registerCompletionCommand(program: Command): void {
   program
     .command('completion <shell>')

--- a/packages/idenplane-cli/src/commands/config.ts
+++ b/packages/idenplane-cli/src/commands/config.ts
@@ -4,6 +4,11 @@ import { loadConfig } from '../config.js';
 import { HttpClient } from '../http.js';
 import { printResult, success } from '../output.js';
 
+/**
+ * Registers `idenplane config show|validate` subcommands for inspecting the
+ * saved CLI configuration (credentials masked) and checking that the
+ * configured server is reachable with valid credentials.
+ */
 export function registerConfigCommands(program: Command): void {
   const cfg = program.command('config').description('Manage CLI configuration');
 

--- a/packages/idenplane-cli/src/commands/group.ts
+++ b/packages/idenplane-cli/src/commands/group.ts
@@ -3,6 +3,10 @@ import { HttpClient } from '../http.js';
 import { printResult, success } from '../output.js';
 import { confirm } from '../prompt.js';
 
+/**
+ * Registers `idenplane group list|create|get|update|delete` subcommands for
+ * managing groups (including nested groups via `--parent`) within a realm.
+ */
 export function registerGroupCommands(program: Command): void {
   const group = program.command('group').description('Manage groups');
 

--- a/packages/idenplane-cli/src/commands/init.ts
+++ b/packages/idenplane-cli/src/commands/init.ts
@@ -6,6 +6,11 @@ import { ask, askPassword, confirm, select } from '../prompt.js';
 import { printResult, success } from '../output.js';
 import type { LoginResponse } from '../types.js';
 
+/**
+ * Registers `idenplane init`, an interactive setup wizard that walks through
+ * connecting to a server (username/password or API key), then optionally
+ * creating a realm, a client, and default `admin`/`user` roles.
+ */
 export function registerInitCommand(program: Command): void {
   program
     .command('init')

--- a/packages/idenplane-cli/src/commands/migrate.ts
+++ b/packages/idenplane-cli/src/commands/migrate.ts
@@ -42,6 +42,11 @@ function printReport(report: MigrationReport): void {
   console.log(chalk.bold(`\nTotal: ${chalk.green(totalCreated + ' created')}, ${chalk.red(totalFailed + ' failed')}`));
 }
 
+/**
+ * Registers `idenplane migrate keycloak|auth0` subcommands for importing
+ * users and configuration from a Keycloak realm export or an Auth0
+ * Management API export, printing a formatted (or `--json`) migration report.
+ */
 export function registerMigrateCommand(program: Command): void {
   const migrate = program.command('migrate').description('Migrate from other IAM providers');
 

--- a/packages/idenplane-cli/src/commands/realm.ts
+++ b/packages/idenplane-cli/src/commands/realm.ts
@@ -4,6 +4,11 @@ import { HttpClient } from '../http.js';
 import { printResult, success } from '../output.js';
 import { confirm } from '../prompt.js';
 
+/**
+ * Registers `idenplane realm list|create|get|update|delete|export|import`
+ * subcommands for managing realms, including exporting a realm to (or
+ * importing one from) a JSON file.
+ */
 export function registerRealmCommands(program: Command): void {
   const realm = program.command('realm').description('Manage realms');
 

--- a/packages/idenplane-cli/src/commands/role.ts
+++ b/packages/idenplane-cli/src/commands/role.ts
@@ -3,6 +3,12 @@ import { HttpClient } from '../http.js';
 import { printResult, success } from '../output.js';
 import { confirm } from '../prompt.js';
 
+/**
+ * Registers `idenplane role list|create|get|update|delete|assign|unassign`
+ * subcommands for realm-role management, including assigning/removing a
+ * role on a user. `remove` is also registered as a back-compat alias for
+ * `unassign`.
+ */
 export function registerRoleCommands(program: Command): void {
   const role = program.command('role').description('Manage roles');
 

--- a/packages/idenplane-cli/src/commands/upgrade-status.ts
+++ b/packages/idenplane-cli/src/commands/upgrade-status.ts
@@ -18,6 +18,11 @@ interface UpgradeAuditResponse {
   total: number;
 }
 
+/**
+ * Registers `idenplane upgrade:status`, which checks server connectivity and
+ * then prints the upgrade audit history (or `--json`) as a table of past
+ * upgrade/rollback attempts, honoring `--limit` (default 20, capped to 100).
+ */
 export function registerUpgradeStatusCommand(program: Command): void {
   program
     .command('upgrade:status')

--- a/packages/idenplane-cli/src/commands/upgrade.ts
+++ b/packages/idenplane-cli/src/commands/upgrade.ts
@@ -75,6 +75,16 @@ interface HealthCheckResult {
   };
 }
 
+/**
+ * Registers `idenplane upgrade`, which runs pre-flight checks (server
+ * connectivity, backup status, pending migrations, pre-upgrade validation,
+ * config compatibility) and then applies pending database migrations via
+ * `prisma migrate deploy`, followed by a post-upgrade health check. Supports
+ * `--dry-run` (preview only), `--yes` (skip confirmations), `--json`, and
+ * `--rollback` (roll back the last applied migration via
+ * `prisma migrate resolve --rolled-back`). On a failed migration, attempts
+ * an automatic restore from the last known backup.
+ */
 export function registerUpgradeCommand(program: Command): void {
   program
     .command('upgrade')

--- a/packages/idenplane-cli/src/commands/user.ts
+++ b/packages/idenplane-cli/src/commands/user.ts
@@ -7,6 +7,11 @@ import { confirm, askPassword } from '../prompt.js';
 import type { UserListResponse, BulkUserInput, BulkImportResult } from '../types.js';
 import { parseCsv } from '../csv.js';
 
+/**
+ * Registers `idenplane user list|create|get|update|delete|set-password|bulk-import`
+ * subcommands for managing users within a realm, including CSV/JSON
+ * bulk-import with per-row validation and a `--dry-run` preview mode.
+ */
 export function registerUserCommands(program: Command): void {
   const user = program.command('user').description('Manage users');
 

--- a/packages/idenplane-cli/src/config.ts
+++ b/packages/idenplane-cli/src/config.ts
@@ -88,6 +88,18 @@ function decryptSecrets(envelope: EncryptedEnvelope): Secrets {
   return JSON.parse(plaintext.toString('utf-8')) as Secrets;
 }
 
+/**
+ * Load the CLI config from `~/.idenplane/config.json`, falling back to the
+ * legacy `~/.authme/config.json` path if the new one doesn't exist.
+ *
+ * This has a write side effect: if the loaded file is the legacy path, or is
+ * a pre-existing plaintext (unencrypted) config, the config is immediately
+ * re-saved to the current on-disk format (`saveConfig`) and a notice is
+ * printed via `console.warn`.
+ *
+ * @returns The config, or `null` if no config file exists at either path.
+ * @throws {Error} If the config file exists but contains invalid JSON.
+ */
 export function loadConfig(): CliConfig | null {
   const file = existsSync(CONFIG_FILE)
     ? CONFIG_FILE
@@ -128,6 +140,12 @@ export function loadConfig(): CliConfig | null {
   return config;
 }
 
+/**
+ * Persist the CLI config to `~/.idenplane/config.json`, encrypting
+ * `accessToken`/`apiKey` at rest (AES-256-GCM) so they aren't sitting in
+ * plaintext JSON on disk. `serverUrl` and `defaultRealm` are stored in the
+ * clear.
+ */
 export function saveConfig(config: CliConfig): void {
   if (!existsSync(CONFIG_DIR)) {
     mkdirSync(CONFIG_DIR, { recursive: true });
@@ -141,6 +159,7 @@ export function saveConfig(config: CliConfig): void {
   writeFileSync(CONFIG_FILE, JSON.stringify(envelope, null, 2), { mode: 0o600 });
 }
 
+/** Remove the saved config file and its encryption key file, if present (used by `idenplane logout`). */
 export function clearConfig(): void {
   if (existsSync(CONFIG_FILE)) {
     unlinkSync(CONFIG_FILE);
@@ -168,6 +187,17 @@ function readEnv(...names: string[]): string | undefined {
   return undefined;
 }
 
+/**
+ * Resolve the server URL and auth header to use for API requests.
+ *
+ * Checks env vars first (`IDENPLANE_SERVER_URL`/`AUTHME_SERVER_URL` paired
+ * with either `ADMIN_API_KEY` or `IDENPLANE_TOKEN`/`AUTHME_TOKEN`) — a server
+ * URL alone is not enough, it must be paired with a credential or this falls
+ * through to the saved config. Falls back to `loadConfig()` if no complete
+ * env var pair is set.
+ *
+ * @throws {Error} If neither a complete env var pair nor a saved config is available.
+ */
 export function requireAuth(): { serverUrl: string; headers: Record<string, string> } {
   const envUrl = readEnv('IDENPLANE_SERVER_URL', 'AUTHME_SERVER_URL');
   const envApiKey = process.env['ADMIN_API_KEY'];

--- a/packages/idenplane-cli/src/csv.ts
+++ b/packages/idenplane-cli/src/csv.ts
@@ -1,6 +1,10 @@
 /**
  * Minimal CSV parser that handles quoted fields.
  * Returns an array of objects keyed by the header row.
+ *
+ * @param raw - Raw CSV text, with the first line treated as the header row.
+ * @returns One object per data row, with all values trimmed. Returns `[]`
+ * if there are fewer than two non-blank lines (no header, or header only).
  */
 export function parseCsv(raw: string): Record<string, string>[] {
   const lines = raw.split(/\r?\n/).filter((l) => l.trim() !== '');

--- a/packages/idenplane-cli/src/http.ts
+++ b/packages/idenplane-cli/src/http.ts
@@ -3,10 +3,27 @@ import { buildUrlWithQuery, extractErrorMessage, rawRequest } from '@idenplane/h
 import { requireAuth } from './config.js';
 import type { CliConfig } from './types.js';
 
+/**
+ * Thin JSON HTTP client for talking to the Idenplane admin API.
+ *
+ * Every method resolves with the parsed JSON response body, except that a
+ * `204 No Content` response resolves with `undefined` regardless of the
+ * requested type `T`. A non-2xx response rejects with an `Error` whose
+ * message is the chalk-red-colored string `Error <status>: <server message>`
+ * (server message extracted via `extractErrorMessage`).
+ */
 export class HttpClient {
   private serverUrl: string;
   private headers: Record<string, string>;
 
+  /**
+   * If `config` is omitted, credentials and server URL are resolved via
+   * `requireAuth()` (env vars, falling back to the saved CLI config).
+   *
+   * @throws {Error} If `config` is omitted and no credentials are available
+   * from either environment variables or the saved config file (the error
+   * message from `requireAuth()` tells the user to run `idenplane login`).
+   */
   constructor(config?: { serverUrl: string; headers?: Record<string, string> }) {
     const { serverUrl, headers } = config ?? requireAuth();
     this.serverUrl = serverUrl.replace(/\/$/, '');
@@ -16,18 +33,25 @@ export class HttpClient {
     };
   }
 
+  /** Send a `GET` request, optionally appending `query` as URL search params. */
   async get<T>(path: string, query?: Record<string, string>): Promise<T> {
     return this.request<T>('GET', buildUrlWithQuery(this.serverUrl, path, query));
   }
 
+  /** Send a `POST` request with a JSON `body`, optionally appending `query` as URL search params. */
   async post<T>(path: string, body?: unknown, query?: Record<string, string>): Promise<T> {
     return this.request<T>('POST', buildUrlWithQuery(this.serverUrl, path, query), body);
   }
 
+  /** Send a `PUT` request with a JSON `body`. */
   async put<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>('PUT', buildUrlWithQuery(this.serverUrl, path), body);
   }
 
+  /**
+   * Send a `DELETE` request, optionally with a JSON `body`.
+   * Resolves with `undefined` on the typical `204 No Content` response.
+   */
   async delete<T>(path: string, body?: unknown): Promise<T | void> {
     return this.request<T>('DELETE', buildUrlWithQuery(this.serverUrl, path), body);
   }
@@ -47,6 +71,12 @@ export class HttpClient {
   }
 }
 
+/**
+ * Build an `HttpClient` from an already-loaded `CliConfig` instead of
+ * resolving credentials via `requireAuth()`. Prefers `apiKey` over
+ * `accessToken` when both are present; if neither is set, the returned
+ * client sends no auth header.
+ */
 export function createHttpClient(config: CliConfig): HttpClient {
   const headers: Record<string, string> = {};
   if (config.apiKey) {
@@ -57,6 +87,13 @@ export function createHttpClient(config: CliConfig): HttpClient {
   return new HttpClient({ serverUrl: config.serverUrl, headers });
 }
 
+/**
+ * Normalize a caught error into a chalk-red-colored `Error` and rethrow it.
+ * Intended for wrapping command actions that call the HTTP client so
+ * failures are reported consistently, e.g. `try { ... } catch (e) { handleApiError(e); }`.
+ *
+ * @throws {Error} Always — this function never returns.
+ */
 export function handleApiError(error: unknown): never {
   const message =
     error instanceof Error ? error.message : 'An unexpected error occurred';

--- a/packages/idenplane-cli/src/output.ts
+++ b/packages/idenplane-cli/src/output.ts
@@ -26,6 +26,14 @@ function redactCredentials<T>(data: T): T {
   return data;
 }
 
+/**
+ * Print a command result to stdout, either as pretty JSON (`opts.json`), an
+ * aligned table (array of objects), key/value lines (a single object), or a
+ * bare scalar. Stored credential fields (`apiKey`, `accessToken`) are
+ * recursively redacted before printing; other secrets returned directly from
+ * an API call (e.g. `clientSecret` from `client rotate-secret`) are left
+ * intact since the user explicitly requested them.
+ */
 export function printResult(data: unknown, opts: { json?: boolean }): void {
   const safe = redactCredentials(data);
 
@@ -79,10 +87,12 @@ function isComplexValue(val: unknown): boolean {
   return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
+/** Print a green `OK <msg>` line to stdout. */
 export function success(msg: string): void {
   console.log(chalk.green('OK') + ' ' + msg);
 }
 
+/** Print a yellow `WARN <msg>` line to stdout. */
 export function warn(msg: string): void {
   console.log(chalk.yellow('WARN') + ' ' + msg);
 }

--- a/packages/idenplane-cli/src/prompt.ts
+++ b/packages/idenplane-cli/src/prompt.ts
@@ -1,5 +1,10 @@
 import { createInterface } from 'readline';
 
+/**
+ * Print `question` and read a line of trimmed input from stdin.
+ *
+ * @throws {Error} If stdin closes (EOF) before an answer is entered.
+ */
 export function ask(question: string): Promise<string> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve, reject) => {
@@ -17,6 +22,12 @@ export function ask(question: string): Promise<string> {
   });
 }
 
+/**
+ * Print `question` and read a password from stdin without echoing it —
+ * each typed character prints as `*`, backspace erases the last `*`.
+ *
+ * @throws {Error} If Ctrl+C is pressed, or if stdin closes (EOF) before input is submitted.
+ */
 export async function askPassword(question: string): Promise<string> {
   process.stdout.write(question);
   return new Promise((resolve, reject) => {
@@ -62,11 +73,18 @@ export async function askPassword(question: string): Promise<string> {
   });
 }
 
+/** Ask a yes/no `question`, defaulting to "no" for any answer other than `y`/`yes` (case-insensitive). */
 export async function confirm(question: string): Promise<boolean> {
   const answer = await ask(`${question} (y/N) `);
   return answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
 }
 
+/**
+ * Print `question` followed by a numbered list of `options`, then prompt for
+ * a 1-based choice and return the selected option.
+ *
+ * @throws {Error} If the entered number is out of range (`1`..`options.length`).
+ */
 export async function select(question: string, options: string[]): Promise<string> {
   console.log(question);
   options.forEach((opt, i) => console.log(`  ${i + 1}) ${opt}`));

--- a/packages/idenplane-cli/src/types.ts
+++ b/packages/idenplane-cli/src/types.ts
@@ -101,6 +101,7 @@ export interface MigrationReport {
   dryRun: boolean;
   startedAt: string;
   completedAt: string;
+  /** Keyed by entity type (e.g. "users", "realms", "clients"). */
   summary: Record<string, MigrationEntityStats>;
   errors: MigrationError[];
   warnings: MigrationWarning[];

--- a/packages/idenplane-mcp/src/client.ts
+++ b/packages/idenplane-mcp/src/client.ts
@@ -1,10 +1,20 @@
 import { buildUrlWithQuery, extractErrorMessage, rawRequest } from '@idenplane/http-internal';
 
+/** Configuration required to talk to an Idenplane admin API. */
 export interface ClientConfig {
+  /** Base URL of the Idenplane server (trailing slash stripped by {@link getConfig}). */
   serverUrl: string;
+  /** Admin API token, sent as the `x-admin-api-key` header on every request. */
   adminToken: string;
 }
 
+/**
+ * Reads and validates the `IDENPLANE_URL` and `IDENPLANE_ADMIN_TOKEN`
+ * environment variables into a {@link ClientConfig}.
+ *
+ * @returns The resolved client configuration, with `serverUrl`'s trailing slash removed.
+ * @throws {Error} If `IDENPLANE_URL` or `IDENPLANE_ADMIN_TOKEN` is not set.
+ */
 export function getConfig(): ClientConfig {
   const serverUrl = process.env['IDENPLANE_URL'];
   const adminToken = process.env['IDENPLANE_ADMIN_TOKEN'];
@@ -19,10 +29,19 @@ export function getConfig(): ClientConfig {
   return { serverUrl: serverUrl.replace(/\/$/, ''), adminToken };
 }
 
+/**
+ * Thin HTTP client for the Idenplane admin API. Wraps `@idenplane/http-internal`'s
+ * `rawRequest` to add the admin auth header, JSON content type, and
+ * translation of non-ok responses into {@link ApiError}.
+ */
 export class IdenplaneClient {
   private readonly baseUrl: string;
   private readonly headers: Record<string, string>;
 
+  /**
+   * @param config Server URL and admin token used to authenticate every request
+   *   (sent as the `x-admin-api-key` header, not `Authorization`).
+   */
   constructor(config: ClientConfig) {
     this.baseUrl = config.serverUrl;
     this.headers = {
@@ -31,18 +50,57 @@ export class IdenplaneClient {
     };
   }
 
+  /**
+   * Issues a `GET` request.
+   *
+   * @param path Admin API path, appended to the configured base URL.
+   * @param query Optional query parameters; entries with an `undefined` value are omitted.
+   * @returns The parsed JSON response body. Note: on a `204 No Content`
+   *   response this resolves to `undefined` at runtime even though the
+   *   return type is `Promise<T>` (the type does not reflect this case).
+   * @throws {ApiError} If the response status is not ok.
+   */
   async get<T>(path: string, query?: Record<string, string | undefined>): Promise<T> {
     return this.request<T>('GET', buildUrlWithQuery(this.baseUrl, path, query));
   }
 
+  /**
+   * Issues a `POST` request with a JSON-serialized body.
+   *
+   * @param path Admin API path, appended to the configured base URL.
+   * @param body Optional request body, JSON-serialized.
+   * @returns The parsed JSON response body. Note: on a `204 No Content`
+   *   response this resolves to `undefined` at runtime even though the
+   *   return type is `Promise<T>` (the type does not reflect this case).
+   * @throws {ApiError} If the response status is not ok.
+   */
   async post<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>('POST', buildUrlWithQuery(this.baseUrl, path), body);
   }
 
+  /**
+   * Issues a `PUT` request with a JSON-serialized body.
+   *
+   * @param path Admin API path, appended to the configured base URL.
+   * @param body Optional request body, JSON-serialized.
+   * @returns The parsed JSON response body. Note: on a `204 No Content`
+   *   response this resolves to `undefined` at runtime even though the
+   *   return type is `Promise<T>` (the type does not reflect this case).
+   * @throws {ApiError} If the response status is not ok.
+   */
   async put<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>('PUT', buildUrlWithQuery(this.baseUrl, path), body);
   }
 
+  /**
+   * Issues a `DELETE` request. Some admin endpoints (e.g. bulk role-mapping
+   * removal) accept a JSON body on `DELETE`, so one can still be passed.
+   *
+   * @param path Admin API path, appended to the configured base URL.
+   * @param body Optional request body, JSON-serialized.
+   * @returns The parsed JSON response body, or `undefined` for a `204 No Content` response.
+   * @throws {ApiError} If the response status is not ok.
+   */
   async delete<T>(path: string, body?: unknown): Promise<T | undefined> {
     return this.request<T>('DELETE', buildUrlWithQuery(this.baseUrl, path), body);
   }
@@ -60,7 +118,14 @@ export class IdenplaneClient {
   }
 }
 
+/** Thrown by {@link IdenplaneClient} when the admin API returns a non-ok HTTP status. */
 export class ApiError extends Error {
+  /**
+   * @param status HTTP status code of the failed response.
+   * @param message Human-readable error detail extracted from the response body
+   *   (see `extractErrorMessage` in `@idenplane/http-internal`); combined with
+   *   `status` into this error's `message` as `HTTP <status>: <message>`.
+   */
   constructor(
     public readonly status: number,
     message: string,
@@ -70,6 +135,15 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Converts a caught error into a plain string suitable for an MCP tool's
+ * error output. `ApiError` (and any other `Error`) yields its `message`
+ * (an `ApiError` message is already formatted as `HTTP <status>: <detail>`);
+ * anything else falls back to a generic message.
+ *
+ * @param err The value caught from a tool handler, of unknown type.
+ * @returns A human-readable error string.
+ */
 export function toToolError(err: unknown): string {
   if (err instanceof ApiError) {
     return err.message;

--- a/packages/idenplane-mcp/src/schemas.ts
+++ b/packages/idenplane-mcp/src/schemas.ts
@@ -12,7 +12,14 @@ import { z } from 'zod';
 const PATH_SEGMENT_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const PATH_SEGMENT_MESSAGE = 'must contain only letters, numbers, underscores, and hyphens';
 
-/** A `z.string()` restricted to characters safe for URL path interpolation. */
+/**
+ * Builds a `z.string()` restricted to characters safe for URL path
+ * interpolation (see the rationale above {@link PATH_SEGMENT_PATTERN}).
+ *
+ * @param description Human-readable description attached to the schema via `.describe()`,
+ *   surfaced to MCP clients as the parameter's documentation.
+ * @returns A Zod string schema requiring a non-empty value matching {@link PATH_SEGMENT_PATTERN}.
+ */
 export function pathSegment(description: string): z.ZodString {
   return z.string().min(1).regex(PATH_SEGMENT_PATTERN, PATH_SEGMENT_MESSAGE).describe(description);
 }

--- a/packages/idenplane-mcp/src/tools/audit.ts
+++ b/packages/idenplane-mcp/src/tools/audit.ts
@@ -25,9 +25,18 @@ const AdminEventSchema = z.object({
   error: z.string().optional(),
 });
 
+/** A user-facing login/auth event, inferred from {@link LoginEventSchema}. */
 export type LoginEvent = z.infer<typeof LoginEventSchema>;
+/** An admin API operation event, inferred from {@link AdminEventSchema}. */
 export type AdminEvent = z.infer<typeof AdminEventSchema>;
 
+/**
+ * Registers audit/event-log MCP tools on `server`:
+ *
+ * - `query_audit_events` (read-only) — Query a realm's login events and/or
+ *   admin operation events, with optional filtering by user ID, event type,
+ *   and time window.
+ */
 export function registerAuditTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'query_audit_events',

--- a/packages/idenplane-mcp/src/tools/clients.ts
+++ b/packages/idenplane-mcp/src/tools/clients.ts
@@ -14,8 +14,15 @@ const ClientSchema = z.object({
   redirectUris: z.array(z.string()).optional(),
 });
 
+/** An OAuth2/OIDC client, inferred from {@link ClientSchema}. */
 export type OidcClient = z.infer<typeof ClientSchema>;
 
+/**
+ * Registers OAuth2/OIDC client MCP tools on `server`:
+ *
+ * - `list_clients` (read-only) — List all clients registered in a realm.
+ * - `create_client` (`[WRITE]`) — Register a new OAuth2/OIDC client in a realm.
+ */
 export function registerClientTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'list_clients',

--- a/packages/idenplane-mcp/src/tools/groups.ts
+++ b/packages/idenplane-mcp/src/tools/groups.ts
@@ -10,8 +10,20 @@ const GroupSchema = z.object({
   parentId: z.string().optional(),
 });
 
+/** A group, inferred from {@link GroupSchema}. */
 export type Group = z.infer<typeof GroupSchema>;
 
+/**
+ * Registers group MCP tools on `server`:
+ *
+ * - `list_groups` (read-only) — List all groups defined in a realm.
+ * - `get_group` (read-only) — Get full details for a specific group by ID.
+ * - `create_group` (`[WRITE]`) — Create a new group, optionally nested under a parent group.
+ * - `update_group` (`[WRITE]`) — Update a group's mutable fields; omitted fields are left as-is.
+ * - `delete_group` (`[WRITE]`) — Delete a group. Cannot be undone.
+ * - `add_group_member` (`[WRITE]`) — Add a user to a group.
+ * - `remove_group_member` (`[WRITE]`) — Remove a user from a group.
+ */
 export function registerGroupTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'list_groups',

--- a/packages/idenplane-mcp/src/tools/realms.ts
+++ b/packages/idenplane-mcp/src/tools/realms.ts
@@ -11,8 +11,17 @@ const RealmSchema = z.object({
   createdAt: z.string().optional(),
 });
 
+/** A realm, inferred from {@link RealmSchema}. */
 export type Realm = z.infer<typeof RealmSchema>;
 
+/**
+ * Registers realm MCP tools on `server`:
+ *
+ * - `list_realms` (read-only) — List all realms on this Idenplane instance.
+ * - `get_realm` (read-only) — Get the full configuration for a specific realm by name.
+ * - `create_realm` (`[WRITE]`) — Create a new realm (an isolated tenant namespace
+ *   for users, clients, and roles).
+ */
 export function registerRealmTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'list_realms',

--- a/packages/idenplane-mcp/src/tools/roles.ts
+++ b/packages/idenplane-mcp/src/tools/roles.ts
@@ -10,8 +10,16 @@ const RoleSchema = z.object({
   composite: z.boolean().optional(),
 });
 
+/** A realm role, inferred from {@link RoleSchema}. */
 export type Role = z.infer<typeof RoleSchema>;
 
+/**
+ * Registers role MCP tools on `server`:
+ *
+ * - `list_roles` (read-only) — List all realm roles defined in a realm.
+ * - `assign_role` (`[WRITE]`) — Assign one or more realm roles to a user, additively
+ *   (existing role assignments are preserved).
+ */
 export function registerRoleTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'list_roles',

--- a/packages/idenplane-mcp/src/tools/sessions.ts
+++ b/packages/idenplane-mcp/src/tools/sessions.ts
@@ -13,8 +13,17 @@ const SessionSchema = z.object({
   lastAccess: z.number().optional(),
 });
 
+/** An active login session, inferred from {@link SessionSchema}. */
 export type Session = z.infer<typeof SessionSchema>;
 
+/**
+ * Registers session MCP tools on `server`:
+ *
+ * - `list_active_sessions` (read-only) — List active login sessions in a realm,
+ *   optionally filtered to a specific user.
+ * - `revoke_session` (`[DESTRUCTIVE]`) — Revoke (terminate) a specific active
+ *   session by ID, logging that user out immediately.
+ */
 export function registerSessionTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'list_active_sessions',

--- a/packages/idenplane-mcp/src/tools/users.ts
+++ b/packages/idenplane-mcp/src/tools/users.ts
@@ -18,9 +18,20 @@ const UserListResponseSchema = z.object({
   total: z.number(),
 });
 
+/** A user, inferred from {@link UserSchema}. */
 export type User = z.infer<typeof UserSchema>;
+/** A paginated user list response, inferred from {@link UserListResponseSchema}. */
 export type UserListResponse = z.infer<typeof UserListResponseSchema>;
 
+/**
+ * Registers user MCP tools on `server`:
+ *
+ * - `list_users` (read-only) — List users in a realm with optional search and pagination.
+ * - `get_user` (read-only) — Get full details for a specific user by ID.
+ * - `create_user` (`[WRITE]`) — Create a new user in a realm.
+ * - `set_user_roles` (`[WRITE]`) — Replace a user's complete set of realm roles,
+ *   removing existing assignments not in the given list (an empty array strips all roles).
+ */
 export function registerUserTools(server: McpServer, client: IdenplaneClient): void {
   server.registerTool(
     'list_users',


### PR DESCRIPTION
## Summary
- Add JSDoc (`@param`/`@returns`/`@throws`) to every exported class, function, and type in `packages/idenplane-cli/` (`http.ts`, `output.ts`, `config.ts`, `csv.ts`, `prompt.ts`, all 12 `commands/*.ts` files) and `packages/idenplane-mcp/` (`client.ts`, `schemas.ts`, all 7 `tools/*.ts` files), matching the doc-comment density already established in `idenplane-js/src/client.ts` (21 JSDoc blocks).
- Comment-only change — no logic, imports, or exported signatures touched. Confirmed via diff: 312 insertions / 1 deletion (the one deletion is an old one-line comment expanded into a full JSDoc block in `schemas.ts`).
- A couple of real behaviors surfaced along the way: `IdenplaneClient`'s `get`/`post`/`put` resolve to `undefined` at runtime on a `204` response even though their return type is `Promise<T>` (only `delete`'s signature reflects this) — documented rather than silently glossed over. `auth.ts` registers top-level `login`/`logout`/`whoami` (not nested under an `auth` subcommand) and `upgrade-status.ts` registers `upgrade:status` (colon, not space) — both called out explicitly since they're easy to get wrong from the file name alone.

## Verification
- `npm run build`, `npm run typecheck`, `npm run test` all pass in `packages/idenplane-cli/` (38/38 tests).
- `npm run build`, `npm run typecheck`, `npm run test:all` all pass in `packages/idenplane-mcp/` (17/17 tests, smoke test confirms all 21 tools still register).

Closes #1290

🤖 Generated with [Claude Code](https://claude.com/claude-code)