### PR TITLE
fix(events): record admin event for realm creation

### DIFF
--- a/src/events/admin-event.interceptor.spec.ts
+++ b/src/events/admin-event.interceptor.spec.ts
@@ -367,6 +367,63 @@ describe('AdminEventInterceptor', () => {
       });
     });
 
+    // ─── Realm creation (issue #1346) ────────────────
+
+    it('should record REALM CREATE for POST /admin/realms using the id from the response body', (done) => {
+      const context = createContext({
+        method: 'POST',
+        path: '/admin/realms',
+        realm: null,
+      });
+      const handler = { handle: () => of({ id: 'new-realm-id', name: 'new-realm' }) };
+
+      interceptor.intercept(context as any, handler).subscribe({
+        complete: () => {
+          expect(eventsService.recordAdminEvent).toHaveBeenCalledWith({
+            realmId: 'new-realm-id',
+            adminUserId: 'admin-1',
+            operationType: OperationType.CREATE,
+            resourceType: ResourceType.REALM,
+            resourcePath: '/admin/realms',
+            representation: {},
+            ipAddress: '127.0.0.1',
+          });
+          done();
+        },
+      });
+    });
+
+    it('should not record for POST /admin/realms if the response has no id', (done) => {
+      const context = createContext({
+        method: 'POST',
+        path: '/admin/realms',
+        realm: null,
+      });
+      const handler = { handle: () => of({ message: 'unexpected shape' }) };
+
+      interceptor.intercept(context as any, handler).subscribe({
+        complete: () => {
+          expect(eventsService.recordAdminEvent).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
+    it('should still skip other realm-scoped paths with no realm set (not just the create-realm route)', (done) => {
+      const context = createContext({
+        method: 'POST',
+        path: '/admin/realms/test/roles',
+        realm: null,
+      });
+
+      interceptor.intercept(context as any, nextHandler).subscribe({
+        complete: () => {
+          expect(eventsService.recordAdminEvent).not.toHaveBeenCalled();
+          done();
+        },
+      });
+    });
+
     it('should use "api-key" when adminUser has no userId or id', (done) => {
       const context = createContext({
         method: 'POST',

--- a/src/events/admin-event.interceptor.ts
+++ b/src/events/admin-event.interceptor.ts
@@ -77,7 +77,14 @@ export class AdminEventInterceptor implements NestInterceptor {
     const realm = adminReq.realm;
     const adminUser = adminReq.adminUser;
 
-    if (!realm || !adminUser) return next.handle();
+    // POST /admin/realms (creating a realm) has no :realmName param for
+    // RealmGuard to resolve, so `realm` is never set for it — the one admin
+    // write with no pre-existing realm to attach the event to. Special-case
+    // it: the new realm's id is in the response body once creation succeeds.
+    const isRealmCreation =
+      method === 'POST' && request.path === '/admin/realms';
+
+    if ((!realm && !isRealmCreation) || !adminUser) return next.handle();
 
     const operationType = METHOD_TO_OPERATION[method];
     if (!operationType) return next.handle();
@@ -89,9 +96,12 @@ export class AdminEventInterceptor implements NestInterceptor {
       method !== 'DELETE' ? this.redactBody(request.body) : undefined;
 
     return next.handle().pipe(
-      tap(() => {
+      tap((response: unknown) => {
+        const realmId = realm?.id ?? this.extractRealmId(response);
+        if (!realmId) return;
+
         void this.eventsService.recordAdminEvent({
-          realmId: realm.id,
+          realmId,
           adminUserId: adminUser.userId ?? adminUser.id ?? 'api-key',
           operationType,
           resourceType,
@@ -101,6 +111,16 @@ export class AdminEventInterceptor implements NestInterceptor {
         });
       }),
     );
+  }
+
+  /** Reads `id` off a successful creation response (used only when the
+   * request itself had no realm to resolve — see isRealmCreation above). */
+  private extractRealmId(response: unknown): string | null {
+    if (response && typeof response === 'object' && 'id' in response) {
+      const id = (response as { id?: unknown }).id;
+      return typeof id === 'string' ? id : null;
+    }
+    return null;
   }
 
   private resolveResourceType(path: string): ResourceTypeValue | null {


### PR DESCRIPTION
## Summary

Fixes #1346. Every other admin write operation (create/update/delete on users, clients, roles, groups, etc.) is recorded as an admin event by the global `AdminEventInterceptor`. Realm creation was the one exception: `POST /admin/realms` produced no audit trail at all, regardless of the realm's `adminEventsEnabled` setting.

## Root cause

`RealmGuard` resolves `request.params['realmName']` and attaches the realm to `request.realm` — but `POST /admin/realms` has no `:realmName` param (the realm doesn't exist yet), so the guard's early return means `request.realm` is never set for this one route. `AdminEventInterceptor` then bails out on `if (!realm || !adminUser) return next.handle();` before ever recording anything.

## Fix

The interceptor already defers `recordAdminEvent` into a `tap()` callback that runs *after* `next.handle()` resolves — meaning for a successful `POST /admin/realms`, the new realm's `id` is already sitting in the response body by the time the event would be recorded. Special-cased exactly this route (`method === 'POST' && path === '/admin/realms'`) to read the realm ID from the response instead of `request.realm`, and added an `extractRealmId` helper with a safe no-op when the response doesn't have the expected shape.

## Tests

Added 3 tests to `admin-event.interceptor.spec.ts`: records `REALM`/`CREATE` using the response body's `id`, silently skips if the response has no `id` (defensive, since this only runs on the response path), and confirms other realm-scoped routes with no realm attached still skip as before (this fix only applies to the exact realm-creation route, not to every route with a missing realm). Full `src/events/` suite: 67/67 passing.

Fixes #1346.