### PR TITLE
feat(sdk): wire real server integration tests into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,91 @@ jobs:
           path: admin-ui/coverage/
           retention-days: 14
 
+  sdk-integration-tests:
+    # idenplane-mcp already had a real integration suite
+    # (packages/idenplane-mcp/tests/integration.mjs) that probes for a live
+    # Idenplane instance and silently skips itself when one isn't reachable —
+    # which meant it had never actually run in CI. idenplane-js had no
+    # server-facing integration coverage at all: its unit suite mocks `jose`
+    # entirely, so nothing ever checked that verifyToken() can validate a
+    # token this server actually issues. This job boots a real backend and
+    # runs both against it.
+    name: SDK Integration Tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: idenplane_test
+          POSTGRES_PASSWORD: test_password
+          POSTGRES_DB: idenplane_test
+        ports: ['5432:5432']
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://idenplane_test:test_password@localhost:5432/idenplane_test
+      ADMIN_API_KEY: dev-admin-key
+      NODE_ENV: test
+      PORT: '3000'
+      IDENPLANE_URL: http://localhost:3000
+      IDENPLANE_ADMIN_TOKEN: dev-admin-key
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npx prisma generate
+      - run: npx prisma migrate deploy
+      - name: Build backend
+        run: npm run build
+
+      - name: Start backend
+        run: |
+          node dist/main.js > backend.log 2>&1 &
+          echo "Waiting for backend on :3000/health..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/health > /dev/null; then
+              echo "Backend is up."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Backend did not become healthy in time."
+          cat backend.log
+          exit 1
+
+      # mcp consumes @idenplane/http-internal through
+      # `file:../idenplane-http-internal`, and its dist/ is gitignored — so on
+      # a fresh checkout it has no compiled output to resolve. Build it first
+      # (mirrors the same step in the sdk-packages job).
+      - name: Build the local idenplane-http-internal dependency
+        working-directory: packages/idenplane-http-internal
+        run: |
+          npm ci
+          npm run build
+
+      - name: idenplane-mcp integration suite
+        working-directory: packages/idenplane-mcp
+        run: |
+          npm ci
+          npm run build
+          npm run test:all
+
+      - name: idenplane-js integration suite
+        working-directory: packages/idenplane-js
+        run: |
+          npm ci
+          npm run test:integration
+
   admin-ui-e2e:
     # The existing "E2E Tests" job drives the NestJS app in-process via
     # supertest — it never listens on a real port, so it can't catch bugs in

