### PR TITLE
chore(licensing): split server AGPL-3.0-only from MIT-licensed SDKs/clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "idenplane",
       "version": "0.3.0",
       "hasInstallScript": true,
-      "license": "AGPL-3.0-or-later",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "@apollo/server": "^5.0.0",
         "@nestjs/apollo": "^13.4.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "author": "",
   "private": true,
-  "license": "AGPL-3.0-or-later",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "build": "nest build",
     "admin:dev": "cd admin-ui && npm run dev",

--- a/packages/idenplane-android/LICENSE
+++ b/packages/idenplane-android/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Idenplane Maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/idenplane-android/README.md
+++ b/packages/idenplane-android/README.md
@@ -348,4 +348,4 @@ class AuthViewModel(private val authMe: IdenplaneClient) : ViewModel() {
 
 ## License
 
-MIT — see the root [LICENSE](../../LICENSE) file.
+MIT — see the [LICENSE](./LICENSE) file.

--- a/packages/idenplane-cli/LICENSE
+++ b/packages/idenplane-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Idenplane Maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/idenplane-cli/README.md
+++ b/packages/idenplane-cli/README.md
@@ -153,4 +153,4 @@ npm test
 
 ## License
 
-MIT. See [LICENSE](../../LICENSE).
+MIT. See [LICENSE](./LICENSE).

--- a/packages/idenplane-go/LICENSE
+++ b/packages/idenplane-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Idenplane Maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/idenplane-go/README.md
+++ b/packages/idenplane-go/README.md
@@ -200,4 +200,4 @@ go test ./...
 
 ## License
 
-MIT. See [LICENSE](../../LICENSE).
+MIT. See [LICENSE](./LICENSE).

--- a/packages/idenplane-ios/LICENSE
+++ b/packages/idenplane-ios/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Idenplane Maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/idenplane-ios/README.md
+++ b/packages/idenplane-ios/README.md
@@ -287,4 +287,4 @@ struct ContentView: View {
 
 ## License
 
-MIT — see the root [LICENSE](../../LICENSE) file.
+MIT — see the [LICENSE](./LICENSE) file.

--- a/packages/idenplane-mcp/package-lock.json
+++ b/packages/idenplane-mcp/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "idenplane-mcp",
       "version": "0.1.0",
-      "license": "AGPL-3.0-or-later",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.0",
         "zod": "^3.25.67"

--- a/packages/idenplane-mcp/package.json
+++ b/packages/idenplane-mcp/package.json
@@ -46,7 +46,7 @@
     "oidc",
     "model-context-protocol"
   ],
-  "license": "AGPL-3.0-or-later",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/idenplane/idenplane.git",

--- a/terraform-provider-idenplane/LICENSE
+++ b/terraform-provider-idenplane/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Idenplane Maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Maintainer decision (see #1325/#1326 discussion): the server/core stays AGPL-3.0, every SDK/client package is MIT.

- Root server: `AGPL-3.0-or-later` → `AGPL-3.0-only` (SPDX field only; the LICENSE file's AGPLv3 text is unchanged).
- **Real bug fixed, not just inconsistency:** `packages/idenplane-mcp` declared `AGPL-3.0-or-later` while every other npm SDK package already said MIT. Confirmed via the public npm registry it was never actually published, so nothing shipped incorrectly — caught before it could.
- `idenplane-android`, `idenplane-go`, `idenplane-cli`, `idenplane-ios`: each README already claimed MIT but linked `../../LICENSE` (the root AGPL text) with no local LICENSE file of their own. Added a local MIT LICENSE to each (matching `idenplane-python`'s existing correct pattern) and fixed the links.
- `terraform-provider-idenplane`: had no license declared anywhere at all. Added MIT as a client/integration tool under the same umbrella as the CLI/SDKs.

## Test plan
- [x] `npm install --package-lock-only` used (not hand-edited) to regenerate the two touched lockfiles' root `license` field — diffs confirmed to touch only that field, no dependency drift
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)