### PR TITLE
feat(docs): add framework-free vanilla JS quickstart for idenplane-sdk

### DIFF
--- a/docs/docs/guides/sdks/javascript.mdx
+++ b/docs/docs/guides/sdks/javascript.mdx
@@ -252,6 +252,9 @@ See the [Authentication Guide](/guides/authentication) for how these signals are
 
 <div className="row">
 
+[**Vanilla JS Quickstart Template**](https://github.com/idenplane/idenplane/tree/dev/examples/vanilla-js-quickstart)
+A complete, framework-free app (login, callback, logout) with no build step, runnable with `docker compose up`
+
 [**Authentication Guide**](/guides/authentication)
 OAuth 2.0 flows in depth
 

--- a/examples/vanilla-js-quickstart/README.md
+++ b/examples/vanilla-js-quickstart/README.md
@@ -1,0 +1,56 @@
+# idenplane-sdk — Vanilla JS Quickstart
+
+The simplest possible integration: no React, no bundler, no build step. A
+plain `<script type="module">` and a browser [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) resolve `idenplane-sdk` straight from
+`node_modules`, the same way a bundler normally would for you.
+
+## Run it with Docker (fastest)
+
+```bash
+docker compose up
+```
+
+This starts Idenplane + Postgres, seeds a `quickstart` realm with a
+`vanilla-js-quickstart` public client and a `demo` / `Demo1234!` user, then
+serves this site at **http://localhost:3002**.
+
+## Run it without Docker
+
+You'll need an already-running Idenplane server (see the [root README](../../README.md)
+or `docker compose up db idenplane` from the repo root) with a realm and a
+**public** client registered with:
+
+- Redirect URI: `http://localhost:3002/callback.html`
+- Post-logout redirect URI: `http://localhost:3002/index.html`
+- Web origin: `http://localhost:3002`
+
+Then:
+
+```bash
+npm install
+npm start
+```
+
+Edit [`config.js`](./config.js) if your server URL, realm, or client ID
+differ from the defaults.
+
+## How it works
+
+- **`index.html` / `main.js`** — `client.init()` restores an existing session
+  from storage on load; `client.login()` redirects to Idenplane's hosted
+  login page; `client.getUserInfo()` reads the cached ID token claims once
+  authenticated.
+- **`callback.html` / `callback.js`** — the page your redirect URI points at.
+  `client.handleCallback()` exchanges the authorization code for tokens (PKCE,
+  no client secret needed since this is a public client), then this page
+  bounces back to `index.html`.
+- **`config.js`** — the one file you'd change per environment. There's no
+  build step to inject env vars into, so it's just a plain exported object.
+
+## Why an import map instead of a CDN link
+
+You could instead import `idenplane-sdk` from a CDN like `esm.sh` with zero
+local setup at all — but pinning to what's actually in your own
+`node_modules` (via `npm install`) means you get the exact version your
+`package.json` declares, offline-capable local development, and no
+third-party CDN in your trust chain for a security library.

--- a/examples/vanilla-js-quickstart/callback.html
+++ b/examples/vanilla-js-quickstart/callback.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Signing you in…</title>
+    <script type="importmap">
+      { "imports": { "idenplane-sdk": "./node_modules/idenplane-sdk/dist/index.js" } }
+    </script>
+  </head>
+  <body>
+    <p>Signing you in…</p>
+    <script type="module" src="./callback.js"></script>
+  </body>
+</html>

--- a/examples/vanilla-js-quickstart/callback.js
+++ b/examples/vanilla-js-quickstart/callback.js
@@ -1,0 +1,7 @@
+import { IdenplaneClient } from 'idenplane-sdk';
+import { config } from './config.js';
+
+const client = new IdenplaneClient(config);
+
+const success = await client.handleCallback();
+window.location.href = success ? './index.html' : './index.html?error=login_failed';

--- a/examples/vanilla-js-quickstart/config.js
+++ b/examples/vanilla-js-quickstart/config.js
@@ -1,0 +1,9 @@
+// Shared client config for index.html and callback.html. In a real app these
+// values would typically come from build-time env vars or a small server
+// endpoint — hardcoded here since this example deliberately has no build step.
+export const config = {
+  url: 'http://localhost:3000',
+  realm: 'quickstart',
+  clientId: 'vanilla-js-quickstart',
+  redirectUri: 'http://localhost:3002/callback.html',
+};

--- a/examples/vanilla-js-quickstart/docker-compose.yml
+++ b/examples/vanilla-js-quickstart/docker-compose.yml
@@ -1,0 +1,64 @@
+# Quickstart-only stack: Idenplane server + Postgres + a one-shot seed job
+# that creates a demo realm/client/user + this static site, served after
+# `npm install` pulls down idenplane-sdk (there's no build step otherwise).
+#
+# The fixed secrets below are for local, throwaway use only — never reuse
+# them for anything internet-facing. See the root docker-compose.yml for a
+# production-oriented setup.
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: idenplane
+      POSTGRES_PASSWORD: idenplane
+      POSTGRES_DB: idenplane
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U idenplane"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  idenplane:
+    image: islamawad/idenplane:latest
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: postgresql://idenplane:idenplane@db:5432/idenplane
+      PORT: "3000"
+      NODE_ENV: production
+      ADMIN_API_KEY: quickstart-dev-admin-key-do-not-use-in-production
+      WEBHOOK_SECRET_KEY: 0000000000000000000000000000000000000000000000000000000000000000
+      WEBHOOK_ENCRYPTION_SALT: 00000000000000000000000000000000
+      BASE_URL: http://localhost:3000
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  seed:
+    image: curlimages/curl:8.11.1
+    depends_on:
+      idenplane:
+        condition: service_healthy
+    volumes:
+      - ./seed.sh:/seed.sh:ro
+    entrypoint: ["sh", "/seed.sh"]
+    environment:
+      IDENPLANE_URL: http://idenplane:3000
+      ADMIN_API_KEY: quickstart-dev-admin-key-do-not-use-in-production
+
+  web:
+    image: node:22-alpine
+    working_dir: /app
+    ports:
+      - "3002:3002"
+    volumes:
+      - ./:/app
+    command: sh -c "npm install && npx --yes serve -l 3002 ."
+    depends_on:
+      seed:
+        condition: service_completed_successfully

--- a/examples/vanilla-js-quickstart/index.html
+++ b/examples/vanilla-js-quickstart/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>idenplane-sdk — Vanilla JS Quickstart</title>
+    <!--
+      No bundler here on purpose — this import map is what lets a plain
+      <script type="module"> resolve the bare "idenplane-sdk" specifier
+      straight from node_modules, the same way a bundler would. Run
+      `npm install` once before `npm start`.
+    -->
+    <script type="importmap">
+      { "imports": { "idenplane-sdk": "./node_modules/idenplane-sdk/dist/index.js" } }
+    </script>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 640px; margin: 4rem auto; padding: 0 1rem; }
+      button { font-size: 1rem; padding: 0.5rem 1rem; cursor: pointer; }
+      pre { background: #f4f4f4; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+    </style>
+  </head>
+  <body>
+    <h1>idenplane-sdk — Vanilla JS Quickstart</h1>
+    <p>No React, no build step — just <code>idenplane-sdk</code> imported directly in the browser.</p>
+
+    <button id="login-btn" hidden>Sign In</button>
+    <button id="logout-btn" hidden>Sign Out</button>
+
+    <div id="authenticated-view" hidden>
+      <h2>Welcome!</h2>
+      <p>Your user info from the ID token:</p>
+      <pre id="profile"></pre>
+    </div>
+
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/examples/vanilla-js-quickstart/main.js
+++ b/examples/vanilla-js-quickstart/main.js
@@ -1,0 +1,26 @@
+import { IdenplaneClient } from 'idenplane-sdk';
+import { config } from './config.js';
+
+const client = new IdenplaneClient(config);
+
+const loginBtn = document.getElementById('login-btn');
+const logoutBtn = document.getElementById('logout-btn');
+const authenticatedView = document.getElementById('authenticated-view');
+const profile = document.getElementById('profile');
+
+function render() {
+  const authed = client.isAuthenticated();
+  loginBtn.hidden = authed;
+  logoutBtn.hidden = !authed;
+  authenticatedView.hidden = !authed;
+  if (authed) {
+    profile.textContent = JSON.stringify(client.getUserInfo(), null, 2);
+  }
+}
+
+loginBtn.addEventListener('click', () => client.login());
+logoutBtn.addEventListener('click', () => client.logout());
+
+// Restores an existing session (if any) from storage before the first render.
+await client.init();
+render();

--- a/examples/vanilla-js-quickstart/package-lock.json
+++ b/examples/vanilla-js-quickstart/package-lock.json
@@ -1,0 +1,33 @@
+{
+  "name": "vanilla-js-quickstart",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vanilla-js-quickstart",
+      "version": "1.0.0",
+      "dependencies": {
+        "idenplane-sdk": "^1.0.2"
+      }
+    },
+    "node_modules/idenplane-sdk": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/idenplane-sdk/-/idenplane-sdk-1.0.2.tgz",
+      "integrity": "sha512-1g9IgqI/fvRIzjIIt+ucow4TlG0DVyphWFlA38BHC/LXuXNyqs7yWaVlh7+i53B6aDh1qvdQTL0rVrBcA4yvFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "jose": ">=5.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/examples/vanilla-js-quickstart/package.json
+++ b/examples/vanilla-js-quickstart/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "vanilla-js-quickstart",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Framework-free example: login, callback, and logout using idenplane-sdk directly in the browser via an import map — no bundler.",
+  "scripts": {
+    "start": "npx --yes serve -l 3002 ."
+  },
+  "dependencies": {
+    "idenplane-sdk": "^1.0.2"
+  }
+}

--- a/examples/vanilla-js-quickstart/seed.sh
+++ b/examples/vanilla-js-quickstart/seed.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# One-shot seed job: creates the demo realm, a public OIDC client for this
+# quickstart, and a demo user. Idempotent — safe to re-run (a 409 from an
+# already-existing realm/client/user is treated as success).
+set -eu
+
+BASE="$IDENPLANE_URL/admin/realms"
+AUTH_HEADER="x-admin-api-key: $ADMIN_API_KEY"
+
+post() {
+  # $1 = path, $2 = JSON body. Prints the response body; exits non-zero only
+  # on an unexpected (non-2xx, non-409) status.
+  path="$1"
+  body="$2"
+  response=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+    -X POST "$BASE$path" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d "$body")
+  if [ "$response" != "409" ] && [ "${response#2}" = "$response" ]; then
+    echo "POST $path failed with status $response:" >&2
+    cat /tmp/resp.json >&2
+    exit 1
+  fi
+  cat /tmp/resp.json
+}
+
+echo "Seeding realm 'quickstart'..."
+post "" '{"name":"quickstart","displayName":"Quickstart","enabled":true}' > /dev/null
+
+echo "Seeding client 'vanilla-js-quickstart'..."
+post "/quickstart/clients" '{
+  "clientId": "vanilla-js-quickstart",
+  "name": "Vanilla JS Quickstart",
+  "publicClient": true,
+  "enabled": true,
+  "redirectUris": ["http://localhost:3002/callback.html"],
+  "postLogoutRedirectUris": ["http://localhost:3002/index.html"],
+  "webOrigins": ["http://localhost:3002"],
+  "grantTypes": ["authorization_code", "refresh_token"]
+}' > /dev/null
+
+echo "Seeding demo user 'demo'..."
+user_response=$(post "/quickstart/users" '{
+  "username": "demo",
+  "email": "demo@example.com",
+  "firstName": "Demo",
+  "lastName": "User",
+  "enabled": true,
+  "emailVerified": true
+}')
+user_id=$(echo "$user_response" | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+
+if [ -n "${user_id:-}" ]; then
+  echo "Setting demo user password..."
+  curl -sS -o /dev/null -w "%{http_code}\n" \
+    -X PUT "$BASE/quickstart/users/$user_id/reset-password" \
+    -H "$AUTH_HEADER" -H "Content-Type: application/json" \
+    -d '{"password":"Demo1234!"}'
+else
+  echo "User 'demo' already existed — skipping password set (use Demo1234! if this is a fresh seed, or reset it via the admin console otherwise)."
+fi
+
+echo "Seed complete. Realm: quickstart | Client: vanilla-js-quickstart | Demo user: demo / Demo1234!"

--- a/examples/vanilla-js-quickstart/serve.json
+++ b/examples/vanilla-js-quickstart/serve.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": false
+}


### PR DESCRIPTION
## Summary

MVP-of-the-MVP for #1307: #1338 added a Next.js quickstart; this adds the framework-free version for the core \`idenplane-sdk\` package itself — no React, no bundler, no build step. A plain \`<script type="module">\` plus a browser [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) resolve the bare \`idenplane-sdk\` specifier straight from \`node_modules\`, the same way a bundler would — following the "Vanilla JavaScript / TypeScript" example already documented in the package's own README, just made runnable.

## What's added

\`examples/vanilla-js-quickstart/\`: \`index.html\`/\`main.js\` (login button, cached user info once authenticated), \`callback.html\`/\`callback.js\` (exchanges the code via \`handleCallback()\`), \`config.js\` (the one file to edit per environment), plus the same \`docker-compose.yml\`/\`seed.sh\` pattern as the Next.js quickstart (Postgres + Idenplane + a one-shot seed job), swapped to serve static files instead of a Next.js build.

Linked from the JavaScript SDK guide's "Next steps" section.

## A real bug caught while verifying this

\`serve\` (the static server both \`npm start\` and the Docker \`web\` service use) redirects \`/callback.html\` → \`/callback\` by default — and drops the query string on that redirect. That would have silently thrown away the OAuth \`code\`/\`state\` params before \`callback.js\` ever ran, breaking login for anyone who actually tried it. Confirmed with curl:

\`\`\`
# before: serve.json didn't exist
$ curl -sv "http://localhost:PORT/callback.html?code=abc123&state=xyz"
< HTTP/1.1 301 Moved Permanently
< Location: /callback          # query string gone

# after: serve.json { "cleanUrls": false }
$ curl -sv "http://localhost:PORT/callback.html?code=abc123&state=xyz"
< HTTP/1.1 200 OK               # served directly, query string intact
\`\`\`

## Verification

- [x] \`npm install\` against the real, now-fixed npm registry (\`idenplane-sdk@^1.0.2\` from #1348) resolves and installs cleanly
- [x] Confirmed \`node_modules/idenplane-sdk/dist/index.js\` and its relative chunk import both serve with 200 over a real static server
- [x] Confirmed (see above) the callback query-string bug is actually fixed, not just assumed
- [x] \`docs\` build succeeds with the new "Next steps" link
- [ ] Full login round-trip against a live backend — same constraint as every other example added this session (no Docker in this sandbox); the Docker Compose path is the actual verification route for anyone running this for real

Relates to #1307.