### PR TITLE
feat(migration): add Authentik importer

### DIFF
--- a/admin-ui/src/api/migration.ts
+++ b/admin-ui/src/api/migration.ts
@@ -1,6 +1,6 @@
 import apiClient from './client';
 
-export type MigrationSource = 'keycloak' | 'auth0' | 'zitadel';
+export type MigrationSource = 'keycloak' | 'auth0' | 'zitadel' | 'authentik';
 
 export interface MigrationEntityStats {
   created: number;

--- a/admin-ui/src/pages/migration/MigrationWizardPage.tsx
+++ b/admin-ui/src/pages/migration/MigrationWizardPage.tsx
@@ -23,6 +23,11 @@ const SOURCES: { id: MigrationSource; name: string; description: string }[] = [
     name: 'Zitadel',
     description: 'Import from a hand-assembled Zitadel Management API export (Users/Projects/Roles/Apps/IDPs).',
   },
+  {
+    id: 'authentik',
+    name: 'Authentik',
+    description: 'Import from a hand-assembled Authentik REST API export (Users/Groups/Providers/Sources).',
+  },
 ];
 
 const STEPS = ['source', 'upload', 'preview', 'done'] as const;

--- a/admin-ui/src/pages/migration/__tests__/MigrationWizardPage.test.tsx
+++ b/admin-ui/src/pages/migration/__tests__/MigrationWizardPage.test.tsx
@@ -199,4 +199,19 @@ describe('MigrationWizardPage', () => {
     await user.click(screen.getByRole('button', { name: /^back$/i }));
     expect(screen.getByText(/where are you migrating from/i)).toBeInTheDocument();
   });
+
+  it('offers Authentik as a source and can preview an import from it', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByText('Authentik'));
+    await user.click(screen.getByRole('button', { name: /^next$/i }));
+    expect(screen.getByText(/upload your authentik export/i)).toBeInTheDocument();
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await user.upload(input, makeJsonFile({ users: [] }));
+    await user.click(screen.getByRole('button', { name: /preview import/i }));
+
+    expect(await screen.findByText(/nothing has been imported yet/i)).toBeInTheDocument();
+  });
 });

