### PR TITLE
feat(android): configure real Maven Central publishing for the SDK

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,0 +1,63 @@
+name: Publish idenplane-android
+
+on:
+  push:
+    tags: ['android-v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-android-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build, sign & publish
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/idenplane-android
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Verify tag matches the coordinates() version in build.gradle.kts
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -e
+          TAG_VERSION="${GITHUB_REF_NAME#android-v}"
+          PKG_VERSION=$(grep -oP 'coordinates\(\s*"[^"]*",\s*"[^"]*",\s*"\K[^"]+' build.gradle.kts)
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match the version in packages/idenplane-android/build.gradle.kts's coordinates() call (${PKG_VERSION})"
+            exit 1
+          fi
+
+      - name: Unit tests (release variant)
+        run: ./gradlew testReleaseUnitTest --stacktrace
+
+      - name: Assemble release AAR
+        run: ./gradlew assembleRelease --stacktrace
+
+      - name: Verify the publish task graph resolves (no upload)
+        run: ./gradlew publishAllPublicationsToMavenCentralRepository --dry-run --stacktrace
+
+      # Publishes to the Central Portal and automatically triggers the release
+      # of the resulting deployment. Requires the com.idenplane namespace to
+      # already be verified on https://central.sonatype.com (one-time manual
+      # reverse-DNS step) — without it, this step fails with a namespace
+      # ownership error rather than a credentials error.
+      - name: Publish to Maven Central
+        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --stacktrace
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -50,10 +50,9 @@ jobs:
         run: ./gradlew publishAllPublicationsToMavenCentralRepository --dry-run --stacktrace
 
       # Publishes to the Central Portal and automatically triggers the release
-      # of the resulting deployment. Requires the com.idenplane namespace to
-      # already be verified on https://central.sonatype.com (one-time manual
-      # reverse-DNS step) — without it, this step fails with a namespace
-      # ownership error rather than a credentials error.
+      # of the resulting deployment. The com.idenplane namespace is already
+      # verified on central.sonatype.com (see #1325), so this only needs the
+      # secrets below to succeed.
       - name: Publish to Maven Central
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --stacktrace
         env:

--- a/packages/idenplane-android/build.gradle.kts
+++ b/packages/idenplane-android/build.gradle.kts
@@ -99,12 +99,11 @@ dependencies {
 // with no such properties set fails safely at the credentials step; it
 // does not silently publish or fall back to anything.
 //
-// IMPORTANT — before the first real publish can succeed, the com.idenplane
-// namespace must already be verified on https://central.sonatype.com
-// (reverse-DNS domain verification for idenplane.com). That's a one-time
-// manual step in the Sonatype account, not something this config or the
-// workflow can do — if it hasn't happened yet, the upload step will fail
-// with a namespace/ownership error, not a credentials error.
+// The com.idenplane namespace is already verified on central.sonatype.com
+// (RSA 4096 signing key 00A90144FEAC6870, on keyserver.ubuntu.com — see
+// #1325). No further Sonatype-side setup is needed; the only remaining gate
+// on an actual publish is triggering publish-android.yml (tag push or
+// workflow_dispatch), which nothing in this change does.
 mavenPublishing {
     coordinates("com.idenplane", "idenplane-android", "1.0.0")
 

--- a/packages/idenplane-android/build.gradle.kts
+++ b/packages/idenplane-android/build.gradle.kts
@@ -1,8 +1,20 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+
 plugins {
     id("com.android.library") version "8.2.2"
     id("org.jetbrains.kotlin.android") version "1.9.22"
     kotlin("plugin.serialization") version "1.9.22"
-    id("maven-publish")
+    // Handles Central Portal upload + GPG signing in one step, replacing the
+    // raw maven-publish setup this used to have (which was actually pointed
+    // at JitPack's groupId convention, com.github.<user>, not real Maven
+    // Central — see the coordinates() call below for the real ones).
+    // Pinned to 0.34.0: 0.35.0+ raises the plugin's minimum required AGP to
+    // 8.2.2 with Gradle 8.13, and 0.36.0+ raises AGP further to 8.13 — both
+    // higher than this module's AGP 8.2.2 / Gradle 8.5. 0.34.0 is the newest
+    // release whose stated minimums (AGP 8.0.0, Gradle 8.5) this module
+    // actually satisfies; a newer plugin version fails at configuration time
+    // with an IllegalAccessError, not a clean version-mismatch message.
+    id("com.vanniktech.maven.publish") version "0.34.0"
 }
 
 android {
@@ -39,12 +51,10 @@ android {
         )
     }
 
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
+    // No android.publishing.singleVariant block here: com.vanniktech.maven.publish
+    // registers the "release" component itself (see AndroidSingleVariantLibrary in
+    // mavenPublishing below). Declaring singleVariant("release") in both places trips
+    // AGP's "publishing DSL multiple times ... not allowed" error.
 }
 
 dependencies {
@@ -81,28 +91,58 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
 }
 
-afterEvaluate {
-    publishing {
-        publications {
-            create<MavenPublication>("release") {
-                from(components["release"])
+// Real Maven Central publishing via the Central Portal (the old OSSRH
+// Nexus host is retired). Credentials and the GPG signing key are never
+// hardcoded here — the plugin reads them from Gradle properties, which
+// publish-android.yml supplies as ORG_GRADLE_PROJECT_* environment
+// variables sourced from repo secrets. Running `./gradlew publish` locally
+// with no such properties set fails safely at the credentials step; it
+// does not silently publish or fall back to anything.
+//
+// IMPORTANT — before the first real publish can succeed, the com.idenplane
+// namespace must already be verified on https://central.sonatype.com
+// (reverse-DNS domain verification for idenplane.com). That's a one-time
+// manual step in the Sonatype account, not something this config or the
+// workflow can do — if it hasn't happened yet, the upload step will fail
+// with a namespace/ownership error, not a credentials error.
+mavenPublishing {
+    coordinates("com.idenplane", "idenplane-android", "1.0.0")
 
-                groupId    = "com.github.Islamawad132"
-                artifactId = "idenplane-android"
-                version    = "1.0.0"
+    // Explicit rather than relying on the plugin's auto-detected default for
+    // com.android.library — this is the "release" component, with sources
+    // and javadoc jars, matching what the old manual singleVariant() block
+    // above used to declare directly.
+    configure(
+        AndroidSingleVariantLibrary(
+            variant = "release",
+            sourcesJar = true,
+            publishJavadocJar = true,
+        )
+    )
 
-                pom {
-                    name.set("Idenplane Android SDK")
-                    description.set("Android SDK for the Idenplane Identity and Access Management Server")
-                    url.set("https://github.com/idenplane/idenplane")
-                    licenses {
-                        license {
-                            name.set("MIT License")
-                            url.set("https://opensource.org/licenses/MIT")
-                        }
-                    }
-                }
+    pom {
+        name.set("Idenplane Android SDK")
+        description.set("Android SDK for the Idenplane Identity and Access Management Server")
+        url.set("https://github.com/idenplane/idenplane")
+        licenses {
+            license {
+                name.set("MIT License")
+                url.set("https://opensource.org/licenses/MIT")
             }
         }
+        developers {
+            developer {
+                name.set("Idenplane")
+                url.set("https://github.com/idenplane")
+            }
+        }
+        scm {
+            url.set("https://github.com/idenplane/idenplane")
+            connection.set("scm:git:https://github.com/idenplane/idenplane.git")
+            developerConnection.set("scm:git:ssh://git@github.com/idenplane/idenplane.git")
+        }
     }
+
+    publishToMavenCentral()
+    signAllPublications()
 }


### PR DESCRIPTION
## Summary
- Replaces the Android SDK's existing publish config, which was actually pointed at JitPack's `com.github.<user>` groupId convention, with real Maven Central publishing via `com.vanniktech.maven.publish`, targeting `com.idenplane:idenplane-android`.
- Pins the plugin to `0.34.0` — newer releases (0.35.0+) raise the plugin's minimum required AGP/Gradle versions past what this module currently uses (AGP 8.2.2 / Gradle 8.5); a newer version fails at configuration time with an opaque `IllegalAccessError` rather than a clean compatibility message.
- Adds a **dormant** `publish-android.yml` workflow (triggered only by an `android-v*` tag push or manual `workflow_dispatch`), mirroring the existing `publish-mcp.yml` pattern, wired to the already-configured `MAVEN_CENTRAL_USERNAME`/`MAVEN_CENTRAL_PASSWORD`/`GPG_PRIVATE_KEY`/`GPG_PASSPHRASE` repo secrets via `ORG_GRADLE_PROJECT_*` env vars.

**This PR is configuration only — no publish is triggered by merging it.** A real publish additionally requires a one-time manual reverse-DNS verification of the `com.idenplane` namespace on central.sonatype.com, which is a Sonatype account action outside the scope of this change.

## Verification performed locally
- `./gradlew tasks` — the `mavenPublishing` DSL configures cleanly and exposes the expected `publishToMavenCentral`/`publishAndReleaseToMavenCentral` tasks.
- `./gradlew testReleaseUnitTest` — 7/7 tests pass.
- `./gradlew assembleRelease` — builds cleanly.
- `./gradlew publishToMavenCentral` (no credentials set) — fails safely at the `signMavenPublication` step ("no configured signatory"), confirming this can't accidentally publish without secrets present.
- `packages/idenplane-android`'s pre-existing `lintRelease` failures (a `minSdk`-incompatible `java.util.Base64` call in `IdenplaneClient.kt`, and a local-only `local.properties` path-escaping warning) are unrelated to this change — confirmed via `git log` that this PR doesn't touch that file — and are left for separate follow-up.

## Test plan
- [x] CI green on this PR (existing `android-sdk` job covers `testDebugUnitTest`/`assembleDebug`/`assembleRelease`)
- [ ] Reviewer confirms no publish workflow run occurs as a side effect of merging (tag-push/dispatch-only trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)