### PR TITLE
fix(packages): add prepublishOnly build guard to all published SDK packages

### DIFF
--- a/packages/idenplane-angular/package.json
+++ b/packages/idenplane-angular/package.json
@@ -24,7 +24,8 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@angular/common": "^22.0.1",

--- a/packages/idenplane-cli/package.json
+++ b/packages/idenplane-cli/package.json
@@ -12,7 +12,8 @@
     "build": "tsup && node scripts/fix-node-imports.mjs",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && node --test dist/tests/*.test.js"
+    "test": "npm run build && node --test dist/tests/*.test.js",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "commander": "^13.0.0",

--- a/packages/idenplane-js/package.json
+++ b/packages/idenplane-js/package.json
@@ -65,7 +65,8 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/packages/idenplane-nextjs/package.json
+++ b/packages/idenplane-nextjs/package.json
@@ -66,7 +66,8 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/node": "^22.10.7",

--- a/packages/idenplane-vue/package.json
+++ b/packages/idenplane-vue/package.json
@@ -33,7 +33,8 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@vue/test-utils": "^2.4.0",


### PR DESCRIPTION
## Summary — critical, live finding

Every currently-published version of these packages on npm (all at `1.0.1`) is broken — missing the `dist/` output entirely, `idenplane-cli@1.0.1` is even missing its README:

| Package | Published tarball contents |
|---|---|
| `idenplane-sdk` | `package.json`, `README.md` only — no `dist/` |
| `idenplane-nextjs` | `package.json`, `README.md` only — no `dist/` |
| `idenplane-vue` | `package.json`, `README.md` only — no `dist/` |
| `idenplane-angular` | `package.json`, `README.md` only — no `dist/` |
| `idenplane-cli` | `package.json` **only** — no README, no `dist/`, no `bin` |

Verified directly against the real registry via `npm pack <pkg>@1.0.1`. **Anyone running `npm install idenplane-nextjs` (or any of these five) right now gets a non-functional package** — this is how I found it, while verifying the Next.js quickstart in a separate PR.

## Root cause

Each package's `files` field was already correctly declared (e.g. `["dist", "README.md"]`). But `files` only includes paths that exist at pack time — it doesn't error if they're missing. Whoever ran `npm publish` for 1.0.1 did so without a fresh `npm run build` first (these packages have no CI-driven publish workflow, only `idenplane-mcp` does — these five appear to be published manually), so npm silently packed whatever partial `dist/` state was on disk.

## Fix

Adds `"prepublishOnly": "npm run build"` to all five `package.json` files — npm's own lifecycle hook that always runs immediately before packing, for both `npm publish` and `npm pack`. Verified this actually works by deleting `dist/` by hand and running `npm publish --dry-run`: the tarball listing went from empty to the full rebuilt `dist/` (26 files for idenplane-sdk, 22 for idenplane-cli). This makes the missing-dist failure mode structurally impossible going forward, regardless of who runs the publish or from what state their checkout is in.

## What this does NOT do

This does not republish the currently-broken `1.0.1` versions. That requires npm publish credentials and a live push to a public registry — not something I'll do without a human explicitly driving it. **Someone with publish access needs to ship a fresh version (1.0.2, or re-publish 1.0.1 if npm's unpublish window still allows it) as soon as possible** — every current install of these five packages is non-functional until then.

## Test plan
- [x] `npm publish --dry-run` after deleting `dist/` for `idenplane-js` — tarball correctly rebuilds and includes all 26 files
- [x] `npm publish --dry-run` after deleting `dist/` for `idenplane-cli` — tarball correctly rebuilds and includes all 22 files
- [x] `npm test` in all 5 packages — all pass (146 + 23 + 19 + 11 + 38 tests)
- [x] `npm run build` in all 5 packages — all succeed
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK