### PR TITLE
feat(continuous-verification): email users when a session is terminated

### DIFF
--- a/src/continuous-verification/session-termination.service.spec.ts
+++ b/src/continuous-verification/session-termination.service.spec.ts
@@ -5,6 +5,7 @@ describe('SessionTerminationService', () => {
   let prisma: any;
   let sessionsService: { revokeSession: jest.Mock };
   let sessionEvents: { emitSessionTerminated: jest.Mock };
+  let emailService: { sendEmail: jest.Mock };
 
   const mockProfile = {
     sessionId: 'sess-1',
@@ -30,14 +31,19 @@ describe('SessionTerminationService', () => {
       continuousRiskEvent: {
         create: jest.fn().mockResolvedValue({}),
       },
+      realm: {
+        findUnique: jest.fn().mockResolvedValue({ name: 'test-realm' }),
+      },
     };
     sessionsService = { revokeSession: jest.fn().mockResolvedValue(undefined) };
     sessionEvents = { emitSessionTerminated: jest.fn() };
+    emailService = { sendEmail: jest.fn().mockResolvedValue(undefined) };
 
     service = new SessionTerminationService(
       prisma,
       sessionsService as any,
       sessionEvents as any,
+      emailService as any,
     );
   });
 
@@ -86,6 +92,66 @@ describe('SessionTerminationService', () => {
         'sess-1',
         'oauth',
       );
+    });
+
+    it('emails the affected user with the realm name resolved from realmId', async () => {
+      await service.terminateSessionById('sess-1', 'Impossible travel detected');
+
+      expect(prisma.realm.findUnique).toHaveBeenCalledWith({
+        where: { id: 'realm-1' },
+        select: { name: true },
+      });
+      expect(emailService.sendEmail).toHaveBeenCalledWith(
+        'test-realm',
+        'alice@example.com',
+        'Your session was ended',
+        expect.stringContaining('Impossible travel detected'),
+      );
+    });
+
+    it('escapes the username and reason in the email body', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue({
+        ...mockProfile,
+        session: {
+          ...mockProfile.session,
+          user: { username: '<script>alert(1)</script>', email: 'alice@example.com' },
+        },
+      });
+
+      await service.terminateSessionById('sess-1', '<img src=x onerror=alert(1)>');
+
+      const html = emailService.sendEmail.mock.calls[0][3] as string;
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('<img src=x onerror=alert(1)>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('does not email when the user has no email on file', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue({
+        ...mockProfile,
+        session: {
+          ...mockProfile.session,
+          user: { username: 'alice', email: null },
+        },
+      });
+
+      await service.terminateSessionById('sess-1');
+
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not throw and still completes termination when the email send fails', async () => {
+      emailService.sendEmail.mockRejectedValue(new Error('SMTP down'));
+
+      await expect(service.terminateSessionById('sess-1')).resolves.toBeUndefined();
+      expect(sessionEvents.emitSessionTerminated).toHaveBeenCalled();
+    });
+
+    it('skips the email silently if the realm cannot be resolved', async () => {
+      prisma.realm.findUnique.mockResolvedValue(null);
+
+      await expect(service.terminateSessionById('sess-1')).resolves.toBeUndefined();
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/continuous-verification/session-termination.service.ts
+++ b/src/continuous-verification/session-termination.service.ts
@@ -3,6 +3,8 @@ import { Interval } from '@nestjs/schedule';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { SessionsService } from '../sessions/sessions.service.js';
 import { SessionEventsGateway } from '../realtime/session-events.gateway.js';
+import { EmailService } from '../email/email.service.js';
+import { escapeHtml } from '../common/utils/html-escape.util.js';
 
 /**
  * SessionTerminationService
@@ -22,6 +24,7 @@ export class SessionTerminationService {
     private readonly prisma: PrismaService,
     private readonly sessionsService: SessionsService,
     private readonly sessionEvents: SessionEventsGateway,
+    private readonly emailService: EmailService,
   ) {}
 
   /**
@@ -228,7 +231,60 @@ export class SessionTerminationService {
       timestamp: now.toISOString(),
     });
 
-    // TODO: Send notification to user about session termination
-    // await this.emailService.sendSessionTerminationNotice(session.user.email, session.user.username);
+    // Notify the user by email, if they have one on file.
+    if (session.user?.email) {
+      await this.sendTerminationEmail(
+        session.realmId,
+        session.user.email,
+        session.user.username,
+        terminationReason,
+        now,
+      );
+    }
+  }
+
+  private async sendTerminationEmail(
+    realmId: string,
+    userEmail: string,
+    username: string,
+    reason: string,
+    timestamp: Date,
+  ): Promise<void> {
+    const realm = await this.prisma.realm.findUnique({
+      where: { id: realmId },
+      select: { name: true },
+    });
+    if (!realm) return;
+
+    const time = escapeHtml(timestamp.toUTCString());
+    const safeReason = escapeHtml(reason);
+    const safeUsername = escapeHtml(username);
+
+    const html = `
+      <h2>Session Ended</h2>
+      <p>Hi ${safeUsername},</p>
+      <p>One of your sessions was ended by Idenplane's security monitoring.</p>
+      <table style="border-collapse:collapse;margin-top:12px">
+        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Time</td><td>${time}</td></tr>
+        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Reason</td><td>${safeReason}</td></tr>
+      </table>
+      <p style="margin-top:16px">
+        If you're still signed in elsewhere, you may need to sign in again on the device where this session was active.
+        If you don't recognize this activity, please contact your administrator.
+      </p>
+    `;
+
+    try {
+      await this.emailService.sendEmail(
+        realm.name,
+        userEmail,
+        'Your session was ended',
+        html,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to send session-termination email to ${userEmail}: ${(err as Error).message}`,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Relates to #1309 (user security-event notifications, email + in-app) — a scoped MVP for one trigger: emailing a user when one of their sessions is terminated. This is the second of the two TODOs that used to sit in `session-termination.service.ts` (the first, WebSocket push, was completed in #1335).
- Follows the existing pattern for security notification emails already used in `risk-assessment.service.ts`'s `sendBlockedLoginEmail` — a plain escaped-HTML body sent via the existing `EmailService.sendEmail(realmName, to, subject, html)`, not a new Handlebars theme template (those are reserved for branded user-facing pages like login/register/reset-password; this is a transactional security notice, matching the existing precedent).
- `terminateSession()` only had `realmId` on hand, not the realm's name (`EmailService.sendEmail` takes a name) — `Session` has no `realm` relation in the Prisma schema, only the `realmId` scalar, so this resolves the name via a small `prisma.realm.findUnique({ where: { id }, select: { name: true } })` lookup right before sending.
- Failure handling: skips silently (with a warned log) if the user has no email on file, the realm can't be resolved, or the send itself throws — the session is already revoked and the WebSocket event already pushed by that point regardless of whether the email succeeds.
- Not attempted (rest of #1309's acceptance criteria): other trigger events (new device login, password changed, MFA added/removed), in-app notification center, user-configurable notification preferences, admin-configurable per-event toggles at the realm level, and Handlebars-customizable templates.

## Test plan
- [x] `npm test -- session-termination` — 9/9 pass (5 new: sends with the resolved realm name, escapes username/reason against XSS, skips when no email on file, doesn't throw when the send fails, skips silently when the realm can't be resolved)
- [x] `npm run build` — clean
- [x] `npm run lint` (scoped to the touched file) — clean
- [x] Full backend suite: `npm test` — 131 suites / 2177 tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK