### PR TITLE
feat(admin-ui): add locked-out accounts panel to the dashboard

### DIFF
--- a/admin-ui/src/api/bruteForce.ts
+++ b/admin-ui/src/api/bruteForce.ts
@@ -1,0 +1,15 @@
+import apiClient from './client';
+
+export interface LockedUser {
+  id: string;
+  username: string;
+  email: string | null;
+  lockedUntil: string;
+}
+
+export async function getLockedUsers(realmName: string): Promise<LockedUser[]> {
+  const { data } = await apiClient.get<LockedUser[]>(
+    `/realms/${realmName}/brute-force/locked-users`,
+  );
+  return data;
+}

--- a/admin-ui/src/components/dashboard/LockedUsersPanel.tsx
+++ b/admin-ui/src/components/dashboard/LockedUsersPanel.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLockedUsers } from '../../api/bruteForce';
+import { Card, Icons } from '../ui';
+
+interface LockedUsersPanelProps {
+  realmName: string;
+}
+
+function formatRemaining(lockedUntil: string): string {
+  const ms = new Date(lockedUntil).getTime() - Date.now();
+  if (ms <= 0) return 'expiring now';
+  const minutes = Math.ceil(ms / 60_000);
+  if (minutes < 60) return `${minutes}m remaining`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h remaining`;
+}
+
+export default function LockedUsersPanel({ realmName }: LockedUsersPanelProps) {
+  const { data, isLoading } = useQuery({
+    queryKey: ['lockedUsers', realmName],
+    queryFn: () => getLockedUsers(realmName),
+    staleTime: 30_000,
+    // Lockouts expire on their own — refresh often enough that a cleared
+    // one doesn't linger on the dashboard for minutes after it's stale.
+    refetchInterval: 30_000,
+  });
+
+  return (
+    <div>
+      <h2 className="mb-3 text-base font-semibold text-fg">Locked Out Accounts</h2>
+      <Card padding="sm">
+        {isLoading ? (
+          <div className="h-16 animate-pulse rounded-md bg-sunken" />
+        ) : !data || data.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted">No accounts are currently locked out.</p>
+        ) : (
+          <ul className="divide-y divide-line">
+            {data.map((user) => (
+              <li key={user.id} className="flex items-center gap-3 py-2.5">
+                <Icons.Lock className="h-4 w-4 shrink-0 text-danger" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-fg">{user.username}</p>
+                  {user.email && <p className="truncate text-xs text-subtle">{user.email}</p>}
+                </div>
+                <span className="shrink-0 text-xs font-medium text-danger-fg">
+                  {formatRemaining(user.lockedUntil)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/admin-ui/src/components/dashboard/__tests__/LockedUsersPanel.test.tsx
+++ b/admin-ui/src/components/dashboard/__tests__/LockedUsersPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test/mocks/server';
+import { render } from '../../../test/utils';
+import { makeLockedUser } from '../../../test/mocks/data';
+import LockedUsersPanel from '../LockedUsersPanel';
+
+const BASE = '/admin';
+
+function renderPanel(realmName = 'test-realm') {
+  return render(<LockedUsersPanel realmName={realmName} />);
+}
+
+describe('LockedUsersPanel', () => {
+  it('renders the section heading', async () => {
+    renderPanel();
+    expect(await screen.findByRole('heading', { name: /locked out accounts/i })).toBeInTheDocument();
+  });
+
+  it('shows an empty-state message when nobody is locked out', async () => {
+    renderPanel();
+    expect(await screen.findByText(/no accounts are currently locked out/i)).toBeInTheDocument();
+  });
+
+  it('lists a locked user with their remaining lockout time', async () => {
+    server.use(
+      http.get(`${BASE}/realms/:name/brute-force/locked-users`, () =>
+        HttpResponse.json([
+          makeLockedUser({
+            username: 'alice',
+            email: 'alice@example.com',
+            lockedUntil: new Date(Date.now() + 5 * 60_000).toISOString(),
+          }),
+        ]),
+      ),
+    );
+    renderPanel();
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.getByText(/5m remaining/i)).toBeInTheDocument();
+  });
+
+  it('renders multiple locked users', async () => {
+    server.use(
+      http.get(`${BASE}/realms/:name/brute-force/locked-users`, () =>
+        HttpResponse.json([
+          makeLockedUser({ id: 'u1', username: 'alice' }),
+          makeLockedUser({ id: 'u2', username: 'bob', email: null }),
+        ]),
+      ),
+    );
+    renderPanel();
+
+    expect(await screen.findByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/pages/DashboardPage.tsx
+++ b/admin-ui/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { getRealmStats, getHealthStatus, type RealmStats } from '../api/stats';
 import { getErrorMessage } from '../utils/getErrorMessage';
 import { Card, Badge, Icons } from '../components/ui';
 import FailedLoginHeatmap from '../components/dashboard/FailedLoginHeatmap';
+import LockedUsersPanel from '../components/dashboard/LockedUsersPanel';
 
 // ─── Stat Card ────────────────────────────────────────────────────────────────
 
@@ -216,6 +217,9 @@ function RealmStatsSection({ realmName }: { realmName: string }) {
 
       {/* Failed-login heatmap */}
       <FailedLoginHeatmap realmName={realmName} />
+
+      {/* Currently locked-out accounts */}
+      <LockedUsersPanel realmName={realmName} />
 
       {/* Recent events feed */}
       <div>

--- a/admin-ui/src/test/mocks/data.ts
+++ b/admin-ui/src/test/mocks/data.ts
@@ -1,6 +1,7 @@
 import type { Realm, User, Client, Role, NhiIdentity, ConsentCategory } from '../../types';
 import type { LoginEvent, AdminEvent } from '../../api/events';
 import type { RealmStats, FailedLoginHeatmap } from '../../api/stats';
+import type { LockedUser } from '../../api/bruteForce';
 import type { AuthFlow } from '../../api/authFlows';
 import type { UpgradeAuditEntry, PreUpgradeValidationResult, UpgradeHealthResult, RollbackCapability } from '../../api/upgrade';
 import type { NhiIdentityType, NhiLifecycleStatus } from '../../api/nhi';
@@ -164,6 +165,16 @@ export function makeFailedLoginHeatmap(
     windowDays: 30,
     totalFailures: 0,
     heatmap: Array.from({ length: 7 }, () => new Array<number>(24).fill(0)),
+    ...overrides,
+  };
+}
+
+export function makeLockedUser(overrides: Partial<LockedUser> = {}): LockedUser {
+  return {
+    id: 'user-locked-1',
+    username: 'locked.user',
+    email: 'locked.user@example.com',
+    lockedUntil: new Date(Date.now() + 10 * 60_000).toISOString(),
     ...overrides,
   };
 }

--- a/admin-ui/src/test/mocks/handlers.ts
+++ b/admin-ui/src/test/mocks/handlers.ts
@@ -146,6 +146,10 @@ export const handlers = [
     return HttpResponse.json(makeFailedLoginHeatmap());
   }),
 
+  http.get(`${BASE}/realms/:name/brute-force/locked-users`, () => {
+    return HttpResponse.json([]);
+  }),
+
   // Migration
   http.post(`${BASE}/migration/:source`, async ({ request, params }) => {
     const body = (await request.json()) as { dryRun?: boolean };


### PR DESCRIPTION
## Summary

MVP-of-the-MVP for #1315: the backend already has full brute-force lockout tracking (`BruteForceService.getLockedUsers`, `GET /admin/realms/:realm/brute-force/locked-users`) with zero admin-ui surface. Adds a dashboard panel showing currently locked-out accounts and their remaining lockout time, right after the existing failed-login heatmap from #1333.

## Deliberately out of scope

The backend also has an unlock endpoint (`POST .../brute-force/users/:userId/unlock`), but it requires MFA step-up authentication, and there's no step-up challenge-response UI flow anywhere in admin-ui to drive that from a button click — this panel is read-only. Wiring up an "Unlock" button properly means building that step-up flow first, which is real, separate scope rather than something to bolt on here.

## Tests

4 new tests (heading renders, empty state, single locked user with remaining time, multiple users). Full admin-ui suite: 50/50 files, 437 tests passing.

Relates to #1315.