### PR TITLE
feat(admin-ui): add application integration catalog to Create Client

### DIFF
--- a/admin-ui/src/data/clientTemplates.ts
+++ b/admin-ui/src/data/clientTemplates.ts
@@ -1,0 +1,141 @@
+export interface ClientTemplate {
+  id: string;
+  name: string;
+  category: 'DevOps' | 'Productivity' | 'Infrastructure';
+  description: string;
+  /** Redirect URI pattern with a {baseUrl} placeholder for the target app's own URL. */
+  redirectUriPattern: string;
+  clientType: 'CONFIDENTIAL' | 'PUBLIC';
+  grantTypes: string[];
+  /** Short, numbered setup steps on the target application's side. */
+  setupInstructions: string[];
+}
+
+/**
+ * A starter catalog of pre-configured OIDC client templates for popular
+ * self-hosted applications. Redirect URI patterns and setup steps reflect
+ * each application's generic/OpenID-Connect login mechanism as of the
+ * versions commonly deployed today — always double-check against the
+ * specific version you're running, since third-party apps change these
+ * paths between releases.
+ *
+ * Contribute more templates by adding an entry here — see CONTRIBUTING.md.
+ */
+export const CLIENT_TEMPLATES: ClientTemplate[] = [
+  {
+    id: 'grafana',
+    name: 'Grafana',
+    category: 'DevOps',
+    description: 'Dashboards and observability platform.',
+    redirectUriPattern: '{baseUrl}/login/generic_oauth',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'In grafana.ini (or via GF_AUTH_GENERIC_OAUTH_* env vars), set auth.generic_oauth.enabled = true.',
+      'Set client_id and client_secret to the values from this client.',
+      'Set auth_url, token_url, and api_url to your Idenplane realm\'s OIDC discovery endpoints.',
+      'Restart Grafana and look for the "Sign in with Idenplane" option on the login page.',
+    ],
+  },
+  {
+    id: 'gitlab',
+    name: 'GitLab (self-hosted)',
+    category: 'DevOps',
+    description: 'Git hosting, CI/CD, and DevOps platform.',
+    redirectUriPattern: '{baseUrl}/users/auth/openid_connect/callback',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'In gitlab.rb, add an openid_connect entry under gitlab_rails[\'omniauth_providers\'].',
+      'Set client_id, client_secret, and issuer to this client and your realm\'s issuer URL.',
+      'Set gitlab_rails[\'omniauth_allow_single_sign_on\'] to [\'openid_connect\'] if you want auto-provisioning.',
+      'Run gitlab-ctl reconfigure and restart.',
+    ],
+  },
+  {
+    id: 'argocd',
+    name: 'Argo CD',
+    category: 'DevOps',
+    description: 'Declarative GitOps continuous delivery for Kubernetes.',
+    redirectUriPattern: '{baseUrl}/auth/callback',
+    clientType: 'PUBLIC',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'Edit the argocd-cm ConfigMap and add an oidc.config block with this client\'s clientID and your realm\'s issuer.',
+      'Argo CD\'s dex-free OIDC mode expects a public client (no client secret) using PKCE.',
+      'Map realm roles to Argo CD RBAC via the requestedIDTokenClaims / groups claim if you use group-based policies.',
+      'Restart the argocd-server pod to pick up the ConfigMap change.',
+    ],
+  },
+  {
+    id: 'portainer',
+    name: 'Portainer',
+    category: 'Infrastructure',
+    description: 'Container management UI for Docker and Kubernetes.',
+    redirectUriPattern: '{baseUrl}',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'In Portainer, go to Settings → Authentication → OAuth.',
+      'Choose "Custom" as the provider and fill in Client ID / Client Secret from this client.',
+      'Set the Authorization, Access Token, and Resource URLs from your realm\'s OIDC discovery document.',
+      'Set the redirect URI shown above exactly as Portainer\'s own base URL (it does not use a dedicated callback path).',
+    ],
+  },
+  {
+    id: 'nextcloud',
+    name: 'Nextcloud',
+    category: 'Productivity',
+    description: 'Self-hosted file sync, sharing, and collaboration.',
+    redirectUriPattern: '{baseUrl}/apps/user_oidc/code',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'Install and enable the "OpenID Connect user backend" (user_oidc) app from the Nextcloud app store.',
+      'Under Settings → OpenID Connect, add a new provider with this client\'s ID/secret and your realm\'s discovery URL.',
+      'The exact callback path can differ by user_oidc version — check the app\'s own settings page, which usually displays the redirect URI to register.',
+    ],
+  },
+  {
+    id: 'outline',
+    name: 'Outline',
+    category: 'Productivity',
+    description: 'Team knowledge base and wiki.',
+    redirectUriPattern: '{baseUrl}/auth/oidc.callback',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'Set the OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, and OIDC_AUTH_URI / OIDC_TOKEN_URI / OIDC_USERINFO_URI environment variables.',
+      'Set OIDC_DISPLAY_NAME to whatever label you want on Outline\'s login button.',
+      'Restart Outline for the environment changes to take effect.',
+    ],
+  },
+  {
+    id: 'mattermost',
+    name: 'Mattermost',
+    category: 'Productivity',
+    description: 'Team messaging and collaboration platform.',
+    redirectUriPattern: '{baseUrl}/signup/openid/complete',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'In System Console → Authentication → OpenID Connect, enable it and select "OpenID Connect" as the type.',
+      'Fill in Client ID, Client Secret, Discovery Endpoint (your realm\'s .well-known/openid-configuration URL).',
+      'Save, then confirm the "Sign in with OpenID Connect" button appears on the login page.',
+    ],
+  },
+  {
+    id: 'pgadmin',
+    name: 'pgAdmin',
+    category: 'Infrastructure',
+    description: 'Web-based PostgreSQL administration.',
+    redirectUriPattern: '{baseUrl}/oauth2/authorize',
+    clientType: 'CONFIDENTIAL',
+    grantTypes: ['authorization_code', 'refresh_token'],
+    setupInstructions: [
+      'In config_local.py, set AUTHENTICATION_SOURCES to include "oauth2".',
+      'Add an OAUTH2_CONFIG entry with this client\'s ID/secret and your realm\'s authorization/token/userinfo endpoints.',
+      'Restart pgAdmin; an "Login with <OAUTH2_NAME>" button appears on the login page.',
+    ],
+  },
+];

