### PR TITLE
fix(webhooks): correct off-by-one in durable-queue retry backoff

### DIFF
--- a/docs/docs/guides/webhooks.mdx
+++ b/docs/docs/guides/webhooks.mdx
@@ -227,10 +227,10 @@ Test deliveries and real events take genuinely different code paths, with differ
 |---|---|---|
 | Trigger | `POST .../webhooks/{id}/test` | An event matching `eventTypes` |
 | Delivery mechanism | Inline, fire-and-forget from the request handler | Durable `WebhookEvent` outbox row, polled by a scheduler tick every 10 seconds |
-| Attempts | Up to 4 (`1s → 10s → 60s` backoff) | Up to 4 (`10s → 60s → 600s` backoff) |
+| Attempts | Up to 4 (`1s → 10s → 60s` backoff) | Up to 5 (`1s → 10s → 60s → 600s` backoff) |
 | Backoff override | `WEBHOOK_RETRY_DELAYS_MS` (JSON array of milliseconds) | Fixed in code; does not read that variable |
 
-The real-event scheduler's backoff array is defined as `[1s, 10s, 60s, 600s]`, and its own code comment describes the schedule as "1s → 10s → 60s → 10 min." In practice the first entry is never used — the retry delay is looked up by the *new* attempt count (which is already 1 after the first failure), so the first retry fires at the second array entry, 10s, not the first. Effectively real events get **4 attempts total** with **10s → 60s → 600s** between them; the 1s entry and the fifth (would-be) attempt implied by the comment don't happen. If you're correlating delivery timestamps in your own logs against the documented schedule, use the numbers above rather than the source comment.
+The real-event scheduler's backoff array is `[1s, 10s, 60s, 600s]`, giving 5 total delivery attempts (the initial send plus 4 retries): 1s after the first failure, 10s after the second, 60s after the third, and 10 minutes after the fourth, before it's marked permanently failed.
 
 A delivery blocked by SSRF protection (destination resolves to a private/loopback/link-local address) stops retrying immediately rather than burning the full backoff — it's a policy rejection, not a transient failure, and retrying would just re-run the same check against the same result. Every attempt (and every redirect hop) re-resolves DNS at send time, so a URL that was public when you configured it can still be rejected later if it now resolves internally. See [Troubleshooting → Test deliveries and real events use two different retry paths](/troubleshooting#test-deliveries-and-real-events-use-two-different-retry-paths) and [→ Delivery silently fails with "target address is not publicly routable"](/troubleshooting#delivery-silently-fails-with-target-address-is-not-publicly-routable) for the full detail, including the `WEBHOOK_ALLOW_PRIVATE_TARGETS` escape hatch for self-hosted receivers.
 

--- a/docs/docs/troubleshooting.mdx
+++ b/docs/docs/troubleshooting.mdx
@@ -196,13 +196,11 @@ This asymmetry explains a common "it worked in the test button but not in produc
 | | Test delivery (`POST .../webhooks/{id}/test`) | Real events (login, user created, etc.) |
 |---|---|---|
 | Delivery path | Inline, fire-and-forget from the request handler | Durable outbox: a `WebhookEvent` row is written first, then picked up by a scheduler tick every 10 seconds |
-| Retry backoff | `1s → 10s → 60s` (4 attempts total) | `10s → 60s → 600s` (4 attempts total) |
+| Retry backoff | `1s → 10s → 60s` (4 attempts total) | `1s → 10s → 60s → 600s` (5 attempts total) |
 | On SSRF rejection | Retry loop stops immediately (no point retrying a policy rejection) | Same — but still logged as a `WebhookDelivery` row |
 | Where to check the result | `GET .../webhooks/{id}/deliveries` (the test call itself just returns `{ status: 'queued' }`) | Same endpoint — one `WebhookDelivery` row per delivery attempt, not one row with an incrementing counter |
 
 The inline test-delivery schedule can be overridden via `WEBHOOK_RETRY_DELAYS_MS` (a JSON array of milliseconds) — mainly useful for shortening retries in CI. The durable queue's schedule is fixed in code and does not read that variable.
-
-The durable queue's backoff array is `[1s, 10s, 60s, 600s]`, and its own code comment claims a "1s → 10s → 60s → 10 min" / 5-attempt schedule — but the retry delay is indexed by the attempt count *after* incrementing (already 1 on the first failure), so the `1s` entry is never actually used and the loop's own bound cuts it off one attempt earlier than the comment implies. If a delivery log's timestamps don't match "1s → 10s → 60s → 600s," this is why — go by the table above, not the source comment.
 
 ### Delivery silently fails with "target address is not publicly routable"
 
@@ -253,7 +251,7 @@ Not necessarily. Failed binds, a wrong `usersDn`, or a bad `searchFilter` are sw
 Almost always a mismatch between `BASE_URL`'s host/port and the realm's `webAuthnRpId`. The expected origin is built from `BASE_URL`'s scheme/port plus `webAuthnRpId`'s hostname — if `webAuthnRpId` is still `localhost` in a deployed environment, every ceremony will fail. See [Origin / RP ID mismatch](#origin--rp-id-mismatch--the-most-common-cause-of-registration-failures).
 
 **Why did my test webhook succeed (or fail) differently than the same event in production?**
-The test button delivers inline with up to 4 attempts (`1s/10s/60s` backoff); real events go through a durable queue with up to 4 attempts (`10s/60s/600s` backoff) on a 10-second scheduler tick. They're genuinely different code paths. See [Test deliveries and real events use two different retry paths](#test-deliveries-and-real-events-use-two-different-retry-paths).
+The test button delivers inline with up to 4 attempts (`1s/10s/60s` backoff); real events go through a durable queue with up to 5 attempts (`1s/10s/60s/600s` backoff) on a 10-second scheduler tick. They're genuinely different code paths. See [Test deliveries and real events use two different retry paths](#test-deliveries-and-real-events-use-two-different-retry-paths).
 
 **My webhook receiver is on my internal network and deliveries keep failing — why?**
 Every delivery attempt re-resolves DNS and blocks private/loopback/link-local targets by default (SSRF protection), even if the URL was public when you first configured it. Set `WEBHOOK_ALLOW_PRIVATE_TARGETS=true` if that's an intentional, self-hosted setup.

--- a/src/webhooks/webhook-scheduler.service.spec.ts
+++ b/src/webhooks/webhook-scheduler.service.spec.ts
@@ -175,6 +175,58 @@ describe('WebhookSchedulerService', () => {
       expect(updateCall.data.nextRetryAt.getTime()).toBeGreaterThan(Date.now());
     });
 
+    // Pins the documented 1s -> 10s -> 60s -> 10min backoff (issue #1332:
+    // the scheduler previously indexed RETRY_DELAYS_MS by the new attempt
+    // count instead of new attempt count - 1, so the 1s entry was never
+    // reachable and the schedule was actually 10s -> 60s -> 600s over only
+    // 4 total attempts instead of 5).
+    it.each([
+      [0, 1_000],
+      [1, 10_000],
+      [2, 60_000],
+      [3, 600_000],
+    ])(
+      'schedules a %dms-old event\'s retry after %dms',
+      async (attemptsBefore, expectedDelayMs) => {
+        const event = { ...pendingEvent, attempts: attemptsBefore, maxAttempts: 5 };
+        prisma.webhookEvent.findMany.mockResolvedValue([event]);
+        prisma.webhookEvent.updateMany.mockResolvedValue({ count: 1 });
+        prisma.webhook.findMany.mockResolvedValue([mockWebhook]);
+        prisma.webhookDelivery.create.mockResolvedValue({ id: 'del-1' });
+        prisma.webhookDelivery.update.mockResolvedValue({});
+        prisma.webhookEvent.update.mockResolvedValue({});
+
+        mockSafePost.mockRejectedValueOnce(new Error('Connection refused'));
+
+        const before = Date.now();
+        await service.processQueue();
+
+        const updateCall = prisma.webhookEvent.update.mock.calls[0][0];
+        expect(updateCall.data.status).toBe('FAILED');
+        const actualDelayMs = updateCall.data.nextRetryAt.getTime() - before;
+        expect(actualDelayMs).toBeGreaterThanOrEqual(expectedDelayMs);
+        expect(actualDelayMs).toBeLessThan(expectedDelayMs + 2_000);
+      },
+    );
+
+    it('permanently fails after the 5th attempt, not the 4th', async () => {
+      const event = { ...pendingEvent, attempts: 4, maxAttempts: 5 };
+      prisma.webhookEvent.findMany.mockResolvedValue([event]);
+      prisma.webhookEvent.updateMany.mockResolvedValue({ count: 1 });
+      prisma.webhook.findMany.mockResolvedValue([mockWebhook]);
+      prisma.webhookDelivery.create.mockResolvedValue({ id: 'del-1' });
+      prisma.webhookDelivery.update.mockResolvedValue({});
+      prisma.webhookEvent.update.mockResolvedValue({});
+
+      mockSafePost.mockRejectedValueOnce(new Error('Still down'));
+
+      await service.processQueue();
+
+      const updateCall = prisma.webhookEvent.update.mock.calls[0][0];
+      expect(updateCall.data.status).toBe('FAILED');
+      expect(updateCall.data.nextRetryAt).toBeUndefined();
+    });
+
     it('should mark event terminally FAILED when all attempts are exhausted', async () => {
       const exhaustedEvent = {
         ...pendingEvent,

--- a/src/webhooks/webhook-scheduler.service.ts
+++ b/src/webhooks/webhook-scheduler.service.ts
@@ -170,9 +170,9 @@ export class WebhookSchedulerService {
 
     // At least one delivery failed.  Schedule a retry or give up.
     const retriesLeft = (event.maxAttempts ?? MAX_ATTEMPTS) - newAttemptCount;
-    if (retriesLeft > 0 && newAttemptCount < RETRY_DELAYS_MS.length) {
+    if (retriesLeft > 0 && newAttemptCount <= RETRY_DELAYS_MS.length) {
       const delayMs =
-        RETRY_DELAYS_MS[newAttemptCount] ??
+        RETRY_DELAYS_MS[newAttemptCount - 1] ??
         RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
       const nextRetry = new Date(Date.now() + delayMs);
       await this.db.webhookEvent.update({


### PR DESCRIPTION
## Summary

Fixes #1332. `RETRY_DELAYS_MS` in `webhook-scheduler.service.ts` was indexed by `newAttemptCount` (already `1` on the first failure) instead of `newAttemptCount - 1`, so the `1_000` (1s) entry was never reachable, and the loop's bound (`newAttemptCount < RETRY_DELAYS_MS.length`) cut the schedule off one attempt earlier than `MAX_ATTEMPTS` (5) implies.

Real events were actually getting **4 total attempts** with **10s → 60s → 600s** backoff, not the intended **5 attempts** / **1s → 10s → 60s → 600s** that the code comment and `MAX_ATTEMPTS` constant already described. The test-delivery path (`POST .../webhooks/{id}/test`) was never affected — it indexes correctly.

## Fix

```diff
- if (retriesLeft > 0 && newAttemptCount < RETRY_DELAYS_MS.length) {
+ if (retriesLeft > 0 && newAttemptCount <= RETRY_DELAYS_MS.length) {
    const delayMs =
-     RETRY_DELAYS_MS[newAttemptCount] ??
+     RETRY_DELAYS_MS[newAttemptCount - 1] ??
      RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1];
```

## Tests

Added a table-driven test asserting the exact delay for each of the 4 retry attempts (1s / 10s / 60s / 600s, with a tolerance window), and a test confirming permanent failure now happens on the 5th attempt rather than the 4th. Full `src/webhooks/` suite: 49/49 passing.

## Docs

`docs/docs/guides/webhooks.mdx` and `docs/docs/troubleshooting.mdx` were updated in #1329 to document the *buggy* behavior as ground truth (the right call at the time, since the code was in fact buggy). Reverted that wording back to the originally-intended schedule now that the code matches it.

Fixes #1332.