### PR TITLE
feat(admin-ui): add user and role management E2E coverage

### DIFF
--- a/admin-ui/e2e/user-and-role-management.spec.ts
+++ b/admin-ui/e2e/user-and-role-management.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function login(page: Page) {
+  await page.goto('/console/login');
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+  await expect(page).toHaveURL(/\/console\/?$/);
+}
+
+test('creates a user and a role in a fresh realm', async ({ page }) => {
+  const realmName = `e2e-ur-${test.info().workerIndex}-${Date.now()}`;
+
+  await login(page);
+
+  await page.goto('/console/realms/create');
+  await page.getByLabel('Name', { exact: true }).fill(realmName);
+  await page.getByRole('button', { name: 'Create Realm' }).click();
+  await expect(page).toHaveURL(/\/console\/realms\/?$/);
+
+  // ── User ──
+  await page.goto(`/console/realms/${realmName}/users/create`);
+  await page.getByLabel('Username').fill('e2e-test-user');
+  await page.getByLabel('Password', { exact: true }).fill('correct-horse-battery-staple-1');
+  await page.getByRole('button', { name: 'Create User' }).click();
+
+  await expect(page).toHaveURL(new RegExp(`/console/realms/${realmName}/users/?$`));
+  await expect(page.locator('td', { hasText: 'e2e-test-user' })).toBeVisible();
+
+  // ── Role ──
+  await page.goto(`/console/realms/${realmName}/roles`);
+  await page.getByRole('button', { name: 'Create Role' }).click();
+  await page.getByLabel('Role Name').fill('e2e-test-role');
+  await page.getByLabel('Description').fill('Created by an E2E test');
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+  await expect(page.locator('td', { hasText: new RegExp('^e2e-test-role$') })).toBeVisible();
+
+  // Delete it back out through the confirm dialog, proving both halves of
+  // the delete flow (the guard and the actual removal) work end to end.
+  await page.getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByText(/are you sure you want to delete the role/i)).toBeVisible();
+  await page.getByRole('button', { name: 'Confirm', exact: true }).click();
+
+  await expect(page.getByText(/no roles found in this realm/i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary

MVP-of-the-MVP for #1310: extends the Playwright suite from #1344 (login, realm+client creation) with a create-user and create/delete-role flow in a fresh realm.

## What's covered

- Create a realm, then create a user in it, confirm it lands in the user list
- Create a role via the inline create form on the roles page
- Delete that role through the confirm dialog, verifying both that the dialog gates the action and that confirming it actually removes the row (not just that the dialog opens)

## Verification

This sandbox has no local Postgres, so — same as #1344/#1345/#1351 — this can only be verified by the `admin-ui-e2e` CI job, which boots a real backend for it. Locally verified: `npx playwright test --list` discovers the new spec, ESLint is clean, and the full Vitest unit suite (49 files / 433 tests) still passes with `e2e/` excluded.

Relates to #1310.