### PR TITLE
feat(java-sdk): add Spring Boot auto-configuration starter

### DIFF
--- a/packages/idenplane-java/idenplane-java-spring/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring/pom.xml
@@ -34,6 +34,18 @@
             <artifactId>spring-security-web</artifactId>
         </dependency>
 
+        <!-- JWT decoding/validation support for the OAuth2 Resource Server integration
+             (NimbusJwtDecoder, JwtValidators, JwtAuthenticationConverter) -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+        </dependency>
+
         <!-- Spring Boot Auto-configuration -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,6 +63,18 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test-autoconfigure</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneAudienceValidator.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneAudienceValidator.java
@@ -1,0 +1,34 @@
+package com.idenplane.sdk.spring;
+
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Validates that a JWT's {@code aud} claim contains the configured client ID.
+ *
+ * <p>{@link org.springframework.security.oauth2.jwt.JwtValidators#createDefaultWithIssuer}
+ * checks the issuer and timestamps but deliberately leaves audience validation to the
+ * application, since it's application-specific — without this, a token minted for a completely
+ * different client in the same realm would still pass.
+ */
+public class IdenplaneAudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+    private static final OAuth2Error INVALID_AUDIENCE =
+            new OAuth2Error("invalid_token", "The required audience is missing", null);
+
+    private final String clientId;
+
+    public IdenplaneAudienceValidator(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @Override
+    public OAuth2TokenValidatorResult validate(Jwt jwt) {
+        if (jwt.getAudience() != null && jwt.getAudience().contains(clientId)) {
+            return OAuth2TokenValidatorResult.success();
+        }
+        return OAuth2TokenValidatorResult.failure(INVALID_AUDIENCE);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneAuthoritiesConverter.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneAuthoritiesConverter.java
@@ -1,0 +1,65 @@
+package com.idenplane.sdk.spring;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Maps Idenplane's {@code realm_access.roles} and {@code resource_access.<clientId>.roles}
+ * claims onto Spring Security {@link GrantedAuthority} instances, so {@code @PreAuthorize} and
+ * friends can use {@code hasRole(...)}/{@code hasAuthority(...)} directly against roles issued
+ * by the realm, without every application reimplementing this claim traversal.
+ *
+ * <p>Realm roles map to {@code ROLE_<role>} (Spring's {@code hasRole(...)} convention). Client
+ * (resource) roles for the configured {@code clientId} map to {@code ROLE_<clientId>_<role>} to
+ * avoid colliding with realm roles or another client's roles of the same name.
+ */
+public class IdenplaneAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+
+    private final String clientId;
+
+    public IdenplaneAuthoritiesConverter(String clientId) {
+        this.clientId = clientId;
+    }
+
+    @Override
+    public Collection<GrantedAuthority> convert(Jwt jwt) {
+        List<GrantedAuthority> authorities = new ArrayList<>();
+
+        Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+        if (realmAccess != null) {
+            for (String role : rolesOf(realmAccess)) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+            }
+        }
+
+        Map<String, Object> resourceAccess = jwt.getClaimAsMap("resource_access");
+        if (resourceAccess != null && resourceAccess.get(clientId) instanceof Map<?, ?> clientAccess) {
+            for (String role : rolesOf(asStringObjectMap(clientAccess))) {
+                authorities.add(new SimpleGrantedAuthority("ROLE_" + clientId + "_" + role));
+            }
+        }
+
+        return authorities;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> rolesOf(Map<String, Object> accessClaim) {
+        Object roles = accessClaim.get("roles");
+        if (roles instanceof List<?> list) {
+            return (List<String>) list;
+        }
+        return List.of();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asStringObjectMap(Map<?, ?> map) {
+        return (Map<String, Object>) map;
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneAutoConfiguration.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneAutoConfiguration.java
@@ -1,0 +1,76 @@
+package com.idenplane.sdk.spring;
+
+import com.idenplane.sdk.IdenplaneClient;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+/**
+ * Auto-configures Spring Security OAuth2 Resource Server support for an Idenplane realm: a
+ * {@link JwtDecoder} (issuer + audience validated) and a {@link JwtAuthenticationConverter} that
+ * maps {@code realm_access}/{@code resource_access} roles to authorities — plus an
+ * {@link IdenplaneClient} bean for apps that need more than Bearer-token validation (the
+ * Authorization Code flow, userinfo, logout).
+ *
+ * <p>Activates once {@code idenplane.issuer-uri} is set. To use it in a resource server, just
+ * reference the {@code JwtDecoder} bean as usual:
+ *
+ * <pre>{@code
+ * http.oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+ * }</pre>
+ *
+ * Spring Security picks up the {@code JwtAuthenticationConverter} bean automatically.
+ */
+@AutoConfiguration
+@ConditionalOnClass(JwtDecoder.class)
+@ConditionalOnProperty(prefix = "idenplane", name = "issuer-uri")
+@EnableConfigurationProperties(IdenplaneProperties.class)
+public class IdenplaneAutoConfiguration {
+
+    private final IdenplaneProperties properties;
+
+    public IdenplaneAutoConfiguration(IdenplaneProperties properties) {
+        this.properties = properties;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JwtDecoder.class)
+    public JwtDecoder idenplaneJwtDecoder() {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withIssuerLocation(properties.getIssuerUri()).build();
+
+        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(properties.getIssuerUri());
+        OAuth2TokenValidator<Jwt> withAudience = new IdenplaneAudienceValidator(properties.getClientId());
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(withIssuer, withAudience));
+
+        return decoder;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(JwtAuthenticationConverter.class)
+    public JwtAuthenticationConverter idenplaneJwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(new IdenplaneAuthoritiesConverter(properties.getClientId()));
+        return converter;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(IdenplaneClient.class)
+    public IdenplaneClient idenplaneClient() {
+        IdenplaneClient.Builder builder =
+                IdenplaneClient.builder(properties.getIssuerUri(), properties.getClientId());
+        if (properties.getClientSecret() != null) {
+            builder.clientSecret(properties.getClientSecret());
+        }
+        return builder.build();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneProperties.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/main/java/com/idenplane/sdk/spring/IdenplaneProperties.java
@@ -1,0 +1,57 @@
+package com.idenplane.sdk.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for the Idenplane Spring Boot integration, bound from the
+ * {@code idenplane.*} prefix (e.g. {@code application.yml}).
+ *
+ * <pre>{@code
+ * idenplane:
+ *   issuer-uri: https://idenplane.example.com/realms/my-realm
+ *   client-id: my-spring-app
+ * }</pre>
+ */
+@ConfigurationProperties(prefix = "idenplane")
+public class IdenplaneProperties {
+
+    /**
+     * The realm issuer URL, e.g. {@code https://host/realms/my-realm}. Required — the
+     * auto-configuration in this module only activates once this is set.
+     */
+    private String issuerUri;
+
+    /**
+     * The OAuth2 client ID registered in the realm. Required for token audience validation.
+     */
+    private String clientId;
+
+    /**
+     * The client secret, for confidential clients. Public/native clients should omit this.
+     */
+    private String clientSecret;
+
+    public String getIssuerUri() {
+        return issuerUri;
+    }
+
+    public void setIssuerUri(String issuerUri) {
+        this.issuerUri = issuerUri;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/packages/idenplane-java/idenplane-java-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.idenplane.sdk.spring.IdenplaneAutoConfiguration

--- a/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplaneAudienceValidatorTest.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplaneAudienceValidatorTest.java
@@ -1,0 +1,42 @@
+package com.idenplane.sdk.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdenplaneAudienceValidatorTest {
+
+    private final IdenplaneAudienceValidator validator = new IdenplaneAudienceValidator("my-client");
+
+    @Test
+    void succeedsWhenAudienceContainsClientId() {
+        Jwt jwt = jwtWithAudience("my-client");
+
+        OAuth2TokenValidatorResult result = validator.validate(jwt);
+
+        assertThat(result.hasErrors()).isFalse();
+    }
+
+    @Test
+    void failsWhenAudienceIsDifferentClient() {
+        Jwt jwt = jwtWithAudience("some-other-client");
+
+        OAuth2TokenValidatorResult result = validator.validate(jwt);
+
+        assertThat(result.hasErrors()).isTrue();
+    }
+
+    private static Jwt jwtWithAudience(String audience) {
+        return Jwt.withTokenValue("token-value")
+                .header("alg", "RS256")
+                .subject("user-123")
+                .audience(java.util.List.of(audience))
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .build();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplaneAuthoritiesConverterTest.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplaneAuthoritiesConverterTest.java
@@ -1,0 +1,69 @@
+package com.idenplane.sdk.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdenplaneAuthoritiesConverterTest {
+
+    private static final String CLIENT_ID = "my-client";
+    private final IdenplaneAuthoritiesConverter converter = new IdenplaneAuthoritiesConverter(CLIENT_ID);
+
+    @Test
+    void mapsRealmRolesToRolePrefixedAuthorities() {
+        Jwt jwt = jwtWithClaims(Map.of("realm_access", Map.of("roles", List.of("user", "admin"))));
+
+        Collection<GrantedAuthority> authorities = converter.convert(jwt);
+
+        assertThat(authorities).extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("ROLE_user", "ROLE_admin");
+    }
+
+    @Test
+    void mapsResourceRolesForConfiguredClientOnly() {
+        Jwt jwt = jwtWithClaims(Map.of("resource_access", Map.of(
+                CLIENT_ID, Map.of("roles", List.of("manage-account")),
+                "some-other-client", Map.of("roles", List.of("should-not-appear")))));
+
+        Collection<GrantedAuthority> authorities = converter.convert(jwt);
+
+        assertThat(authorities).extracting(GrantedAuthority::getAuthority)
+                .containsExactly("ROLE_my-client_manage-account");
+    }
+
+    @Test
+    void combinesRealmAndResourceRoles() {
+        Jwt jwt = jwtWithClaims(Map.of(
+                "realm_access", Map.of("roles", List.of("user")),
+                "resource_access", Map.of(CLIENT_ID, Map.of("roles", List.of("viewer")))));
+
+        Collection<GrantedAuthority> authorities = converter.convert(jwt);
+
+        assertThat(authorities).extracting(GrantedAuthority::getAuthority)
+                .containsExactlyInAnyOrder("ROLE_user", "ROLE_my-client_viewer");
+    }
+
+    @Test
+    void returnsEmptyWhenNeitherClaimPresent() {
+        Jwt jwt = jwtWithClaims(Map.of());
+
+        assertThat(converter.convert(jwt)).isEmpty();
+    }
+
+    private static Jwt jwtWithClaims(Map<String, Object> extraClaims) {
+        Jwt.Builder builder = Jwt.withTokenValue("token-value")
+                .header("alg", "RS256")
+                .subject("user-123")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300));
+        extraClaims.forEach(builder::claim);
+        return builder.build();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplaneAutoConfigurationTest.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplaneAutoConfigurationTest.java
@@ -1,0 +1,123 @@
+package com.idenplane.sdk.spring;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class IdenplaneAutoConfigurationTest {
+
+    private static final String CLIENT_ID = "my-client";
+
+    private final ApplicationContextRunner contextRunner =
+            new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(IdenplaneAutoConfiguration.class));
+
+    @Test
+    void doesNotActivateWithoutIssuerUri() {
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(JwtDecoder.class);
+            assertThat(context).doesNotHaveBean(JwtAuthenticationConverter.class);
+            assertThat(context).doesNotHaveBean(IdenplaneClient.class);
+        });
+    }
+
+    @Test
+    void createsExpectedBeansOnceIssuerUriIsSet() throws IOException {
+        try (LocalOidcServer oidc = LocalOidcServer.start(SpringTestTokens.generate())) {
+            contextRunner
+                    .withPropertyValues("idenplane.issuer-uri=" + oidc.issuer, "idenplane.client-id=" + CLIENT_ID)
+                    .run(context -> {
+                        assertThat(context).hasSingleBean(JwtDecoder.class);
+                        assertThat(context).hasSingleBean(JwtAuthenticationConverter.class);
+                        assertThat(context).hasSingleBean(IdenplaneClient.class);
+                    });
+        }
+    }
+
+    @Test
+    void jwtDecoder_decodesAndValidatesARealToken() throws IOException {
+        SpringTestTokens tokens = SpringTestTokens.generate();
+        try (LocalOidcServer oidc = LocalOidcServer.start(tokens)) {
+            String token = tokens.sign(validClaims(oidc.issuer));
+
+            contextRunner
+                    .withPropertyValues("idenplane.issuer-uri=" + oidc.issuer, "idenplane.client-id=" + CLIENT_ID)
+                    .run(context -> {
+                        JwtDecoder decoder = context.getBean(JwtDecoder.class);
+                        Jwt jwt = decoder.decode(token);
+                        assertThat(jwt.getSubject()).isEqualTo("user-123");
+                        assertThat(jwt.getAudience()).contains(CLIENT_ID);
+                    });
+        }
+    }
+
+    @Test
+    void jwtDecoder_rejectsTokenWithWrongAudience() throws IOException {
+        SpringTestTokens tokens = SpringTestTokens.generate();
+        try (LocalOidcServer oidc = LocalOidcServer.start(tokens)) {
+            JWTClaimsSet wrongAudience = new JWTClaimsSet.Builder()
+                    .claim("iss", oidc.issuer)
+                    .claim("sub", "user-123")
+                    .claim("aud", "some-other-client")
+                    .issueTime(java.util.Date.from(Instant.now()))
+                    .expirationTime(java.util.Date.from(Instant.now().plusSeconds(300)))
+                    .build();
+            String token = tokens.sign(wrongAudience);
+
+            contextRunner
+                    .withPropertyValues("idenplane.issuer-uri=" + oidc.issuer, "idenplane.client-id=" + CLIENT_ID)
+                    .run(context -> {
+                        JwtDecoder decoder = context.getBean(JwtDecoder.class);
+                        assertThatThrownBy(() -> decoder.decode(token)).isInstanceOf(JwtValidationException.class);
+                    });
+        }
+    }
+
+    @Test
+    void existingJwtDecoderBeanIsNotOverridden() throws IOException {
+        try (LocalOidcServer oidc = LocalOidcServer.start(SpringTestTokens.generate())) {
+            contextRunner
+                    .withPropertyValues("idenplane.issuer-uri=" + oidc.issuer, "idenplane.client-id=" + CLIENT_ID)
+                    .withUserConfiguration(CustomJwtDecoderConfig.class)
+                    .run(context -> {
+                        assertThat(context).hasSingleBean(JwtDecoder.class);
+                        assertThat(context.getBean(JwtDecoder.class)).isSameAs(CustomJwtDecoderConfig.STUB);
+                    });
+        }
+    }
+
+    private static JWTClaimsSet validClaims(String issuer) {
+        return new JWTClaimsSet.Builder()
+                .claim("iss", issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .issueTime(java.util.Date.from(Instant.now()))
+                .expirationTime(java.util.Date.from(Instant.now().plusSeconds(300)))
+                .build();
+    }
+
+    @Configuration
+    static class CustomJwtDecoderConfig {
+        static final JwtDecoder STUB = token -> {
+            throw new UnsupportedOperationException("stub decoder — should never actually be invoked");
+        };
+
+        @Bean
+        JwtDecoder jwtDecoder() {
+            return STUB;
+        }
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplanePropertiesTest.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/IdenplanePropertiesTest.java
@@ -1,0 +1,20 @@
+package com.idenplane.sdk.spring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdenplanePropertiesTest {
+
+    @Test
+    void gettersAndSettersRoundTrip() {
+        IdenplaneProperties properties = new IdenplaneProperties();
+        properties.setIssuerUri("https://idenplane.test/realms/r");
+        properties.setClientId("my-client");
+        properties.setClientSecret("shh");
+
+        assertThat(properties.getIssuerUri()).isEqualTo("https://idenplane.test/realms/r");
+        assertThat(properties.getClientId()).isEqualTo("my-client");
+        assertThat(properties.getClientSecret()).isEqualTo("shh");
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/LocalOidcServer.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/LocalOidcServer.java
@@ -1,0 +1,54 @@
+package com.idenplane.sdk.spring;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A minimal real HTTP server serving an OIDC discovery document and JWKS, so
+ * {@code NimbusJwtDecoder.withIssuerLocation(...)} performs a real discovery + JWKS fetch
+ * against it rather than a mock.
+ */
+final class LocalOidcServer implements AutoCloseable {
+
+    private final HttpServer server;
+    final String issuer;
+
+    private LocalOidcServer(HttpServer server, String issuer) {
+        this.server = server;
+        this.issuer = issuer;
+    }
+
+    static LocalOidcServer start(SpringTestTokens tokens) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        String issuer = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        server.createContext("/.well-known/openid-configuration", exchange -> respond(exchange, "{"
+                + "\"issuer\":\"" + issuer + "\","
+                + "\"authorization_endpoint\":\"" + issuer + "/protocol/openid-connect/auth\","
+                + "\"token_endpoint\":\"" + issuer + "/protocol/openid-connect/token\","
+                + "\"jwks_uri\":\"" + issuer + "/protocol/openid-connect/certs\""
+                + "}"));
+        server.createContext("/protocol/openid-connect/certs", exchange -> respond(exchange, tokens.jwksJson()));
+        server.start();
+
+        return new LocalOidcServer(server, issuer);
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/SpringTestTokens.java
+++ b/packages/idenplane-java/idenplane-java-spring/src/test/java/com/idenplane/sdk/spring/SpringTestTokens.java
@@ -1,0 +1,62 @@
+package com.idenplane.sdk.spring;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+/**
+ * Mints a real RS256-signed JWT and matching JWKS, so the auto-configured
+ * {@code NimbusJwtDecoder} is exercised against actual cryptography end-to-end instead of a
+ * hand-built {@code Jwt} object.
+ */
+final class SpringTestTokens {
+
+    final RSAKey rsaJwk;
+    final String keyId;
+
+    private SpringTestTokens(RSAKey rsaJwk) {
+        this.rsaJwk = rsaJwk;
+        this.keyId = rsaJwk.getKeyID();
+    }
+
+    static SpringTestTokens generate() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair keyPair = generator.generateKeyPair();
+            RSAKey jwk = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                    .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                    .keyID(UUID.randomUUID().toString())
+                    .build();
+            return new SpringTestTokens(jwk);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    String jwksJson() {
+        return new JWKSet(rsaJwk.toPublicJWK()).toString();
+    }
+
+    String sign(JWTClaimsSet claims) {
+        try {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(keyId).build(), claims);
+            jwt.sign(new RSASSASigner(rsaJwk));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -134,11 +134,39 @@
                 <version>6.5.11</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-oauth2-jose</artifactId>
+                <version>6.5.10</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-oauth2-resource-server</artifactId>
+                <version>6.5.10</version>
+            </dependency>
+
             <!-- Spring Boot Auto-configuration -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-autoconfigure</artifactId>
                 <version>3.5.4</version>
+            </dependency>
+
+            <!-- Test support for exercising @AutoConfiguration classes via
+                 ApplicationContextRunner, without a full Spring Boot app -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test</artifactId>
+                <version>3.5.4</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test-autoconfigure</artifactId>
+                <version>3.5.4</version>
+                <scope>test</scope>
             </dependency>
 
             <!-- Spring Boot Configuration Processor -->


### PR DESCRIPTION
## Summary
Phase 1, item 1 of the maintainer-approved Java-SDK-first plan for #1326 (Spring Boot starter → Jakarta filter → reactive module → sample app → docs → tests).

`idenplane-java-spring` previously had dependencies declared but zero source files. Adds real Spring Security OAuth2 Resource Server integration:

- `IdenplaneAutoConfiguration`: activates once `idenplane.issuer-uri` is set, auto-configures a `JwtDecoder` (via Spring's own `NimbusJwtDecoder.withIssuerLocation`, so it plugs into the standard `http.oauth2ResourceServer(oauth2 -> oauth2.jwt(...))` config apps already expect), a `JwtAuthenticationConverter`, and an `IdenplaneClient` bean — each only created if the app hasn't already defined one (`@ConditionalOnMissingBean`).
- `IdenplaneAudienceValidator`: Spring's `JwtValidators.createDefaultWithIssuer` checks issuer/timestamps but deliberately leaves audience validation to the application — without this, a token minted for a different client in the same realm would still pass.
- `IdenplaneAuthoritiesConverter`: maps `realm_access`/`resource_access` role claims to `GrantedAuthority` (`ROLE_<role>` / `ROLE_<clientId>_<role>`), so `@PreAuthorize("hasRole(...)")` works against realm-issued roles out of the box.
- `IdenplaneProperties`: `idenplane.issuer-uri` / `client-id` / `client-secret`, bound via `@ConfigurationProperties`.

## Test plan
- [x] 12 tests, favoring real end-to-end coverage over hand-built objects: a live local HTTP server serves discovery + JWKS so `NimbusJwtDecoder` performs a genuine discovery+fetch+RS256-verify against a token minted with a real RSA key; a wrong-audience rejection test; a test proving `@ConditionalOnMissingBean` actually defers to a user-supplied `JwtDecoder` instead of silently overriding it.
- [x] `mvn verify` passes locally (jacoco 80% coverage gate met without needing padding tests — the integration tests already exercise nearly everything)
- [x] CI green

## Still open on #1326
Jakarta EE/Servlet filter, reactive module, sample app, Docusaurus docs — next up per the approved order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)