--- a/admin-ui/src/pages/clients/ClientCreatePage.tsx
+++ b/admin-ui/src/pages/clients/ClientCreatePage.tsx
@@ -3,6 +3,9 @@ import { useParams, useNavigate } from 'react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '../../api/clients';
 import { getErrorMessage } from '../../utils/getErrorMessage';
+import { CLIENT_TEMPLATES, type ClientTemplate } from '../../data/clientTemplates';
+
+const TEMPLATE_CATEGORIES = Array.from(new Set(CLIENT_TEMPLATES.map((t) => t.category)));
 
 export default function ClientCreatePage() {
   const { name } = useParams<{ name: string }>();
@@ -22,6 +25,25 @@ export default function ClientCreatePage() {
   });
 
   const [createdSecret, setCreatedSecret] = useState<string | null>(null);
+  const [selectedTemplateId, setSelectedTemplateId] = useState('');
+  const selectedTemplate = CLIENT_TEMPLATES.find((t) => t.id === selectedTemplateId) ?? null;
+
+  function applyTemplate(template: ClientTemplate | null) {
+    if (!template) {
+      setSelectedTemplateId('');
+      return;
+    }
+    setSelectedTemplateId(template.id);
+    setForm((prev) => ({
+      ...prev,
+      clientId: prev.clientId || template.id,
+      name: template.name,
+      description: template.description,
+      clientType: template.clientType,
+      redirectUris: template.redirectUriPattern,
+      grantTypes: template.grantTypes.join(', '),
+    }));
+  }
 
   const mutation = useMutation({
     mutationFn: () =>
@@ -102,6 +124,49 @@ export default function ClientCreatePage() {
         <p className="mt-1 text-sm text-subtle">
           Register a new client application in <span className="font-medium">{name}</span>
         </p>
+      </div>
+
+      <div className="mb-6 rounded-lg border border-line bg-surface p-6 shadow-sm">
+        <label htmlFor="template" className="mb-1.5 block text-sm font-medium text-muted">
+          Start from a template
+        </label>
+        <select
+          id="template"
+          value={selectedTemplateId}
+          onChange={(e) =>
+            applyTemplate(CLIENT_TEMPLATES.find((t) => t.id === e.target.value) ?? null)
+          }
+          className="w-full rounded-md border border-line-strong px-3 py-2 text-sm shadow-sm focus:border-accent focus:ring-1 focus:ring-accent focus:outline-none"
+        >
+          <option value="">— None (start from scratch) —</option>
+          {TEMPLATE_CATEGORIES.map((category) => (
+            <optgroup key={category} label={category}>
+              {CLIENT_TEMPLATES.filter((t) => t.category === category).map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.name}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+
+        {selectedTemplate && (
+          <div className="mt-4 rounded-md border border-info-soft bg-info-soft p-4 text-sm">
+            <p className="font-medium text-info-fg">
+              Redirect URI pattern: <code>{selectedTemplate.redirectUriPattern}</code>
+            </p>
+            <p className="mt-1 text-info-fg">
+              Replace <code>{'{baseUrl}'}</code> with {selectedTemplate.name}&apos;s own URL, then update the
+              Redirect URIs field below before saving.
+            </p>
+            <p className="mt-3 font-medium text-info-fg">Setup on the {selectedTemplate.name} side:</p>
+            <ol className="mt-1 list-decimal space-y-1 pl-5 text-info-fg">
+              {selectedTemplate.setupInstructions.map((step, i) => (
+                <li key={i}>{step}</li>
+              ))}
+            </ol>
+          </div>
+        )}
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6 rounded-lg border border-line bg-surface p-6 shadow-sm">

--- a/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
+++ b/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
@@ -116,4 +116,53 @@ describe('ClientCreatePage', () => {
     // for why an in-flight request outliving the test breaks the whole run.
     await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /creating/i }));
   });
+
+  describe('application templates', () => {
+    it('renders the template picker with no template selected by default', () => {
+      renderPage();
+      expect(screen.getByLabelText(/start from a template/i)).toHaveValue('');
+    });
+
+    it('prefills the form when a template is selected', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.selectOptions(screen.getByLabelText(/start from a template/i), 'grafana');
+
+      expect(screen.getByRole('textbox', { name: /^name$/i })).toHaveValue('Grafana');
+      expect(screen.getByLabelText(/^client type$/i)).toHaveValue('CONFIDENTIAL');
+      expect(screen.getByLabelText(/^redirect uris/i)).toHaveValue('{baseUrl}/login/generic_oauth');
+      expect(screen.getByLabelText(/^grant types/i)).toHaveValue('authorization_code, refresh_token');
+    });
+
+    it('shows setup instructions for the selected template', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.selectOptions(screen.getByLabelText(/start from a template/i), 'argocd');
+
+      expect(screen.getByText(/setup on the argo cd side/i)).toBeInTheDocument();
+      expect(screen.getByText(/argocd-cm configmap/i)).toBeInTheDocument();
+    });
+
+    it('does not overwrite a client ID the user already typed', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.type(screen.getByLabelText(/^client id$/i), 'my-custom-id');
+      await user.selectOptions(screen.getByLabelText(/start from a template/i), 'outline');
+
+      expect(screen.getByLabelText(/^client id$/i)).toHaveValue('my-custom-id');
+    });
+
+    it('reverts to a blank state when switching back to "None"', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.selectOptions(screen.getByLabelText(/start from a template/i), 'nextcloud');
+      await user.selectOptions(screen.getByLabelText(/start from a template/i), '');
+
+      expect(screen.queryByText(/setup on the/i)).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Relates to #1313 (application integration catalog, 50+ pre-configured client templates) — a scoped MVP with 8 templates instead of 50+.
- Adds a "Start from a template" picker at the top of `ClientCreatePage`. Selecting a template pre-fills name, client type, redirect URI pattern, and grant types, and shows the target app's own setup steps inline (never overwrites a client ID the admin already typed).
- Templates live in `admin-ui/src/data/clientTemplates.ts` as a plain TypeScript array, grouped by category (DevOps: Grafana, GitLab, Argo CD, Portainer; Productivity: Nextcloud, Outline, Mattermost; Infrastructure: pgAdmin) — a straightforward file to extend with more entries.
- Redirect URI patterns and setup steps reflect each app's generic/OIDC login mechanism as commonly deployed; flagged in the file's own doc comment (and specifically for Nextcloud, whose OIDC app callback path varies by version) that these are a starting point to verify against the specific version being integrated, not guaranteed-exact for every deployment.
- Not attempted (rest of #1313's acceptance criteria): the other ~40+ applications the epic calls for, JSON/YAML-file-based template storage (this is in-code), CLI and Terraform provider template support.

## Test plan
- [x] `npx vitest run ClientCreatePage` — 16/16 pass (5 new: default empty selection, prefill on select, setup instructions render, doesn't clobber a typed client ID, reverts cleanly to "None")
- [x] Full admin-ui suite: `npx vitest run` — 48 files / 421 tests pass
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK