### PR TITLE
feat(admin-ui): add real-browser E2E test suite with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,112 @@ jobs:
           path: admin-ui/coverage/
           retention-days: 14
 
+  admin-ui-e2e:
+    # The existing "E2E Tests" job drives the NestJS app in-process via
+    # supertest — it never listens on a real port, so it can't catch bugs in
+    # the admin console's own UI (routing, forms, the vite dev proxy). This
+    # job boots a real backend and a real browser against it.
+    name: Admin UI E2E Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: idenplane_test
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: idenplane_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://idenplane_test:test_password@localhost:5432/idenplane_test
+      ADMIN_API_KEY: test-admin-key
+      NODE_ENV: test
+      PORT: '3000'
+      DEMO_MODE: 'true'
+      ADMIN_USER: admin
+      ADMIN_PASSWORD: e2e-test-admin-password
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx prisma generate
+      - run: npx prisma migrate deploy
+      - name: Build backend
+        run: npm run build
+
+      # AdminSeedService creates the master realm + ADMIN_USER/ADMIN_PASSWORD
+      # on first boot (src/admin-auth/admin-seed.service.ts), and DEMO_MODE
+      # makes the login page prefill those same credentials — no manual seed
+      # step needed.
+      - name: Start backend
+        run: |
+          node dist/main.js > backend.log 2>&1 &
+          echo "Waiting for backend on :3000/health..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/health > /dev/null; then
+              echo "Backend is up."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Backend did not become healthy in time."
+          cat backend.log
+          exit 1
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: admin-ui/package-lock.json
+
+      - name: Install admin-ui dependencies
+        working-directory: admin-ui
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: admin-ui
+        run: npx playwright install --with-deps chromium
+
+      - name: Start admin-ui dev server
+        working-directory: admin-ui
+        run: |
+          npm run dev > vite.log 2>&1 &
+          echo "Waiting for admin-ui on :5173..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:5173/console/login > /dev/null; then
+              echo "admin-ui is up."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "admin-ui did not become healthy in time."
+          cat vite.log
+          exit 1
+
+      - name: Run Playwright tests
+        working-directory: admin-ui
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: admin-ui/playwright-report/
+          retention-days: 14
+
   sdk-packages:
     # Nothing built or tested these until now, so breakage sat unnoticed:
     # idenplane-angular had not compiled since Angular went ESM-only, and a

--- a/admin-ui/.gitignore
+++ b/admin-ui/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/admin-ui/e2e/login.spec.ts
+++ b/admin-ui/e2e/login.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+
+// Requires a live backend on :3000 with DEMO_MODE=true, which auto-bootstraps
+// a master-realm admin user and prefills the login form (see LoginPage.tsx).
+
+test('signs in with the demo admin credentials and reaches the dashboard', async ({ page }) => {
+  await page.goto('/console/login');
+
+  await expect(page.getByText('Demo environment')).toBeVisible();
+  await expect(page.getByLabel('Username')).not.toHaveValue('');
+  await expect(page.getByLabel('Password')).not.toHaveValue('');
+
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await expect(page).toHaveURL(/\/console\/?$/);
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
+});
+
+test('rejects an invalid password', async ({ page }) => {
+  await page.goto('/console/login');
+
+  await page.getByLabel('Password').fill('definitely-not-the-password');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+
+  await expect(page.getByRole('alert')).toContainText(/invalid username or password/i);
+  await expect(page).toHaveURL(/\/console\/login$/);
+});