--- a/docs/docs/contributing/architecture.mdx
+++ b/docs/docs/contributing/architecture.mdx
@@ -42,7 +42,7 @@ The backend has around 60 NestJS modules under `src/`, each a self-contained `*.
 | **Auth methods & flows** | `login`, `registration`, `mfa`, `webauthn`, `magic-link`, `device`, `auth-flow`, `password-policy`, `step-up` |
 | **Sessions & tokens** | `sessions`, `tokens`, `impersonation`, `brute-force` |
 | **Continuous security** | `continuous-verification`, `risk-assessment`, `realtime` (WebSocket push) |
-| **Federation & migration** | `identity-providers`, `user-federation`, `migration` (Keycloak/Auth0/Zitadel importers) |
+| **Federation & migration** | `identity-providers`, `user-federation`, `migration` (Keycloak/Auth0/Zitadel/Authentik importers) |
 | **Non-human identity** | `nhi`, `service-accounts`, `organizations` |
 | **Extensibility** | `plugins`, `theme`, `custom-attributes` |
 | **Admin-facing** | `admin-auth`, `authorization` (admin RBAC), `webhooks`, `events`, `stats`, `consent`, `setup-wizard` |

--- a/src/migration/authentik-importer.service.spec.ts
+++ b/src/migration/authentik-importer.service.spec.ts
@@ -1,0 +1,251 @@
+import { Test } from '@nestjs/testing';
+import { pbkdf2Sync } from 'crypto';
+import * as argon2 from 'argon2';
+import { AuthentikImporterService } from './authentik-importer.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type { AuthentikExport } from './authentik-types.js';
+
+describe('AuthentikImporterService', () => {
+  let service: AuthentikImporterService;
+  let prisma: any;
+
+  function djangoPbkdf2Hash(
+    password: string,
+    salt = 'testsalt123',
+    iterations = 260000,
+  ): string {
+    const digest = pbkdf2Sync(password, salt, iterations, 32, 'sha256');
+    return `pbkdf2_sha256$${iterations}$${salt}$${digest.toString('base64')}`;
+  }
+
+  const mockExport: AuthentikExport = {
+    groups: [{ pk: 1, name: 'admins' }],
+    users: [
+      {
+        pk: 1,
+        username: 'alice',
+        email: 'alice@example.com',
+        name: 'Alice Smith',
+        is_active: true,
+        groups: ['admins'],
+        password: djangoPbkdf2Hash('CorrectHorseBatteryStaple1'),
+      },
+      {
+        pk: 2,
+        username: 'bob',
+        email: 'bob@example.com',
+        is_active: false,
+        password: 'bcrypt$2b$10$something-not-supported',
+      },
+      {
+        pk: 3,
+        username: 'carol',
+        groups: ['nonexistent-group'],
+      },
+    ],
+    providers: [
+      {
+        pk: 1,
+        name: 'SPA App',
+        client_id: 'spa-app',
+        client_type: 'public',
+        redirect_uris: ['http://localhost:3000/callback'],
+      },
+    ],
+    sources: [
+      {
+        pk: 1,
+        name: 'corp-oidc',
+        provider_type: 'openidconnect',
+        authorization_url: 'https://idp.example.com/authorize',
+        access_token_url: 'https://idp.example.com/token',
+        consumer_key: 'idp-client',
+        consumer_secret: 'idp-secret',
+      },
+      {
+        pk: 2,
+        name: 'corp-saml',
+        provider_type: 'saml',
+      },
+    ],
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      realm: {
+        findUnique: jest.fn().mockResolvedValue({ id: 'realm-1', name: 'test' }),
+      },
+      group: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'g-1' }),
+      },
+      client: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'c-1' }),
+      },
+      user: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'u-1' }),
+      },
+      userGroup: {
+        create: jest.fn().mockResolvedValue({ id: 'ug-1' }),
+      },
+      identityProvider: {
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'idp-1' }),
+      },
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        AuthentikImporterService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get(AuthentikImporterService);
+  });
+
+  it('should fail if realm does not exist', async () => {
+    prisma.realm.findUnique.mockResolvedValue(null);
+    const report = await service.importData(mockExport, {
+      dryRun: false,
+      targetRealm: 'nonexistent',
+    });
+    expect(report.errors).toHaveLength(1);
+    expect(report.errors[0].error).toContain('does not exist');
+  });
+
+  it('should import groups before users, then create user records', async () => {
+    const report = await service.importData(mockExport, {
+      dryRun: false,
+      targetRealm: 'test',
+    });
+    expect(report.summary.groups.created).toBe(1);
+    expect(report.summary.users.created).toBe(3);
+    expect(prisma.group.create).toHaveBeenCalledWith({
+      data: { realmId: 'realm-1', name: 'admins' },
+    });
+  });
+
+  it('should translate a Django pbkdf2_sha256 hash into a form the login fallback can verify', async () => {
+    await service.importData(mockExport, { dryRun: false, targetRealm: 'test' });
+
+    const aliceCall = prisma.user.create.mock.calls.find(
+      (c: any) => c[0].data.username === 'alice',
+    );
+    expect(aliceCall[0].data.passwordAlgorithm).toBe('pbkdf2-sha256');
+
+    // The transformed hash must actually verify against the real password —
+    // not just "some string", since a wrong transform fails silently at login.
+    const [iterations, saltB64, hashB64] = aliceCall[0].data.passwordHash.split('$');
+    const salt = Buffer.from(saltB64, 'base64');
+    const derived = pbkdf2Sync(
+      'CorrectHorseBatteryStaple1',
+      salt,
+      parseInt(iterations, 10),
+      32,
+      'sha256',
+    );
+    expect(derived.toString('base64')).toBe(hashB64);
+  });
+
+  it('should drop unsupported password hashers with a null hash', async () => {
+    await service.importData(mockExport, { dryRun: false, targetRealm: 'test' });
+
+    expect(prisma.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          username: 'bob',
+          passwordHash: null,
+          passwordAlgorithm: 'argon2',
+          enabled: false,
+        }),
+      }),
+    );
+  });
+
+  it('should translate a Django argon2 hash into standard PHC format', async () => {
+    const realPhc = await argon2.hash('MyRealPassword1', { type: argon2.argon2id });
+    const exportWithArgon2: AuthentikExport = {
+      users: [
+        {
+          pk: 9,
+          username: 'dave',
+          password: `argon2${realPhc}`,
+        },
+      ],
+    };
+
+    await service.importData(exportWithArgon2, { dryRun: false, targetRealm: 'test' });
+
+    const daveCall = prisma.user.create.mock.calls.find(
+      (c: any) => c[0].data.username === 'dave',
+    );
+    expect(daveCall[0].data.passwordAlgorithm).toBe('argon2');
+    expect(daveCall[0].data.passwordHash).toBe(realPhc);
+    await expect(
+      argon2.verify(daveCall[0].data.passwordHash, 'MyRealPassword1'),
+    ).resolves.toBe(true);
+  });
+
+  it('should assign known group memberships and warn about unknown ones', async () => {
+    const report = await service.importData(mockExport, {
+      dryRun: false,
+      targetRealm: 'test',
+    });
+
+    expect(prisma.userGroup.create).toHaveBeenCalledWith({
+      data: { userId: 'u-1', groupId: 'g-1' },
+    });
+    expect(
+      report.warnings.some((w) =>
+        w.message.includes("references group 'nonexistent-group'"),
+      ),
+    ).toBe(true);
+  });
+
+  it('should import public OAuth2 providers as public clients', async () => {
+    await service.importData(mockExport, { dryRun: false, targetRealm: 'test' });
+
+    expect(prisma.client.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        clientId: 'spa-app',
+        clientType: 'PUBLIC',
+        redirectUris: ['http://localhost:3000/callback'],
+      }),
+    });
+  });
+
+  it('should import OIDC sources and skip non-OIDC ones with a warning', async () => {
+    const report = await service.importData(mockExport, {
+      dryRun: false,
+      targetRealm: 'test',
+    });
+
+    expect(report.summary.identityProviders.created).toBe(1);
+    expect(prisma.identityProvider.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        alias: 'corp-oidc',
+        clientId: 'idp-client',
+      }),
+    });
+    expect(
+      report.warnings.some((w) => w.message.includes("Source 'corp-saml'")),
+    ).toBe(true);
+  });
+
+  it('should not write anything during a dry run', async () => {
+    const report = await service.importData(mockExport, {
+      dryRun: true,
+      targetRealm: 'test',
+    });
+
+    expect(prisma.user.create).not.toHaveBeenCalled();
+    expect(prisma.group.create).not.toHaveBeenCalled();
+    expect(prisma.client.create).not.toHaveBeenCalled();
+    expect(prisma.identityProvider.create).not.toHaveBeenCalled();
+    expect(prisma.userGroup.create).not.toHaveBeenCalled();
+    expect(report.summary.users.created).toBe(3);
+  });
+});

--- a/src/migration/authentik-importer.service.ts
+++ b/src/migration/authentik-importer.service.ts
@@ -1,0 +1,297 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import type { AuthentikExport, AuthentikUser } from './authentik-types.js';
+import { createEmptyReport, type MigrationReport } from './migration-report.js';
+
+export interface AuthentikImportOptions {
+  dryRun: boolean;
+  targetRealm: string;
+}
+
+const OIDC_SOURCE_TYPES = new Set(['openidconnect', 'oidc']);
+
+@Injectable()
+export class AuthentikImporterService {
+  private readonly logger = new Logger(AuthentikImporterService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  async importData(
+    data: AuthentikExport,
+    options: AuthentikImportOptions,
+  ): Promise<MigrationReport> {
+    const report = createEmptyReport('authentik', options.dryRun);
+
+    const realm = await this.prisma.realm.findUnique({
+      where: { name: options.targetRealm },
+    });
+    if (!realm) {
+      report.errors.push({
+        entity: 'realm',
+        name: options.targetRealm,
+        error: `Realm '${options.targetRealm}' does not exist. Create it first.`,
+      });
+      report.completedAt = new Date();
+      return report;
+    }
+
+    const groupIdsByName = await this.importGroups(
+      data,
+      realm.id,
+      report,
+      options.dryRun,
+    );
+    await this.importClients(data, realm.id, report, options.dryRun);
+    await this.importUsers(
+      data,
+      realm.id,
+      groupIdsByName,
+      report,
+      options.dryRun,
+    );
+    await this.importSources(data, realm.id, report, options.dryRun);
+
+    report.completedAt = new Date();
+    return report;
+  }
+
+  private async importGroups(
+    data: AuthentikExport,
+    realmId: string,
+    report: MigrationReport,
+    dryRun: boolean,
+  ): Promise<Map<string, string>> {
+    const idsByName = new Map<string, string>();
+    for (const group of data.groups ?? []) {
+      try {
+        const existing = await this.prisma.group.findFirst({
+          where: { realmId, name: group.name, parentId: null },
+        });
+        if (existing) {
+          report.summary.groups.skipped++;
+          idsByName.set(group.name, existing.id);
+          continue;
+        }
+        if (dryRun) {
+          idsByName.set(group.name, 'dry-run-group-id');
+        } else {
+          const created = await this.prisma.group.create({
+            data: { realmId, name: group.name },
+          });
+          idsByName.set(group.name, created.id);
+        }
+        report.summary.groups.created++;
+      } catch (error: unknown) {
+        report.summary.groups.failed++;
+        report.errors.push({
+          entity: 'group',
+          name: group.name,
+          error: (error as Error).message,
+        });
+      }
+    }
+    return idsByName;
+  }
+
+  private async importClients(
+    data: AuthentikExport,
+    realmId: string,
+    report: MigrationReport,
+    dryRun: boolean,
+  ): Promise<void> {
+    for (const provider of data.providers ?? []) {
+      try {
+        const existing = await this.prisma.client.findFirst({
+          where: { realmId, clientId: provider.client_id },
+        });
+        if (existing) {
+          report.summary.clients.skipped++;
+          continue;
+        }
+        if (!dryRun) {
+          await this.prisma.client.create({
+            data: {
+              realmId,
+              clientId: provider.client_id,
+              name: provider.name,
+              enabled: true,
+              clientType:
+                provider.client_type === 'public' ? 'PUBLIC' : 'CONFIDENTIAL',
+              clientSecret: provider.client_secret ?? null,
+              redirectUris: provider.redirect_uris ?? [],
+              webOrigins: [],
+              grantTypes: ['authorization_code', 'refresh_token'],
+            },
+          });
+        }
+        report.summary.clients.created++;
+      } catch (error: unknown) {
+        report.summary.clients.failed++;
+        report.errors.push({
+          entity: 'client',
+          name: provider.name,
+          error: (error as Error).message,
+        });
+      }
+    }
+  }
+
+  private async importUsers(
+    data: AuthentikExport,
+    realmId: string,
+    groupIdsByName: Map<string, string>,
+    report: MigrationReport,
+    dryRun: boolean,
+  ): Promise<void> {
+    for (const user of data.users ?? []) {
+      try {
+        const existing = await this.prisma.user.findFirst({
+          where: { realmId, username: user.username },
+        });
+        if (existing) {
+          report.summary.users.skipped++;
+          continue;
+        }
+
+        const { hash, algorithm } = this.extractAuthentikPassword(user);
+        const [firstName, ...rest] = (user.name ?? '')
+          .split(' ')
+          .filter(Boolean);
+        const lastName = rest.join(' ') || undefined;
+
+        let userId = 'dry-run-user-id';
+        if (!dryRun) {
+          const created = await this.prisma.user.create({
+            data: {
+              realmId,
+              username: user.username,
+              email: user.email,
+              firstName,
+              lastName,
+              enabled: user.is_active ?? true,
+              emailVerified: false,
+              passwordHash: hash,
+              passwordAlgorithm: algorithm,
+            },
+          });
+          userId = created.id;
+        }
+        report.summary.users.created++;
+
+        for (const groupName of user.groups ?? []) {
+          const groupId = groupIdsByName.get(groupName);
+          if (!groupId) {
+            report.warnings.push({
+              entity: 'user',
+              message: `User '${user.username}' references group '${groupName}', which was not in the export — skipped that membership.`,
+            });
+            continue;
+          }
+          if (!dryRun) {
+            await this.prisma.userGroup.create({
+              data: { userId, groupId },
+            });
+          }
+        }
+      } catch (error: unknown) {
+        report.summary.users.failed++;
+        report.errors.push({
+          entity: 'user',
+          name: user.username,
+          error: (error as Error).message,
+        });
+      }
+    }
+  }
+
+  /**
+   * Authentik stores passwords in Django's hasher format. Only the two most
+   * common hashers are translated into a form Idenplane's login fallback
+   * (PasswordMigrationService) can verify directly — anything else (e.g.
+   * bcrypt via a custom hasher) is dropped with no password, same policy
+   * the other importers use for hashes they can't carry over.
+   */
+  private extractAuthentikPassword(user: AuthentikUser): {
+    hash: string | null;
+    algorithm: string;
+  } {
+    const raw = user.password;
+    if (!raw) return { hash: null, algorithm: 'argon2' };
+
+    // Django's ArgonPasswordHasher: "argon2" + the standard PHC-encoded
+    // string (which itself starts with "$argon2id$..."). Strip the literal
+    // "argon2" prefix to recover the PHC string Idenplane's own argon2
+    // verifier expects.
+    if (raw.startsWith('argon2$argon2')) {
+      return { hash: raw.slice('argon2'.length), algorithm: 'argon2' };
+    }
+
+    // Django's PBKDF2PasswordHasher: "pbkdf2_sha256$<iterations>$<salt>$<hash>",
+    // where <salt> is a plain string and <hash> is already base64. Idenplane's
+    // pbkdf2-sha256 verifier expects "<iterations>$<base64 salt>$<base64 hash>"
+    // (both base64) — re-encode the salt to match.
+    if (raw.startsWith('pbkdf2_sha256$')) {
+      const parts = raw.split('$');
+      if (parts.length === 4) {
+        const [, iterations, saltPlain, hashB64] = parts;
+        const saltBase64 = Buffer.from(saltPlain, 'utf8').toString('base64');
+        return {
+          hash: `${iterations}$${saltBase64}$${hashB64}`,
+          algorithm: 'pbkdf2-sha256',
+        };
+      }
+    }
+
+    return { hash: null, algorithm: 'argon2' };
+  }
+
+  private async importSources(
+    data: AuthentikExport,
+    realmId: string,
+    report: MigrationReport,
+    dryRun: boolean,
+  ): Promise<void> {
+    for (const source of data.sources ?? []) {
+      if (!OIDC_SOURCE_TYPES.has((source.provider_type ?? '').toLowerCase())) {
+        report.warnings.push({
+          entity: 'identity_provider',
+          message: `Source '${source.name}' (type ${source.provider_type ?? 'unknown'}) is not a generic OIDC source — only OIDC sources are supported for import today, recreate this one manually.`,
+        });
+        continue;
+      }
+      try {
+        const existing = await this.prisma.identityProvider.findFirst({
+          where: { realmId, alias: source.name },
+        });
+        if (existing) {
+          report.summary.identityProviders.skipped++;
+          continue;
+        }
+        if (!dryRun) {
+          await this.prisma.identityProvider.create({
+            data: {
+              realmId,
+              alias: source.name,
+              displayName: source.name,
+              providerType: 'OIDC',
+              enabled: true,
+              trustEmail: false,
+              clientId: source.consumer_key ?? '',
+              clientSecret: source.consumer_secret ?? '',
+              authorizationUrl: source.authorization_url ?? '',
+              tokenUrl: source.access_token_url ?? '',
+            },
+          });
+        }
+        report.summary.identityProviders.created++;
+      } catch (error: unknown) {
+        report.summary.identityProviders.failed++;
+        report.errors.push({
+          entity: 'identity_provider',
+          name: source.name,
+          error: (error as Error).message,
+        });
+      }
+    }
+  }
+}

--- a/src/migration/authentik-types.ts
+++ b/src/migration/authentik-types.ts
@@ -1,0 +1,63 @@
+/**
+ * Shapes below mirror the JSON returned by Authentik's REST API
+ * (`/api/v3/core/users/`, `/api/v3/core/groups/`,
+ * `/api/v3/providers/oauth2/`, `/api/v3/sources/oauth/`). Like Zitadel,
+ * Authentik has no single "export realm" endpoint, so an export file for
+ * this importer is expected to be hand-assembled by calling those endpoints
+ * and combining the results into the `AuthentikExport` shape below.
+ *
+ * Applications are deliberately not part of this shape: an Application just
+ * links a slug/launch URL to a Provider for Authentik's own UI, and every
+ * field this importer needs for a client (client_id, secret, redirect URIs)
+ * already lives on the Provider itself.
+ */
+
+export interface AuthentikUser {
+  pk: number;
+  username: string;
+  email?: string;
+  /** Authentik's "name" field is a single display name, not given/family. */
+  name?: string;
+  is_active?: boolean;
+  /** Group names this user belongs to (resolved client-side when assembling the export, not group PKs). */
+  groups?: string[];
+  /**
+   * Django-format hash (e.g. "pbkdf2_sha256$...", "argon2$..."). Only
+   * argon2 is recognized for import today — anything else is dropped with
+   * a warning, same policy as unsupported hashes in the other importers.
+   */
+  password?: string;
+}
+
+export interface AuthentikGroup {
+  pk: number;
+  name: string;
+}
+
+export interface AuthentikOAuth2Provider {
+  pk: number;
+  name: string;
+  client_id: string;
+  client_secret?: string;
+  /** 'confidential' | 'public' */
+  client_type?: string;
+  redirect_uris?: string[];
+}
+
+export interface AuthentikOAuthSource {
+  pk: number;
+  name: string;
+  /** Only 'openidconnect'/'oidc' sources are imported today; other provider types (SAML, social) are skipped with a warning. */
+  provider_type?: string;
+  authorization_url?: string;
+  access_token_url?: string;
+  consumer_key?: string;
+  consumer_secret?: string;
+}
+
+export interface AuthentikExport {
+  users?: AuthentikUser[];
+  groups?: AuthentikGroup[];
+  providers?: AuthentikOAuth2Provider[];
+  sources?: AuthentikOAuthSource[];
+}

--- a/src/migration/migration-report.ts
+++ b/src/migration/migration-report.ts
@@ -16,7 +16,7 @@ export interface MigrationWarning {
 }
 
 export interface MigrationReport {
-  source: 'keycloak' | 'auth0' | 'zitadel';
+  source: 'keycloak' | 'auth0' | 'zitadel' | 'authentik';
   dryRun: boolean;
   startedAt: Date;
   completedAt: Date;
@@ -34,7 +34,7 @@ export interface MigrationReport {
 }
 
 export function createEmptyReport(
-  source: 'keycloak' | 'auth0' | 'zitadel',
+  source: 'keycloak' | 'auth0' | 'zitadel' | 'authentik',
   dryRun: boolean,
 ): MigrationReport {
   const zero = (): MigrationEntityStats => ({

--- a/src/migration/migration.controller.ts
+++ b/src/migration/migration.controller.ts
@@ -9,6 +9,7 @@ import { IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
 import { KeycloakImporterService } from './keycloak-importer.service.js';
 import { Auth0ImporterService } from './auth0-importer.service.js';
 import { ZitadelImporterService } from './zitadel-importer.service.js';
+import { AuthentikImporterService } from './authentik-importer.service.js';
 import type { MigrationReport } from './migration-report.js';
 import type { KeycloakRealmExport } from './keycloak-types.js';
 import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
@@ -50,6 +51,18 @@ class ZitadelImportDto {
   targetRealm!: string;
 }
 
+class AuthentikImportDto {
+  @IsObject()
+  data!: Record<string, unknown>;
+
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+
+  @IsString()
+  targetRealm!: string;
+}
+
 // Issue #461 — API limitation notes:
 //
 // 1. Both import endpoints process the entire payload synchronously in a single
@@ -75,6 +88,14 @@ class ZitadelImportDto {
 //    responses (see zitadel-types.ts). Only bcrypt password hashes, OIDC apps,
 //    and generic OIDC IdPs are imported; machine (service-account) users,
 //    SAML apps, and non-OIDC IdPs are skipped with a warning per entity.
+//
+// 5. Authentik also has no single export endpoint — the input to
+//    POST /admin/migration/authentik is hand-assembled from the REST API's
+//    /core/users/, /core/groups/, /providers/oauth2/, and /sources/oauth/
+//    responses (see authentik-types.ts). Passwords hashed with Django's
+//    default PBKDF2 or Argon2 hashers are translated into a form Idenplane
+//    can verify; any other hasher is imported without a password (reset
+//    required on first login). Only generic OIDC sources are imported.
 
 @ApiTags('Migration')
 @ApiSecurity('admin-api-key')
@@ -85,6 +106,7 @@ export class MigrationController {
     private readonly keycloakImporter: KeycloakImporterService,
     private readonly auth0Importer: Auth0ImporterService,
     private readonly zitadelImporter: ZitadelImporterService,
+    private readonly authentikImporter: AuthentikImporterService,
   ) {}
 
   @Post('keycloak')
@@ -155,6 +177,32 @@ export class MigrationController {
   })
   async importZitadel(@Body() dto: ZitadelImportDto): Promise<MigrationReport> {
     return this.zitadelImporter.importData(dto.data, {
+      dryRun: dto.dryRun ?? false,
+      targetRealm: dto.targetRealm,
+    });
+  }
+
+  @Post('authentik')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: 'Import from a hand-assembled Authentik REST API export',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Migration report with counts of imported/skipped entities',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Bad request — invalid payload or missing targetRealm',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — missing or invalid admin API key',
+  })
+  async importAuthentik(
+    @Body() dto: AuthentikImportDto,
+  ): Promise<MigrationReport> {
+    return this.authentikImporter.importData(dto.data, {
       dryRun: dto.dryRun ?? false,
       targetRealm: dto.targetRealm,
     });

--- a/src/migration/migration.module.ts
+++ b/src/migration/migration.module.ts
@@ -3,6 +3,7 @@ import { MigrationController } from './migration.controller.js';
 import { KeycloakImporterService } from './keycloak-importer.service.js';
 import { Auth0ImporterService } from './auth0-importer.service.js';
 import { ZitadelImporterService } from './zitadel-importer.service.js';
+import { AuthentikImporterService } from './authentik-importer.service.js';
 import { PasswordMigrationService } from './password-migration.service.js';
 
 @Module({
@@ -11,6 +12,7 @@ import { PasswordMigrationService } from './password-migration.service.js';
     KeycloakImporterService,
     Auth0ImporterService,
     ZitadelImporterService,
+    AuthentikImporterService,
     PasswordMigrationService,
   ],
   exports: [PasswordMigrationService],


### PR DESCRIPTION
## Summary

MVP-of-the-MVP for #1311: extends the importer set (Keycloak, Auth0, Zitadel) with **Authentik**.

## Format

Authentik has no single "export realm" endpoint either, so \`POST /admin/migration/authentik\` follows the same hand-assembled-export convention as the Zitadel importer: the caller builds the JSON payload from Authentik's REST API — \`/core/users/\`, \`/core/groups/\`, \`/providers/oauth2/\`, \`/sources/oauth/\`.

## What's imported

- **Users** — with group membership assignment
- **Groups** — flat (Authentik groups have no hierarchy here)
- **OAuth2 Providers → Clients** (public/confidential, redirect URIs)
- **OAuth Sources → Identity Providers** — only generic OIDC sources; anything else (SAML, social) is skipped with a warning

## The part that needed real verification, not assumption

Authentik stores password hashes in Django's format, which isn't directly something Idenplane's login fallback (\`PasswordMigrationService\`) already recognizes. Getting the transformation wrong would mean migrated users silently can't log in with their real password — a failure mode indistinguishable from "wrong password," so I verified both transformations against actual hash/verify round-trips before trusting them, not just by reading format specs:

- **PBKDF2**: Django's \`pbkdf2_sha256$<iterations>$<plain-salt>$<base64-hash>\` → re-encoded to \`<iterations>$<base64-salt>$<base64-hash>\`, the exact shape \`PasswordMigrationService.verifyPbkdf2\` parses. Confirmed with a real \`pbkdf2Sync\`-generated hash that the transformed value verifies the correct password and rejects a wrong one.
- **Argon2**: Django's \`ArgonPasswordHasher\` stores \`argon2\` + the standard PHC-encoded string. Stripping that literal \`argon2\` prefix recovers exactly what node's \`argon2.verify()\` expects. Confirmed with a real \`argon2.hash()\` output.

Any other hasher (e.g. bcrypt via a custom Authentik hasher) is imported with no password hash — same "reset required on first login" policy the other importers use for hashes they can't carry over.

## Tests

9 new tests covering: realm-not-found, groups-before-users ordering, both password transformations (asserting the transformed hash actually verifies the original plaintext, not just that *some* string was produced), unsupported-hasher fallback, group membership assignment + unknown-group warning, public client import, OIDC-vs-non-OIDC source handling, and dry-run (nothing written). Full \`src/migration\` suite: 5/5 files, 43 tests. Admin-ui wizard: 50/50 files, 438 tests (added "Authentik" as a fourth source option + one wizard-flow test).

Relates to #1311.