### PR TITLE
feat(realtime): push session-termination events over WebSocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@types/qrcode": "^1.5.6",
         "@types/sanitize-html": "^2.16.1",
         "@types/supertest": "^7.2.1",
+        "@types/ws": "^8.18.1",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.5.6",
@@ -4665,6 +4666,16 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/xml-encryption": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "@types/qrcode": "^1.5.6",
     "@types/sanitize-html": "^2.16.1",
     "@types/supertest": "^7.2.1",
+    "@types/ws": "^8.18.1",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.5.6",

--- a/src/continuous-verification/continuous-verification.module.ts
+++ b/src/continuous-verification/continuous-verification.module.ts
@@ -17,6 +17,7 @@ import { ImpossibleTravelService } from '../risk-assessment/impossible-travel.se
 import { SessionsModule } from '../sessions/sessions.module.js';
 import { StepUpModule } from '../step-up/step-up.module.js';
 import { CacheModule } from '../cache/cache.module.js';
+import { RealtimeModule } from '../realtime/realtime.module.js';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { CacheModule } from '../cache/cache.module.js';
     SessionsModule,
     StepUpModule,
     CacheModule,
+    RealtimeModule,
   ],
   providers: [
     ContinuousRiskAssessmentService,

--- a/src/continuous-verification/session-termination.service.spec.ts
+++ b/src/continuous-verification/session-termination.service.spec.ts
@@ -1,0 +1,91 @@
+import { SessionTerminationService } from './session-termination.service.js';
+
+describe('SessionTerminationService', () => {
+  let service: SessionTerminationService;
+  let prisma: any;
+  let sessionsService: { revokeSession: jest.Mock };
+  let sessionEvents: { emitSessionTerminated: jest.Mock };
+
+  const mockProfile = {
+    sessionId: 'sess-1',
+    riskScore: 95,
+    riskLevel: 'CRITICAL',
+    terminationReason: null,
+    session: {
+      id: 'sess-1',
+      userId: 'user-1',
+      realmId: 'realm-1',
+      clientId: 'client-1',
+      user: { username: 'alice', email: 'alice@example.com' },
+    },
+  };
+
+  beforeEach(() => {
+    prisma = {
+      sessionRiskProfile: {
+        findMany: jest.fn(),
+        findUnique: jest.fn().mockResolvedValue(mockProfile),
+        update: jest.fn().mockResolvedValue({}),
+      },
+      continuousRiskEvent: {
+        create: jest.fn().mockResolvedValue({}),
+      },
+    };
+    sessionsService = { revokeSession: jest.fn().mockResolvedValue(undefined) };
+    sessionEvents = { emitSessionTerminated: jest.fn() };
+
+    service = new SessionTerminationService(
+      prisma,
+      sessionsService as any,
+      sessionEvents as any,
+    );
+  });
+
+  describe('terminateSessionById', () => {
+    it('pushes a session.terminated event to the affected user over the realtime gateway', async () => {
+      await service.terminateSessionById('sess-1', 'Impossible travel detected');
+
+      expect(sessionEvents.emitSessionTerminated).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          sessionId: 'sess-1',
+          reason: 'Impossible travel detected',
+          timestamp: expect.any(String),
+        }),
+      );
+    });
+
+    it('falls back to the profile termination reason when none is given', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue({
+        ...mockProfile,
+        terminationReason: 'Stored reason',
+      });
+
+      await service.terminateSessionById('sess-1');
+
+      expect(sessionEvents.emitSessionTerminated).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ reason: 'Stored reason' }),
+      );
+    });
+
+    it('throws if no risk profile exists for the session', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue(null);
+
+      await expect(service.terminateSessionById('missing')).rejects.toThrow(
+        'Session risk profile not found for session: missing',
+      );
+      expect(sessionEvents.emitSessionTerminated).not.toHaveBeenCalled();
+    });
+
+    it('revokes the session via SessionsService', async () => {
+      await service.terminateSessionById('sess-1');
+
+      expect(sessionsService.revokeSession).toHaveBeenCalledWith(
+        null,
+        'sess-1',
+        'oauth',
+      );
+    });
+  });
+});

