### PR TITLE
tech-debt(sdk): centralize bearer-token extraction, JWT decoding, and role resolution

### DIFF
--- a/packages/idenplane-js/package.json
+++ b/packages/idenplane-js/package.json
@@ -36,6 +36,16 @@
         "types": "./dist/server.d.cts",
         "default": "./dist/server.cjs"
       }
+    },
+    "./token": {
+      "import": {
+        "types": "./dist/token.d.ts",
+        "default": "./dist/token.js"
+      },
+      "require": {
+        "types": "./dist/token.d.cts",
+        "default": "./dist/token.cjs"
+      }
     }
   },
   "peerDependencies": {

--- a/packages/idenplane-js/src/__tests__/token.test.ts
+++ b/packages/idenplane-js/src/__tests__/token.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { parseJwt, isTokenExpired, getTokenExpiresIn } from '../token.js';
+import {
+  parseJwt,
+  decodeJwtPayload,
+  extractBearerToken,
+  getRolesFromToken,
+  isTokenExpired,
+  getTokenExpiresIn,
+} from '../token.js';
 
 // Helper: create a fake JWT with the given payload (handles unicode)
 function createJwt(payload: Record<string, unknown>): string {
@@ -36,6 +43,78 @@ describe('parseJwt', () => {
     expect(() => parseJwt('not-a-jwt')).toThrow('Invalid JWT format');
     expect(() => parseJwt('a.b')).toThrow('Invalid JWT format');
     expect(() => parseJwt('a.b.c.d')).toThrow('Invalid JWT format');
+  });
+});
+
+describe('decodeJwtPayload', () => {
+  it('should decode a valid JWT and return the payload', () => {
+    const jwt = createJwt({ sub: 'user-1', exp: 9999999999 });
+    expect(decodeJwtPayload(jwt)).toMatchObject({ sub: 'user-1', exp: 9999999999 });
+  });
+
+  it('should return null for malformed input (not 3 parts)', () => {
+    expect(decodeJwtPayload('not-a-jwt')).toBeNull();
+    expect(decodeJwtPayload('a.b')).toBeNull();
+    expect(decodeJwtPayload('a.b.c.d')).toBeNull();
+  });
+
+  it('should return null for a payload segment that is not valid base64url JSON', () => {
+    expect(decodeJwtPayload('a.not-valid-json-!!!.c')).toBeNull();
+  });
+
+  // The base64url payload segment's length mod 4 varies with the JSON
+  // payload's byte length, and each remainder (0, 2, 3 — 1 is impossible
+  // for valid base64) exercises different padding behavior in `atob`.
+  // Missing `=` padding must not cause a decode failure for any of them.
+  it.each([0, 1, 2, 3, 4, 5, 6, 7, 8])(
+    'should correctly decode payloads regardless of base64url padding remainder (extra chars: %i)',
+    (extraChars) => {
+      const jwt = createJwt({ sub: 'user-1', pad: 'x'.repeat(extraChars) });
+      expect(decodeJwtPayload(jwt)).toMatchObject({ sub: 'user-1', pad: 'x'.repeat(extraChars) });
+    },
+  );
+});
+
+describe('extractBearerToken', () => {
+  it('should extract the token from a Bearer header', () => {
+    expect(extractBearerToken('Bearer my-token-123')).toBe('my-token-123');
+  });
+
+  it('should return null for a missing header', () => {
+    expect(extractBearerToken(undefined)).toBeNull();
+    expect(extractBearerToken(null)).toBeNull();
+  });
+
+  it('should return null for a non-Bearer scheme', () => {
+    expect(extractBearerToken('Basic dXNlcjpwYXNz')).toBeNull();
+  });
+
+  it('should use the first value when given an array of header values', () => {
+    expect(extractBearerToken(['Bearer token-a', 'Bearer token-b'])).toBe('token-a');
+  });
+});
+
+describe('getRolesFromToken', () => {
+  const payload = {
+    realm_access: { roles: ['user', 'admin'] },
+    resource_access: { 'test-client': { roles: ['read', 'write'] } },
+  };
+
+  it('should return realm roles when no clientId is given', () => {
+    expect(getRolesFromToken(payload)).toEqual(['user', 'admin']);
+  });
+
+  it('should return client roles for the given clientId', () => {
+    expect(getRolesFromToken(payload, 'test-client')).toEqual(['read', 'write']);
+  });
+
+  it('should return an empty array for an unknown client', () => {
+    expect(getRolesFromToken(payload, 'unknown-client')).toEqual([]);
+  });
+
+  it('should return an empty array for null/undefined claims', () => {
+    expect(getRolesFromToken(null)).toEqual([]);
+    expect(getRolesFromToken(undefined)).toEqual([]);
   });
 });
 

