### PR TITLE
chore(sdk): bump idenplane-sdk/nextjs/vue/angular/cli to 1.0.2

### DIFF
--- a/packages/idenplane-angular/package-lock.json
+++ b/packages/idenplane-angular/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idenplane-angular",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idenplane-angular",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@angular/common": "^22.0.1",

--- a/packages/idenplane-angular/package.json
+++ b/packages/idenplane-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idenplane-angular",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Angular SDK for Idenplane Identity and Access Management Server",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/idenplane-cli/package-lock.json
+++ b/packages/idenplane-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idenplane-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idenplane-cli",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.0",

--- a/packages/idenplane-cli/package.json
+++ b/packages/idenplane-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idenplane-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI tool for managing an Idenplane IAM server",
   "type": "module",
   "bin": {

--- a/packages/idenplane-js/package-lock.json
+++ b/packages/idenplane-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idenplane-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idenplane-sdk",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^19.0.0",

--- a/packages/idenplane-js/package.json
+++ b/packages/idenplane-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idenplane-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Client SDK for Idenplane Identity and Access Management Server",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/idenplane-nextjs/package-lock.json
+++ b/packages/idenplane-nextjs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idenplane-nextjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idenplane-nextjs",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.10.7",

--- a/packages/idenplane-nextjs/package.json
+++ b/packages/idenplane-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idenplane-nextjs",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Next.js SDK for Idenplane Identity and Access Management Server",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/idenplane-vue/package-lock.json
+++ b/packages/idenplane-vue/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idenplane-vue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idenplane-vue",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@vue/test-utils": "^2.4.0",

--- a/packages/idenplane-vue/package.json
+++ b/packages/idenplane-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idenplane-vue",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Vue SDK for Idenplane Identity and Access Management Server",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

All 5 packages have now been published to npm at 1.0.2 with a working `prepublishOnly` build guard (#1337), so `dist/` is correctly included this time — verified live on the registry:

| Package | 1.0.1 files | 1.0.2 files |
|---|---|---|
| idenplane-sdk | 2 | 26 |
| idenplane-nextjs | 2 | 26 |
| idenplane-vue | 2 | 8 |
| idenplane-angular | 2 | 14 |
| idenplane-cli | 1 | 22 |

This commit just syncs the repo's `package.json`/`package-lock.json` versions to match what's live, so the next publish starts from the correct base version instead of colliding with 1.0.2.

Closes #1343.