### PR TITLE
feat(admin-ui): add interactive migration wizard

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -38,6 +38,7 @@ import AdminEventsPage from './pages/events/AdminEventsPage';
 import AuthFlowListPage from './pages/auth-flows/AuthFlowListPage';
 import AuthFlowEditorPage from './pages/auth-flows/AuthFlowEditorPage';
 import SetupWizardPage from './pages/setup-wizard/SetupWizardPage';
+import MigrationWizardPage from './pages/migration/MigrationWizardPage';
 import PendingRegistrationsPage from './pages/registration/PendingRegistrationsPage';
 import RegistrationFieldsPage from './pages/registration/RegistrationFieldsPage';
 import RegistrationSettingsPage from './pages/registration/RegistrationSettingsPage';
@@ -124,6 +125,7 @@ export default function App() {
           <Route path="/console/realms/:name/clients" element={<ClientListPage />} />
           <Route path="/console/realms/:name/clients/new" element={<ClientCreatePage />} />
           <Route path="/console/realms/:name/clients/:id" element={<ClientDetailPage />} />
+          <Route path="/console/realms/:name/migration" element={<MigrationWizardPage />} />
           <Route path="/console/realms/:name/roles" element={<RoleListPage />} />
           <Route path="/console/realms/:name/groups" element={<GroupListPage />} />
           <Route path="/console/realms/:name/groups/create" element={<GroupCreatePage />} />

--- a/admin-ui/src/api/migration.ts
+++ b/admin-ui/src/api/migration.ts
@@ -1,0 +1,44 @@
+import apiClient from './client';
+
+export type MigrationSource = 'keycloak' | 'auth0' | 'zitadel';
+
+export interface MigrationEntityStats {
+  created: number;
+  skipped: number;
+  failed: number;
+}
+
+export interface MigrationError {
+  entity: string;
+  name: string;
+  error: string;
+}
+
+export interface MigrationWarning {
+  entity: string;
+  message: string;
+}
+
+export interface MigrationReport {
+  source: MigrationSource;
+  dryRun: boolean;
+  startedAt: string;
+  completedAt: string;
+  summary: Record<string, MigrationEntityStats>;
+  errors: MigrationError[];
+  warnings: MigrationWarning[];
+}
+
+export async function runMigration(
+  source: MigrationSource,
+  data: Record<string, unknown>,
+  targetRealm: string,
+  dryRun: boolean,
+): Promise<MigrationReport> {
+  const { data: report } = await apiClient.post<MigrationReport>(`/migration/${source}`, {
+    data,
+    targetRealm,
+    dryRun,
+  });
+  return report;
+}

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -69,6 +69,7 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}/authorization-policies`, label: 'Authorization', icon: Icons.Roles },
         { to: `/console/realms/${currentRealm}/theme-builder`, label: 'Theme Builder', icon: Icons.Sun },
         { to: `/console/realms/${currentRealm}/nhi`, label: 'Non-Human Identity', icon: Icons.Server },
+        { to: `/console/realms/${currentRealm}/migration`, label: 'Migration Wizard', icon: Icons.Download },
       ]
     : [];
 

--- a/admin-ui/src/pages/migration/MigrationWizardPage.tsx
+++ b/admin-ui/src/pages/migration/MigrationWizardPage.tsx
@@ -1,0 +1,305 @@
+import { useState, type ChangeEvent } from 'react';
+import { useParams, useNavigate } from 'react-router';
+import { runMigration, type MigrationReport, type MigrationSource } from '../../api/migration';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+import { Icons } from '../../components/ui';
+
+const SOURCES: { id: MigrationSource; name: string; description: string }[] = [
+  { id: 'keycloak', name: 'Keycloak', description: 'Import from a Keycloak realm export JSON file.' },
+  { id: 'auth0', name: 'Auth0', description: 'Import from an Auth0 Management API export JSON file.' },
+  {
+    id: 'zitadel',
+    name: 'Zitadel',
+    description: 'Import from a hand-assembled Zitadel Management API export (Users/Projects/Roles/Apps/IDPs).',
+  },
+];
+
+const STEPS = ['source', 'upload', 'preview', 'done'] as const;
+type Step = (typeof STEPS)[number];
+
+const STEP_LABELS: Record<Step, string> = {
+  source: 'Select Source',
+  upload: 'Upload Export',
+  preview: 'Preview & Confirm',
+  done: 'Summary',
+};
+
+function MigrationReportSummary({ report }: { report: MigrationReport }) {
+  const entities = Object.entries(report.summary).filter(
+    ([, stats]) => stats.created > 0 || stats.skipped > 0 || stats.failed > 0,
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-3 gap-3">
+        {entities.length === 0 && (
+          <p className="col-span-3 text-sm text-subtle">Nothing to import from this file.</p>
+        )}
+        {entities.map(([entity, stats]) => (
+          <div key={entity} className="rounded-md border border-line bg-sunken p-3">
+            <p className="text-xs font-medium uppercase tracking-wide text-subtle">{entity}</p>
+            <p className="mt-1 text-sm">
+              <span className="text-success-fg">{stats.created} created</span>
+              {stats.skipped > 0 && <span className="text-subtle">, {stats.skipped} skipped</span>}
+              {stats.failed > 0 && <span className="text-danger-fg">, {stats.failed} failed</span>}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {report.warnings.length > 0 && (
+        <div className="rounded-md border border-warning-soft bg-warning-soft p-3">
+          <p className="text-sm font-medium text-warning-fg">Warnings ({report.warnings.length})</p>
+          <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-warning-fg">
+            {report.warnings.map((w, i) => (
+              <li key={i}>
+                <span className="font-medium">[{w.entity}]</span> {w.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {report.errors.length > 0 && (
+        <div className="rounded-md border border-danger-soft bg-danger-soft p-3">
+          <p className="text-sm font-medium text-danger-fg">Errors ({report.errors.length})</p>
+          <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-danger-fg">
+            {report.errors.map((e, i) => (
+              <li key={i}>
+                <span className="font-medium">
+                  [{e.entity}] {e.name}:
+                </span>{' '}
+                {e.error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function MigrationWizardPage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState<Step>('source');
+  const [source, setSource] = useState<MigrationSource | null>(null);
+  const [fileName, setFileName] = useState('');
+  const [fileData, setFileData] = useState<Record<string, unknown> | null>(null);
+  const [dryRunReport, setDryRunReport] = useState<MigrationReport | null>(null);
+  const [finalReport, setFinalReport] = useState<MigrationReport | null>(null);
+  const [isRunning, setIsRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    try {
+      const text = await file.text();
+      const parsed = JSON.parse(text) as Record<string, unknown>;
+      setFileName(file.name);
+      setFileData(parsed);
+    } catch {
+      setError('That file is not valid JSON.');
+      setFileData(null);
+      setFileName('');
+    }
+  }
+
+  async function handlePreview() {
+    if (!source || !fileData || !name) return;
+    setIsRunning(true);
+    setError(null);
+    try {
+      const report = await runMigration(source, fileData, name, true);
+      setDryRunReport(report);
+      setStep('preview');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to preview the import.'));
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  async function handleImport() {
+    if (!source || !fileData || !name) return;
+    setIsRunning(true);
+    setError(null);
+    try {
+      const report = await runMigration(source, fileData, name, false);
+      setFinalReport(report);
+      setStep('done');
+    } catch (err) {
+      setError(getErrorMessage(err, 'Failed to run the import.'));
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  function startOver() {
+    setStep('source');
+    setSource(null);
+    setFileName('');
+    setFileData(null);
+    setDryRunReport(null);
+    setFinalReport(null);
+    setError(null);
+  }
+
+  const stepIndex = STEPS.indexOf(step);
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-fg">Migration Wizard</h1>
+        <p className="mt-1 text-sm text-subtle">
+          Import users, clients, roles, and identity providers into <span className="font-medium">{name}</span>
+        </p>
+      </div>
+
+      {/* Step indicator */}
+      <ol className="mb-6 flex items-center gap-2 text-sm">
+        {STEPS.map((s, i) => (
+          <li key={s} className="flex items-center gap-2">
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full text-xs font-semibold ${
+                i < stepIndex
+                  ? 'bg-success text-white'
+                  : i === stepIndex
+                    ? 'bg-accent text-white'
+                    : 'bg-active text-muted'
+              }`}
+            >
+              {i + 1}
+            </span>
+            <span className={i === stepIndex ? 'font-medium text-fg' : 'text-subtle'}>{STEP_LABELS[s]}</span>
+            {i < STEPS.length - 1 && <span className="mx-1 text-subtle">&rarr;</span>}
+          </li>
+        ))}
+      </ol>
+
+      <div className="rounded-lg border border-line bg-surface p-6 shadow-sm">
+        {error && <div className="mb-4 rounded-md bg-danger-soft p-3 text-sm text-danger-fg">{error}</div>}
+
+        {step === 'source' && (
+          <div>
+            <h2 className="mb-3 text-lg font-semibold text-fg">Where are you migrating from?</h2>
+            <div className="space-y-2">
+              {SOURCES.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  onClick={() => setSource(s.id)}
+                  className={`w-full rounded-md border p-4 text-left transition-colors ${
+                    source === s.id
+                      ? 'border-accent bg-accent-soft'
+                      : 'border-line-strong hover:bg-hover'
+                  }`}
+                >
+                  <p className="font-medium text-fg">{s.name}</p>
+                  <p className="mt-0.5 text-sm text-subtle">{s.description}</p>
+                </button>
+              ))}
+            </div>
+            <div className="mt-6 flex justify-end">
+              <button
+                type="button"
+                disabled={!source}
+                onClick={() => setStep('upload')}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 'upload' && (
+          <div>
+            <h2 className="mb-3 text-lg font-semibold text-fg">
+              Upload your {SOURCES.find((s) => s.id === source)?.name} export
+            </h2>
+            <input
+              type="file"
+              accept="application/json,.json"
+              onChange={handleFileChange}
+              className="block w-full text-sm text-muted file:mr-4 file:rounded-md file:border-0 file:bg-accent-soft file:px-4 file:py-2 file:text-sm file:font-medium file:text-accent hover:file:bg-accent-soft"
+            />
+            {fileName && (
+              <p className="mt-2 text-sm text-success-fg">
+                <Icons.CheckCircle className="mr-1 inline h-4 w-4" />
+                {fileName} loaded
+              </p>
+            )}
+            <div className="mt-6 flex justify-between">
+              <button
+                type="button"
+                onClick={() => setStep('source')}
+                className="rounded-md border border-line-strong bg-surface px-4 py-2 text-sm font-medium text-muted hover:bg-hover"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                disabled={!fileData || isRunning}
+                onClick={handlePreview}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+              >
+                {isRunning ? 'Previewing...' : 'Preview Import (Dry Run)'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 'preview' && dryRunReport && (
+          <div>
+            <h2 className="mb-3 text-lg font-semibold text-fg">Preview — nothing has been imported yet</h2>
+            <MigrationReportSummary report={dryRunReport} />
+            <div className="mt-6 flex justify-between">
+              <button
+                type="button"
+                onClick={() => setStep('upload')}
+                className="rounded-md border border-line-strong bg-surface px-4 py-2 text-sm font-medium text-muted hover:bg-hover"
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                disabled={isRunning}
+                onClick={handleImport}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+              >
+                {isRunning ? 'Importing...' : 'Run Import'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 'done' && finalReport && (
+          <div>
+            <h2 className="mb-3 text-lg font-semibold text-fg">Import complete</h2>
+            <MigrationReportSummary report={finalReport} />
+            <div className="mt-6 flex justify-between">
+              <button
+                type="button"
+                onClick={startOver}
+                className="rounded-md border border-line-strong bg-surface px-4 py-2 text-sm font-medium text-muted hover:bg-hover"
+              >
+                Import Another File
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate(`/console/realms/${name}/users`)}
+                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+              >
+                View Users
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/migration/__tests__/MigrationWizardPage.test.tsx
+++ b/admin-ui/src/pages/migration/__tests__/MigrationWizardPage.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test/mocks/server';
+import { render } from '../../../test/utils';
+import MigrationWizardPage from '../MigrationWizardPage';
+
+function renderPage(realm = 'test-realm') {
+  return render(<MigrationWizardPage />, {
+    initialUrl: `/console/realms/${realm}/migration`,
+    routePattern: '/console/realms/:name/migration',
+  });
+}
+
+function makeJsonFile(content: unknown, name = 'export.json') {
+  return new File([JSON.stringify(content)], name, { type: 'application/json' });
+}
+
+describe('MigrationWizardPage', () => {
+  it('renders the page heading and starts on the source-selection step', () => {
+    renderPage();
+    expect(screen.getByRole('heading', { name: /migration wizard/i })).toBeInTheDocument();
+    expect(screen.getByText(/where are you migrating from/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled();
+  });
+
+  it('requires a source to be selected before continuing', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Keycloak'));
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/upload your keycloak export/i)).toBeInTheDocument();
+  });
+
+  it('parses a valid JSON file and enables the preview button', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Auth0'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+
+    const file = makeJsonFile({ users: [{ user_id: 'u1' }] });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, file);
+
+    expect(await screen.findByText(/export.json loaded/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /preview import/i })).toBeEnabled();
+  });
+
+  it('shows an error for an invalid JSON file', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Keycloak'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+
+    const badFile = new File(['not json'], 'bad.json', { type: 'application/json' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, badFile);
+
+    expect(await screen.findByText(/not valid json/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /preview import/i })).toBeDisabled();
+  });
+
+  it('runs a dry-run preview then a real import through the full flow', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Keycloak'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, makeJsonFile({ users: [] }));
+    await user.click(screen.getByRole('button', { name: /preview import/i }));
+
+    expect(await screen.findByText(/nothing has been imported yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 created/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^run import$/i }));
+
+    expect(await screen.findByText(/import complete/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import another file/i })).toBeInTheDocument();
+  });
+
+  it('shows warnings and errors from the migration report', async () => {
+    server.use(
+      http.post('/admin/migration/:source', () =>
+        HttpResponse.json({
+          source: 'auth0',
+          dryRun: true,
+          startedAt: '2026-01-01T00:00:00.000Z',
+          completedAt: '2026-01-01T00:00:01.000Z',
+          summary: { users: { created: 1, skipped: 0, failed: 1 } },
+          errors: [{ entity: 'user', name: 'bob', error: 'No email' }],
+          warnings: [{ entity: 'organizations', message: '1 organization skipped' }],
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Auth0'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, makeJsonFile({ users: [] }));
+    await user.click(screen.getByRole('button', { name: /preview import/i }));
+
+    expect(await screen.findByText(/1 organization skipped/i)).toBeInTheDocument();
+    expect(screen.getByText(/No email/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message when the API call fails', async () => {
+    server.use(
+      http.post('/admin/migration/:source', () =>
+        HttpResponse.json({ message: 'Realm does not exist' }, { status: 400 }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Keycloak'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, makeJsonFile({ users: [] }));
+    await user.click(screen.getByRole('button', { name: /preview import/i }));
+
+    expect(await screen.findByText(/realm does not exist/i)).toBeInTheDocument();
+  });
+
+  it('allows going back a step', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Zitadel'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/upload your zitadel export/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^back$/i }));
+    expect(screen.getByText(/where are you migrating from/i)).toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/test/mocks/handlers.ts
+++ b/admin-ui/src/test/mocks/handlers.ts
@@ -146,6 +146,24 @@ export const handlers = [
     return HttpResponse.json(makeFailedLoginHeatmap());
   }),
 
+  // Migration
+  http.post(`${BASE}/migration/:source`, async ({ request, params }) => {
+    const body = (await request.json()) as { dryRun?: boolean };
+    return HttpResponse.json({
+      source: params.source,
+      dryRun: body.dryRun ?? false,
+      startedAt: '2026-01-01T00:00:00.000Z',
+      completedAt: '2026-01-01T00:00:01.000Z',
+      summary: {
+        users: { created: 2, skipped: 0, failed: 0 },
+        clients: { created: 1, skipped: 0, failed: 0 },
+        roles: { created: 0, skipped: 0, failed: 0 },
+      },
+      errors: [],
+      warnings: [],
+    });
+  }),
+
   // Events (for dashboard)
   http.get(`${BASE}/realms/:name/events`, () => {
     return HttpResponse.json([


### PR DESCRIPTION
## Summary
- Relates to #1312 (interactive migration wizard) — a scoped MVP wrapping the three importers that already exist (Keycloak, Auth0, Zitadel from #1311) in a GUI.
- New 4-step wizard at `/console/realms/:name/migration`: select source → upload export JSON → dry-run preview → confirm real import → summary. New nav entry ("Migration Wizard") added to the realm sidebar.
- Steps 3/4 both call the existing `POST admin/migration/{source}` endpoint with `dryRun: true`/`false` and render the returned `MigrationReport` (per-entity created/skipped/failed counts, warnings, errors) — same report shape the CLI's `migrate` command already prints.
- No fabricated progress bar: each import is a single synchronous backend call with no incremental progress signal to poll, so the wizard shows a "Previewing.../Importing..." button state instead of pretending there's real-time per-entity progress the backend doesn't actually report.
- Not attempted (rest of #1312's acceptance criteria): connecting to a source via a live API instead of a file upload, conflict-resolution UI (skip/overwrite/merge) beyond what each importer's own dedup-by-name logic already does, cancel-mid-import support, Authentik/Ory/FusionAuth sources (no importers exist for those yet).

## Test plan
- [x] `npx vitest run MigrationWizardPage` — 8/8 pass (default state, source-required gating, valid/invalid JSON file handling, full preview→import flow, warnings/errors rendering, API-failure error message, back navigation)
- [x] Full admin-ui suite: `npx vitest run` — 49 files / 429 tests pass
- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Umx7BfAhFxWBHpqJ2BQnoK