### PR TITLE
feat(account): send a security email when a user changes their password

### DIFF
--- a/src/account/account.controller.spec.ts
+++ b/src/account/account.controller.spec.ts
@@ -27,6 +27,7 @@ describe('AccountController', () => {
   };
   let themeRender: { render: jest.Mock };
   let webAuthnService: { getUserCredentials: jest.Mock };
+  let emailService: { sendEmail: jest.Mock };
 
   const realm = {
     id: 'realm-1',
@@ -75,6 +76,7 @@ describe('AccountController', () => {
     };
     themeRender = { render: jest.fn() };
     webAuthnService = { getUserCredentials: jest.fn().mockResolvedValue([]) };
+    emailService = { sendEmail: jest.fn().mockResolvedValue(undefined) };
     const csrfService = {
       validate: jest.fn().mockReturnValue(true),
       generateToken: jest.fn().mockReturnValue('csrf-token-test'),
@@ -92,12 +94,15 @@ describe('AccountController', () => {
       undefined as any, // dataExportService — not exercised in these tests
       undefined as any, // accountDeletionService — not exercised in these tests
       csrfService as any,
+      emailService as any,
     );
 
     mockRes = { redirect: jest.fn(), cookie: jest.fn(), clearCookie: jest.fn() };
     mockReqWithSession = {
       cookies: { IDENPLANE_SESSION: 'valid-token' },
       query: {},
+      headers: { 'user-agent': 'jest-test-agent' },
+      socket: { remoteAddress: '127.0.0.1' },
     };
     mockReqNoSession = { cookies: {} };
 
@@ -356,6 +361,86 @@ describe('AccountController', () => {
       expect(mockRes.redirect).toHaveBeenCalledWith(
         expect.stringContaining('success='),
       );
+    });
+
+    it('should send a password-changed security email to the account holder', async () => {
+      passwordPolicyService.validate.mockReturnValue({ valid: true, errors: [] });
+      crypto.verifyPassword.mockResolvedValue(true);
+      passwordPolicyService.checkHistory.mockResolvedValue(false);
+      crypto.hashPassword.mockResolvedValue('new-hash');
+      prisma.user.update.mockResolvedValue({});
+
+      await controller.changePassword(
+        realm,
+        {
+          currentPassword: 'old',
+          newPassword: 'newpass',
+          confirmPassword: 'newpass',
+        },
+        mockReqWithSession,
+        mockRes as any,
+      );
+
+      // The email is fire-and-forget (`void ...`), so let its promise settle.
+      await new Promise(process.nextTick);
+
+      expect(emailService.sendEmail).toHaveBeenCalledWith(
+        'test-realm',
+        'test@example.com',
+        'Your Password Was Changed',
+        expect.stringContaining('Your Password Was Changed'),
+      );
+    });
+
+    it('should not fail the password change if the notification email fails to send', async () => {
+      passwordPolicyService.validate.mockReturnValue({ valid: true, errors: [] });
+      crypto.verifyPassword.mockResolvedValue(true);
+      passwordPolicyService.checkHistory.mockResolvedValue(false);
+      crypto.hashPassword.mockResolvedValue('new-hash');
+      prisma.user.update.mockResolvedValue({});
+      emailService.sendEmail.mockRejectedValue(new Error('SMTP down'));
+
+      await controller.changePassword(
+        realm,
+        {
+          currentPassword: 'old',
+          newPassword: 'newpass',
+          confirmPassword: 'newpass',
+        },
+        mockReqWithSession,
+        mockRes as any,
+      );
+      await new Promise(process.nextTick);
+
+      expect(mockRes.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('success='),
+      );
+    });
+
+    it('should not attempt to send an email when the account has no email address', async () => {
+      loginService.validateLoginSession.mockResolvedValue({
+        ...sessionUser,
+        email: null,
+      });
+      passwordPolicyService.validate.mockReturnValue({ valid: true, errors: [] });
+      crypto.verifyPassword.mockResolvedValue(true);
+      passwordPolicyService.checkHistory.mockResolvedValue(false);
+      crypto.hashPassword.mockResolvedValue('new-hash');
+      prisma.user.update.mockResolvedValue({});
+
+      await controller.changePassword(
+        realm,
+        {
+          currentPassword: 'old',
+          newPassword: 'newpass',
+          confirmPassword: 'newpass',
+        },
+        mockReqWithSession,
+        mockRes as any,
+      );
+      await new Promise(process.nextTick);
+
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
     });
   });
 

--- a/src/account/account.controller.ts
+++ b/src/account/account.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Req,
   Res,
+  Logger,
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
@@ -28,12 +29,17 @@ import { WebAuthnService } from '../webauthn/webauthn.service.js';
 import { DataExportService } from './data-export.service.js';
 import { AccountDeletionService } from './account-deletion.service.js';
 import { CsrfService } from '../common/csrf/csrf.service.js';
+import { EmailService } from '../email/email.service.js';
+import { escapeHtml } from '../common/utils/html-escape.util.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
 
 @ApiExcludeController()
 @Controller('realms/:realmName/account')
 @UseGuards(RealmGuard)
 @Public()
 export class AccountController {
+  private readonly logger = new Logger(AccountController.name);
+
   constructor(
     private readonly loginService: LoginService,
     private readonly prisma: PrismaService,
@@ -45,6 +51,7 @@ export class AccountController {
     private readonly dataExportService: DataExportService,
     private readonly accountDeletionService: AccountDeletionService,
     private readonly csrfService: CsrfService,
+    private readonly emailService: EmailService,
   ) {}
 
   /** Set a fresh CSRF cookie and return the token for embedding in the form. */
@@ -296,9 +303,55 @@ export class AccountController {
       realm.passwordHistoryCount,
     );
 
+    void this.sendPasswordChangedEmail(realm.name, user, req);
+
     res.redirect(
       `/realms/${realm.name}/account?success=${encodeURIComponent('Password changed successfully.')}`,
     );
+  }
+
+  /**
+   * Best-effort security alert so the account holder can catch an
+   * unauthorized password change — never blocks the change itself on
+   * email delivery, matching sendBlockedLoginEmail's fire-and-forget shape.
+   */
+  private async sendPasswordChangedEmail(
+    realmName: string,
+    user: { email: string | null; username: string },
+    req: Request,
+  ): Promise<void> {
+    if (!user.email) return;
+
+    const time = escapeHtml(new Date().toUTCString());
+    const ip = escapeHtml(resolveClientIp(req));
+    const device = escapeHtml(req.headers?.['user-agent'] ?? 'Unknown');
+
+    const html = `
+      <h2>Your Password Was Changed</h2>
+      <p>The password for account "${escapeHtml(user.username)}" was just changed.</p>
+      <table style="border-collapse:collapse;margin-top:12px">
+        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Time</td><td>${time}</td></tr>
+        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">IP Address</td><td>${ip}</td></tr>
+        <tr><td style="padding:4px 12px 4px 0;font-weight:bold">Device</td><td>${device}</td></tr>
+      </table>
+      <p style="margin-top:16px">
+        If this was you, no action is required.<br/>
+        If you did not make this change, contact your administrator immediately.
+      </p>
+    `;
+
+    try {
+      await this.emailService.sendEmail(
+        realmName,
+        user.email,
+        'Your Password Was Changed',
+        html,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to send password-changed email to ${user.email}: ${(err as Error).message}`,
+      );
+    }
   }
 
   // ─── TOTP SETUP ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

MVP-of-the-MVP for #1309. Self-service password change (\`POST /realms/:realm/account/password\`) had zero notification — the standard "your password was changed" alert most identity platforms send precisely so an account holder can catch a change they didn't make.

Other security-sensitive paths already send an email in this codebase (brute-force lockout, blocked suspicious login, forced session termination from continuous risk assessment) — this fills in the most common gap of the set.

## Implementation

Mirrors \`RiskAssessmentService.sendBlockedLoginEmail\`'s exact shape rather than introducing a new pattern: inline HTML with every interpolated value passed through \`escapeHtml\` (time, IP via \`resolveClientIp\`, User-Agent), fire-and-forget with a try/catch + warn log so email delivery can never fail or block the actual password change. Skips sending entirely when the account has no email on file.

## Tests

3 new tests: the email is sent with the expected recipient/subject/body, a failed send doesn't block the password-change success redirect, and no email is attempted when the account has no email address. Full \`src/account\` + \`src/email\` suites: 54/54 passing.

## Deliberately out of scope

The epic title also asks for "in-app" notifications — there's no notification data model in the schema at all, so that's a genuinely separate, larger feature (new Prisma model + migration + read/unread UI), not something to fold into this slice.

Relates to #1309.