### PR TITLE
docs: add Go, Python, and CLI pages to SDK Guides

### DIFF
--- a/docs/docs/guides/sdks/cli.mdx
+++ b/docs/docs/guides/sdks/cli.mdx
@@ -1,0 +1,163 @@
+---
+id: cli
+title: CLI
+description: Manage realms, clients, users, roles, and groups on an Idenplane server from the terminal using the official CLI
+---
+
+# CLI
+
+`idenplane-cli` is the official command-line tool for administering an Idenplane server — realms, clients, users, roles, and groups — without touching the admin console or the raw REST API.
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| Node.js | 18+ |
+
+---
+
+## Installation
+
+```bash
+npm install -g idenplane-cli
+```
+
+Installs a single `idenplane` binary.
+
+---
+
+## Authenticate
+
+```bash
+idenplane login --server https://auth.example.com
+```
+
+Prompts for username/password (or pass `--username`/`--password`), or authenticate with a static admin API key instead:
+
+```bash
+idenplane login --server https://auth.example.com --api-key <admin-api-key>
+```
+
+Credentials are saved to `~/.idenplane/config.json`, encrypted at rest (AES-256-GCM). Inspect or verify the saved config:
+
+```bash
+idenplane config show       # server URL and masked credentials
+idenplane config validate   # checks the server is reachable and credentials are valid
+idenplane whoami            # current authenticated identity
+idenplane logout            # clear saved credentials
+```
+
+### Environment variables (CI / scripting)
+
+As an alternative to `idenplane login`, set a server URL together with either an API key or a bearer token — no config file is written:
+
+```bash
+export IDENPLANE_SERVER_URL=https://auth.example.com
+export ADMIN_API_KEY=<admin-api-key>
+# — or —
+export IDENPLANE_TOKEN=<bearer-token>
+```
+
+Every command accepts `--json` to print machine-readable output instead of a table.
+
+---
+
+## Command reference
+
+### Realms
+
+| Command | Description |
+|---|---|
+| `realm list` | List all realms |
+| `realm create <name>` | Create a new realm |
+| `realm get <name>` | Get realm details |
+| `realm update <name>` | Update a realm |
+| `realm delete <name>` | Delete a realm |
+| `realm export <name>` | Export a realm to a JSON file |
+| `realm import <file>` | Import a realm from a JSON file |
+
+### Clients
+
+| Command | Description |
+|---|---|
+| `client list --realm <realm>` | List clients in a realm |
+| `client create <clientId>` | Create a client |
+| `client get <clientId>` | Get client details |
+| `client update <clientId>` | Update a client |
+| `client delete <clientId>` | Delete a client |
+| `client rotate-secret <clientId>` | Rotate the client secret for a CONFIDENTIAL client |
+
+### Users
+
+| Command | Description |
+|---|---|
+| `user list --realm <realm>` | List users in a realm |
+| `user create <username>` | Create a user |
+| `user get <id>` | Get a user by ID |
+| `user update <id>` | Update a user |
+| `user delete <id>` | Delete a user |
+| `user set-password <id>` | Set a user's password |
+| `user bulk-import` | Import users from a CSV or JSON file |
+
+### Roles
+
+| Command | Description |
+|---|---|
+| `role list --realm <realm>` | List realm roles |
+| `role create <name>` | Create a realm role |
+| `role get <name>` | Get role details |
+| `role update <name>` | Update a realm role |
+| `role delete <name>` | Delete a realm role |
+| `role assign <userId> <roleName>` | Assign a realm role to a user |
+| `role unassign <userId> <roleName>` | Remove a realm role from a user (`role remove` is an alias) |
+
+### Groups
+
+| Command | Description |
+|---|---|
+| `group list --realm <realm>` | List groups in a realm |
+| `group create <name>` | Create a group |
+| `group get <id>` | Get group details |
+| `group update <id>` | Update a group |
+| `group delete <id>` | Delete a group |
+
+### Other commands
+
+| Command | Description |
+|---|---|
+| `init` | Interactive setup: connect, create a realm, client, and roles |
+| `migrate keycloak` | Import from a Keycloak realm export JSON |
+| `migrate auth0` | Import from an Auth0 Management API export |
+| `upgrade` | Run pre-flight checks then apply database migrations |
+| `upgrade:status` | View upgrade audit history |
+| `completion <shell>` | Output a shell completion script (bash, zsh, fish) |
+
+Run `idenplane <command> --help` for the full option list of any command.
+
+---
+
+## Next Steps
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
+
+[**Go SDK**](/guides/sdks/go-sdk)
+Server-side Go SDK for the same admin API
+
+[**Python SDK**](/guides/sdks/python-sdk)
+Server-side Python SDK for the same admin API
+
+[**API Reference**](/api)
+Complete REST API documentation
+
+[**Configuration**](/getting-started/configuration)
+Learn about all configuration options
+
+</div>
+
+---
+
+<p align="center">
+  <a href="https://idenplane.com">idenplane.com</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
+  <a href="https://discord.gg/idenplane">Discord</a>
+</p>

--- a/docs/docs/guides/sdks/go.mdx
+++ b/docs/docs/guides/sdks/go.mdx
@@ -1,0 +1,225 @@
+---
+id: go-sdk
+title: Go SDK
+description: Integrate Idenplane admin management (users, roles, groups) and OIDC discovery into a Go backend using the official Go SDK
+---
+
+# Go SDK
+
+`idenplane-go` is the official server-side Go SDK for Idenplane. It wraps the admin-management REST API (users, roles, groups) and OIDC discovery in an idiomatic, context-aware Go client with no third-party runtime dependencies.
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| Go | 1.24+ |
+
+---
+
+## Installation
+
+```bash
+go get github.com/idenplane/idenplane/packages/idenplane-go
+```
+
+---
+
+## Quick start
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	idenplane "github.com/idenplane/idenplane/packages/idenplane-go"
+)
+
+func main() {
+	client := idenplane.NewClient(idenplane.Config{
+		ServerURL:  "https://auth.example.com",
+		Realm:      "my-realm",
+		ClientID:   "my-app",
+		AdminToken: "eyJ...", // service-account token with the realm-management role
+	})
+
+	ctx := context.Background()
+
+	user, err := client.Users.Create(ctx, idenplane.CreateUserRequest{
+		Username: "alice",
+		Email:    "alice@example.com",
+		Enabled:  true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("created user", user.ID)
+}
+```
+
+`NewClientWithDefaults(serverURL, realm, clientID)` is a shorthand for the common case where you don't need to override `Scopes`, `HTTPClient`, `DiscoveryTTL`, or `HTTPTimeout`.
+
+`Config.ServerURL` must be `https://` unless the host is a loopback address (`localhost`, `127.0.0.1`, `::1`) or `Config.AllowInsecureHTTP` is explicitly set — plaintext HTTP would otherwise send `AdminToken` over the wire unencrypted.
+
+---
+
+## Authentication
+
+Every admin-API call (`Users`, `Roles`, `Groups`) is authenticated with `Config.AdminToken`, sent as `Authorization: Bearer <token>`. Typically this is obtained via the OAuth 2.0 client-credentials flow against a service account that holds the `realm-management` role. If `AdminToken` is empty, the `Authorization` header is simply omitted — useful for discovery-only usage.
+
+---
+
+## User management
+
+```go
+// Get
+user, err := client.Users.Get(ctx, "user-id-123")
+
+// List with filters and pagination (page is 1-based, limit defaults to 20)
+users, total, err := client.Users.List(ctx, idenplane.ListUsersParams{
+	Search: "alice",
+	Page:   1,
+	Limit:  25,
+})
+
+// Update (returns error only; fetch again with Get if you need the updated record)
+newEmail := "new@example.com"
+err = client.Users.Update(ctx, "user-id-123", idenplane.UpdateUserRequest{
+	Email: &newEmail,
+})
+
+// Reset password
+err = client.Users.ResetPassword(ctx, "user-id-123", "S3cret!", true /* temporary */)
+
+// Delete
+err = client.Users.Delete(ctx, "user-id-123")
+```
+
+`Create` follows the admin API's `201` + `Location` header response with a `GET` to populate the full record, unless the `POST` body already carried one.
+
+---
+
+## Role management
+
+Realm roles are addressed by **name**, not by ID:
+
+```go
+role, err := client.Roles.Create(ctx, idenplane.CreateRoleRequest{
+	Name:        "billing-admin",
+	Description: "Can manage billing settings",
+})
+
+role, err = client.Roles.Get(ctx, "billing-admin")
+
+roles, err := client.Roles.List(ctx)
+
+desc := "Updated description"
+role, err = client.Roles.Update(ctx, "billing-admin", idenplane.UpdateRoleRequest{
+	Description: &desc,
+})
+
+err = client.Roles.Delete(ctx, "billing-admin")
+```
+
+---
+
+## Group management
+
+Groups are addressed by ID and support nesting via `ParentID`:
+
+```go
+parent, err := client.Groups.Create(ctx, idenplane.CreateGroupRequest{Name: "engineering"})
+
+child, err := client.Groups.Create(ctx, idenplane.CreateGroupRequest{
+	Name:     "platform-team",
+	ParentID: parent.ID,
+})
+
+group, err := client.Groups.Get(ctx, child.ID)
+
+groups, err := client.Groups.List(ctx)
+
+newName := "platform-infra"
+group, err = client.Groups.Update(ctx, child.ID, idenplane.UpdateGroupRequest{Name: &newName})
+
+err = client.Groups.Delete(ctx, child.ID)
+```
+
+---
+
+## OIDC discovery
+
+```go
+discovery := idenplane.NewDiscoveryClient(idenplane.Config{
+	ServerURL: "https://auth.example.com",
+	Realm:     "my-realm",
+	ClientID:  "my-app",
+})
+
+oidc, err := discovery.Get(ctx) // cached for Config.DiscoveryTTL (default 1 hour)
+fmt.Println(oidc.TokenEndpoint)
+
+oidc, err = discovery.Refresh(ctx) // force a refetch, bypassing the cache
+```
+
+---
+
+## Error handling
+
+All SDK errors are `*idenplane.Error`, carrying a stable `Code`:
+
+```go
+user, err := client.Users.Get(ctx, "missing-id")
+var idenplaneErr *idenplane.Error
+if errors.As(err, &idenplaneErr) && idenplaneErr.Code == idenplane.ErrCodeUserNotFound {
+	// handle not-found
+}
+
+if idenplane.IsRetryable(err) {
+	// network error or 5xx — safe to retry
+}
+```
+
+| Code | Meaning |
+|---|---|
+| `ErrCodeInvalidConfig` | Missing or invalid `Config` field |
+| `ErrCodeNotAuthenticated` | No valid session |
+| `ErrCodeTokenExpired` | Access token has expired |
+| `ErrCodeServerError` | Non-2xx response from the Idenplane server |
+| `ErrCodeNetworkError` | HTTP / IO error |
+| `ErrCodeDiscoveryFailed` | OIDC discovery document fetch failed |
+| `ErrCodeJWTError` | JWT parsing/validation error |
+| `ErrCodeUserNotFound` | `Users.Get`/`Update`/`Delete` for an unknown ID |
+| `ErrCodeRoleNotFound` | `Roles.Get`/`Update`/`Delete` for an unknown name |
+| `ErrCodeGroupNotFound` | `Groups.Get`/`Update`/`Delete` for an unknown ID |
+| `ErrCodeInvalidToken` | Malformed or invalid token |
+
+---
+
+## Next Steps
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
+
+[**Python SDK**](/guides/sdks/python-sdk)
+Server-side Python SDK for the same admin API
+
+[**CLI**](/guides/sdks/cli)
+Manage the same resources from the terminal
+
+[**API Reference**](/api)
+Complete REST API documentation
+
+[**Configuration**](/getting-started/configuration)
+Learn about all configuration options
+
+</div>
+
+---
+
+<p align="center">
+  <a href="https://idenplane.com">idenplane.com</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
+  <a href="https://discord.gg/idenplane">Discord</a>
+</p>

--- a/docs/docs/guides/sdks/python.mdx
+++ b/docs/docs/guides/sdks/python.mdx
@@ -1,0 +1,195 @@
+---
+id: python-sdk
+title: Python SDK
+description: Integrate Idenplane admin management (users, roles, groups) and OIDC discovery into a Python backend using the official Python SDK
+---
+
+# Python SDK
+
+`idenplane` is the official server-side Python SDK for Idenplane. It wraps OIDC discovery and admin management (users, roles, groups) against the Idenplane realm-management API with a fully-typed, `mypy --strict`-clean client.
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| Python | 3.9+ |
+
+The only runtime dependency is `requests`.
+
+---
+
+## Installation
+
+```bash
+pip install idenplane
+```
+
+---
+
+## Quick start
+
+```python
+from idenplane import Client, Config
+
+# Or: Config.from_env() — reads IDENPLANE_BASE_URL, IDENPLANE_REALM,
+# IDENPLANE_ADMIN_TOKEN.
+cfg = Config(
+    base_url="https://auth.example.com",
+    realm="my-realm",
+    admin_token="eyJ...",  # service-account token with realm-management role
+)
+
+with Client(cfg) as client:
+    # OIDC discovery (cached for 5 minutes by default)
+    oidc = client.discovery.get()
+    print(oidc["token_endpoint"])
+
+    # Create a user
+    user = client.users.create({
+        "username": "alice",
+        "email": "alice@example.com",
+        "firstName": "Alice",
+        "enabled": True,
+    })
+    print(user["id"])
+```
+
+The `Client` owns a single `requests.Session`, reused across calls for connection pooling. Use it as a context manager (as above) so the session is closed automatically, or call `client.close()` yourself.
+
+---
+
+## User management
+
+```python
+from idenplane import Client, Config, ListUsersOptions
+
+with Client(Config.from_env()) as client:
+    # Read
+    user = client.users.get("user-id-123")
+
+    # List with filters and pagination (page is 1-based, limit defaults to 20)
+    result = client.users.list(
+        ListUsersOptions(page=1, limit=25, search="alice", enabled=True)
+    )
+    print(result["total"], "users")
+    for u in result["users"]:
+        print(u["username"])
+
+    # Update
+    user = client.users.update("user-id-123", {"email": "new@example.com"})
+
+    # Reset password
+    client.users.reset_password("user-id-123", "S3cret!", temporary=True)
+
+    # Delete
+    client.users.delete("user-id-123")
+```
+
+---
+
+## Role management
+
+Realm roles are addressed by **name**, not by ID, and the endpoint returns the full record synchronously on create/update — no follow-up fetch needed:
+
+```python
+with Client(Config.from_env()) as client:
+    role = client.roles.create({"name": "billing-admin", "description": "Can manage billing settings"})
+
+    role = client.roles.get("billing-admin")
+
+    roles = client.roles.list()
+
+    role = client.roles.update("billing-admin", {"description": "Updated description"})
+
+    client.roles.delete("billing-admin")
+```
+
+---
+
+## Group management
+
+Groups are addressed by ID and support nesting via `parentId`:
+
+```python
+with Client(Config.from_env()) as client:
+    parent = client.groups.create({"name": "engineering"})
+
+    child = client.groups.create({"name": "platform-team", "parentId": parent["id"]})
+
+    group = client.groups.get(child["id"])
+
+    groups = client.groups.list()
+
+    group = client.groups.update(child["id"], {"name": "platform-infra"})
+
+    client.groups.delete(child["id"])
+```
+
+---
+
+## Errors
+
+All SDK errors inherit from `idenplane.IdenplaneError`. HTTP responses are
+mapped to typed subclasses so callers can catch what they care about:
+
+| Status | Exception            |
+|--------|----------------------|
+| 401/403 | `AuthError`         |
+| 404    | `NotFoundError`      |
+| 429    | `RateLimitError`     |
+| 5xx    | `ServerError`        |
+| other  | `IdenplaneError`     |
+
+```python
+from idenplane import Client, Config
+from idenplane.exceptions import NotFoundError
+
+with Client(Config.from_env()) as client:
+    try:
+        client.users.get("does-not-exist")
+    except NotFoundError as exc:
+        print("not found:", exc.status_code, exc.body)
+```
+
+---
+
+## Discovery cache
+
+`DiscoveryCache` is thread-safe and TTL-bounded (default 5 minutes). It is
+exposed via `client.discovery.cache` for tests and advanced use:
+
+```python
+with Client(cfg) as client:
+    client.discovery.get()              # network call
+    client.discovery.get()              # cache hit
+    client.discovery.invalidate()       # clear all realms
+    client.discovery.refresh()          # forced refetch
+```
+
+---
+
+## Next Steps
+
+<div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>
+
+[**Go SDK**](/guides/sdks/go-sdk)
+Server-side Go SDK for the same admin API
+
+[**CLI**](/guides/sdks/cli)
+Manage the same resources from the terminal
+
+[**API Reference**](/api)
+Complete REST API documentation
+
+[**Configuration**](/getting-started/configuration)
+Learn about all configuration options
+
+</div>
+
+---
+
+<p align="center">
+  <a href="https://idenplane.com">idenplane.com</a> &middot;
+  <a href="https://github.com/idenplane/idenplane">GitHub</a> &middot;
+  <a href="https://discord.gg/idenplane">Discord</a>
+</p>

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -109,6 +109,21 @@ const sidebars: SidebarsConfig = {
           id: 'guides/sdks/ios-sdk',
           label: 'iOS',
         },
+        {
+          type: 'doc',
+          id: 'guides/sdks/go-sdk',
+          label: 'Go',
+        },
+        {
+          type: 'doc',
+          id: 'guides/sdks/python-sdk',
+          label: 'Python',
+        },
+        {
+          type: 'doc',
+          id: 'guides/sdks/cli',
+          label: 'CLI',
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary
- Add `docs/docs/guides/sdks/go.mdx` (id `go-sdk`), `python.mdx` (id `python-sdk`), `cli.mdx` (id `cli`) — filenames follow the existing convention (`android.mdx` → id `android-sdk`, etc.).
- Register all three in `sidebars.ts`'s SDK Guides category.
- Content adapted from the READMEs added in #1288, plus the Role/Group services added in #1293 (Go) / #1294 (Python), following the existing guide pages' structure (Requirements table, Installation, code examples, Next Steps grid, footer).

Go, Python, and the CLI were the three maintained packages/tools with zero documentation-site coverage despite Go being the primary backend-integration SDK and the CLI the primary server-administration tool.

## Verification
- `npm run build` in `docs/` succeeds with no broken-link warnings; confirmed the built site produces `build/guides/sdks/go-sdk/`, `python-sdk/`, and `cli/` at the expected routes.

Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)