--- a/packages/idenplane-js/integration/verify-token.integration.test.ts
+++ b/packages/idenplane-js/integration/verify-token.integration.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Integration test for idenplane-sdk/server — exercises `verifyToken`
+ * against a real Idenplane instance's real token issuance and JWKS
+ * endpoints, rather than a mocked `jose` module (see
+ * ../src/__tests__/server.test.ts for the unit-level, mocked version).
+ *
+ * Prerequisites:
+ *   A running Idenplane instance reachable at IDENPLANE_URL, with an
+ *   admin API key matching IDENPLANE_ADMIN_TOKEN.
+ *
+ * Environment variables:
+ *   IDENPLANE_URL          (default: http://localhost:3000)
+ *   IDENPLANE_ADMIN_TOKEN  (default: dev-admin-key)
+ *
+ * Run: npm run test:integration
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { verifyToken } from '../src/server.js';
+
+const IDENPLANE_URL = process.env['IDENPLANE_URL'] ?? 'http://localhost:3000';
+const IDENPLANE_ADMIN_TOKEN = process.env['IDENPLANE_ADMIN_TOKEN'] ?? 'dev-admin-key';
+const TEST_REALM = `sdk-it-${Date.now()}`;
+const TEST_CLIENT_ID = 'sdk-it-client';
+
+async function skipReason(): Promise<string | false> {
+  try {
+    const res = await fetch(`${IDENPLANE_URL}/health`, { signal: AbortSignal.timeout(3000) });
+    return res.ok ? false : `Idenplane at ${IDENPLANE_URL} answered /health with ${res.status}`;
+  } catch {
+    return `no Idenplane instance reachable at ${IDENPLANE_URL} — start one and set IDENPLANE_URL/IDENPLANE_ADMIN_TOKEN`;
+  }
+}
+
+async function adminFetch(path: string, init: RequestInit = {}) {
+  const res = await fetch(`${IDENPLANE_URL}${path}`, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      'x-admin-api-key': IDENPLANE_ADMIN_TOKEN,
+      ...init.headers,
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`${init.method ?? 'GET'} ${path} -> ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+describe.skipIf(await skipReason())('verifyToken against a live server', () => {
+  let clientSecret: string;
+
+  beforeAll(async () => {
+    await adminFetch('/admin/realms', {
+      method: 'POST',
+      body: JSON.stringify({ name: TEST_REALM, displayName: 'SDK Integration Test' }),
+    });
+
+    const client = await adminFetch(`/admin/realms/${TEST_REALM}/clients`, {
+      method: 'POST',
+      body: JSON.stringify({
+        clientId: TEST_CLIENT_ID,
+        name: 'SDK Integration Test Client',
+        clientType: 'CONFIDENTIAL',
+        grantTypes: ['client_credentials'],
+      }),
+    });
+    clientSecret = client.clientSecret;
+  });
+
+  afterAll(async () => {
+    await fetch(`${IDENPLANE_URL}/admin/realms/${TEST_REALM}`, {
+      method: 'DELETE',
+      headers: { 'x-admin-api-key': IDENPLANE_ADMIN_TOKEN },
+    }).catch(() => undefined);
+  });
+
+  it('validates a real access token issued by the server', async () => {
+    const tokenRes = await fetch(
+      `${IDENPLANE_URL}/realms/${TEST_REALM}/protocol/openid-connect/token`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'client_credentials',
+          client_id: TEST_CLIENT_ID,
+          client_secret: clientSecret,
+        }),
+      },
+    );
+    expect(tokenRes.ok).toBe(true);
+    const { access_token: accessToken } = await tokenRes.json();
+    expect(typeof accessToken).toBe('string');
+
+    const payload = await verifyToken(accessToken, {
+      issuerUrl: IDENPLANE_URL,
+      realm: TEST_REALM,
+    });
+
+    expect(payload.azp).toBe(TEST_CLIENT_ID);
+    expect(payload.iss).toBe(`${IDENPLANE_URL}/realms/${TEST_REALM}`);
+    expect(typeof payload.exp).toBe('number');
+  });
+
+  it('rejects a token verified against the wrong realm', async () => {
+    const tokenRes = await fetch(
+      `${IDENPLANE_URL}/realms/${TEST_REALM}/protocol/openid-connect/token`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'client_credentials',
+          client_id: TEST_CLIENT_ID,
+          client_secret: clientSecret,
+        }),
+      },
+    );
+    const { access_token: accessToken } = await tokenRes.json();
+
+    await expect(
+      verifyToken(accessToken, { issuerUrl: IDENPLANE_URL, realm: 'master' }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects a tampered token', async () => {
+    const tokenRes = await fetch(
+      `${IDENPLANE_URL}/realms/${TEST_REALM}/protocol/openid-connect/token`,
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'client_credentials',
+          client_id: TEST_CLIENT_ID,
+          client_secret: clientSecret,
+        }),
+      },
+    );
+    const { access_token: accessToken } = await tokenRes.json();
+    const tampered = accessToken.slice(0, -4) + 'abcd';
+
+    await expect(
+      verifyToken(tampered, { issuerUrl: IDENPLANE_URL, realm: TEST_REALM }),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/idenplane-js/package.json
+++ b/packages/idenplane-js/package.json
@@ -66,6 +66,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/packages/idenplane-js/vitest.config.ts
+++ b/packages/idenplane-js/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+// integration/ holds tests that need a live Idenplane server and run via
+// `npm run test:integration` (see vitest.integration.config.ts) — excluded
+// here so plain `npm test` stays a fast, server-less unit run.
+export default defineConfig({
+  test: {
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+      'integration/**',
+    ],
+  },
+});

--- a/packages/idenplane-js/vitest.integration.config.ts
+++ b/packages/idenplane-js/vitest.integration.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Runs only integration/**, which needs a live Idenplane server (see
+// integration/README.md). Kept separate from vitest.config.ts so a plain
+// `npm test` never attempts these without one.
+export default defineConfig({
+  test: {
+    include: ['integration/**/*.integration.test.ts'],
+    testTimeout: 20_000,
+  },
+});

--- a/packages/idenplane-mcp/tests/integration.mjs
+++ b/packages/idenplane-mcp/tests/integration.mjs
@@ -130,6 +130,21 @@ describe('Idenplane MCP integration (over protocol)', { skip: await skipReason()
   describe('User + Audit tools', () => {
     let createdUserId;
 
+    // Admin event logging is opt-in per realm (Realm.adminEventsEnabled
+    // defaults to false — new realms record no admin events at all until
+    // this is turned on), and create_realm doesn't expose the flag. Enable
+    // it directly via REST before relying on query_audit_events below.
+    before(async () => {
+      await fetch(`${IDENPLANE_URL}/admin/realms/${TEST_REALM}`, {
+        method: 'PATCH',
+        headers: {
+          'content-type': 'application/json',
+          'x-admin-api-key': IDENPLANE_ADMIN_TOKEN,
+        },
+        body: JSON.stringify({ adminEventsEnabled: true }),
+      });
+    });
+
     it('create_user creates a user and get_user retrieves them', async () => {
       const user = await callTool('create_user', {
         realmName: TEST_REALM,


### PR DESCRIPTION
## Summary

MVP slice of #1306. Wires two SDK integration test suites to a real, live Idenplane backend in CI — one already existed but had never actually run; the other is new.

## What was found

- **`idenplane-mcp`** already has `tests/integration.mjs`: a full suite exercising every MCP tool call over the protocol against a live server. It correctly self-skips when no server is reachable (a deliberate design so `npm test` doesn't fail everywhere) — but no CI job ever gave it one, so the code has been sitting there unexercised.
- **`idenplane-js`** (the core SDK) had zero integration coverage. Its unit suite (`src/__tests__/server.test.ts`) fully mocks `jose`, so nothing ever confirmed that `verifyToken()` from `idenplane-sdk/server` can actually validate a token this server issues, against its real JWKS endpoint (`/realms/:realm/protocol/openid-connect/certs`) and real issuer format.

## What this adds

- `packages/idenplane-js/integration/verify-token.integration.test.ts` — creates a realm + a `client_credentials` client via the admin API, gets a real access token from `/realms/:realm/protocol/openid-connect/token`, and asserts `verifyToken()`: validates it correctly (checks `azp`, `iss`), rejects it when checked against the wrong realm's JWKS, and rejects a tampered token. Self-skips (mirroring the mcp suite's exact pattern) when `IDENPLANE_URL` isn't reachable.
- `packages/idenplane-js/vitest.config.ts` / `vitest.integration.config.ts` — split so the new suite lives under its own `npm run test:integration` script and never runs as part of the fast, server-less `npm test` used by the existing `sdk-packages` CI matrix job.
- New `sdk-integration-tests` CI job: boots Postgres + the backend (`ADMIN_API_KEY=dev-admin-key`), then runs `idenplane-mcp`'s `test:all` (now actually exercising `integration.mjs` instead of skipping it) and `idenplane-js`'s new `test:integration`.

## What's NOT covered (out of scope for this slice)

This doesn't touch the browser-facing SDKs (`idenplane-js`'s own `IdenplaneClient`, `idenplane-vue`, `idenplane-angular`, `idenplane-nextjs`). Those are redirect/PKCE-flow based and need a real browser to drive meaningfully — the admin-ui E2E harness added in #1344 (Playwright + a real backend) is the template for that, but wiring each SDK's example app through it is separate follow-up work, not attempted here. `idenplane-go`, `idenplane-python`, and `idenplane-cli` also have no live-server integration coverage yet. #1306 stays open.

## Verification

- [x] `npx tsc --noEmit --strict ...` on the new integration test file — no type errors
- [x] `npm run build` / `npm run typecheck` in `idenplane-js` — unaffected, still pass
- [x] `npm test` in `idenplane-js` — 146/146 unit tests still pass, `integration/` correctly excluded (was previously verified to *not* collide, the same way the admin-ui Playwright specs needed excluding from Vitest in #1344)
- [x] `npm run test:integration` locally without a live server — self-skips cleanly (3 skipped), confirming the skip guard works before CI ever needs it
- [x] Hand-validated `.github/workflows/ci.yml` YAML after editing (`js-yaml`), confirmed `sdk-integration-tests` registers correctly
- [ ] Full run against a live backend — this sandbox has no local Postgres/Docker, and I will not run `prisma db push`/`migrate` against even a scratch local database without a human in the loop present to consent (Prisma's own AI-agent safety guard refused that for me mid-session, correctly). CI is the actual gate here.

Relates to #1306.