--- a/admin-ui/e2e/login.spec.ts
+++ b/admin-ui/e2e/login.spec.ts
@@ -8,9 +8,11 @@ test('signs in with the demo admin credentials and reaches the dashboard', async
 
   await expect(page.getByText('Demo environment')).toBeVisible();
   await expect(page.getByLabel('Username')).not.toHaveValue('');
-  await expect(page.getByLabel('Password')).not.toHaveValue('');
+  // Non-exact `getByLabel('Password')` also substring-matches the "Show
+  // password" visibility-toggle button (#1283), so it must be exact here.
+  await expect(page.getByLabel('Password', { exact: true })).not.toHaveValue('');
 
-  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click();
 
   await expect(page).toHaveURL(/\/console\/?$/);
   await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible();
@@ -19,8 +21,8 @@ test('signs in with the demo admin credentials and reaches the dashboard', async
 test('rejects an invalid password', async ({ page }) => {
   await page.goto('/console/login');
 
-  await page.getByLabel('Password').fill('definitely-not-the-password');
-  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.getByLabel('Password', { exact: true }).fill('definitely-not-the-password');
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click();
 
   await expect(page.getByRole('alert')).toContainText(/invalid username or password/i);
   await expect(page).toHaveURL(/\/console\/login$/);

--- a/admin-ui/e2e/realm-and-client.spec.ts
+++ b/admin-ui/e2e/realm-and-client.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/console/login');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await expect(page).toHaveURL(/\/console\/?$/);
+}
+
+test('creates a realm, then creates a client from the Grafana template', async ({ page }) => {
+  const realmName = `e2e-${test.info().workerIndex}-${Date.now()}`;
+
+  await login(page);
+
+  await page.goto('/console/realms/create');
+  await page.getByLabel('Name').fill(realmName);
+  await page.getByLabel('Display Name').fill('E2E Test Realm');
+  await page.getByRole('button', { name: 'Create Realm' }).click();
+
+  await expect(page).toHaveURL(/\/console\/realms\/?$/);
+  await expect(page.getByText(realmName)).toBeVisible();
+
+  await page.goto(`/console/realms/${realmName}/clients/new`);
+  await page.getByLabel('Start from a template').selectOption({ label: 'Grafana' });
+
+  // Applying a template pre-fills Client ID/Name/Type/Redirect URIs and shows
+  // the per-app setup instructions panel.
+  await expect(page.locator('#clientId')).toHaveValue('grafana');
+  await expect(page.getByText('Setup on the Grafana side:')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Create Client' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Client Created Successfully' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Go to Clients' }).click();
+  await expect(page).toHaveURL(new RegExp(`/console/realms/${realmName}/clients/?$`));
+  await expect(page.getByText('grafana')).toBeVisible();
+});

--- a/admin-ui/e2e/realm-and-client.spec.ts
+++ b/admin-ui/e2e/realm-and-client.spec.ts
@@ -20,8 +20,9 @@ test('creates a realm, then creates a client from the Grafana template', async (
   await expect(page).toHaveURL(/\/console\/realms\/?$/);
   // Scoped to <td> rather than getByText: the row itself also carries the
   // realm name in its aria-label, and matching loose text risks resolving
-  // to both the row and the cell.
-  await expect(page.locator('td', { hasText: realmName })).toBeVisible();
+  // to both the row and the cell. Anchored exactly so it can't also match
+  // a longer cell value that happens to contain this string.
+  await expect(page.locator('td', { hasText: new RegExp(`^${realmName}$`) })).toBeVisible();
 
   await page.goto(`/console/realms/${realmName}/clients/new`);
   await page.getByLabel('Start from a template').selectOption({ label: 'Grafana' });
@@ -37,5 +38,7 @@ test('creates a realm, then creates a client from the Grafana template', async (
 
   await page.getByRole('button', { name: 'Go to Clients' }).click();
   await expect(page).toHaveURL(new RegExp(`/console/realms/${realmName}/clients/?$`));
-  await expect(page.locator('td', { hasText: 'grafana' })).toBeVisible();
+  // Exact + anchored: the template's Name column renders "Grafana", which
+  // would otherwise also match a case-insensitive substring filter.
+  await expect(page.locator('td', { hasText: /^grafana$/ })).toBeVisible();
 });

--- a/admin-ui/e2e/realm-and-client.spec.ts
+++ b/admin-ui/e2e/realm-and-client.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 
 async function login(page: Page) {
   await page.goto('/console/login');
-  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click();
   await expect(page).toHaveURL(/\/console\/?$/);
 }
 
@@ -12,12 +12,16 @@ test('creates a realm, then creates a client from the Grafana template', async (
   await login(page);
 
   await page.goto('/console/realms/create');
-  await page.getByLabel('Name').fill(realmName);
+  // Non-exact `getByLabel('Name')` also substring-matches "Display Name".
+  await page.getByLabel('Name', { exact: true }).fill(realmName);
   await page.getByLabel('Display Name').fill('E2E Test Realm');
   await page.getByRole('button', { name: 'Create Realm' }).click();
 
   await expect(page).toHaveURL(/\/console\/realms\/?$/);
-  await expect(page.getByText(realmName)).toBeVisible();
+  // Scoped to <td> rather than getByText: the row itself also carries the
+  // realm name in its aria-label, and matching loose text risks resolving
+  // to both the row and the cell.
+  await expect(page.locator('td', { hasText: realmName })).toBeVisible();
 
   await page.goto(`/console/realms/${realmName}/clients/new`);
   await page.getByLabel('Start from a template').selectOption({ label: 'Grafana' });
@@ -33,5 +37,5 @@ test('creates a realm, then creates a client from the Grafana template', async (
 
   await page.getByRole('button', { name: 'Go to Clients' }).click();
   await expect(page).toHaveURL(new RegExp(`/console/realms/${realmName}/clients/?$`));
-  await expect(page.getByText('grafana')).toBeVisible();
+  await expect(page.locator('td', { hasText: 'grafana' })).toBeVisible();
 });

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -871,6 +872,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4429,6 +4446,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
@@ -23,6 +25,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/admin-ui/playwright.config.ts
+++ b/admin-ui/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Real end-to-end tests: a Chromium browser drives the admin console (served
+// by `vite dev` on :5173) against a live backend on :3000. CI starts both
+// processes (with DEMO_MODE=true so an admin user is auto-bootstrapped) and
+// waits for /health before running these; see the `admin-ui-e2e` job in
+// .github/workflows/ci.yml. There is no webServer entry here because the
+// backend needs a database migration step that Playwright can't orchestrate.
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'html',
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/admin-ui/vitest.config.ts
+++ b/admin-ui/vitest.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setupTests.ts'],
+    // e2e/ holds Playwright specs, run via `npm run test:e2e` — Vitest's
+    // default include glob otherwise picks them up and fails, since
+    // Playwright's `test()` isn't a sync call the way Vitest expects.
+    exclude: ['**/node_modules/**', '**/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov', 'html'],


### PR DESCRIPTION
## Summary

MVP slice of #1310. Adds a real, browser-driven E2E test suite for the admin console using Playwright, plus a CI job that boots an actual backend + Postgres + admin-ui dev server + Chromium to run it.

## Why this was needed

Neither existing CI job covers this:
- **`e2e-tests`** drives the NestJS app in-process via supertest/Jest — it never listens on a real port and never touches a browser or the admin-ui's own code.
- **`admin-ui-tests`** runs Vitest component tests against MSW-mocked handlers — real, but nothing ever exercises the actual React Router navigation, the vite dev proxy, or a live backend response shape.

So a regression in routing, a broken form submission, or a backend/frontend contract drift could pass both existing jobs and still break the console for a real user.

## What's covered

- `login.spec.ts` — signs in via the auto-bootstrapped demo admin user (`AdminSeedService` creates the master realm + admin user from `ADMIN_USER`/`ADMIN_PASSWORD` on first boot; `DEMO_MODE=true` prefills them on the login form) and reaches the dashboard; also asserts an invalid password is rejected.
- `realm-and-client.spec.ts` — creates a realm through the UI, then creates a client from the Grafana template (#1313) and confirms it lands in the client list.

New `admin-ui-e2e` CI job: builds the backend, starts it with `DEMO_MODE=true`, starts `vite dev` (which proxies `/admin`, `/realms`, `/health` to the backend per `vite.config.ts`), installs Chromium via `playwright install --with-deps`, then runs the suite. Playwright's HTML report uploads as an artifact on every run.

## What's NOT covered (out of scope for this slice)

This is a golden-path starting point, not the full "E2E test suite for the admin console" epic — #1310 stays open. Not attempted here: MFA/WebAuthn flows, SAML/OIDC federation setup, user/group/role CRUD, session management, consent flows, or cross-browser coverage (Firefox/WebKit). Extending coverage to those areas is straightforward follow-up now that the harness (config, CI job, demo-bootstrap pattern) exists.

## Verification

This sandbox has no local Postgres/Docker, so the full flow can only be verified by CI (which has both) — this mirrors the same constraint already noted on prior Docker/Java-dependent PRs in this series. Locally verified everything that doesn't require a live backend:
- [x] `npx playwright test --list` correctly discovers all 3 tests
- [x] `npm run lint` passes on the new files
- [x] `npm run build` (tsc -b && vite build) succeeds
- [x] `npm run test:coverage` — 429/429 unit tests still pass; `e2e/` is now excluded from Vitest's own test discovery (it was picking up the Playwright specs and failing, since Playwright's `test()` isn't a sync call the way Vitest expects)
- [x] Hand-validated `.github/workflows/ci.yml` YAML syntax after editing (loaded via `js-yaml`, confirmed the new `admin-ui-e2e` job registers correctly alongside the existing 9 jobs)
- [ ] Full Playwright run against a live backend — needs CI to confirm

Relates to #1310.