### PR TITLE
feat(deployment): add production Docker Compose template with Traefik TLS + Redis

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,0 +1,100 @@
+# Production template: Idenplane + PostgreSQL + Redis + Traefik with
+# automatic Let's Encrypt TLS. Requires a real domain name pointed at this
+# host (Traefik's ACME TLS challenge needs to be publicly reachable on 443).
+#
+# Usage:
+#   DOMAIN=auth.example.com ACME_EMAIL=you@example.com \
+#   ADMIN_API_KEY=$(openssl rand -hex 32) \
+#   WEBHOOK_SECRET_KEY=$(openssl rand -hex 32) \
+#   WEBHOOK_ENCRYPTION_SALT=$(openssl rand -hex 16) \
+#   ADMIN_PASSWORD=$(openssl rand -hex 16) \
+#   docker compose -f docker-compose.production.yml up -d
+services:
+  traefik:
+    image: traefik:v3.2
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL:?Set ACME_EMAIL to an address Let's Encrypt can contact}"
+      - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "letsencrypt:/letsencrypt"
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: idenplane
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}
+      POSTGRES_DB: idenplane
+    # No published port — only reachable from other containers on this network.
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U idenplane"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: ["redis-server", "--save", "3600", "1", "--appendonly", "yes"]
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  app:
+    image: islamawad/idenplane:latest
+    environment:
+      DATABASE_URL: postgresql://idenplane:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}@db:5432/idenplane
+      PORT: "3000"
+      NODE_ENV: production
+      ADMIN_API_KEY: ${ADMIN_API_KEY:?Set ADMIN_API_KEY (openssl rand -hex 32)}
+      ADMIN_USER: ${ADMIN_USER:-admin}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD:?Set ADMIN_PASSWORD}
+      WEBHOOK_SECRET_KEY: ${WEBHOOK_SECRET_KEY:?Set WEBHOOK_SECRET_KEY (openssl rand -hex 32)}
+      WEBHOOK_ENCRYPTION_SALT: ${WEBHOOK_ENCRYPTION_SALT:?Set WEBHOOK_ENCRYPTION_SALT (openssl rand -hex 16)}
+      THROTTLE_TTL: ${THROTTLE_TTL:-60000}
+      THROTTLE_LIMIT: ${THROTTLE_LIMIT:-100}
+      BASE_URL: https://${DOMAIN:?Set DOMAIN to your public hostname}
+      REDIS_URL: redis://redis:6379
+      SESSION_STORE: redis
+      # Traefik is the only thing forwarding requests here — trust its
+      # X-Forwarded-For unconditionally within this compose network.
+      TRUSTED_PROXIES: "*"
+      BACKUP_DIR: /var/lib/idenplane/backups
+    volumes:
+      - backups:/var/lib/idenplane/backups
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.idenplane.rule=Host(`${DOMAIN:?Set DOMAIN to your public hostname}`)"
+      - "traefik.http.routers.idenplane.entrypoints=websecure"
+      - "traefik.http.routers.idenplane.tls.certresolver=letsencrypt"
+      - "traefik.http.services.idenplane.loadbalancer.server.port=3000"
+    restart: unless-stopped
+
+volumes:
+  pgdata:
+  redisdata:
+  letsencrypt:
+  backups:

--- a/docs/docs/deployment/docker.mdx
+++ b/docs/docs/deployment/docker.mdx
@@ -147,6 +147,32 @@ docker compose logs -f app
 
 ---
 
+## Production with TLS (Traefik + Redis)
+
+The example above expects you to put your own TLS-terminating reverse proxy in front of it. If you'd rather have a complete, ready-to-run stack — automatic Let's Encrypt certificates via [Traefik](https://traefik.io/), plus Redis for the cache/session layer — use [`docker-compose.production.yml`](https://github.com/idenplane/idenplane/blob/dev/docker-compose.production.yml) from the repo root instead.
+
+This requires a real domain name already pointed at the host, since Traefik's ACME TLS challenge must be reachable on port 443 from the public internet.
+
+```bash
+DOMAIN=auth.example.com \
+ACME_EMAIL=you@example.com \
+POSTGRES_PASSWORD=$(openssl rand -hex 16) \
+ADMIN_API_KEY=$(openssl rand -hex 32) \
+ADMIN_PASSWORD=$(openssl rand -hex 16) \
+WEBHOOK_SECRET_KEY=$(openssl rand -hex 32) \
+WEBHOOK_ENCRYPTION_SALT=$(openssl rand -hex 16) \
+docker compose -f docker-compose.production.yml up -d
+```
+
+What it sets up beyond the basic production example:
+
+- **Traefik** terminates TLS on `:443` (redirecting `:80` to it) and requests/renews a Let's Encrypt certificate for `$DOMAIN` automatically — no manual certbot steps.
+- **Redis** is enabled out of the box (`REDIS_URL`, `SESSION_STORE=redis` are already set on the `app` service — you don't need to uncomment anything).
+- `db` and `redis` have no published ports — only the `app` and `traefik` containers can reach them, reducing the attack surface versus the basic example's `127.0.0.1:5432` binding.
+- `TRUSTED_PROXIES=*` is set on `app` since Traefik is the only thing that can reach it directly within the compose network — safe here, but don't copy this value into a setup where the app is also directly reachable from elsewhere.
+
+---
+
 ## Development Deployment
 
 The development configuration builds from source, enabling hot-reload for active development.


### PR DESCRIPTION
## Summary
- Relates to #1317 (production-ready community starter templates) — a scoped MVP with just the Docker Compose template.
- New `docker-compose.production.yml` at the repo root: Idenplane + PostgreSQL + Redis + Traefik with automatic Let's Encrypt TLS (TLS-ALPN-01 challenge, no manual certbot). Complements (doesn't replace) the existing basic production example in `docker-compose.yml`, which expects the deployer to already have a TLS proxy in place.
- Documented in `docs/docs/deployment/docker.mdx` under a new "Production with TLS (Traefik + Redis)" section, right after the existing basic production section, explaining what it adds over the basic example.
- Hardening beyond the basic example: `db`/`redis` have no published ports (only reachable from `app`/`traefik` on the compose network, vs. the basic example's `127.0.0.1:5432` binding); every secret uses Compose's `${VAR:?message}` required-with-no-fallback form instead of `change-me-in-production` defaults; Redis session store is on by default instead of commented out.
- Not attempted (rest of #1317's acceptance criteria): a Kubernetes/Helm production example, a Terraform module for AWS (ECS/EKS), and the two "complete example" apps (multi-tenant SaaS with Organizations, API gateway with service accounts).

## Test plan
- [x] `docker-compose.production.yml` parsed with `js-yaml` — valid, all 4 services (`traefik`, `db`, `redis`, `app`) and 4 volumes present as expected
- [x] `npm run build` in `docs/` — clean, no broken links
- [ ] An actual `docker compose up` run against a real domain + Let's Encrypt — **not verified**. No Docker daemon was available in this environment, and a real ACME TLS challenge needs a publicly resolvable host this sandbox doesn't have. Flagging this explicitly as the main risk in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK