### PR TITLE
feat(admin-ui): confirm before a real migration import, add report download

### DIFF
--- a/admin-ui/src/pages/migration/MigrationWizardPage.tsx
+++ b/admin-ui/src/pages/migration/MigrationWizardPage.tsx
@@ -3,6 +3,17 @@ import { useParams, useNavigate } from 'react-router';
 import { runMigration, type MigrationReport, type MigrationSource } from '../../api/migration';
 import { getErrorMessage } from '../../utils/getErrorMessage';
 import { Icons } from '../../components/ui';
+import ConfirmDialog from '../../components/ConfirmDialog';
+
+function downloadReport(report: MigrationReport, realmName: string) {
+  const blob = new Blob([JSON.stringify(report, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${realmName}-${report.source}-migration-report.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 const SOURCES: { id: MigrationSource; name: string; description: string }[] = [
   { id: 'keycloak', name: 'Keycloak', description: 'Import from a Keycloak realm export JSON file.' },
@@ -91,6 +102,7 @@ export default function MigrationWizardPage() {
   const [finalReport, setFinalReport] = useState<MigrationReport | null>(null);
   const [isRunning, setIsRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showRunConfirm, setShowRunConfirm] = useState(false);
 
   async function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -268,7 +280,7 @@ export default function MigrationWizardPage() {
               <button
                 type="button"
                 disabled={isRunning}
-                onClick={handleImport}
+                onClick={() => setShowRunConfirm(true)}
                 className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50"
               >
                 {isRunning ? 'Importing...' : 'Run Import'}
@@ -281,7 +293,7 @@ export default function MigrationWizardPage() {
           <div>
             <h2 className="mb-3 text-lg font-semibold text-fg">Import complete</h2>
             <MigrationReportSummary report={finalReport} />
-            <div className="mt-6 flex justify-between">
+            <div className="mt-6 flex items-center justify-between">
               <button
                 type="button"
                 onClick={startOver}
@@ -289,17 +301,39 @@ export default function MigrationWizardPage() {
               >
                 Import Another File
               </button>
-              <button
-                type="button"
-                onClick={() => navigate(`/console/realms/${name}/users`)}
-                className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
-              >
-                View Users
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => downloadReport(finalReport, name!)}
+                  className="rounded-md border border-line-strong bg-surface px-4 py-2 text-sm font-medium text-muted hover:bg-hover"
+                >
+                  Download Report
+                </button>
+                <button
+                  type="button"
+                  onClick={() => navigate(`/console/realms/${name}/users`)}
+                  className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+                >
+                  View Users
+                </button>
+              </div>
             </div>
           </div>
         )}
       </div>
+
+      <ConfirmDialog
+        isOpen={showRunConfirm}
+        title="Run this import for real?"
+        message="This will create the users, clients, roles, and identity providers shown in the preview above. This cannot be undone from here — you would need to remove them individually afterward."
+        confirmText={isRunning ? 'Importing...' : 'Yes, Run Import'}
+        confirmDisabled={isRunning}
+        onConfirm={() => {
+          setShowRunConfirm(false);
+          void handleImport();
+        }}
+        onCancel={() => setShowRunConfirm(false)}
+      />
     </div>
   );
 }

--- a/admin-ui/src/pages/migration/__tests__/MigrationWizardPage.test.tsx
+++ b/admin-ui/src/pages/migration/__tests__/MigrationWizardPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -81,9 +81,64 @@ describe('MigrationWizardPage', () => {
     expect(screen.getByText(/2 created/)).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: /^run import$/i }));
+    expect(screen.getByText(/run this import for real/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /^yes, run import$/i }));
 
     expect(await screen.findByText(/import complete/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /import another file/i })).toBeInTheDocument();
+  });
+
+  it('cancels the confirmation dialog without running the import', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Keycloak'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, makeJsonFile({ users: [] }));
+    await user.click(screen.getByRole('button', { name: /preview import/i }));
+    await screen.findByText(/nothing has been imported yet/i);
+
+    await user.click(screen.getByRole('button', { name: /^run import$/i }));
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(screen.queryByText(/run this import for real/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/nothing has been imported yet/i)).toBeInTheDocument();
+  });
+
+  it('lets you download the completed migration report', async () => {
+    const user = userEvent.setup();
+    // Patch only these two methods (jsdom doesn't implement them) rather than
+    // stubbing the whole URL global — replacing URL itself breaks `new URL()`,
+    // which MSW's request matching relies on for every subsequent test.
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+    const createObjectURL = vi.fn(() => 'blob:mock-url');
+    const revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+
+    try {
+      renderPage();
+
+      await user.click(screen.getByText('Keycloak'));
+      await user.click(screen.getByRole('button', { name: /^next$/i }));
+      const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+      await user.upload(input, makeJsonFile({ users: [] }));
+      await user.click(screen.getByRole('button', { name: /preview import/i }));
+      await screen.findByText(/nothing has been imported yet/i);
+      await user.click(screen.getByRole('button', { name: /^run import$/i }));
+      await user.click(screen.getByRole('button', { name: /^yes, run import$/i }));
+      await screen.findByText(/import complete/i);
+
+      await user.click(screen.getByRole('button', { name: /download report/i }));
+
+      expect(createObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+    } finally {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    }
   });
 
   it('shows warnings and errors from the migration report', async () => {


### PR DESCRIPTION
## Summary

Polish pass on #1312's migration wizard.

**Confirm before a real import.** Previously the same "Run Import" button drove both the dry-run preview and the actual mutating call — the only difference was the button's own label switching from "Run Import" to "Importing...". Clicking through without reading the preview (or a stray double-click) would create real users/clients/roles/IdPs with no undo path. Added a `ConfirmDialog` (reused the existing component, already used elsewhere for realm/user deletion) between "Run Import" and the actual `runMigration(..., dryRun: false)` call.

**Download the report.** The completion screen only showed the created/skipped/failed/warnings summary while the page stayed open — navigating away lost it. Added a "Download Report" button using the same `Blob` + `createObjectURL` pattern already used for realm export.

## Tests

Updated the existing full-flow test to click through the new confirmation step, added a test for cancelling the dialog (import must not run), and a test for the download button. Full admin-ui suite: 49/49 files, 433 tests passing.

One thing worth flagging for anyone touching this test file again: the download test patches `URL.createObjectURL`/`URL.revokeObjectURL` directly (jsdom doesn't implement them) rather than `vi.stubGlobal('URL', ...)` — replacing the whole `URL` global breaks `new URL()`, which MSW's request matching depends on for every test that runs afterward in the same file. Caught this the hard way while writing it (three unrelated-looking test failures downstream, all stuck on the same step).

Relates to #1312.