### PR TITLE
feat(realtime): push step-up-required over WebSocket, not just termination

### DIFF
--- a/src/continuous-verification/session-step-up-trigger.spec.ts
+++ b/src/continuous-verification/session-step-up-trigger.spec.ts
@@ -1,0 +1,150 @@
+import { SessionStepUpTrigger } from './session-step-up-trigger.js';
+import {
+  createMockPrismaService,
+  type MockPrismaService,
+} from '../prisma/prisma.mock.js';
+import { ACR_MFA, ACR_WEBAUTHN } from '../step-up/step-up.service.js';
+
+describe('SessionStepUpTrigger', () => {
+  let trigger: SessionStepUpTrigger;
+  let prisma: MockPrismaService & {
+    sessionRiskProfile: Record<string, jest.Mock>;
+    continuousRiskEvent: Record<string, jest.Mock>;
+  };
+  let stepUpService: { recordStepUp: jest.Mock; getAcrStrength: jest.Mock };
+  let sessionEvents: { emitStepUpRequired: jest.Mock };
+
+  const baseProfile = {
+    sessionId: 'session-1',
+    riskScore: 65,
+    riskLevel: 'HIGH' as const,
+    stepUpReason: 'Impossible travel detected',
+    stepUpExpiresAt: new Date(Date.now() + 60_000),
+    session: {
+      id: 'session-1',
+      userId: 'user-1',
+      realmId: 'realm-1',
+      clientId: null,
+      user: { username: 'alice', email: 'alice@example.com' },
+    },
+  };
+
+  beforeEach(() => {
+    prisma = createMockPrismaService() as typeof prisma;
+    prisma.sessionRiskProfile = {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    };
+    prisma.continuousRiskEvent = { create: jest.fn().mockResolvedValue({}) };
+    prisma.client.findUnique = jest.fn();
+    prisma.client.update = jest.fn();
+
+    stepUpService = {
+      recordStepUp: jest.fn().mockResolvedValue(undefined),
+      getAcrStrength: jest.fn((acr: string) => (acr === ACR_WEBAUTHN ? 2 : acr === ACR_MFA ? 1 : 0)),
+    };
+    sessionEvents = { emitStepUpRequired: jest.fn() };
+
+    trigger = new SessionStepUpTrigger(
+      prisma as any,
+      stepUpService as any,
+      sessionEvents as any,
+    );
+  });
+
+  describe('triggerStepUpForSession', () => {
+    it('pushes a real-time step-up event to the session owner', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue(baseProfile);
+
+      await trigger.triggerStepUpForSession('session-1');
+
+      expect(sessionEvents.emitStepUpRequired).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          sessionId: 'session-1',
+          requiredAcr: ACR_MFA,
+          reason: 'Impossible travel detected',
+        }),
+      );
+    });
+
+    it('requires WebAuthn for critical risk scores instead of MFA', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue({
+        ...baseProfile,
+        riskScore: 85,
+      });
+
+      await trigger.triggerStepUpForSession('session-1');
+
+      expect(stepUpService.recordStepUp).toHaveBeenCalledWith(
+        'session-1',
+        ACR_WEBAUTHN,
+        expect.any(Number),
+      );
+      expect(sessionEvents.emitStepUpRequired).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ requiredAcr: ACR_WEBAUTHN }),
+      );
+    });
+
+    it('uses the override reason over the stored one when provided', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue(baseProfile);
+
+      await trigger.triggerStepUpForSession('session-1', 'Manually triggered by admin');
+
+      expect(sessionEvents.emitStepUpRequired).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({ reason: 'Manually triggered by admin' }),
+      );
+    });
+
+    it('throws when no risk profile exists for the session', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue(null);
+
+      await expect(
+        trigger.triggerStepUpForSession('missing-session'),
+      ).rejects.toThrow('Session risk profile not found');
+      expect(sessionEvents.emitStepUpRequired).not.toHaveBeenCalled();
+    });
+
+    it('does not push an event when the profile has no attached session', async () => {
+      prisma.sessionRiskProfile.findUnique.mockResolvedValue({
+        ...baseProfile,
+        session: null,
+      });
+
+      await trigger.triggerStepUpForSession('session-1');
+
+      expect(sessionEvents.emitStepUpRequired).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkAndTriggerStepUp', () => {
+    it('processes every session found by the scheduled query and pushes an event for each', async () => {
+      prisma.sessionRiskProfile.findMany.mockResolvedValue([
+        baseProfile,
+        {
+          ...baseProfile,
+          sessionId: 'session-2',
+          session: { ...baseProfile.session, id: 'session-2', userId: 'user-2' },
+        },
+      ]);
+
+      await trigger.checkAndTriggerStepUp();
+
+      expect(sessionEvents.emitStepUpRequired).toHaveBeenCalledTimes(2);
+      expect(sessionEvents.emitStepUpRequired).toHaveBeenCalledWith(
+        'user-2',
+        expect.objectContaining({ sessionId: 'session-2' }),
+      );
+    });
+
+    it('does nothing when no sessions require step-up', async () => {
+      prisma.sessionRiskProfile.findMany.mockResolvedValue([]);
+
+      await trigger.checkAndTriggerStepUp();
+
+      expect(sessionEvents.emitStepUpRequired).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/continuous-verification/session-step-up-trigger.ts
+++ b/src/continuous-verification/session-step-up-trigger.ts
@@ -6,6 +6,7 @@ import {
   ACR_MFA,
   ACR_WEBAUTHN,
 } from '../step-up/step-up.service.js';
+import { SessionEventsGateway } from '../realtime/session-events.gateway.js';
 
 /**
  * SessionStepUpTrigger
@@ -25,6 +26,7 @@ export class SessionStepUpTrigger {
   constructor(
     private readonly prisma: PrismaService,
     private readonly stepUpService: StepUpService,
+    private readonly sessionEvents: SessionEventsGateway,
   ) {}
 
   /**
@@ -236,13 +238,18 @@ export class SessionStepUpTrigger {
       },
     });
 
-    // Emit a step-up event for real-time notification (could use EventEmitter2)
+    // Emit a step-up event for real-time notification
     this.logger.log(
       `Step-up authentication required for session ${profile.sessionId} ` +
         `(user: ${session.user?.username ?? 'unknown'}, risk: ${profile.riskScore}, level: ${profile.riskLevel})`,
     );
 
-    // TODO: Emit event for WebSocket/push notification to client application
-    // this.eventEmitter.emit('session.stepup.required', { sessionId, requiredAcr, reason });
+    this.sessionEvents.emitStepUpRequired(session.userId, {
+      sessionId: profile.sessionId,
+      requiredAcr,
+      reason:
+        overrideReason ?? profile.stepUpReason ?? 'Risk threshold exceeded',
+      timestamp: now.toISOString(),
+    });
   }
 }

--- a/src/realtime/session-events.gateway.spec.ts
+++ b/src/realtime/session-events.gateway.spec.ts
@@ -168,4 +168,58 @@ describe('SessionEventsGateway', () => {
       expect(socket.send).not.toHaveBeenCalled();
     });
   });
+
+  describe('emitStepUpRequired', () => {
+    it('does nothing when the user has no open connections', () => {
+      expect(() =>
+        service.emitStepUpRequired('user-1', {
+          sessionId: 'sess-1',
+          requiredAcr: 'urn:idenplane:acr:mfa',
+          reason: 'Risk threshold exceeded',
+          timestamp: new Date().toISOString(),
+        }),
+      ).not.toThrow();
+    });
+
+    it('sends a session.stepup_required event to every OPEN socket for the user', () => {
+      const openSocket = makeFakeSocket(WebSocket.OPEN);
+      const closedSocket = makeFakeSocket(WebSocket.CLOSED);
+      (service as any).connections.set(
+        'user-1',
+        new Set([openSocket, closedSocket]),
+      );
+
+      service.emitStepUpRequired('user-1', {
+        sessionId: 'sess-1',
+        requiredAcr: 'urn:idenplane:acr:mfa',
+        reason: 'Risk threshold exceeded',
+        timestamp: '2026-08-02T00:00:00.000Z',
+      });
+
+      expect(openSocket.send).toHaveBeenCalledWith(
+        JSON.stringify({
+          type: 'session.stepup_required',
+          sessionId: 'sess-1',
+          requiredAcr: 'urn:idenplane:acr:mfa',
+          reason: 'Risk threshold exceeded',
+          timestamp: '2026-08-02T00:00:00.000Z',
+        }),
+      );
+      expect(closedSocket.send).not.toHaveBeenCalled();
+    });
+
+    it('does not deliver to a different user', () => {
+      const socket = makeFakeSocket(WebSocket.OPEN);
+      (service as any).connections.set('user-1', new Set([socket]));
+
+      service.emitStepUpRequired('user-2', {
+        sessionId: 'sess-1',
+        requiredAcr: 'urn:idenplane:acr:mfa',
+        reason: 'Risk threshold exceeded',
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(socket.send).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/realtime/session-events.gateway.ts
+++ b/src/realtime/session-events.gateway.ts
@@ -13,6 +13,13 @@ export interface SessionTerminatedEvent {
   timestamp: string;
 }
 
+export interface StepUpRequiredEvent {
+  sessionId: string;
+  requiredAcr: string;
+  reason: string;
+  timestamp: string;
+}
+
 /**
  * Real-time push for session lifecycle events, replacing the polling-based
  * "did my session get revoked?" pattern. A client connects to
@@ -70,10 +77,27 @@ export class SessionEventsGateway {
 
   /** Push a session-termination event to every connection for this user. */
   emitSessionTerminated(userId: string, event: SessionTerminatedEvent): void {
+    this.broadcast(userId, 'session.terminated', event);
+  }
+
+  /**
+   * Push a step-up-required event to every connection for this user, so a
+   * client application can prompt for re-authentication immediately instead
+   * of only discovering the requirement on its next API call.
+   */
+  emitStepUpRequired(userId: string, event: StepUpRequiredEvent): void {
+    this.broadcast(userId, 'session.stepup_required', event);
+  }
+
+  private broadcast<T extends object>(
+    userId: string,
+    type: string,
+    event: T,
+  ): void {
     const sockets = this.connections.get(userId);
     if (!sockets || sockets.size === 0) return;
 
-    const payload = JSON.stringify({ type: 'session.terminated', ...event });
+    const payload = JSON.stringify({ type, ...event });
     for (const ws of sockets) {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(payload);


### PR DESCRIPTION
## Summary

MVP-of-the-MVP for #1308. The epic's own title asks for "real-time push notifications for session events (real-time termination/step-up)" — only termination was ever wired up. `SessionStepUpTrigger` had a literal:

\`\`\`ts
// TODO: Emit event for WebSocket/push notification to client application
// this.eventEmitter.emit('session.stepup.required', { sessionId, requiredAcr, reason });
\`\`\`

at the exact point it decides a session's risk crossed the threshold and now requires MFA/WebAuthn re-authentication. Clients had no way to find out except on their next API call.

## What's added

- `SessionEventsGateway.emitStepUpRequired(userId, event)` — same delivery mechanism as the existing `emitSessionTerminated` (factored the duplicated per-socket broadcast loop into one private `broadcast<T>` helper both now call).
- Wired into `SessionStepUpTrigger` at both call sites that create a step-up record: the scheduled per-minute sweep (`checkAndTriggerStepUp`) and the manual `triggerStepUpForSession`.

## Tests

`SessionStepUpTrigger` had no test file at all before this. Added one covering: the event fires with the right payload on both entry points, WebAuthn is required over MFA for critical risk scores, the override-reason path, the not-found error path, and the no-attached-session guard. Extended the existing gateway spec with the same three cases already covered for `emitSessionTerminated` (no connections, delivers to open sockets only, doesn't leak to a different user).

Relates to #1308.