### PR TITLE
fix(android): don't auto-release the Maven Central publish workflow

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -49,12 +49,14 @@ jobs:
       - name: Verify the publish task graph resolves (no upload)
         run: ./gradlew publishAllPublicationsToMavenCentralRepository --dry-run --stacktrace
 
-      # Publishes to the Central Portal and automatically triggers the release
-      # of the resulting deployment. The com.idenplane namespace is already
-      # verified on central.sonatype.com (see #1325), so this only needs the
-      # secrets below to succeed.
+      # Uploads to the Central Portal as a "validated" pending deployment — it deliberately
+      # does NOT use publishAndReleaseToMavenCentral, which would auto-release it and make it
+      # public immediately with no further gate. Actually releasing the deployment is a
+      # separate, explicit action in the Central Portal UI. The com.idenplane namespace is
+      # already verified on central.sonatype.com (see #1325), so this only needs the secrets
+      # below to succeed.
       - name: Publish to Maven Central
-        run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache --stacktrace
+        run: ./gradlew publishToMavenCentral --no-configuration-cache --stacktrace
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
## Summary
- `publish-android.yml` called `publishAndReleaseToMavenCentral`, which uploads **and immediately releases** the deployment (makes it public), with no further gate.
- `workflow_dispatch` has no version check (that check is tag-push-only), the coordinates are already a non-SNAPSHOT `1.0.0`, the namespace is verified, and the secrets exist — a single manual dispatch of this workflow would have produced a real, permanent Maven Central release of a library that isn't ready to publish, contradicting the explicit "prepare but don't publish" constraint this whole effort was built under.
- Switches to `publishToMavenCentral`, which uploads as a reversible "validated" pending deployment — an actual release still requires a separate, explicit action in the Central Portal UI. This also brings Android's safety posture in line with the Java SDK's publish config (`autoPublish=false`), which was correct from the start.

Caught during a second-opinion review of the Android/Java publish configs, before it could cause harm — no publish was ever triggered.

## Test plan
- [x] CI green on this PR
- [ ] Reviewer confirms `publishToMavenCentral` (not `publishAndReleaseToMavenCentral`) is the only Gradle publish task referenced anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)