--- a/src/continuous-verification/session-termination.service.ts
+++ b/src/continuous-verification/session-termination.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Interval } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { SessionsService } from '../sessions/sessions.service.js';
+import { SessionEventsGateway } from '../realtime/session-events.gateway.js';
 
 /**
  * SessionTerminationService
@@ -20,6 +21,7 @@ export class SessionTerminationService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly sessionsService: SessionsService,
+    private readonly sessionEvents: SessionEventsGateway,
   ) {}
 
   /**
@@ -220,8 +222,11 @@ export class SessionTerminationService {
     });
 
     // Emit termination event for real-time notification
-    // TODO: Emit event for WebSocket/push notification to client application
-    // this.eventEmitter.emit('session.terminated', { sessionId, reason: terminationReason });
+    this.sessionEvents.emitSessionTerminated(session.userId, {
+      sessionId: profile.sessionId,
+      reason: terminationReason,
+      timestamp: now.toISOString(),
+    });
 
     // TODO: Send notification to user about session termination
     // await this.emailService.sendSessionTerminationNotice(session.user.email, session.user.username);

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { GlobalExceptionFilter } from './common/filters/http-exception.filter.js
 import { registerHandlebarsHelpers } from './theme/handlebars-helpers.js';
 import { CorsOriginService } from './cors/cors-origin.service.js';
 import { NormalizeRoleBodyPipe } from './roles/pipes/normalize-role-body.pipe.js';
+import { SessionEventsGateway } from './realtime/session-events.gateway.js';
 
 /** Known-insecure / placeholder values that must never reach production. */
 const INSECURE_ADMIN_API_KEY_VALUES = new Set([
@@ -296,6 +297,8 @@ async function bootstrap() {
 
   // Preload CORS origin cache before accepting requests
   await corsOriginService.preloadCache();
+
+  app.get(SessionEventsGateway).attach(app.getHttpServer());
 
   const port = process.env['PORT'] ?? 3000;
   await app.listen(port);

--- a/src/realtime/realtime.module.ts
+++ b/src/realtime/realtime.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SessionEventsGateway } from './session-events.gateway.js';
+import { TokensModule } from '../tokens/tokens.module.js';
+
+@Module({
+  imports: [TokensModule],
+  providers: [SessionEventsGateway],
+  exports: [SessionEventsGateway],
+})
+export class RealtimeModule {}

--- a/src/realtime/session-events.gateway.spec.ts
+++ b/src/realtime/session-events.gateway.spec.ts
@@ -1,0 +1,171 @@
+// Mock JwkService to avoid importing jose (ESM-only) in Jest's CJS transform.
+jest.mock('../crypto/jwk.service.js', () => ({
+  JwkService: jest.fn(),
+}));
+
+import { WebSocket } from 'ws';
+import { SessionEventsGateway } from './session-events.gateway.js';
+import {
+  createMockPrismaService,
+  type MockPrismaService,
+} from '../prisma/prisma.mock.js';
+
+describe('SessionEventsGateway', () => {
+  let service: SessionEventsGateway;
+  let prisma: MockPrismaService;
+  let jwkService: { verifyJwt: jest.Mock };
+  let blacklist: { isBlacklisted: jest.Mock };
+
+  const mockRealm = { id: 'realm-1', name: 'test-realm' };
+  const mockSigningKey = {
+    id: 'key-1',
+    realmId: 'realm-1',
+    publicKey: 'public-key-pem',
+    active: true,
+  };
+
+  function authenticate(searchParams: Record<string, string>) {
+    return (service as unknown as {
+      authenticate: (
+        p: URLSearchParams,
+      ) => Promise<{ userId: string } | null>;
+    }).authenticate(new URLSearchParams(searchParams));
+  }
+
+  function makeFakeSocket(readyState: number) {
+    return { readyState, send: jest.fn() };
+  }
+
+  beforeEach(() => {
+    prisma = createMockPrismaService();
+    prisma.session.findUnique = jest.fn();
+    jwkService = { verifyJwt: jest.fn() };
+    blacklist = { isBlacklisted: jest.fn().mockResolvedValue(false) };
+
+    service = new SessionEventsGateway(
+      prisma as any,
+      jwkService as any,
+      blacklist as any,
+    );
+  });
+
+  describe('authenticate', () => {
+    it('returns null when token or realm query params are missing', async () => {
+      expect(await authenticate({ realm: 'test-realm' })).toBeNull();
+      expect(await authenticate({ token: 'abc' })).toBeNull();
+    });
+
+    it('returns null when the realm does not exist', async () => {
+      prisma.realm.findUnique.mockResolvedValue(null);
+      expect(
+        await authenticate({ token: 'abc', realm: 'nonexistent' }),
+      ).toBeNull();
+    });
+
+    it('returns null when the realm has no active signing key', async () => {
+      prisma.realm.findUnique.mockResolvedValue(mockRealm);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(null);
+      expect(
+        await authenticate({ token: 'abc', realm: 'test-realm' }),
+      ).toBeNull();
+    });
+
+    it('returns null when the token fails verification', async () => {
+      prisma.realm.findUnique.mockResolvedValue(mockRealm);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockRejectedValue(new Error('invalid signature'));
+      expect(
+        await authenticate({ token: 'bad', realm: 'test-realm' }),
+      ).toBeNull();
+    });
+
+    it('returns null when the jti is blacklisted', async () => {
+      prisma.realm.findUnique.mockResolvedValue(mockRealm);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue({ sub: 'user-1', jti: 'jti-1' });
+      blacklist.isBlacklisted.mockResolvedValue(true);
+      expect(
+        await authenticate({ token: 'abc', realm: 'test-realm' }),
+      ).toBeNull();
+    });
+
+    it('returns null when the token has a sid but the session no longer exists', async () => {
+      prisma.realm.findUnique.mockResolvedValue(mockRealm);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue({ sub: 'user-1', sid: 'sess-1' });
+      prisma.session.findUnique.mockResolvedValue(null);
+      expect(
+        await authenticate({ token: 'abc', realm: 'test-realm' }),
+      ).toBeNull();
+    });
+
+    it('returns the userId for a valid token with a live session', async () => {
+      prisma.realm.findUnique.mockResolvedValue(mockRealm);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue({ sub: 'user-1', sid: 'sess-1' });
+      prisma.session.findUnique.mockResolvedValue({ id: 'sess-1' });
+      expect(
+        await authenticate({ token: 'abc', realm: 'test-realm' }),
+      ).toEqual({ userId: 'user-1' });
+    });
+
+    it('returns the userId for a valid token with no sid claim', async () => {
+      prisma.realm.findUnique.mockResolvedValue(mockRealm);
+      prisma.realmSigningKey.findFirst.mockResolvedValue(mockSigningKey);
+      jwkService.verifyJwt.mockResolvedValue({ sub: 'user-1' });
+      expect(
+        await authenticate({ token: 'abc', realm: 'test-realm' }),
+      ).toEqual({ userId: 'user-1' });
+    });
+  });
+
+  describe('emitSessionTerminated', () => {
+    it('does nothing when the user has no open connections', () => {
+      expect(() =>
+        service.emitSessionTerminated('user-1', {
+          sessionId: 'sess-1',
+          reason: 'Critical risk detected',
+          timestamp: new Date().toISOString(),
+        }),
+      ).not.toThrow();
+    });
+
+    it('sends the event to every OPEN socket for the user and skips closed ones', () => {
+      const openSocket = makeFakeSocket(WebSocket.OPEN);
+      const closedSocket = makeFakeSocket(WebSocket.CLOSED);
+      (service as any).connections.set(
+        'user-1',
+        new Set([openSocket, closedSocket]),
+      );
+
+      service.emitSessionTerminated('user-1', {
+        sessionId: 'sess-1',
+        reason: 'Critical risk detected',
+        timestamp: '2026-08-02T00:00:00.000Z',
+      });
+
+      expect(openSocket.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'session.terminated',
+          sessionId: 'sess-1',
+          reason: 'Critical risk detected',
+          timestamp: '2026-08-02T00:00:00.000Z',
+        }),
+      );
+      expect(closedSocket.send).not.toHaveBeenCalled();
+    });
+
+    it('does not deliver to a different user', () => {
+      const socket = makeFakeSocket(WebSocket.OPEN);
+      (service as any).connections.set('user-1', new Set([socket]));
+
+      service.emitSessionTerminated('user-2', {
+        sessionId: 'sess-1',
+        reason: 'Critical risk detected',
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(socket.send).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/realtime/session-events.gateway.ts
+++ b/src/realtime/session-events.gateway.ts
@@ -1,0 +1,138 @@
+import type { Server as HttpServer } from 'http';
+import { Injectable, Logger } from '@nestjs/common';
+import { WebSocketServer, WebSocket } from 'ws';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { JwkService } from '../crypto/jwk.service.js';
+import { TokenBlacklistService } from '../tokens/token-blacklist.service.js';
+
+export const SESSION_EVENTS_PATH = '/ws/events';
+
+export interface SessionTerminatedEvent {
+  sessionId: string;
+  reason: string;
+  timestamp: string;
+}
+
+/**
+ * Real-time push for session lifecycle events, replacing the polling-based
+ * "did my session get revoked?" pattern. A client connects to
+ * `SESSION_EVENTS_PATH` with `?token=<access_token>&realm=<realmName>`; the
+ * token is verified exactly like the /userinfo endpoint (realm signing key,
+ * blacklist, session-still-exists check) before the socket is accepted.
+ *
+ * Connections are registered by userId, so a client only ever receives
+ * events about that user's own sessions.
+ */
+@Injectable()
+export class SessionEventsGateway {
+  private readonly logger = new Logger(SessionEventsGateway.name);
+  private readonly connections = new Map<string, Set<WebSocket>>();
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly jwkService: JwkService,
+    private readonly blacklist: TokenBlacklistService,
+  ) {}
+
+  /** Wire the WebSocket upgrade handler onto the app's underlying HTTP server. */
+  attach(server: HttpServer): void {
+    const wss = new WebSocketServer({ noServer: true });
+
+    server.on('upgrade', (req, socket, head) => {
+      const url = new URL(req.url ?? '', 'http://localhost');
+      if (url.pathname !== SESSION_EVENTS_PATH) {
+        socket.destroy();
+        return;
+      }
+
+      this.authenticate(url.searchParams)
+        .then((auth) => {
+          if (!auth) {
+            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+          wss.handleUpgrade(req, socket, head, (ws) => {
+            this.registerConnection(auth.userId, ws);
+            ws.on('close', () => this.unregisterConnection(auth.userId, ws));
+            ws.on('error', () => this.unregisterConnection(auth.userId, ws));
+          });
+        })
+        .catch((error: unknown) => {
+          this.logger.debug(
+            `WebSocket auth failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+          socket.destroy();
+        });
+    });
+  }
+
+  /** Push a session-termination event to every connection for this user. */
+  emitSessionTerminated(userId: string, event: SessionTerminatedEvent): void {
+    const sockets = this.connections.get(userId);
+    if (!sockets || sockets.size === 0) return;
+
+    const payload = JSON.stringify({ type: 'session.terminated', ...event });
+    for (const ws of sockets) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(payload);
+      }
+    }
+  }
+
+  private async authenticate(
+    searchParams: URLSearchParams,
+  ): Promise<{ userId: string } | null> {
+    const token = searchParams.get('token');
+    const realmName = searchParams.get('realm');
+    if (!token || !realmName) return null;
+
+    const realm = await this.prisma.realm.findUnique({
+      where: { name: realmName },
+    });
+    if (!realm) return null;
+
+    const signingKey = await this.prisma.realmSigningKey.findFirst({
+      where: { realmId: realm.id, active: true },
+      orderBy: { createdAt: 'desc' },
+    });
+    if (!signingKey) return null;
+
+    let payload;
+    try {
+      payload = await this.jwkService.verifyJwt(token, signingKey.publicKey);
+    } catch {
+      return null;
+    }
+
+    const jti = payload['jti'];
+    if (jti && (await this.blacklist.isBlacklisted(jti))) return null;
+
+    const sid = payload['sid'] as string | undefined;
+    if (sid) {
+      const session = await this.prisma.session.findUnique({
+        where: { id: sid },
+      });
+      if (!session) return null;
+    }
+
+    const userId = payload.sub;
+    if (!userId) return null;
+
+    return { userId };
+  }
+
+  private registerConnection(userId: string, ws: WebSocket): void {
+    const sockets = this.connections.get(userId) ?? new Set<WebSocket>();
+    sockets.add(ws);
+    this.connections.set(userId, sockets);
+  }
+
+  private unregisterConnection(userId: string, ws: WebSocket): void {
+    const sockets = this.connections.get(userId);
+    if (!sockets) return;
+    sockets.delete(ws);
+    if (sockets.size === 0) this.connections.delete(userId);
+  }
+}


### PR DESCRIPTION
## Summary
- Relates to #1308 (real-time WebSocket push for session lifecycle events) — a scoped MVP wiring up just the session-termination event, which was already flagged as a real gap by a TODO comment in the source (`session-termination.service.ts`, "Emit event for WebSocket/push notification to client application").
- New `SessionEventsGateway` (`src/realtime/`) attaches a `ws`-based WebSocket server (`noServer` mode) directly to the app's underlying HTTP server at `/ws/events`, avoiding a new `@nestjs/websockets`/`@nestjs/platform-ws` dependency since `ws` was already in package.json.
- Auth: a client connects with `?token=<access_token>&realm=<realmName>`. The token is verified exactly like the existing `/userinfo` endpoint — realm signing key lookup, `jose` JWT verification, blacklist check via `jti`, and a live-session check via `sid` if present. Connections are registered by `userId`, so a client only ever receives events about its own sessions.
- `SessionTerminationService` now calls `sessionEvents.emitSessionTerminated(userId, { sessionId, reason, timestamp })` wherever it previously just had the TODO comment — covering both the scheduled risk-based termination check and manual `terminateSessionById` calls.
- The second TODO a few lines below (email notification) is untouched — that's #1309's scope, not this PR's.
- Not attempted: step-up-authentication events, graceful degradation to polling, and JS/React/Next.js/Angular/Vue SDK WebSocket listener helpers (the rest of #1308's acceptance criteria).

## Test plan
- [x] `npm test -- session-events` — 11/11 pass (auth: missing params, realm not found, no signing key, invalid token, blacklisted jti, session-gone-for-sid, valid w/ and w/o sid; emit: no connections, delivers only to OPEN sockets, scoped to the right userId)
- [x] `npm test -- session-termination` — 4/4 pass (new spec file; this service had zero prior test coverage) — verifies the emit call fires with the right payload, falls back to the stored termination reason, throws when no risk profile exists, and still revokes via `SessionsService`
- [x] `npm run build` — clean (added `@types/ws` devDependency; `ws` itself was already a runtime dependency)
- [x] `npm run lint` (scoped to touched files) — clean
- [x] Full backend suite: `npm test` — 131 suites / 2172 tests pass
- [ ] CI (this is the first real signal on whether the WebSocket upgrade wiring works end-to-end against a live server — no local DB/app-boot environment was available to verify beyond unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK