### PR TITLE
fix(idenplane-java): correct Maven groupId io.idenplane -> com.idenplane

### DIFF
--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.idenplane</groupId>
+        <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>

--- a/packages/idenplane-java/idenplane-java-jakarta/pom.xml
+++ b/packages/idenplane-java/idenplane-java-jakarta/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.idenplane</groupId>
+        <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -19,7 +19,7 @@
     <dependencies>
         <!-- Idenplane Core Module -->
         <dependency>
-            <groupId>io.idenplane</groupId>
+            <groupId>com.idenplane</groupId>
             <artifactId>idenplane-java-core</artifactId>
         </dependency>
 

--- a/packages/idenplane-java/idenplane-java-reactive/pom.xml
+++ b/packages/idenplane-java/idenplane-java-reactive/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.idenplane</groupId>
+        <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -19,7 +19,7 @@
     <dependencies>
         <!-- Idenplane Core Module -->
         <dependency>
-            <groupId>io.idenplane</groupId>
+            <groupId>com.idenplane</groupId>
             <artifactId>idenplane-java-core</artifactId>
         </dependency>
 

--- a/packages/idenplane-java/idenplane-java-spring/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>io.idenplane</groupId>
+        <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
@@ -19,7 +19,7 @@
     <dependencies>
         <!-- Idenplane Core Module -->
         <dependency>
-            <groupId>io.idenplane</groupId>
+            <groupId>com.idenplane</groupId>
             <artifactId>idenplane-java-core</artifactId>
         </dependency>
 

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.idenplane</groupId>
+    <groupId>com.idenplane</groupId>
     <artifactId>idenplane-java</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -32,28 +32,28 @@
         <dependencies>
             <!-- Idenplane Core Module -->
             <dependency>
-                <groupId>io.idenplane</groupId>
+                <groupId>com.idenplane</groupId>
                 <artifactId>idenplane-java-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <!-- Idenplane Reactive Module -->
             <dependency>
-                <groupId>io.idenplane</groupId>
+                <groupId>com.idenplane</groupId>
                 <artifactId>idenplane-java-reactive</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <!-- Idenplane Spring Module -->
             <dependency>
-                <groupId>io.idenplane</groupId>
+                <groupId>com.idenplane</groupId>
                 <artifactId>idenplane-java-spring</artifactId>
                 <version>${project.version}</version>
             </dependency>
 
             <!-- Idenplane Jakarta Module -->
             <dependency>
-                <groupId>io.idenplane</groupId>
+                <groupId>com.idenplane</groupId>
                 <artifactId>idenplane-java-jakarta</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
## Summary
- Fixes the groupId defect called out in #1326: all 5 `pom.xml` files in `packages/idenplane-java/` declared `groupId io.idenplane`, but every Java package in the module already lives under `com.idenplane.sdk` (verified: `grep -rn "^package " packages/idenplane-java/**/src/main/java` — all `com.idenplane.sdk.*`), matching the Android SDK's namespace (`com.idenplane.sdk`, per #1325).
- Changed: root `pom.xml`'s own `groupId` plus its 4 internal `dependencyManagement` entries, and each of the 4 module `pom.xml`'s `<parent>` groupId and (for jakarta/reactive/spring) their `idenplane-java-core` dependency groupId. 12 occurrences total, all now `com.idenplane`.
- This is **not** a fix for the rest of #1326 — implementing the actual OIDC/token-validation client, JWKS caching, Spring Boot auto-config, and tests is a separately-scoped, much larger effort tracked in that issue. This PR only fixes the groupId mismatch, which is independently verifiable and doesn't depend on the rest of that work.

## Test plan
- [x] `grep -rn "io\.idenplane" packages/idenplane-java/` returns zero matches
- [x] `grep -rn "com\.idenplane" packages/idenplane-java/**/pom.xml` returns 12 matches (all changed sites)
- [x] Diff reviewed line-by-line — no other content changed
- [ ] No local Maven/Java toolchain available to run an actual `mvn validate`/`mvn compile`, and there is currently no CI job for this package (consistent with the issue noting the module has no tests/build wiring yet) — flagging this gap rather than claiming a build was verified
- [ ] CI (other jobs, unrelated to this package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK