### PR TITLE
feat(java-sdk): implement OIDC token-validation client for idenplane-java-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,28 @@ jobs:
       - name: Assemble (debug + release AAR)
         run: ./gradlew assembleDebug assembleRelease --stacktrace
 
+  java-sdk:
+    # packages/idenplane-java had real Java source (data models) but no CI job ever ran `mvn`
+    # against it, so the multi-module reactor build had never actually been exercised — it
+    # couldn't even resolve its POMs (idenplane-java-reactive referenced reactor-test with no
+    # version). (#1326)
+    name: Java SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/idenplane-java
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Verify (build, test, coverage gate)
+        run: mvn -B verify
+
   examples-build:
     # Nothing ever built these — examples/nextjs-quickstart was silently
     # broken from the moment idenplane-sdk/idenplane-nextjs were published

--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -1,0 +1,75 @@
+name: Publish idenplane-java
+
+on:
+  push:
+    tags: ['java-v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-java-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build, sign & publish idenplane-java-core
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/idenplane-java
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+          server-id: central
+          server-username-env-var: MAVEN_CENTRAL_USERNAME
+          server-password-env-var: MAVEN_CENTRAL_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+
+      - name: Verify tag matches idenplane-java-core's project version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -e
+          TAG_VERSION="${GITHUB_REF_NAME#java-v}"
+          PKG_VERSION=$(mvn -q -pl idenplane-java-core help:evaluate -Dexpression=project.version -DforceStdout)
+          if [ "${TAG_VERSION}" != "${PKG_VERSION}" ]; then
+            echo "::error::Tag version (${TAG_VERSION}) does not match idenplane-java-core's project.version (${PKG_VERSION})"
+            exit 1
+          fi
+
+      - name: Build & test (whole reactor)
+        run: mvn -B verify
+
+      # workflow_dispatch skips the tag/version-match check above, so this is the only thing
+      # standing between a manual dispatch and deploying whatever version happens to be in the
+      # pom right now. It matters because SNAPSHOT and release versions behave differently here:
+      # a release version uploads as a reviewable "validated" Central Portal deployment
+      # (autoPublish=false in idenplane-java-core/pom.xml — actually making it public is a
+      # separate step in the Portal UI), but a SNAPSHOT version deploys directly to the public
+      # snapshots repository with no such pending/review stage at all. The project is still on
+      # 1.0.0-SNAPSHOT (see #1326), so without this guard a dispatch today would publish
+      # immediately rather than landing as reversible.
+      - name: Refuse to publish a SNAPSHOT version
+        run: |
+          set -e
+          PKG_VERSION=$(mvn -q -pl idenplane-java-core help:evaluate -Dexpression=project.version -DforceStdout)
+          if echo "${PKG_VERSION}" | grep -q SNAPSHOT; then
+            echo "::error::Refusing to publish SNAPSHOT version ${PKG_VERSION} — bump to a real release version first."
+            exit 1
+          fi
+
+      - name: Publish idenplane-java-core to Maven Central
+        run: mvn -B -pl idenplane-java-core deploy -Pcentral-publish -DskipTests
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          # maven-gpg-plugin's own agent-less/batch passphrase lookup (MGPG-105/MGPG-108) reads
+          # this exact env var name natively — deliberately not routed through settings.xml's
+          # gpg.passphrase property, which Sonatype's own docs warn against relying on in CI.
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/packages/idenplane-java/.gitignore
+++ b/packages/idenplane-java/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.iml
+/.idea/
+.DS_Store

--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -74,4 +74,57 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Everything Maven Central publishing needs: sources + javadoc jars, GPG signing,
+             and the Central Portal upload. Deliberately NOT part of the default build — plain
+             `mvn verify` (what CI runs on every PR) must stay fast and must not require a GPG
+             key. Only publish-java.yml activates this profile (`-Pcentral-publish`), and nothing
+             in this change invokes that workflow. -->
+        <profile>
+            <id>central-publish</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <!-- Declared explicitly rather than relying on inheriting this from
+                             pluginManagement. Note: `mvn help:describe -Dcmd=deploy -Pcentral-publish`
+                             reports `deploy` as still bound to the stock maven-deploy-plugin even
+                             with this — that's help:describe not simulating a profile-injected
+                             extension correctly, not a real problem. Verified against an actual
+                             `mvn -Pcentral-publish deploy` run instead: the log shows
+                             `central-publishing:0.11.0:publish (injected-central-publishing)`
+                             executing, which then failed on a 401 against the Central Portal —
+                             i.e. it reached real auth with no credentials configured, exactly
+                             the safe failure mode this dormant config is meant to have. -->
+                        <extensions>true</extensions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/IdenplaneClient.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/IdenplaneClient.java
@@ -1,0 +1,411 @@
+package com.idenplane.sdk;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.idenplane.sdk.internal.ApacheHttpTransport;
+import com.idenplane.sdk.internal.HttpTransport;
+import com.idenplane.sdk.internal.JwksCache;
+import com.idenplane.sdk.models.OpenIDConfiguration;
+import com.idenplane.sdk.models.TokenClaims;
+import com.idenplane.sdk.models.TokenResponse;
+import com.idenplane.sdk.models.UserInfo;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Client for the OIDC/OAuth2 surface exposed by an Idenplane realm: discovery, JWKS-backed
+ * token validation, the Authorization Code + PKCE flow, token refresh, user info, and logout.
+ *
+ * <p>An instance is safe to reuse and share across requests — the discovery document and JWKS
+ * keys are cached internally and refreshed on expiry or on a JWKS cache miss (key rotation).
+ *
+ * <pre>{@code
+ * IdenplaneClient client = IdenplaneClient.builder(
+ *         "https://idenplane.example.com/realms/my-realm", "my-client-id")
+ *     .build();
+ *
+ * String verifier = PkceUtil.generateCodeVerifier();
+ * String challenge = PkceUtil.deriveCodeChallenge(verifier);
+ * String authorizeUrl = client.buildAuthorizationUrl(redirectUri, state, challenge, List.of());
+ * // ... redirect the user, receive `code` back at redirectUri ...
+ * TokenResponse tokens = client.exchangeAuthorizationCode(code, redirectUri, verifier);
+ * TokenClaims claims = client.validateIdToken(tokens.getIdToken());
+ * }</pre>
+ */
+public final class IdenplaneClient {
+
+    private static final Duration DEFAULT_DISCOVERY_TTL = Duration.ofHours(1);
+    private static final Duration DEFAULT_JWKS_TTL = Duration.ofMinutes(15);
+    // Tolerates small clock differences between the token issuer and this JVM, matching the
+    // 60s default used by most mainstream OIDC client libraries.
+    private static final Duration CLOCK_SKEW = Duration.ofSeconds(60);
+
+    private final String issuer;
+    private final String clientId;
+    private final String clientSecret;
+    private final HttpTransport transport;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Clock clock;
+    private final Duration discoveryTtl;
+
+    private OpenIDConfiguration discoveryCache;
+    private Instant discoveryFetchedAt = Instant.EPOCH;
+    private JwksCache jwksCache;
+
+    private IdenplaneClient(Builder builder) {
+        this.issuer = stripTrailingSlash(Objects.requireNonNull(builder.issuer, "issuer is required"));
+        this.clientId = Objects.requireNonNull(builder.clientId, "clientId is required");
+        this.clientSecret = builder.clientSecret;
+        this.transport = builder.transport != null ? builder.transport : new ApacheHttpTransport();
+        this.clock = builder.clock != null ? builder.clock : Clock.systemUTC();
+        this.discoveryTtl = builder.discoveryTtl != null ? builder.discoveryTtl : DEFAULT_DISCOVERY_TTL;
+    }
+
+    /**
+     * Starts building a client for a realm.
+     *
+     * @param issuer   the realm issuer URL, e.g. {@code https://host/realms/my-realm}
+     *                 (matches the {@code iss} claim on tokens issued by that realm)
+     * @param clientId the OAuth2 client ID registered in that realm
+     * @return a new builder
+     */
+    public static Builder builder(String issuer, String clientId) {
+        return new Builder(issuer, clientId);
+    }
+
+    /**
+     * Fetches (and caches) the realm's OIDC discovery document.
+     *
+     * @return the discovery document
+     */
+    public synchronized OpenIDConfiguration discover() {
+        if (discoveryCache == null || isStale(discoveryFetchedAt, discoveryTtl)) {
+            String json = transport.get(issuer + "/.well-known/openid-configuration");
+            try {
+                discoveryCache = objectMapper.readValue(json, OpenIDConfiguration.class);
+            } catch (Exception e) {
+                throw new IdenplaneClientException("Failed to parse discovery document from " + issuer, e);
+            }
+            discoveryFetchedAt = clock.instant();
+        }
+        return discoveryCache;
+    }
+
+    /**
+     * Validates an ID token: verifies its RS256 signature against the realm's JWKS, then checks
+     * expiry, issuer, audience, and that it really is an ID token (not an access token).
+     *
+     * @param idToken the raw ID token JWT
+     * @return the validated claims
+     * @throws TokenValidationException if the signature or any claim check fails
+     */
+    public TokenClaims validateIdToken(String idToken) {
+        TokenClaims claims = validate(idToken);
+        if (!"ID".equals(claims.getTyp())) {
+            throw new TokenValidationException("Expected an ID token (typ=ID), got typ=" + claims.getTyp());
+        }
+        return claims;
+    }
+
+    /**
+     * Validates an access token: verifies its RS256 signature against the realm's JWKS, then
+     * checks expiry, issuer, audience, and that it really is an access token (not an ID token).
+     *
+     * @param accessToken the raw access token JWT
+     * @return the validated claims
+     * @throws TokenValidationException if the signature or any claim check fails
+     */
+    public TokenClaims validateAccessToken(String accessToken) {
+        TokenClaims claims = validate(accessToken);
+        if (!"Bearer".equals(claims.getTyp())) {
+            throw new TokenValidationException("Expected an access token (typ=Bearer), got typ=" + claims.getTyp());
+        }
+        return claims;
+    }
+
+    /**
+     * Builds the Authorization Code + PKCE authorization URL to redirect the user-agent to.
+     *
+     * @param redirectUri   the registered redirect URI
+     * @param state         an opaque value echoed back on the callback — the caller must
+     *                      generate it randomly and verify it matches, to mitigate CSRF
+     * @param codeChallenge the S256 PKCE code challenge, see {@link PkceUtil#deriveCodeChallenge}
+     * @param scopes        additional requested scopes; {@code openid} is always included
+     * @return the fully-formed authorization URL
+     */
+    public String buildAuthorizationUrl(String redirectUri, String state, String codeChallenge, List<String> scopes) {
+        List<String> effectiveScopes = new ArrayList<>();
+        effectiveScopes.add("openid");
+        if (scopes != null) {
+            for (String scope : scopes) {
+                if (!effectiveScopes.contains(scope)) {
+                    effectiveScopes.add(scope);
+                }
+            }
+        }
+        Map<String, String> params = new LinkedHashMap<>();
+        params.put("response_type", "code");
+        params.put("client_id", clientId);
+        params.put("redirect_uri", redirectUri);
+        params.put("scope", String.join(" ", effectiveScopes));
+        params.put("state", state);
+        params.put("code_challenge", codeChallenge);
+        params.put("code_challenge_method", "S256");
+        return buildUrl(discover().getAuthorizationEndpoint(), params);
+    }
+
+    /**
+     * Exchanges an authorization code for tokens (Authorization Code + PKCE flow).
+     *
+     * @param code         the authorization code returned to the redirect URI
+     * @param redirectUri  the same redirect URI passed to {@link #buildAuthorizationUrl}
+     * @param codeVerifier the PKCE code verifier that produced the original code challenge
+     * @return the token response
+     */
+    public TokenResponse exchangeAuthorizationCode(String code, String redirectUri, String codeVerifier) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "authorization_code");
+        form.put("client_id", clientId);
+        form.put("code", code);
+        form.put("redirect_uri", redirectUri);
+        form.put("code_verifier", codeVerifier);
+        addClientSecretIfPresent(form);
+        return postForToken(form);
+    }
+
+    /**
+     * Exchanges a refresh token for a new token response.
+     *
+     * @param refreshToken a refresh token previously issued to this client
+     * @return the new token response
+     */
+    public TokenResponse refreshToken(String refreshToken) {
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "refresh_token");
+        form.put("client_id", clientId);
+        form.put("refresh_token", refreshToken);
+        addClientSecretIfPresent(form);
+        return postForToken(form);
+    }
+
+    /**
+     * Retrieves the authenticated user's profile from the realm's userinfo endpoint.
+     *
+     * @param accessToken a valid access token
+     * @return the user's profile information
+     */
+    public UserInfo getUserInfo(String accessToken) {
+        String json = transport.getWithBearerToken(discover().getUserinfoEndpoint(), accessToken);
+        try {
+            return objectMapper.readValue(json, UserInfo.class);
+        } catch (Exception e) {
+            throw new IdenplaneClientException("Failed to parse userinfo response", e);
+        }
+    }
+
+    /**
+     * Builds a logout (end-session) URL. Only meaningful if the realm's discovery document
+     * advertises an {@code end_session_endpoint}.
+     *
+     * @param idTokenHint            the ID token issued at login, hinting who is logging out;
+     *                               may be {@code null}
+     * @param postLogoutRedirectUri  where to redirect the user after logout; may be {@code null}
+     * @return the end-session URL
+     * @throws IdenplaneClientException if the realm has no {@code end_session_endpoint}
+     */
+    public String buildLogoutUrl(String idTokenHint, String postLogoutRedirectUri) {
+        String endSessionEndpoint = discover().getEndSessionEndpoint();
+        if (endSessionEndpoint == null) {
+            throw new IdenplaneClientException("This realm does not advertise an end_session_endpoint");
+        }
+        Map<String, String> params = new LinkedHashMap<>();
+        if (idTokenHint != null) {
+            params.put("id_token_hint", idTokenHint);
+        }
+        if (postLogoutRedirectUri != null) {
+            params.put("post_logout_redirect_uri", postLogoutRedirectUri);
+        }
+        return buildUrl(endSessionEndpoint, params);
+    }
+
+    private TokenClaims validate(String jwt) {
+        SignedJWT signedJwt;
+        try {
+            signedJwt = SignedJWT.parse(jwt);
+        } catch (ParseException e) {
+            throw new TokenValidationException("Malformed JWT", e);
+        }
+
+        // Pinned rather than accepted from the token: RSASSAVerifier alone would happily accept
+        // RS384/RS512/PS256/etc, and this realm only ever issues RS256 (see auth.service.ts /
+        // jwk.service.ts). Not pinning this wouldn't allow a signature bypass here, but it's
+        // exactly the kind of "he server changed, the client silently widened" gap OIDC Core
+        // 3.1.3.7 (verify alg matches what was negotiated) exists to close.
+        if (!JWSAlgorithm.RS256.equals(signedJwt.getHeader().getAlgorithm())) {
+            throw new TokenValidationException(
+                    "Unexpected JWS algorithm: " + signedJwt.getHeader().getAlgorithm());
+        }
+
+        String keyId = signedJwt.getHeader().getKeyID();
+        if (keyId == null) {
+            throw new TokenValidationException("JWT header is missing 'kid'");
+        }
+        RSAPublicKey publicKey = jwks().getRsaPublicKey(keyId);
+
+        boolean signatureValid;
+        try {
+            signatureValid = signedJwt.verify(new RSASSAVerifier(publicKey));
+        } catch (JOSEException e) {
+            throw new TokenValidationException("Signature verification failed", e);
+        }
+        if (!signatureValid) {
+            throw new TokenValidationException("Invalid token signature");
+        }
+
+        TokenClaims claims;
+        try {
+            claims = objectMapper.readValue(signedJwt.getPayload().toString(), TokenClaims.class);
+        } catch (Exception e) {
+            throw new TokenValidationException("Failed to parse token claims", e);
+        }
+
+        Instant now = clock.instant();
+        if (claims.getExp() == 0 || Instant.ofEpochSecond(claims.getExp()).plus(CLOCK_SKEW).isBefore(now)) {
+            throw new TokenValidationException("Token has expired");
+        }
+        if (claims.getIat() != 0 && Instant.ofEpochSecond(claims.getIat()).minus(CLOCK_SKEW).isAfter(now)) {
+            throw new TokenValidationException("Token issued-at claim is in the future");
+        }
+        if (!issuer.equals(claims.getIss())) {
+            throw new TokenValidationException("Unexpected issuer: " + claims.getIss());
+        }
+        // The server only ever issues a single string audience equal to the client ID (never an
+        // array) — see auth.service.ts. getAudAsString() also handles the array case defensively
+        // in case that changes, but a plain equality check is the correct match for today's shape.
+        if (!clientId.equals(claims.getAudAsString())) {
+            throw new TokenValidationException("Unexpected audience: " + claims.getAudAsString());
+        }
+
+        return claims;
+    }
+
+    private JwksCache jwks() {
+        if (jwksCache == null) {
+            jwksCache = new JwksCache(discover().getJwksUri(), transport, DEFAULT_JWKS_TTL, clock);
+        }
+        return jwksCache;
+    }
+
+    private boolean isStale(Instant fetchedAt, Duration ttl) {
+        return Duration.between(fetchedAt, clock.instant()).compareTo(ttl) >= 0;
+    }
+
+    private void addClientSecretIfPresent(Map<String, String> form) {
+        if (clientSecret != null) {
+            form.put("client_secret", clientSecret);
+        }
+    }
+
+    private TokenResponse postForToken(Map<String, String> form) {
+        String json = transport.postForm(discover().getTokenEndpoint(), form);
+        try {
+            return objectMapper.readValue(json, TokenResponse.class);
+        } catch (Exception e) {
+            throw new IdenplaneClientException("Failed to parse token response", e);
+        }
+    }
+
+    private static String buildUrl(String base, Map<String, String> params) {
+        StringBuilder query = new StringBuilder();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            if (entry.getValue() == null) {
+                continue;
+            }
+            if (query.length() > 0) {
+                query.append('&');
+            }
+            query.append(urlEncode(entry.getKey())).append('=').append(urlEncode(entry.getValue()));
+        }
+        if (query.length() == 0) {
+            return base;
+        }
+        return base + (base.contains("?") ? '&' : '?') + query;
+    }
+
+    private static String urlEncode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private static String stripTrailingSlash(String url) {
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    /**
+     * Builder for {@link IdenplaneClient}.
+     */
+    public static final class Builder {
+        private final String issuer;
+        private final String clientId;
+        private String clientSecret;
+        private HttpTransport transport;
+        private Clock clock;
+        private Duration discoveryTtl;
+
+        private Builder(String issuer, String clientId) {
+            this.issuer = issuer;
+            this.clientId = clientId;
+        }
+
+        /**
+         * Sets the client secret, for confidential clients. Public/native clients (mobile, SPA)
+         * should omit this and rely on PKCE alone.
+         */
+        public Builder clientSecret(String clientSecret) {
+            this.clientSecret = clientSecret;
+            return this;
+        }
+
+        /**
+         * Overrides the HTTP transport. Intended for tests; production code should leave this
+         * unset to use the default Apache HttpClient 5-backed transport.
+         */
+        public Builder transport(HttpTransport transport) {
+            this.transport = transport;
+            return this;
+        }
+
+        /**
+         * Overrides the clock used for token expiry and cache TTL checks. Intended for tests.
+         */
+        public Builder clock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Overrides how long the discovery document is cached before being refetched.
+         */
+        public Builder discoveryTtl(Duration discoveryTtl) {
+            this.discoveryTtl = discoveryTtl;
+            return this;
+        }
+
+        public IdenplaneClient build() {
+            return new IdenplaneClient(this);
+        }
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/IdenplaneClientException.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/IdenplaneClientException.java
@@ -1,0 +1,15 @@
+package com.idenplane.sdk;
+
+/**
+ * Thrown for network, HTTP, or configuration failures while talking to the Idenplane server.
+ */
+public class IdenplaneClientException extends RuntimeException {
+
+    public IdenplaneClientException(String message) {
+        super(message);
+    }
+
+    public IdenplaneClientException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/PkceUtil.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/PkceUtil.java
@@ -1,0 +1,51 @@
+package com.idenplane.sdk;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * RFC 7636 PKCE (Proof Key for Code Exchange) helper for the Authorization Code flow.
+ */
+public final class PkceUtil {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private PkceUtil() {
+    }
+
+    /**
+     * Generates a cryptographically random code verifier: 32 random bytes, base64url-encoded
+     * without padding, giving 43 characters — within the 43-128 character range required by
+     * RFC 7636 section 4.1.
+     *
+     * @return a new code verifier
+     */
+    public static String generateCodeVerifier() {
+        byte[] bytes = new byte[32];
+        SECURE_RANDOM.nextBytes(bytes);
+        return base64UrlEncode(bytes);
+    }
+
+    /**
+     * Derives the S256 code challenge for a code verifier, per RFC 7636 section 4.2.
+     *
+     * @param codeVerifier a verifier produced by {@link #generateCodeVerifier()}
+     * @return the base64url-encoded SHA-256 code challenge
+     */
+    public static String deriveCodeChallenge(String codeVerifier) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(codeVerifier.getBytes(StandardCharsets.US_ASCII));
+            return base64UrlEncode(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available on this JVM", e);
+        }
+    }
+
+    private static String base64UrlEncode(byte[] bytes) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/TokenValidationException.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/TokenValidationException.java
@@ -1,0 +1,15 @@
+package com.idenplane.sdk;
+
+/**
+ * Thrown when a token fails signature verification or claims validation.
+ */
+public class TokenValidationException extends RuntimeException {
+
+    public TokenValidationException(String message) {
+        super(message);
+    }
+
+    public TokenValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/internal/ApacheHttpTransport.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/internal/ApacheHttpTransport.java
@@ -1,0 +1,76 @@
+package com.idenplane.sdk.internal;
+
+import com.idenplane.sdk.IdenplaneClientException;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * {@link HttpTransport} backed by Apache HttpClient 5.
+ */
+public final class ApacheHttpTransport implements HttpTransport {
+
+    private final CloseableHttpClient httpClient = HttpClients.createDefault();
+
+    @Override
+    public String get(String url) {
+        try (CloseableHttpResponse response = httpClient.execute(new HttpGet(url))) {
+            return readBody(url, response);
+        } catch (IOException e) {
+            throw new IdenplaneClientException("GET " + url + " failed", e);
+        }
+    }
+
+    @Override
+    public String getWithBearerToken(String url, String bearerToken) {
+        HttpGet request = new HttpGet(url);
+        request.addHeader("Authorization", "Bearer " + bearerToken);
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            return readBody(url, response);
+        } catch (IOException e) {
+            throw new IdenplaneClientException("GET " + url + " failed", e);
+        }
+    }
+
+    @Override
+    public String postForm(String url, Map<String, String> formParams) {
+        HttpPost request = new HttpPost(url);
+        List<NameValuePair> params = new ArrayList<>();
+        formParams.forEach((key, value) -> params.add(new BasicNameValuePair(key, value)));
+        request.setEntity(new UrlEncodedFormEntity(params, StandardCharsets.UTF_8));
+        try (CloseableHttpResponse response = httpClient.execute(request)) {
+            return readBody(url, response);
+        } catch (IOException e) {
+            throw new IdenplaneClientException("POST " + url + " failed", e);
+        }
+    }
+
+    private String readBody(String url, CloseableHttpResponse response) throws IOException {
+        int status = response.getCode();
+        String body;
+        try {
+            body = response.getEntity() == null
+                    ? ""
+                    : EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
+        } catch (ParseException e) {
+            throw new IOException("Failed to read response body from " + url, e);
+        }
+        if (status < 200 || status >= 300) {
+            throw new IdenplaneClientException("Request to " + url + " failed with HTTP " + status + ": " + body);
+        }
+        return body;
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/internal/HttpTransport.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/internal/HttpTransport.java
@@ -1,0 +1,17 @@
+package com.idenplane.sdk.internal;
+
+import java.util.Map;
+
+/**
+ * Minimal HTTP seam. Not part of the SDK's public API — it exists so {@code IdenplaneClient}
+ * can be tested against a fake transport instead of a real network call. {@link ApacheHttpTransport}
+ * is the production implementation.
+ */
+public interface HttpTransport {
+
+    String get(String url);
+
+    String getWithBearerToken(String url, String bearerToken);
+
+    String postForm(String url, Map<String, String> formParams);
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/internal/JwksCache.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/internal/JwksCache.java
@@ -1,0 +1,104 @@
+package com.idenplane.sdk.internal;
+
+import com.idenplane.sdk.IdenplaneClientException;
+import com.idenplane.sdk.TokenValidationException;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Caches a realm's JWKS document and resolves RSA public keys by {@code kid}. On a cache miss
+ * (key not found — possibly because it rotated since the last fetch) it refreshes once and
+ * retries before giving up, rather than either trusting a stale cache forever or refetching on
+ * every single validation.
+ *
+ * <p>The miss-triggered refresh is itself rate-limited ({@code minMissRefreshInterval}):
+ * without it, an unauthenticated caller could force unlimited outbound requests to this realm's
+ * own JWKS endpoint just by presenting tokens with many distinct bogus {@code kid} values.
+ */
+public final class JwksCache {
+
+    private static final Duration DEFAULT_MIN_MISS_REFRESH_INTERVAL = Duration.ofSeconds(5);
+
+    private final String jwksUri;
+    private final HttpTransport transport;
+    private final Duration ttl;
+    private final Clock clock;
+    private final Duration minMissRefreshInterval;
+
+    private JWKSet cachedSet;
+    private Instant fetchedAt = Instant.EPOCH;
+    private Instant lastMissRefreshAt = Instant.EPOCH;
+
+    public JwksCache(String jwksUri, HttpTransport transport, Duration ttl, Clock clock) {
+        this(jwksUri, transport, ttl, clock, DEFAULT_MIN_MISS_REFRESH_INTERVAL);
+    }
+
+    public JwksCache(String jwksUri, HttpTransport transport, Duration ttl, Clock clock,
+                      Duration minMissRefreshInterval) {
+        this.jwksUri = jwksUri;
+        this.transport = transport;
+        this.ttl = ttl;
+        this.clock = clock;
+        this.minMissRefreshInterval = minMissRefreshInterval;
+    }
+
+    /**
+     * Resolves the RSA public key for a {@code kid}.
+     *
+     * @throws TokenValidationException if no such key exists in the (possibly refreshed) JWKS —
+     *                                   this is caller input, not an infrastructure failure
+     * @throws IdenplaneClientException if the JWKS itself can't be fetched or parsed
+     */
+    public synchronized RSAPublicKey getRsaPublicKey(String keyId) {
+        if (cachedSet == null || isStale(fetchedAt, ttl)) {
+            refresh();
+        }
+        RSAPublicKey key = resolve(keyId);
+        if (key != null) {
+            return key;
+        }
+        if (isStale(lastMissRefreshAt, minMissRefreshInterval)) {
+            refresh();
+            lastMissRefreshAt = clock.instant();
+            key = resolve(keyId);
+        }
+        if (key == null) {
+            throw new TokenValidationException("No signing key found for kid=" + keyId);
+        }
+        return key;
+    }
+
+    private boolean isStale(Instant since, Duration duration) {
+        return Duration.between(since, clock.instant()).compareTo(duration) >= 0;
+    }
+
+    private RSAPublicKey resolve(String keyId) {
+        JWK jwk = cachedSet.getKeyByKeyId(keyId);
+        if (!(jwk instanceof RSAKey)) {
+            return null;
+        }
+        try {
+            return ((RSAKey) jwk).toRSAPublicKey();
+        } catch (JOSEException e) {
+            throw new IdenplaneClientException("Failed to build RSA public key for kid=" + keyId, e);
+        }
+    }
+
+    private void refresh() {
+        String json = transport.get(jwksUri);
+        try {
+            cachedSet = JWKSet.parse(json);
+        } catch (ParseException e) {
+            throw new IdenplaneClientException("Failed to parse JWKS from " + jwksUri, e);
+        }
+        fetchedAt = clock.instant();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/models/OpenIDConfiguration.java
+++ b/packages/idenplane-java/idenplane-java-core/src/main/java/com/idenplane/sdk/models/OpenIDConfiguration.java
@@ -56,7 +56,7 @@ public class OpenIDConfiguration {
     private java.util.List<String> scopesSupported;
 
     @JsonProperty("token_endpoint_auth_methods_supported")
-    private java.util.List<String> tokenEndpointIdenplanethodsSupported;
+    private java.util.List<String> tokenEndpointAuthMethodsSupported;
 
     @JsonProperty("claims_supported")
     private java.util.List<String> claimsSupported;
@@ -345,17 +345,17 @@ public class OpenIDConfiguration {
      *
      * @return The supported auth methods
      */
-    public java.util.List<String> getTokenEndpointIdenplanethodsSupported() {
-        return tokenEndpointIdenplanethodsSupported;
+    public java.util.List<String> getTokenEndpointAuthMethodsSupported() {
+        return tokenEndpointAuthMethodsSupported;
     }
 
     /**
      * Sets the supported token endpoint authentication methods.
      *
-     * @param tokenEndpointIdenplanethodsSupported The supported auth methods
+     * @param tokenEndpointAuthMethodsSupported The supported auth methods
      */
-    public void setTokenEndpointIdenplanethodsSupported(java.util.List<String> tokenEndpointIdenplanethodsSupported) {
-        this.tokenEndpointIdenplanethodsSupported = tokenEndpointIdenplanethodsSupported;
+    public void setTokenEndpointAuthMethodsSupported(java.util.List<String> tokenEndpointAuthMethodsSupported) {
+        this.tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethodsSupported;
     }
 
     /**

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/FakeHttpTransport.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/FakeHttpTransport.java
@@ -1,0 +1,68 @@
+package com.idenplane.sdk;
+
+import com.idenplane.sdk.internal.HttpTransport;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory {@link HttpTransport} test double. GET responses are registered per URL as a queue
+ * so a test can simulate a value changing between calls (e.g. JWKS key rotation) — the last
+ * queued value repeats once exhausted. Every call is recorded for assertions on what the client
+ * actually sent.
+ */
+final class FakeHttpTransport implements HttpTransport {
+
+    private final Map<String, Deque<String>> getResponseQueues = new HashMap<>();
+    private final Map<String, String> postResponses = new HashMap<>();
+    final List<String> requestedGetUrls = new ArrayList<>();
+    final List<Map<String, String>> postedForms = new ArrayList<>();
+    String lastPostUrl;
+    String lastBearerToken;
+
+    FakeHttpTransport withGetResponse(String url, String body) {
+        return withGetResponses(url, body);
+    }
+
+    FakeHttpTransport withGetResponses(String url, String... bodies) {
+        getResponseQueues.put(url, new ArrayDeque<>(Arrays.asList(bodies)));
+        return this;
+    }
+
+    FakeHttpTransport withPostResponse(String url, String body) {
+        postResponses.put(url, body);
+        return this;
+    }
+
+    @Override
+    public String get(String url) {
+        requestedGetUrls.add(url);
+        Deque<String> queue = getResponseQueues.get(url);
+        if (queue == null || queue.isEmpty()) {
+            throw new IdenplaneClientException("No fake response registered for GET " + url);
+        }
+        return queue.size() > 1 ? queue.poll() : queue.peek();
+    }
+
+    @Override
+    public String getWithBearerToken(String url, String bearerToken) {
+        this.lastBearerToken = bearerToken;
+        return get(url);
+    }
+
+    @Override
+    public String postForm(String url, Map<String, String> formParams) {
+        lastPostUrl = url;
+        postedForms.add(formParams);
+        String body = postResponses.get(url);
+        if (body == null) {
+            throw new IdenplaneClientException("No fake response registered for POST " + url);
+        }
+        return body;
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/IdenplaneClientTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/IdenplaneClientTest.java
@@ -1,0 +1,370 @@
+package com.idenplane.sdk;
+
+import com.idenplane.sdk.models.TokenClaims;
+import com.idenplane.sdk.models.TokenResponse;
+import com.idenplane.sdk.models.UserInfo;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IdenplaneClientTest {
+
+    private static final String ISSUER = "https://idenplane.test/realms/test-realm";
+    private static final String CLIENT_ID = "my-client";
+    private static final String AUTHORIZATION_ENDPOINT = ISSUER + "/protocol/openid-connect/auth";
+    private static final String TOKEN_ENDPOINT = ISSUER + "/protocol/openid-connect/token";
+    private static final String USERINFO_ENDPOINT = ISSUER + "/protocol/openid-connect/userinfo";
+    private static final String JWKS_URI = ISSUER + "/protocol/openid-connect/certs";
+    private static final String END_SESSION_ENDPOINT = ISSUER + "/protocol/openid-connect/logout";
+    private static final String DISCOVERY_URL = ISSUER + "/.well-known/openid-configuration";
+
+    private static final Instant NOW = Instant.parse("2026-08-03T12:00:00Z");
+
+    private TestTokens signingKey;
+    private FakeHttpTransport transport;
+    private IdenplaneClient client;
+
+    @BeforeEach
+    void setUp() {
+        signingKey = TestTokens.generate();
+        transport = new FakeHttpTransport()
+                .withGetResponse(DISCOVERY_URL, discoveryJson())
+                .withGetResponse(JWKS_URI, signingKey.jwksJson());
+        client = IdenplaneClient.builder(ISSUER, CLIENT_ID)
+                .transport(transport)
+                .clock(Clock.fixed(NOW, ZoneOffset.UTC))
+                .build();
+    }
+
+    private static String discoveryJson() {
+        return "{"
+                + "\"issuer\":\"" + ISSUER + "\","
+                + "\"authorization_endpoint\":\"" + AUTHORIZATION_ENDPOINT + "\","
+                + "\"token_endpoint\":\"" + TOKEN_ENDPOINT + "\","
+                + "\"userinfo_endpoint\":\"" + USERINFO_ENDPOINT + "\","
+                + "\"jwks_uri\":\"" + JWKS_URI + "\","
+                + "\"end_session_endpoint\":\"" + END_SESSION_ENDPOINT + "\""
+                + "}";
+    }
+
+    private JWTClaimsSet.Builder baseClaims(String typ, long expEpochSeconds) {
+        return new JWTClaimsSet.Builder()
+                .claim("iss", ISSUER)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("azp", CLIENT_ID)
+                .claim("sid", "session-abc")
+                .claim("typ", typ)
+                .claim("iat", NOW.getEpochSecond())
+                .claim("exp", expEpochSeconds);
+    }
+
+    private String validAccessToken() {
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond())
+                .claim("scope", "openid profile email")
+                .claim("realm_access", Map.of("roles", List.of("user", "admin")))
+                .claim("resource_access", Map.of(CLIENT_ID, Map.of("roles", List.of("viewer"))))
+                .build();
+        return signingKey.sign(claims);
+    }
+
+    private String validIdToken() {
+        JWTClaimsSet claims = baseClaims("ID", NOW.plusSeconds(300).getEpochSecond())
+                .claim("auth_time", NOW.getEpochSecond())
+                .claim("name", "Ada Lovelace")
+                .claim("email", "ada@example.com")
+                .build();
+        return signingKey.sign(claims);
+    }
+
+    @Test
+    void discover_parsesDiscoveryDocument() {
+        var config = client.discover();
+
+        assertThat(config.getIssuer()).isEqualTo(ISSUER);
+        assertThat(config.getAuthorizationEndpoint()).isEqualTo(AUTHORIZATION_ENDPOINT);
+        assertThat(config.getTokenEndpoint()).isEqualTo(TOKEN_ENDPOINT);
+        assertThat(config.getJwksUri()).isEqualTo(JWKS_URI);
+    }
+
+    @Test
+    void discover_isCachedAcrossCalls() {
+        client.discover();
+        client.discover();
+
+        assertThat(transport.requestedGetUrls).filteredOn(DISCOVERY_URL::equals).hasSize(1);
+    }
+
+    @Test
+    void validateAccessToken_succeedsForValidTokenAndExposesRoles() {
+        TokenClaims claims = client.validateAccessToken(validAccessToken());
+
+        assertThat(claims.getSub()).isEqualTo("user-123");
+        assertThat(claims.getAudAsString()).isEqualTo(CLIENT_ID);
+        assertThat(claims.getTyp()).isEqualTo("Bearer");
+        assertThat(claims.getRealmRoles()).containsExactlyInAnyOrder("user", "admin");
+        assertThat(claims.getResourceRoles(CLIENT_ID)).containsExactly("viewer");
+    }
+
+    @Test
+    void validateIdToken_succeedsForValidToken() {
+        TokenClaims claims = client.validateIdToken(validIdToken());
+
+        assertThat(claims.getSub()).isEqualTo("user-123");
+        assertThat(claims.getTyp()).isEqualTo("ID");
+        assertThat(claims.getName()).isEqualTo("Ada Lovelace");
+        assertThat(claims.getEmail()).isEqualTo("ada@example.com");
+    }
+
+    @Test
+    void validateAccessToken_rejectsAnIdTokenPresentedAsAccessToken() {
+        String idToken = validIdToken();
+
+        assertThatThrownBy(() -> client.validateAccessToken(idToken))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("typ=Bearer");
+    }
+
+    @Test
+    void validateIdToken_rejectsAnAccessTokenPresentedAsIdToken() {
+        String accessToken = validAccessToken();
+
+        assertThatThrownBy(() -> client.validateIdToken(accessToken))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("typ=ID");
+    }
+
+    @Test
+    void validate_rejectsExpiredToken() {
+        String expired = signingKey.sign(baseClaims("Bearer", NOW.minusSeconds(600).getEpochSecond()).build());
+
+        assertThatThrownBy(() -> client.validateAccessToken(expired))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("expired");
+    }
+
+    @Test
+    void validate_toleratesClockSkewWithinBounds() {
+        // Expired 30s ago — inside the 60s clock-skew tolerance, so this must still pass.
+        String barelyExpired = signingKey.sign(
+                baseClaims("Bearer", NOW.minusSeconds(30).getEpochSecond()).build());
+
+        assertThat(client.validateAccessToken(barelyExpired)).isNotNull();
+    }
+
+    @Test
+    void validate_rejectsWrongIssuer() {
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond())
+                .claim("iss", "https://not-the-real-issuer.example.com/realms/other")
+                .build();
+        String token = signingKey.sign(claims);
+
+        assertThatThrownBy(() -> client.validateAccessToken(token))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("issuer");
+    }
+
+    @Test
+    void validate_rejectsWrongAudience() {
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond())
+                .claim("aud", "some-other-client")
+                .build();
+        String token = signingKey.sign(claims);
+
+        assertThatThrownBy(() -> client.validateAccessToken(token))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("audience");
+    }
+
+    @Test
+    void validate_rejectsTokenSignedWithAnUnrelatedKey() {
+        TestTokens attackerKey = TestTokens.generate();
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond()).build();
+        // Header kid matches the real signing key's kid (as registered in the realm's JWKS),
+        // but the signature itself is produced by a different, attacker-controlled key.
+        String forged = signingKey.signWithMismatchedKey(claims, attackerKey);
+
+        assertThatThrownBy(() -> client.validateAccessToken(forged))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("signature");
+    }
+
+    @Test
+    void validate_rejectsMalformedJwt() {
+        assertThatThrownBy(() -> client.validateAccessToken("not-a-jwt"))
+                .isInstanceOf(TokenValidationException.class);
+    }
+
+    @Test
+    void jwksCacheMiss_refreshesOnceAndRecoversFromKeyRotation() {
+        TestTokens rotatedKey = TestTokens.generate();
+        // The client's cache is warmed with only the old key; the token below is signed with a
+        // key that only shows up in the JWKS *after* rotation.
+        transport.withGetResponses(JWKS_URI, signingKey.jwksJson(), rotatedKey.jwksJson());
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond()).build();
+        String tokenFromRotatedKey = rotatedKey.sign(claims);
+
+        TokenClaims validated = client.validateAccessToken(tokenFromRotatedKey);
+
+        assertThat(validated.getSub()).isEqualTo("user-123");
+        assertThat(transport.requestedGetUrls).filteredOn(JWKS_URI::equals).hasSize(2);
+    }
+
+    @Test
+    void jwksCacheMiss_failsAfterOneRefreshIfKeyStillUnknown() {
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond()).build();
+        String tokenFromUnknownKey = TestTokens.generate().sign(claims);
+
+        // TokenValidationException, not IdenplaneClientException: an unresolvable kid is bad
+        // caller input (a 401-shaped problem), not an infrastructure failure — a caller that
+        // maps TokenValidationException to 401 and everything else to 500 must get this right.
+        assertThatThrownBy(() -> client.validateAccessToken(tokenFromUnknownKey))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("No signing key found");
+    }
+
+    @Test
+    void jwksCacheMiss_isRateLimitedAcrossRepeatedMisses() {
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond()).build();
+        String tokenFromUnknownKey = TestTokens.generate().sign(claims);
+
+        assertThatThrownBy(() -> client.validateAccessToken(tokenFromUnknownKey))
+                .isInstanceOf(TokenValidationException.class);
+        long jwksCallsAfterFirstMiss = transport.requestedGetUrls.stream().filter(JWKS_URI::equals).count();
+
+        assertThatThrownBy(() -> client.validateAccessToken(tokenFromUnknownKey))
+                .isInstanceOf(TokenValidationException.class);
+        long jwksCallsAfterSecondMiss = transport.requestedGetUrls.stream().filter(JWKS_URI::equals).count();
+
+        // The clock never advances in this test, so the second miss must NOT trigger another
+        // JWKS fetch — otherwise an attacker could force unlimited outbound requests to the
+        // realm's own JWKS endpoint just by sending many distinct unknown kids.
+        assertThat(jwksCallsAfterSecondMiss).isEqualTo(jwksCallsAfterFirstMiss);
+    }
+
+    @Test
+    void validate_rejectsTokenWithUnexpectedAlgorithm() {
+        JWTClaimsSet claims = baseClaims("Bearer", NOW.plusSeconds(300).getEpochSecond()).build();
+        // Still a cryptographically valid RSA signature from the real key — RSASSAVerifier alone
+        // would accept RS384, so this specifically exercises the explicit alg pin, not signature
+        // verification.
+        String token = signingKey.signWithAlgorithm(claims, com.nimbusds.jose.JWSAlgorithm.RS384);
+
+        assertThatThrownBy(() -> client.validateAccessToken(token))
+                .isInstanceOf(TokenValidationException.class)
+                .hasMessageContaining("algorithm");
+    }
+
+    @Test
+    void buildAuthorizationUrl_includesRequiredPkceAndOidcParams() {
+        String url = client.buildAuthorizationUrl(
+                "https://app.example.com/callback", "xyz-state", "abc-challenge", List.of("email"));
+
+        assertThat(url).startsWith(AUTHORIZATION_ENDPOINT + "?");
+        assertThat(url).contains("response_type=code");
+        assertThat(url).contains("client_id=" + CLIENT_ID);
+        assertThat(url).contains("redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback");
+        assertThat(url).contains("scope=openid+email");
+        assertThat(url).contains("state=xyz-state");
+        assertThat(url).contains("code_challenge=abc-challenge");
+        assertThat(url).contains("code_challenge_method=S256");
+    }
+
+    @Test
+    void buildAuthorizationUrl_doesNotDuplicateOpenidScope() {
+        String url = client.buildAuthorizationUrl("https://app.example.com/callback", "s", "c",
+                List.of("openid", "email"));
+
+        String scopeParam = Arrays.stream(url.split("[?&]"))
+                .filter(param -> param.startsWith("scope="))
+                .findFirst()
+                .orElseThrow();
+        assertThat(scopeParam).isEqualTo("scope=openid+email");
+    }
+
+    @Test
+    void exchangeAuthorizationCode_postsExpectedFormAndParsesResponse() {
+        transport.withPostResponse(TOKEN_ENDPOINT, "{"
+                + "\"access_token\":\"at-123\","
+                + "\"token_type\":\"Bearer\","
+                + "\"expires_in\":300,"
+                + "\"refresh_token\":\"rt-456\","
+                + "\"id_token\":\"idtok-789\""
+                + "}");
+
+        TokenResponse response = client.exchangeAuthorizationCode("auth-code", "https://app.example.com/cb", "verifier-1");
+
+        assertThat(response.getAccessToken()).isEqualTo("at-123");
+        assertThat(response.getRefreshToken()).isEqualTo("rt-456");
+        assertThat(response.getIdToken()).isEqualTo("idtok-789");
+        Map<String, String> form = transport.postedForms.get(0);
+        assertThat(form).containsEntry("grant_type", "authorization_code");
+        assertThat(form).containsEntry("code", "auth-code");
+        assertThat(form).containsEntry("code_verifier", "verifier-1");
+        assertThat(form).doesNotContainKey("client_secret");
+    }
+
+    @Test
+    void exchangeAuthorizationCode_includesClientSecretForConfidentialClients() {
+        IdenplaneClient confidentialClient = IdenplaneClient.builder(ISSUER, CLIENT_ID)
+                .clientSecret("shh-secret")
+                .transport(transport)
+                .clock(Clock.fixed(NOW, ZoneOffset.UTC))
+                .build();
+        transport.withPostResponse(TOKEN_ENDPOINT, "{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":300}");
+
+        confidentialClient.exchangeAuthorizationCode("code", "https://app.example.com/cb", "verifier");
+
+        assertThat(transport.postedForms.get(0)).containsEntry("client_secret", "shh-secret");
+    }
+
+    @Test
+    void refreshToken_postsRefreshTokenGrant() {
+        transport.withPostResponse(TOKEN_ENDPOINT, "{\"access_token\":\"new-at\",\"token_type\":\"Bearer\",\"expires_in\":300}");
+
+        TokenResponse response = client.refreshToken("old-refresh-token");
+
+        assertThat(response.getAccessToken()).isEqualTo("new-at");
+        assertThat(transport.postedForms.get(0)).containsEntry("grant_type", "refresh_token");
+        assertThat(transport.postedForms.get(0)).containsEntry("refresh_token", "old-refresh-token");
+    }
+
+    @Test
+    void getUserInfo_sendsBearerTokenAndParsesProfile() {
+        transport.withGetResponse(USERINFO_ENDPOINT, "{"
+                + "\"sub\":\"user-123\",\"preferred_username\":\"ada\",\"email\":\"ada@example.com\""
+                + "}");
+
+        UserInfo userInfo = client.getUserInfo("some-access-token");
+
+        assertThat(userInfo.getSub()).isEqualTo("user-123");
+        assertThat(userInfo.getPreferredUsername()).isEqualTo("ada");
+        assertThat(transport.lastBearerToken).isEqualTo("some-access-token");
+    }
+
+    @Test
+    void buildLogoutUrl_includesHintAndRedirect() {
+        String url = client.buildLogoutUrl("id-token-value", "https://app.example.com/bye");
+
+        assertThat(url).startsWith(END_SESSION_ENDPOINT + "?");
+        assertThat(url).contains("id_token_hint=id-token-value");
+        assertThat(url).contains("post_logout_redirect_uri=https%3A%2F%2Fapp.example.com%2Fbye");
+    }
+
+    @Test
+    void buildLogoutUrl_omitsNullParams() {
+        String url = client.buildLogoutUrl(null, null);
+
+        assertThat(url).isEqualTo(END_SESSION_ENDPOINT);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/PkceUtilTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/PkceUtilTest.java
@@ -1,0 +1,56 @@
+package com.idenplane.sdk;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PkceUtilTest {
+
+    private static final Pattern UNRESERVED = Pattern.compile("^[A-Za-z0-9\\-._~]+$");
+
+    @Test
+    void generateCodeVerifier_isWithinRfc7636LengthAndCharsetBounds() {
+        String verifier = PkceUtil.generateCodeVerifier();
+
+        assertThat(verifier.length()).isBetween(43, 128);
+        assertThat(UNRESERVED.matcher(verifier).matches()).isTrue();
+    }
+
+    @Test
+    void generateCodeVerifier_isRandomAcrossCalls() {
+        Set<String> verifiers = new HashSet<>();
+        for (int i = 0; i < 100; i++) {
+            verifiers.add(PkceUtil.generateCodeVerifier());
+        }
+
+        assertThat(verifiers).hasSize(100);
+    }
+
+    @Test
+    void deriveCodeChallenge_matchesManuallyComputedSha256() throws Exception {
+        String verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+
+        String challenge = PkceUtil.deriveCodeChallenge(verifier);
+
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] expectedHash = digest.digest(verifier.getBytes(StandardCharsets.US_ASCII));
+        String expected = Base64.getUrlEncoder().withoutPadding().encodeToString(expectedHash);
+        assertThat(challenge).isEqualTo(expected);
+        // RFC 7636 appendix B worked example.
+        assertThat(challenge).isEqualTo("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    }
+
+    @Test
+    void deriveCodeChallenge_isDeterministic() {
+        String verifier = PkceUtil.generateCodeVerifier();
+
+        assertThat(PkceUtil.deriveCodeChallenge(verifier)).isEqualTo(PkceUtil.deriveCodeChallenge(verifier));
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/TestTokens.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/TestTokens.java
@@ -1,0 +1,103 @@
+package com.idenplane.sdk;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+/**
+ * Mints real RS256-signed JWTs and a matching JWKS for tests, so token validation is exercised
+ * against actual cryptographic signatures rather than pre-canned strings.
+ */
+final class TestTokens {
+
+    final RSAKey rsaJwk;
+    final String keyId;
+
+    private TestTokens(RSAKey rsaJwk) {
+        this.rsaJwk = rsaJwk;
+        this.keyId = rsaJwk.getKeyID();
+    }
+
+    static TestTokens generate() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair keyPair = generator.generateKeyPair();
+            RSAKey jwk = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                    .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                    .keyID(UUID.randomUUID().toString())
+                    .build();
+            return new TestTokens(jwk);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    String jwksJson() {
+        return new JWKSet(rsaJwk.toPublicJWK()).toString();
+    }
+
+    static String jwksJson(TestTokens... tokens) {
+        java.util.List<com.nimbusds.jose.jwk.JWK> keys = new java.util.ArrayList<>();
+        for (TestTokens t : tokens) {
+            keys.add(t.rsaJwk.toPublicJWK());
+        }
+        return new JWKSet(keys).toString();
+    }
+
+    String sign(JWTClaimsSet claims) {
+        return signWithKey(claims, this.rsaJwk);
+    }
+
+    /**
+     * Signs claims with a header {@code kid} that does NOT match the signing key — simulates a
+     * forged/tampered token that must fail signature verification.
+     */
+    String signWithMismatchedKey(JWTClaimsSet claims, TestTokens signingKey) {
+        try {
+            SignedJWT jwt = new SignedJWT(
+                    new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(this.keyId).build(), claims);
+            jwt.sign(new RSASSASigner(signingKey.rsaJwk));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Signs claims with an explicit JWS algorithm, keeping the real signing key and kid — used
+     * to prove the client pins the expected algorithm rather than accepting anything the
+     * verifier happens to support.
+     */
+    String signWithAlgorithm(JWTClaimsSet claims, JWSAlgorithm algorithm) {
+        try {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(algorithm).keyID(keyId).build(), claims);
+            jwt.sign(new RSASSASigner(rsaJwk));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String signWithKey(JWTClaimsSet claims, RSAKey key) {
+        try {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(keyId).build(), claims);
+            jwt.sign(new RSASSASigner(key));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/internal/ApacheHttpTransportTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/internal/ApacheHttpTransportTest.java
@@ -1,0 +1,115 @@
+package com.idenplane.sdk.internal;
+
+import com.idenplane.sdk.IdenplaneClientException;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Exercises {@link ApacheHttpTransport} against a real local HTTP server rather than mocks, so
+ * the actual Apache HttpClient 5 wiring (headers, form encoding, status handling) is verified,
+ * not just assumed from reading the client's API.
+ */
+class ApacheHttpTransportTest {
+
+    private HttpServer server;
+    private String baseUrl;
+    private final ApacheHttpTransport transport = new ApacheHttpTransport();
+
+    @BeforeEach
+    void startServer() throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    @Test
+    void get_returnsResponseBodyOn200() throws IOException {
+        server.createContext("/ok", exchange -> respond(exchange, 200, "hello"));
+        server.start();
+
+        String body = transport.get(baseUrl + "/ok");
+
+        assertThat(body).isEqualTo("hello");
+    }
+
+    @Test
+    void get_throwsOnNon2xxStatusIncludingBodyAndStatus() throws IOException {
+        server.createContext("/broken", exchange -> respond(exchange, 500, "server exploded"));
+        server.start();
+
+        assertThatThrownBy(() -> transport.get(baseUrl + "/broken"))
+                .isInstanceOf(IdenplaneClientException.class)
+                .hasMessageContaining("500")
+                .hasMessageContaining("server exploded");
+    }
+
+    @Test
+    void get_throwsOnConnectionFailure() {
+        // Nothing is listening on this port — simulates a network-level failure without
+        // depending on any external host.
+        assertThatThrownBy(() -> transport.get("http://127.0.0.1:1/unreachable"))
+                .isInstanceOf(IdenplaneClientException.class);
+    }
+
+    @Test
+    void getWithBearerToken_sendsAuthorizationHeader() throws IOException {
+        AtomicReference<String> receivedAuthHeader = new AtomicReference<>();
+        server.createContext("/secure", exchange -> {
+            receivedAuthHeader.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, "profile-data");
+        });
+        server.start();
+
+        String body = transport.getWithBearerToken(baseUrl + "/secure", "token-abc");
+
+        assertThat(body).isEqualTo("profile-data");
+        assertThat(receivedAuthHeader.get()).isEqualTo("Bearer token-abc");
+    }
+
+    @Test
+    void postForm_sendsUrlEncodedBodyAndContentType() throws IOException {
+        AtomicReference<String> receivedContentType = new AtomicReference<>();
+        AtomicReference<String> receivedBody = new AtomicReference<>();
+        server.createContext("/token", exchange -> {
+            receivedContentType.set(exchange.getRequestHeaders().getFirst("Content-Type"));
+            receivedBody.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            respond(exchange, 200, "{\"access_token\":\"at\"}");
+        });
+        server.start();
+
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "authorization_code");
+        form.put("code", "abc 123");
+        String body = transport.postForm(baseUrl + "/token", form);
+
+        assertThat(body).isEqualTo("{\"access_token\":\"at\"}");
+        assertThat(receivedContentType.get()).startsWith("application/x-www-form-urlencoded");
+        assertThat(receivedBody.get()).contains("grant_type=authorization_code");
+        assertThat(receivedBody.get()).contains("code=abc+123");
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange exchange, int status, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(status, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/OpenIDConfigurationTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/OpenIDConfigurationTest.java
@@ -1,0 +1,72 @@
+package com.idenplane.sdk.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenIDConfigurationTest {
+
+    @Test
+    void roundTripsThroughJsonPreservingAllFields() throws Exception {
+        OpenIDConfiguration original = new OpenIDConfiguration();
+        original.setIssuer("https://idenplane.test/realms/r");
+        original.setAuthorizationEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/auth");
+        original.setTokenEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/token");
+        original.setUserinfoEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/userinfo");
+        original.setJwksUri("https://idenplane.test/realms/r/protocol/openid-connect/certs");
+        original.setEndSessionEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/logout");
+        original.setIntrospectionEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/token/introspect");
+        original.setRevocationEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/revoke");
+        original.setDeviceAuthorizationEndpoint("https://idenplane.test/realms/r/protocol/openid-connect/auth/device");
+        original.setCheckSessionIframe("https://idenplane.test/realms/r/protocol/openid-connect/login-status-iframe.html");
+        original.setResponseTypesSupported(List.of("code"));
+        original.setGrantTypesSupported(List.of("authorization_code", "refresh_token"));
+        original.setSubjectTypesSupported(List.of("public"));
+        original.setIdTokenSigningAlgValuesSupported(List.of("RS256"));
+        original.setScopesSupported(List.of("openid", "profile", "email"));
+        original.setTokenEndpointAuthMethodsSupported(List.of("client_secret_post"));
+        original.setClaimsSupported(List.of("sub", "email"));
+        original.setCodeChallengeMethodsSupported(List.of("S256"));
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(original);
+        OpenIDConfiguration parsed = mapper.readValue(json, OpenIDConfiguration.class);
+
+        assertThat(parsed.getIssuer()).isEqualTo(original.getIssuer());
+        assertThat(parsed.getAuthorizationEndpoint()).isEqualTo(original.getAuthorizationEndpoint());
+        assertThat(parsed.getTokenEndpoint()).isEqualTo(original.getTokenEndpoint());
+        assertThat(parsed.getUserinfoEndpoint()).isEqualTo(original.getUserinfoEndpoint());
+        assertThat(parsed.getJwksUri()).isEqualTo(original.getJwksUri());
+        assertThat(parsed.getEndSessionEndpoint()).isEqualTo(original.getEndSessionEndpoint());
+        assertThat(parsed.getIntrospectionEndpoint()).isEqualTo(original.getIntrospectionEndpoint());
+        assertThat(parsed.getRevocationEndpoint()).isEqualTo(original.getRevocationEndpoint());
+        assertThat(parsed.getDeviceAuthorizationEndpoint()).isEqualTo(original.getDeviceAuthorizationEndpoint());
+        assertThat(parsed.getCheckSessionIframe()).isEqualTo(original.getCheckSessionIframe());
+        assertThat(parsed.getResponseTypesSupported()).isEqualTo(original.getResponseTypesSupported());
+        assertThat(parsed.getGrantTypesSupported()).isEqualTo(original.getGrantTypesSupported());
+        assertThat(parsed.getSubjectTypesSupported()).isEqualTo(original.getSubjectTypesSupported());
+        assertThat(parsed.getIdTokenSigningAlgValuesSupported())
+                .isEqualTo(original.getIdTokenSigningAlgValuesSupported());
+        assertThat(parsed.getScopesSupported()).isEqualTo(original.getScopesSupported());
+        // Regression check: this getter/setter pair (and its backing field) used to be named
+        // tokenEndpointIdenplanethodsSupported — mangled by a blind "AuthMe" -> "Idenplane"
+        // rebrand find/replace ("AuthMethodsSupported" contains "AuthMe" as a substring).
+        assertThat(parsed.getTokenEndpointAuthMethodsSupported())
+                .isEqualTo(original.getTokenEndpointAuthMethodsSupported());
+        assertThat(parsed.getClaimsSupported()).isEqualTo(original.getClaimsSupported());
+        assertThat(parsed.getCodeChallengeMethodsSupported()).isEqualTo(original.getCodeChallengeMethodsSupported());
+        assertThat(parsed.toString()).contains(original.getIssuer());
+    }
+
+    @Test
+    void ignoresUnknownJsonProperties() throws Exception {
+        String json = "{\"issuer\":\"https://x\",\"totally_unknown_field\":\"value\"}";
+
+        OpenIDConfiguration parsed = new ObjectMapper().readValue(json, OpenIDConfiguration.class);
+
+        assertThat(parsed.getIssuer()).isEqualTo("https://x");
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/TokenClaimsTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/TokenClaimsTest.java
@@ -1,0 +1,113 @@
+package com.idenplane.sdk.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenClaimsTest {
+
+    @Test
+    void roundTripsThroughJsonPreservingAllFields() throws Exception {
+        String json = "{"
+                + "\"sub\":\"user-1\",\"iss\":\"https://issuer\",\"aud\":\"client-1\","
+                + "\"exp\":2000000000,\"iat\":1999999000,\"typ\":\"Bearer\",\"azp\":\"client-1\","
+                + "\"sid\":\"session-1\",\"jti\":\"jwt-1\",\"scope\":\"openid email\",\"nonce\":\"nonce-1\","
+                + "\"auth_time\":1999999500,\"at_hash\":\"hash-1\",\"acr\":\"1\","
+                + "\"name\":\"Ada Lovelace\",\"given_name\":\"Ada\",\"family_name\":\"Lovelace\","
+                + "\"preferred_username\":\"ada\",\"email\":\"ada@example.com\",\"email_verified\":true,"
+                + "\"updated_at\":1999999999,"
+                + "\"realm_access\":{\"roles\":[\"user\",\"admin\"]},"
+                + "\"resource_access\":{\"client-1\":{\"roles\":[\"viewer\"]}}"
+                + "}";
+
+        TokenClaims claims = new ObjectMapper().readValue(json, TokenClaims.class);
+
+        assertThat(claims.getSub()).isEqualTo("user-1");
+        assertThat(claims.getIss()).isEqualTo("https://issuer");
+        assertThat(claims.getAud()).isEqualTo("client-1");
+        assertThat(claims.getAudAsString()).isEqualTo("client-1");
+        assertThat(claims.getExp()).isEqualTo(2000000000L);
+        assertThat(claims.getIat()).isEqualTo(1999999000L);
+        assertThat(claims.getTyp()).isEqualTo("Bearer");
+        assertThat(claims.getAzp()).isEqualTo("client-1");
+        assertThat(claims.getSid()).isEqualTo("session-1");
+        assertThat(claims.getJti()).isEqualTo("jwt-1");
+        assertThat(claims.getScope()).isEqualTo("openid email");
+        assertThat(claims.getNonce()).isEqualTo("nonce-1");
+        assertThat(claims.getAuthTime()).isEqualTo(1999999500L);
+        assertThat(claims.getAtHash()).isEqualTo("hash-1");
+        assertThat(claims.getAcr()).isEqualTo("1");
+        assertThat(claims.getName()).isEqualTo("Ada Lovelace");
+        assertThat(claims.getGivenName()).isEqualTo("Ada");
+        assertThat(claims.getFamilyName()).isEqualTo("Lovelace");
+        assertThat(claims.getPreferredUsername()).isEqualTo("ada");
+        assertThat(claims.getEmail()).isEqualTo("ada@example.com");
+        assertThat(claims.isEmailVerified()).isTrue();
+        assertThat(claims.getUpdatedAt()).isEqualTo(1999999999L);
+        assertThat(claims.getRealmRoles()).containsExactlyInAnyOrder("user", "admin");
+        assertThat(claims.getResourceRoles("client-1")).containsExactly("viewer");
+        assertThat(claims.getResourceRoles("nonexistent-client")).isEmpty();
+    }
+
+    @Test
+    void getAudAsString_handlesArrayAudience() throws Exception {
+        String json = "{\"aud\":[\"client-a\",\"client-b\"]}";
+
+        TokenClaims claims = new ObjectMapper().readValue(json, TokenClaims.class);
+
+        assertThat(claims.getAudAsString()).isEqualTo("client-a");
+    }
+
+    @Test
+    void getAudAsString_returnsNullWhenAudIsAbsent() {
+        assertThat(new TokenClaims().getAudAsString()).isNull();
+    }
+
+    @Test
+    void getRealmRoles_returnsEmptyListWhenNoRealmAccess() {
+        assertThat(new TokenClaims().getRealmRoles()).isEmpty();
+    }
+
+    @Test
+    void getResourceRoles_returnsEmptyListWhenNoResourceAccess() {
+        assertThat(new TokenClaims().getResourceRoles("any-client")).isEmpty();
+    }
+
+    @Test
+    void settersAllowDirectConstruction() {
+        TokenClaims claims = new TokenClaims();
+        claims.setSub("s");
+        claims.setIss("i");
+        claims.setAud("a");
+        claims.setExp(1);
+        claims.setIat(2);
+        claims.setTyp("t");
+        claims.setAzp("az");
+        claims.setSid("si");
+        claims.setJti("j");
+        claims.setScope("sc");
+        claims.setNonce("n");
+        claims.setAuthTime(3);
+        claims.setAtHash("ah");
+        claims.setAcr("ac");
+        claims.setName("nm");
+        claims.setGivenName("gn");
+        claims.setFamilyName("fn");
+        claims.setPreferredUsername("pu");
+        claims.setEmail("e");
+        claims.setEmailVerified(true);
+        claims.setUpdatedAt(4);
+        TokenClaims.RealmAccess realmAccess = new TokenClaims.RealmAccess();
+        realmAccess.setRoles(List.of("r"));
+        claims.setRealmAccess(realmAccess);
+        claims.setResourceAccess(Map.of());
+
+        assertThat(claims.getRealmAccess()).isSameAs(realmAccess);
+        assertThat(claims.getResourceAccess()).isEmpty();
+        assertThat(claims.getAud()).isEqualTo("a");
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/TokenResponseTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/TokenResponseTest.java
@@ -1,0 +1,53 @@
+package com.idenplane.sdk.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TokenResponseTest {
+
+    @Test
+    void allArgsConstructorSetsAllFields() {
+        TokenResponse response = new TokenResponse("at", "Bearer", 300, "rt", "idt", "openid email");
+
+        assertThat(response.getAccessToken()).isEqualTo("at");
+        assertThat(response.getTokenType()).isEqualTo("Bearer");
+        assertThat(response.getExpiresIn()).isEqualTo(300);
+        assertThat(response.getRefreshToken()).isEqualTo("rt");
+        assertThat(response.getIdToken()).isEqualTo("idt");
+        assertThat(response.getScope()).isEqualTo("openid email");
+    }
+
+    @Test
+    void roundTripsThroughJson() throws Exception {
+        String json = "{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"expires_in\":600,"
+                + "\"refresh_token\":\"rt\",\"id_token\":\"idt\",\"scope\":\"openid\"}";
+
+        TokenResponse response = new ObjectMapper().readValue(json, TokenResponse.class);
+
+        assertThat(response.getAccessToken()).isEqualTo("at");
+        assertThat(response.getExpiresIn()).isEqualTo(600);
+        assertThat(response.getRefreshToken()).isEqualTo("rt");
+        assertThat(response.getIdToken()).isEqualTo("idt");
+        assertThat(response.getScope()).isEqualTo("openid");
+    }
+
+    @Test
+    void noArgsConstructorAndSettersWork() {
+        TokenResponse response = new TokenResponse();
+        response.setAccessToken("at2");
+        response.setTokenType("Bearer");
+        response.setExpiresIn(120);
+        response.setRefreshToken("rt2");
+        response.setIdToken("idt2");
+        response.setScope("email");
+
+        assertThat(response.getAccessToken()).isEqualTo("at2");
+        assertThat(response.getTokenType()).isEqualTo("Bearer");
+        assertThat(response.getExpiresIn()).isEqualTo(120);
+        assertThat(response.getRefreshToken()).isEqualTo("rt2");
+        assertThat(response.getIdToken()).isEqualTo("idt2");
+        assertThat(response.getScope()).isEqualTo("email");
+    }
+}

--- a/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/UserInfoTest.java
+++ b/packages/idenplane-java/idenplane-java-core/src/test/java/com/idenplane/sdk/models/UserInfoTest.java
@@ -1,0 +1,63 @@
+package com.idenplane.sdk.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserInfoTest {
+
+    @Test
+    void subConstructorSetsSubject() {
+        UserInfo userInfo = new UserInfo("user-1");
+
+        assertThat(userInfo.getSub()).isEqualTo("user-1");
+    }
+
+    @Test
+    void roundTripsThroughJson() throws Exception {
+        String json = "{\"sub\":\"user-1\",\"preferred_username\":\"ada\",\"name\":\"Ada Lovelace\","
+                + "\"given_name\":\"Ada\",\"family_name\":\"Lovelace\",\"email\":\"ada@example.com\","
+                + "\"email_verified\":true}";
+
+        UserInfo userInfo = new ObjectMapper().readValue(json, UserInfo.class);
+
+        assertThat(userInfo.getSub()).isEqualTo("user-1");
+        assertThat(userInfo.getPreferredUsername()).isEqualTo("ada");
+        assertThat(userInfo.getName()).isEqualTo("Ada Lovelace");
+        assertThat(userInfo.getGivenName()).isEqualTo("Ada");
+        assertThat(userInfo.getFamilyName()).isEqualTo("Lovelace");
+        assertThat(userInfo.getEmail()).isEqualTo("ada@example.com");
+        assertThat(userInfo.isEmailVerified()).isTrue();
+        assertThat(userInfo.toString()).contains("user-1", "ada@example.com");
+    }
+
+    @Test
+    void noArgsConstructorAndSettersWork() {
+        UserInfo userInfo = new UserInfo();
+        userInfo.setSub("s");
+        userInfo.setPreferredUsername("pu");
+        userInfo.setName("n");
+        userInfo.setGivenName("gn");
+        userInfo.setFamilyName("fn");
+        userInfo.setEmail("e");
+        userInfo.setEmailVerified(false);
+
+        assertThat(userInfo.getSub()).isEqualTo("s");
+        assertThat(userInfo.getPreferredUsername()).isEqualTo("pu");
+        assertThat(userInfo.getName()).isEqualTo("n");
+        assertThat(userInfo.getGivenName()).isEqualTo("gn");
+        assertThat(userInfo.getFamilyName()).isEqualTo("fn");
+        assertThat(userInfo.getEmail()).isEqualTo("e");
+        assertThat(userInfo.isEmailVerified()).isFalse();
+    }
+
+    @Test
+    void ignoresUnknownJsonProperties() throws Exception {
+        String json = "{\"sub\":\"user-1\",\"some_future_claim\":\"value\"}";
+
+        UserInfo userInfo = new ObjectMapper().readValue(json, UserInfo.class);
+
+        assertThat(userInfo.getSub()).isEqualTo("user-1");
+    }
+}

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -13,6 +13,30 @@
     <description>Java SDK for the Idenplane Identity and Access Management Server</description>
     <url>https://github.com/idenplane/idenplane</url>
 
+    <!-- Client SDK license, distinct from the AGPL-3.0-or-later server this SDK talks to —
+         matches the convention already used for the Android/npm SDK packages, since forcing
+         AGPL's copyleft onto every downstream consumer of a client library would make it
+         unusable in most commercial contexts. Required by Maven Central for POM validation. -->
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Idenplane</name>
+            <url>https://github.com/idenplane</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <url>https://github.com/idenplane/idenplane</url>
+        <connection>scm:git:https://github.com/idenplane/idenplane.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/idenplane/idenplane.git</developerConnection>
+    </scm>
+
     <modules>
         <module>idenplane-java-core</module>
         <module>idenplane-java-reactive</module>
@@ -84,6 +108,13 @@
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
                 <version>3.7.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.projectreactor</groupId>
+                <artifactId>reactor-test</artifactId>
+                <version>3.7.3</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Spring Security — bumped from 6.2.2 to 6.5.7 to address two
@@ -195,6 +226,53 @@
                             </goals>
                         </execution>
                     </executions>
+                </plugin>
+
+                <!-- Real Maven Central publishing via the Central Portal (the old OSSRH Nexus
+                     host is retired). Declared here in pluginManagement only — not every module
+                     activates these, only idenplane-java-core does today, since it's the only
+                     module with real source to publish. Credentials and the GPG key are never
+                     hardcoded: central-publishing-maven-plugin reads settings.xml server
+                     credentials (populated from env vars by actions/setup-java in CI), and
+                     maven-gpg-plugin reads the MAVEN_GPG_PASSPHRASE env var directly (the
+                     modern, non-interactive way — see MGPG-105/MGPG-108). Running `mvn verify`
+                     locally with no such setup fails safely at the signing step with no GPG key
+                     available; it does not silently publish or fall back to anything. -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.2.8</version>
+                    <configuration>
+                        <!-- Disables gpg-agent interactive prompts; the passphrase comes from
+                             the MAVEN_GPG_PASSPHRASE environment variable instead. -->
+                        <useAgent>false</useAgent>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>sign-artifacts</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.11.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <publishingServerId>central</publishingServerId>
+                        <deploymentName>idenplane-java-core</deploymentName>
+                        <!-- Default is false; stated explicitly since it's the property that
+                             makes `mvn deploy` land as a reviewable, still-reversible "validated"
+                             deployment in the Central Portal instead of auto-releasing it. Actual
+                             release is then a separate, explicit action in the Portal UI (or a
+                             deliberate autoPublish=true override), never a side effect of deploy. -->
+                        <autoPublish>false</autoPublish>
+                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
## Summary
`idenplane-java-core` had only data model classes (`TokenClaims`, `TokenResponse`, `UserInfo`, `OpenIDConfiguration`) and zero tests — in fact the multi-module reactor couldn't even resolve its own POMs (`idenplane-java-reactive` referenced `reactor-test` with no version pinned anywhere), so nothing had ever actually compiled or run this module, not CI, not a local machine.

- Adds `IdenplaneClient`: OIDC discovery (cached), JWKS-backed RS256 token validation, Authorization Code + PKCE flow (`PkceUtil`), token refresh, userinfo, and logout URL building.
- Validation logic (issuer format, claim shapes, RS256-only) matches this repo's own `auth.service.ts`/`jwk.service.ts` server behavior, confirmed via direct investigation rather than generic OIDC-spec assumptions.
- **Security-relevant details verified, not assumed:**
  - JWS algorithm is pinned to RS256 explicitly — `RSASSAVerifier` alone would happily accept a validly-signed RS384/PS256/etc token.
  - An unresolvable JWKS `kid` raises `TokenValidationException` (bad caller input → should map to 401), not `IdenplaneClientException` (infra failure → 500) — and the miss-triggered JWKS refresh is rate-limited so a caller can't force unlimited outbound requests to the realm's own JWKS endpoint by presenting many distinct bogus kids.
- 48 tests: real RS256 round-trips via minted JWTs (valid, expired, wrong issuer/audience/algorithm, tampered signature, key rotation), the RFC 7636 Appendix B PKCE test vector, and a live local HTTP server exercising the actual Apache HttpClient 5 transport (not mocked).
- Fixed two pre-existing bugs found along the way: the missing `reactor-test` version (blocked the whole reactor from resolving), and a rebrand-mangled identifier `tokenEndpointIdenplanethodsSupported` (the "AuthMe → Idenplane" rebrand find/replace corrupted `AuthMethodsSupported`, since it contains "AuthMe" as a substring).
- Adds a `java-sdk` CI job (none existed before this) and a **dormant** `publish-java.yml` for Maven Central via the Central Portal, gated behind a `central-publish` Maven profile so plain `mvn verify` never needs a GPG key.

## Deliberately not done in this pass
- The actual first publish. Verified the publish path works correctly (`mvn deploy -Pcentral-publish` with no credentials correctly routes through `central-publishing-maven-plugin` and fails on a real 401; sources/javadoc jars materialize) but never ran it with real credentials.
- The project is still on `1.0.0-SNAPSHOT` — unlike a release version (which lands as a reviewable "validated" Central Portal deployment), a SNAPSHOT deploys straight to the public snapshots repo with **no review stage**. Since `workflow_dispatch` skips the tag/version-match check, I added an explicit guard step that refuses to publish while the version contains `SNAPSHOT`. Bumping off SNAPSHOT is a maintainer decision, not something this PR does.
- Spring Boot starter (`idenplane-java-spring`), Jakarta EE filter (`idenplane-java-jakarta`), and the reactive module (`idenplane-java-reactive`) are still source-less scaffolds — not attempted here.
- No sample app, no Docusaurus docs page.
- One licensing note worth a maintainer decision, not something I changed unilaterally: the root `LICENSE` is AGPL-3.0-or-later, but the Android SDK's README and both SDKs' Maven Central POM metadata (this PR included) declare MIT — following the precedent already set for the Android package's publish config. Worth confirming that's intentional.

## Test plan
- [x] `mvn verify` passes locally (48 tests, jacoco 80% line-coverage gate met)
- [x] `mvn deploy -Pcentral-publish` (no credentials) fails safely on a 401 from the Central Portal, not silently succeeding or falling back
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)