### PR TITLE
docs(go,cli): add package READMEs

### DIFF
--- a/packages/idenplane-cli/README.md
+++ b/packages/idenplane-cli/README.md
@@ -1,0 +1,155 @@
+<p align="center">
+  <img src="https://idenplane.com/logo.svg" alt="Idenplane" width="60" />
+</p>
+
+<h2 align="center">idenplane-cli</h2>
+
+<p align="center">
+  <strong>Official CLI for <a href="https://idenplane.com">Idenplane</a></strong><br />
+  <sub>Manage realms, clients, users, roles, and groups on an Idenplane server from the terminal.</sub>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/npm/v/idenplane-cli?label=idenplane-cli" alt="npm idenplane-cli" />
+  <img src="https://img.shields.io/badge/node-18%2B-339933" alt="Node 18+" />
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT" />
+</p>
+
+---
+
+## Install
+
+```bash
+npm install -g idenplane-cli
+```
+
+Requires Node.js 18 or newer. Installs a single `idenplane` binary.
+
+---
+
+## Authenticate
+
+```bash
+idenplane login --server https://auth.example.com
+```
+
+Prompts for username/password (or pass `--username`/`--password`), or authenticate with a static admin API key instead:
+
+```bash
+idenplane login --server https://auth.example.com --api-key <admin-api-key>
+```
+
+Credentials are saved to `~/.idenplane/config.json`, encrypted at rest (AES-256-GCM). Inspect or verify the saved config:
+
+```bash
+idenplane config show       # server URL and masked credentials
+idenplane config validate   # checks the server is reachable and credentials are valid
+idenplane whoami            # current authenticated identity
+idenplane logout            # clear saved credentials
+```
+
+### Environment variables (CI / scripting)
+
+As an alternative to `idenplane login`, set a server URL together with either an API key or a bearer token — no config file is written:
+
+```bash
+export IDENPLANE_SERVER_URL=https://auth.example.com
+export ADMIN_API_KEY=<admin-api-key>
+# — or —
+export IDENPLANE_TOKEN=<bearer-token>
+```
+
+Every command accepts `--json` to print machine-readable output instead of a table.
+
+---
+
+## Command reference
+
+### `idenplane realm`
+
+| Command | Description |
+|---|---|
+| `realm list` | List all realms |
+| `realm create <name>` | Create a new realm |
+| `realm get <name>` | Get realm details |
+| `realm update <name>` | Update a realm |
+| `realm delete <name>` | Delete a realm |
+| `realm export <name>` | Export a realm to a JSON file |
+| `realm import <file>` | Import a realm from a JSON file |
+
+### `idenplane client`
+
+| Command | Description |
+|---|---|
+| `client list --realm <realm>` | List clients in a realm |
+| `client create <clientId>` | Create a client |
+| `client get <clientId>` | Get client details |
+| `client update <clientId>` | Update a client |
+| `client delete <clientId>` | Delete a client |
+| `client rotate-secret <clientId>` | Rotate the client secret for a CONFIDENTIAL client |
+
+### `idenplane user`
+
+| Command | Description |
+|---|---|
+| `user list --realm <realm>` | List users in a realm |
+| `user create <username>` | Create a user |
+| `user get <id>` | Get a user by ID |
+| `user update <id>` | Update a user |
+| `user delete <id>` | Delete a user |
+| `user set-password <id>` | Set a user's password |
+| `user bulk-import` | Import users from a CSV or JSON file |
+
+### `idenplane role`
+
+| Command | Description |
+|---|---|
+| `role list --realm <realm>` | List realm roles |
+| `role create <name>` | Create a realm role |
+| `role get <name>` | Get role details |
+| `role update <name>` | Update a realm role |
+| `role delete <name>` | Delete a realm role |
+| `role assign <userId> <roleName>` | Assign a realm role to a user |
+| `role unassign <userId> <roleName>` | Remove a realm role from a user (`role remove` is an alias) |
+
+### `idenplane group`
+
+| Command | Description |
+|---|---|
+| `group list --realm <realm>` | List groups in a realm |
+| `group create <name>` | Create a group |
+| `group get <id>` | Get group details |
+| `group update <id>` | Update a group |
+| `group delete <id>` | Delete a group |
+
+### Other commands
+
+| Command | Description |
+|---|---|
+| `init` | Interactive setup: connect, create a realm, client, and roles |
+| `migrate keycloak` | Import from a Keycloak realm export JSON |
+| `migrate auth0` | Import from an Auth0 Management API export |
+| `upgrade` | Run pre-flight checks then apply database migrations |
+| `upgrade:status` | View upgrade audit history |
+| `completion <shell>` | Output a shell completion script (bash, zsh, fish) |
+
+Run `idenplane <command> --help` for the full option list of any command.
+
+---
+
+## Development
+
+```bash
+git clone https://github.com/idenplane/idenplane.git
+cd idenplane/packages/idenplane-cli
+npm install
+npm run build
+npm run typecheck
+npm test
+```
+
+---
+
+## License
+
+MIT. See [LICENSE](../../LICENSE).