--- a/packages/idenplane-js/src/client.ts
+++ b/packages/idenplane-js/src/client.ts
@@ -7,7 +7,7 @@ import type {
   UserInfo,
 } from './types.js';
 import { generateCodeChallenge, generateCodeVerifier, generateState } from './pkce.js';
-import { isTokenExpired, parseJwt } from './token.js';
+import { getRolesFromToken, isTokenExpired, parseJwt } from './token.js';
 import { createStorage, type TokenStorage } from './storage.js';
 import { EventEmitter } from './events.js';
 import { DiscoveryClient } from './discovery.js';
@@ -504,26 +504,22 @@ export class IdenplaneClient {
 
   /** Check if the user has a specific realm role. */
   hasRealmRole(role: string): boolean {
-    const claims = this.getTokenClaims();
-    return claims?.realm_access?.roles?.includes(role) ?? false;
+    return getRolesFromToken(this.getTokenClaims()).includes(role);
   }
 
   /** Check if the user has a specific client role. */
   hasClientRole(clientId: string, role: string): boolean {
-    const claims = this.getTokenClaims();
-    return claims?.resource_access?.[clientId]?.roles?.includes(role) ?? false;
+    return getRolesFromToken(this.getTokenClaims(), clientId).includes(role);
   }
 
   /** Get all realm roles for the current user. */
   getRealmRoles(): string[] {
-    const claims = this.getTokenClaims();
-    return claims?.realm_access?.roles ?? [];
+    return getRolesFromToken(this.getTokenClaims());
   }
 
   /** Get all client roles for a specific client. */
   getClientRoles(clientId: string): string[] {
-    const claims = this.getTokenClaims();
-    return claims?.resource_access?.[clientId]?.roles ?? [];
+    return getRolesFromToken(this.getTokenClaims(), clientId);
   }
 
   /**

--- a/packages/idenplane-js/src/server.ts
+++ b/packages/idenplane-js/src/server.ts
@@ -20,6 +20,9 @@
  */
 
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import { extractBearerToken, getRolesFromToken } from './token.js';
+
+export { extractBearerToken, getRolesFromToken } from './token.js';
 
 export interface IdenplaneServerConfig {
   /** Idenplane server base URL (e.g., 'http://localhost:3000') */
@@ -68,23 +71,13 @@ export async function verifyToken(
 }
 
 /**
- * Extract the Bearer token from an Authorization header value.
- * Returns null if the header is missing or not a Bearer token.
- */
-export function extractBearerToken(authHeader: string | string[] | undefined): string | null {
-  const header = Array.isArray(authHeader) ? authHeader[0] : authHeader;
-  if (!header?.startsWith('Bearer ')) return null;
-  return header.slice(7);
-}
-
-/**
  * Check if a token payload has the required realm roles.
  */
 export function hasRealmRoles(
   payload: IdenplaneTokenPayload,
   requiredRoles: string[],
 ): boolean {
-  const userRoles = payload.realm_access?.roles ?? [];
+  const userRoles = getRolesFromToken(payload);
   return requiredRoles.every((role) => userRoles.includes(role));
 }
 
@@ -96,7 +89,7 @@ export function hasClientRoles(
   clientId: string,
   requiredRoles: string[],
 ): boolean {
-  const userRoles = payload.resource_access?.[clientId]?.roles ?? [];
+  const userRoles = getRolesFromToken(payload, clientId);
   return requiredRoles.every((role) => userRoles.includes(role));
 }
 
@@ -231,19 +224,6 @@ export function createIdenplaneGuard(config: IdenplaneServerConfig) {
   };
 }
 
-/**
- * Helper to extract roles from an Idenplane token payload.
- */
-export function getRolesFromToken(
-  payload: IdenplaneTokenPayload,
-  clientId?: string,
-): string[] {
-  if (clientId) {
-    return payload.resource_access?.[clientId]?.roles ?? [];
-  }
-  return payload.realm_access?.roles ?? [];
-}
-
 // ─── Next.js Helpers ──────────────────────────────────────
 
 export interface NextRequest {
@@ -366,8 +346,7 @@ export function createNextMiddleware(middlewareConfig: NextMiddlewareConfig) {
     const isProtected = protectedPaths.some((path) => pathname.startsWith(path));
     if (!isProtected) return null; // Let Next.js continue
 
-    const authHeader = request.headers.get('authorization');
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const token = extractBearerToken(request.headers.get('authorization'));
 
     if (!token) {
       // Return redirect info — the caller uses NextResponse.redirect

--- a/packages/idenplane-js/src/token.ts
+++ b/packages/idenplane-js/src/token.ts
@@ -1,19 +1,61 @@
 import type { TokenClaims } from './types.js';
 
 /**
+ * Decode a base64url string (no padding required) to a UTF-8 string.
+ * `atob` follows the WHATWG forgiving-base64 algorithm, which tolerates
+ * missing `=` padding, so no manual padding step is needed here.
+ */
+function base64UrlToUtf8(base64url: string): string {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/**
  * Parse a JWT token and return the decoded payload.
  * This does NOT verify the signature — that's the server's responsibility.
+ *
+ * @throws {Error} If `token` is not a well-formed JWT (not three dot-separated parts).
  */
 export function parseJwt(token: string): TokenClaims {
   const parts = token.split('.');
   if (parts.length !== 3) {
     throw new Error('Invalid JWT format');
   }
-  const payload = parts[1];
-  const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
-  const bytes = Uint8Array.from(atob(base64), (char) => char.charCodeAt(0));
-  const json = new TextDecoder().decode(bytes);
-  return JSON.parse(json);
+  return JSON.parse(base64UrlToUtf8(parts[1]));
+}
+
+/**
+ * Decode a JWT's payload without verifying its signature, returning `null`
+ * instead of throwing if `token` is malformed. Prefer {@link parseJwt} when
+ * a malformed token should be treated as an error rather than "no claims".
+ *
+ * SECURITY NOTE: this does not validate the signature, issuer, audience, or
+ * any other security-relevant claim. Do not use the returned payload for
+ * authorization decisions unless the token was already cryptographically
+ * verified (e.g. via `verifyToken` in `idenplane-sdk/server`) by a trusted
+ * upstream layer.
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    return JSON.parse(base64UrlToUtf8(parts[1]));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the Bearer token from an Authorization header value.
+ * Returns `null` if the header is missing, empty, or not a Bearer token.
+ */
+export function extractBearerToken(
+  authHeader: string | string[] | undefined | null,
+): string | null {
+  const header = Array.isArray(authHeader) ? authHeader[0] : authHeader;
+  if (!header?.startsWith('Bearer ')) return null;
+  return header.slice(7);
 }
 
 /** Check if a token is expired, with an optional clock skew buffer in seconds. */
@@ -26,4 +68,30 @@ export function isTokenExpired(claims: TokenClaims, clockSkew = 0): boolean {
 export function getTokenExpiresIn(claims: TokenClaims): number {
   const now = Math.floor(Date.now() / 1000);
   return Math.max(0, claims.exp - now);
+}
+
+/**
+ * Minimal claim shape needed to resolve realm/client roles from a decoded
+ * token payload. Both `idenplane-js`'s `TokenClaims` and the server-side
+ * `IdenplaneTokenPayload` (in `server.ts`) are structurally compatible with
+ * this — role resolution only ever needs these two fields.
+ */
+export interface RoleClaims {
+  realm_access?: { roles: string[] };
+  resource_access?: Record<string, { roles: string[] }>;
+}
+
+/**
+ * Get the roles granted by a token payload: client roles for `clientId` if
+ * given, otherwise realm roles. Returns an empty array if the payload has
+ * no roles for the requested scope.
+ */
+export function getRolesFromToken(
+  claims: RoleClaims | null | undefined,
+  clientId?: string,
+): string[] {
+  if (clientId) {
+    return claims?.resource_access?.[clientId]?.roles ?? [];
+  }
+  return claims?.realm_access?.roles ?? [];
 }

--- a/packages/idenplane-js/tsup.config.ts
+++ b/packages/idenplane-js/tsup.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
     index: 'src/index.ts',
     react: 'src/react.ts',
     server: 'src/server.ts',
+    // Separate entry (not just bundled into index/server) so consumers that
+    // can't afford `jose` in their bundle — e.g. Next.js Edge Middleware —
+    // can import `idenplane-sdk/token` directly without pulling in `server.ts`'s
+    // `jose`-dependent verifyToken/JWKS machinery. token.ts has zero runtime
+    // imports of its own.
+    token: 'src/token.ts',
   },
   format: ['esm', 'cjs'],
   dts: true,

--- a/packages/idenplane-nextjs/src/api.ts
+++ b/packages/idenplane-nextjs/src/api.ts
@@ -73,24 +73,12 @@ export type NextApiHandler = (
 ) => void | Promise<void>;
 
 /**
- * Verify a Bearer token via idenplane-sdk/server (JWKS).
+ * Load the auth helpers from idenplane-sdk/server dynamically. Deferred to
+ * call time (rather than a static import) so this module doesn't force
+ * `jose` into a caller's bundle unless a request is actually handled.
  */
-async function verifyBearerToken(
-  token: string,
-  config: ApiAuthConfig,
-): Promise<TokenPayload> {
-  const { verifyToken } = await import('idenplane-sdk/server');
-  return verifyToken(token, {
-    issuerUrl: config.serverUrl,
-    realm: config.realm,
-  }) as Promise<TokenPayload>;
-}
-
-function extractBearer(headers: Record<string, string | string[] | undefined>): string | null {
-  const raw = headers['authorization'] ?? headers['Authorization'];
-  const header = Array.isArray(raw) ? raw[0] : raw;
-  if (!header?.startsWith('Bearer ')) return null;
-  return header.slice(7);
+async function loadAuthHelpers() {
+  return import('idenplane-sdk/server');
 }
 
 /**
@@ -104,7 +92,8 @@ export function withAuth(
   assertSecureServerUrl(config.serverUrl, config.allowInsecureHttp);
 
   return async (req, res) => {
-    const token = extractBearer(req.headers);
+    const { extractBearerToken, verifyToken, hasRealmRoles } = await loadAuthHelpers();
+    const token = extractBearerToken(req.headers['authorization'] ?? req.headers['Authorization']);
 
     if (!token) {
       return res.status(401).json({ error: 'unauthorized', message: 'Missing Bearer token' });
@@ -112,17 +101,16 @@ export function withAuth(
 
     let payload: TokenPayload;
     try {
-      payload = await verifyBearerToken(token, config);
+      payload = (await verifyToken(token, {
+        issuerUrl: config.serverUrl,
+        realm: config.realm,
+      })) as TokenPayload;
     } catch {
       return res.status(401).json({ error: 'unauthorized', message: 'Invalid or expired token' });
     }
 
-    if (config.requiredRoles?.length) {
-      const userRoles = payload.realm_access?.roles ?? [];
-      const hasAll = config.requiredRoles.every((r) => userRoles.includes(r));
-      if (!hasAll) {
-        return res.status(403).json({ error: 'forbidden', message: 'Insufficient roles' });
-      }
+    if (config.requiredRoles?.length && !hasRealmRoles(payload, config.requiredRoles)) {
+      return res.status(403).json({ error: 'forbidden', message: 'Insufficient roles' });
     }
 
     req.authUser = payload;
@@ -148,8 +136,8 @@ export function withAuthHandler(
   assertSecureServerUrl(config.serverUrl, config.allowInsecureHttp);
 
   return async (req: Request) => {
-    const authHeader = req.headers.get('authorization');
-    const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const { extractBearerToken, verifyToken, hasRealmRoles } = await loadAuthHelpers();
+    const token = extractBearerToken(req.headers.get('authorization'));
 
     if (!token) {
       return Response.json(
@@ -160,7 +148,10 @@ export function withAuthHandler(
 
     let payload: TokenPayload;
     try {
-      payload = await verifyBearerToken(token, config);
+      payload = (await verifyToken(token, {
+        issuerUrl: config.serverUrl,
+        realm: config.realm,
+      })) as TokenPayload;
     } catch {
       return Response.json(
         { error: 'unauthorized', message: 'Invalid or expired token' },
@@ -168,15 +159,11 @@ export function withAuthHandler(
       );
     }
 
-    if (config.requiredRoles?.length) {
-      const userRoles = payload.realm_access?.roles ?? [];
-      const hasAll = config.requiredRoles.every((r) => userRoles.includes(r));
-      if (!hasAll) {
-        return Response.json(
-          { error: 'forbidden', message: 'Insufficient roles' },
-          { status: 403 },
-        );
-      }
+    if (config.requiredRoles?.length && !hasRealmRoles(payload, config.requiredRoles)) {
+      return Response.json(
+        { error: 'forbidden', message: 'Insufficient roles' },
+        { status: 403 },
+      );
     }
 
     return handler(req, payload);

--- a/packages/idenplane-nextjs/src/middleware.ts
+++ b/packages/idenplane-nextjs/src/middleware.ts
@@ -28,6 +28,7 @@
  * ```
  */
 
+import { decodeJwtPayload, extractBearerToken } from 'idenplane-sdk/token';
 import { assertSecureServerUrl } from './internal/url-validation.js';
 
 export interface AuthMiddlewareConfig {
@@ -73,42 +74,29 @@ interface NextResponseStatic {
 }
 
 /**
- * Decode a JWT payload without cryptographic signature verification.
+ * Check whether a token is expired, without cryptographic signature
+ * verification.
  *
- * SECURITY NOTE (#10): This function only checks the token's expiry claim
- * (`exp`) and validates that the token is structurally well-formed (three
- * dot-separated parts, valid base64url encoding).  It does NOT verify the
- * signature.  A tampered or forged token with a future `exp` will pass this
- * check.
+ * SECURITY NOTE (#10): This only checks the token's expiry claim (`exp`) via
+ * `decodeJwtPayload` from `idenplane-sdk/token` (a structural decode — three
+ * dot-separated parts, valid base64url encoding, valid JSON). It does NOT
+ * verify the signature. A tampered or forged token with a future `exp` will
+ * pass this check.
  *
  * This is intentional for Edge Middleware: signature verification requires the
  * JWKS public key and an async network fetch, which adds latency on every
- * request.  The authoritative verification MUST be performed server-side via
+ * request. The authoritative verification MUST be performed server-side via
  * `verifyToken` (JWKS) before acting on any token claims for authorization
- * decisions.  Middleware should only be used as a first-pass redirect guard,
+ * decisions. Middleware should only be used as a first-pass redirect guard,
  * not as a security boundary by itself.
+ *
+ * `idenplane-sdk/token` has zero runtime dependencies (no `jose`), so
+ * importing it here doesn't add anything to the Edge Middleware bundle.
  */
 function isTokenExpiredLocally(token: string): boolean {
-  try {
-    const parts = token.split('.');
-    // Structural validation: a well-formed JWT has exactly three parts.
-    if (parts.length !== 3) return true;
-
-    const [, payloadB64] = parts;
-    // Validate the payload segment contains only valid base64url characters.
-    if (!/^[A-Za-z0-9_-]+$/.test(payloadB64)) return true;
-
-    const paddedPayload = payloadB64.padEnd(
-      payloadB64.length + (4 - (payloadB64.length % 4)) % 4,
-      '=',
-    );
-    const json = atob(paddedPayload.replace(/-/g, '+').replace(/_/g, '/'));
-    const payload = JSON.parse(json) as { exp?: number };
-    if (payload.exp === undefined) return true;
-    return Date.now() / 1000 > payload.exp;
-  } catch {
-    return true;
-  }
+  const payload = decodeJwtPayload(token);
+  if (!payload || typeof payload['exp'] !== 'number') return true;
+  return Date.now() / 1000 > payload['exp'];
 }
 
 /**
@@ -141,10 +129,7 @@ export function createAuthMiddleware(config: AuthMiddlewareConfig) {
     if (pathname.startsWith(loginPath)) return NextResponse.next();
 
     // 1. Try Authorization header (Bearer token)
-    const authHeader = request.headers.get('authorization');
-    const bearerToken = authHeader?.startsWith('Bearer ')
-      ? authHeader.slice(7)
-      : null;
+    const bearerToken = extractBearerToken(request.headers.get('authorization'));
 
     if (bearerToken && !isTokenExpiredLocally(bearerToken)) {
       return NextResponse.next();

--- a/packages/idenplane-nextjs/src/server.ts
+++ b/packages/idenplane-nextjs/src/server.ts
@@ -24,6 +24,8 @@
  * ```
  */
 
+import { decodeJwtPayload as decodeJwtPayloadCore } from 'idenplane-sdk/token';
+
 // ── Shared types ─────────────────────────────────────────────────
 
 export interface ServerAuthConfig {
@@ -98,19 +100,13 @@ export interface ReadonlyRequestCookies {
  * If you are making access-control decisions based on the returned claims,
  * you MUST verify the token first with `verifyToken` from `idenplane-sdk/server`
  * (which performs full JWKS signature verification).
+ *
+ * Delegates to `idenplane-sdk/token`'s `decodeJwtPayload` (the shared,
+ * dependency-free implementation also used by `@idenplane/nextjs/middleware`)
+ * rather than maintaining a separate base64url decode here.
  */
 function decodeJwtPayload(token: string): TokenPayload | null {
-  try {
-    const [, payloadB64] = token.split('.');
-    if (!payloadB64) return null;
-    const json = Buffer.from(
-      payloadB64.replace(/-/g, '+').replace(/_/g, '/'),
-      'base64',
-    ).toString('utf8');
-    return JSON.parse(json) as TokenPayload;
-  } catch {
-    return null;
-  }
+  return decodeJwtPayloadCore(token) as TokenPayload | null;
 }
 
 function isExpired(payload: TokenPayload): boolean {


### PR DESCRIPTION
## Summary

**idenplane-js**
- `token.ts` becomes the single dependency-free home for `extractBearerToken`, new `decodeJwtPayload` (atob-based, returns `null` on failure — distinct contract from `parseJwt`, which throws), and `getRolesFromToken` (promoted from server.ts's own copy). `parseJwt` now shares the same `base64UrlToUtf8` primitive.
- New `token` tsup entry + `"./token"` package export, so consumers that can't afford `jose` in their bundle (Next.js Edge Middleware) can import these without pulling in `server.ts`'s JWKS/`verifyToken` machinery. Confirmed `dist/token.js` has zero references to `jose`.
- `server.ts` re-exports `extractBearerToken`/`getRolesFromToken` for backward compatibility, uses them internally in `hasRealmRoles`/`hasClientRoles`, and fixes `createNextMiddleware`'s inline bearer-extraction — which duplicated `extractBearerToken` ~200 lines below its own definition **in the same file**.
- `client.ts`'s `hasRealmRole`/`hasClientRole`/`getRealmRoles`/`getClientRoles` now call the same `getRolesFromToken` accessor instead of inlining `realm_access`/`resource_access` field access. No signature changes.

**idenplane-nextjs**
- `api.ts`: removed the dead local `extractBearer` and the inline `.every()` role-check duplicated in both `withAuth` and `withAuthHandler`; both now destructure `extractBearerToken`/`hasRealmRoles` from the dynamic `import('idenplane-sdk/server')` already used for `verifyToken`.
- `server.ts`'s `decodeJwtPayload` now delegates to `idenplane-sdk/token` (Node.js Server Components runtime — a small extra static import is fine here).
- `middleware.ts`'s `isTokenExpiredLocally` now delegates to the same shared `decodeJwtPayload` via the lightweight `idenplane-sdk/token` import, replacing ~20 lines of duplicated split/regex/pad/atob/JSON.parse logic while preserving identical fail-closed semantics.

**idenplane-vue and idenplane-angular are untouched.** Their `hasRole` wrappers already delegate to `client.hasRealmRole` with no duplicated logic to remove — renaming them would break a published API and `auth.service.test.ts`'s assertion on the delegation by name, for no benefit. (The issue's suggested `hasRoles`/`getRoles` rename was scoped down to accessor extraction instead — see commit message for the full reasoning.)

## Two things I verified before touching anything
1. **The Edge Runtime constraint**: `idenplane-nextjs/middleware.ts` runs on Edge, where `Buffer` isn't reliably available. A shared decoder needed to be `atob`-based and physically separate from the `jose`-importing `server.ts`, not just "the same function, trust tree-shaking" — hence the new `token` subpath rather than importing from `idenplane-sdk/server`.
2. **Base64url padding**: the three prior implementations padded differently (`middleware.ts` padded explicitly, `Buffer.from` tolerated missing padding, the original `parseJwt` padded not at all). Added parameterized tests covering all padding remainders (0, 2, 3) to lock in that `atob`'s WHATWG forgiving-base64 behavior handles all of them correctly — confirmed empirically, not just assumed.

## Verification
- `idenplane-js`: build/typecheck/test all pass (135 tests, +20 new covering `decodeJwtPayload`/`extractBearerToken`/`getRolesFromToken` including the padding edge cases).
- `idenplane-nextjs`: build/typecheck/test all pass (23 tests, unchanged). Confirmed `dist/middleware.js` still has zero `jose` references.
- `idenplane-vue` / `idenplane-angular`: build/typecheck/test all pass against the updated `idenplane-js` (19 and 11 tests respectively, unchanged) — confirms `hasRealmRole`/`hasClientRole`'s external behavior is unaffected.

Closes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)