--- a/packages/idenplane-go/README.md
+++ b/packages/idenplane-go/README.md
@@ -1,0 +1,203 @@
+<p align="center">
+  <img src="https://idenplane.com/logo.svg" alt="Idenplane" width="60" />
+</p>
+
+<h2 align="center">idenplane-go</h2>
+
+<p align="center">
+  <strong>Official server-side Go SDK for <a href="https://idenplane.com">Idenplane</a></strong><br />
+  <sub>OIDC discovery and admin management (users, roles, groups) against the Idenplane realm-management API.</sub>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/go-1.24%2B-00ADD8" alt="Go 1.24+" />
+  <img src="https://img.shields.io/badge/license-MIT-green" alt="MIT" />
+</p>
+
+---
+
+## Install
+
+```bash
+go get github.com/idenplane/idenplane/packages/idenplane-go
+```
+
+Requires Go 1.24 or newer. No third-party runtime dependencies — only the standard library.
+
+---
+
+## Quick start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	idenplane "github.com/idenplane/idenplane/packages/idenplane-go"
+)
+
+func main() {
+	client := idenplane.NewClient(idenplane.Config{
+		ServerURL:  "https://auth.example.com",
+		Realm:      "my-realm",
+		ClientID:   "my-app",
+		AdminToken: "eyJ...", // service-account token with the realm-management role
+	})
+
+	ctx := context.Background()
+
+	user, err := client.Users.Create(ctx, idenplane.CreateUserRequest{
+		Username: "alice",
+		Email:    "alice@example.com",
+		Enabled:  true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("created user", user.ID)
+}
+```
+
+`NewClientWithDefaults(serverURL, realm, clientID)` is a shorthand for the common case where you don't need to override `Scopes`, `HTTPClient`, `DiscoveryTTL`, or `HTTPTimeout`.
+
+`ServerURL` must be `https://` unless the host is a loopback address (`localhost`, `127.0.0.1`, `::1`) or `Config.AllowInsecureHTTP` is explicitly set — plaintext HTTP would otherwise send `AdminToken` over the wire unencrypted.
+
+---
+
+## Auth
+
+Every admin-API call (`Users`, `Roles`, `Groups`) is authenticated with `Config.AdminToken`, sent as `Authorization: Bearer <token>`. Typically this is obtained via the OAuth 2.0 client-credentials flow against a service account that holds the `realm-management` role. If `AdminToken` is empty, the `Authorization` header is simply omitted — useful for discovery-only usage.
+
+---
+
+## User CRUD
+
+```go
+// Get
+user, err := client.Users.Get(ctx, "user-id-123")
+
+// List with filters and pagination (page is 1-based, limit defaults to 20)
+users, total, err := client.Users.List(ctx, idenplane.ListUsersParams{
+	Search: "alice",
+	Page:   1,
+	Limit:  25,
+})
+
+// Update (returns error only; fetch again with Get if you need the updated record)
+newEmail := "new@example.com"
+err = client.Users.Update(ctx, "user-id-123", idenplane.UpdateUserRequest{
+	Email: &newEmail,
+})
+
+// Reset password
+err = client.Users.ResetPassword(ctx, "user-id-123", "S3cret!", true /* temporary */)
+
+// Delete
+err = client.Users.Delete(ctx, "user-id-123")
+```
+
+`Create` follows the admin API's `201` + `Location` header response with a `GET` to populate the full record, unless the `POST` body already carried one.
+
+---
+
+## Role CRUD
+
+Realm roles are addressed by **name**, not by ID:
+
+```go
+role, err := client.Roles.Create(ctx, idenplane.CreateRoleRequest{
+	Name:        "billing-admin",
+	Description: "Can manage billing settings",
+})
+
+role, err = client.Roles.Get(ctx, "billing-admin")
+
+roles, err := client.Roles.List(ctx)
+
+desc := "Updated description"
+role, err = client.Roles.Update(ctx, "billing-admin", idenplane.UpdateRoleRequest{
+	Description: &desc,
+})
+
+err = client.Roles.Delete(ctx, "billing-admin")
+```
+
+---
+
+## Group CRUD
+
+Groups are addressed by ID and support nesting via `ParentID`:
+
+```go
+parent, err := client.Groups.Create(ctx, idenplane.CreateGroupRequest{Name: "engineering"})
+
+child, err := client.Groups.Create(ctx, idenplane.CreateGroupRequest{
+	Name:     "platform-team",
+	ParentID: parent.ID,
+})
+
+group, err := client.Groups.Get(ctx, child.ID)
+
+groups, err := client.Groups.List(ctx)
+
+newName := "platform-infra"
+group, err = client.Groups.Update(ctx, child.ID, idenplane.UpdateGroupRequest{Name: &newName})
+
+err = client.Groups.Delete(ctx, child.ID)
+```
+
+---
+
+## Discovery
+
+```go
+discovery := idenplane.NewDiscoveryClient(idenplane.Config{
+	ServerURL: "https://auth.example.com",
+	Realm:     "my-realm",
+	ClientID:  "my-app",
+})
+
+oidc, err := discovery.Get(ctx) // cached for Config.DiscoveryTTL (default 1 hour)
+fmt.Println(oidc.TokenEndpoint)
+
+oidc, err = discovery.Refresh(ctx) // force a refetch, bypassing the cache
+```
+
+---
+
+## Errors
+
+All SDK errors are `*idenplane.Error`, carrying a stable `Code` (`idenplane.ErrCodeUserNotFound`, `ErrCodeRoleNotFound`, `ErrCodeGroupNotFound`, `ErrCodeServerError`, `ErrCodeNetworkError`, ...):
+
+```go
+user, err := client.Users.Get(ctx, "missing-id")
+var idenplaneErr *idenplane.Error
+if errors.As(err, &idenplaneErr) && idenplaneErr.Code == idenplane.ErrCodeUserNotFound {
+	// handle not-found
+}
+
+if idenplane.IsRetryable(err) {
+	// network error or 5xx — safe to retry
+}
+```
+
+---
+
+## Development
+
+```bash
+git clone https://github.com/idenplane/idenplane.git
+cd idenplane/packages/idenplane-go
+go build ./...
+go vet ./...
+go test ./...
+```
+
+---
+
+## License
+
+MIT. See [LICENSE](../../LICENSE).


### PR DESCRIPTION
## Summary
- `packages/idenplane-go/README.md`: install, client init, auth, User/Role/Group CRUD (including the Role/Group services added in #1293), OIDC discovery, and error handling. Every code snippet was compiled against the actual package (as a throwaway `main.go`, since discarded) to catch signature mismatches — caught and fixed one: `UserService.Update` returns `error` only, not `(*User, error)` like `RoleService.Update`/`GroupService.Update` do.
- `packages/idenplane-cli/README.md`: install, and the actual auth flow (`idenplane login`, env vars, `config show`/`config validate`) rather than the `idenplane config set` command sketched in the issue text — that command doesn't exist in this codebase (only `config show` and `config validate` are registered), so the README documents what's really there. Full command reference table across all 12 command groups (`realm`, `client`, `user`, `role`, `group`, `init`, `migrate`, `upgrade`, `upgrade:status`, `completion`).

## Verification
- Go SDK snippets compile against `packages/idenplane-go` (verified, then removed the scratch file); `go build`/`vet`/`test` still pass.
- CLI command reference cross-checked against every `commands/*.ts` file's actual registered subcommands and required options.

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)