### PR TITLE
feat(java-sdk): add Jakarta EE Servlet + JAX-RS bearer-token filters

### DIFF
--- a/packages/idenplane-java/idenplane-java-jakarta/pom.xml
+++ b/packages/idenplane-java/idenplane-java-jakarta/pom.xml
@@ -35,6 +35,17 @@
         </dependency>
 
         <!-- Testing -->
+        <!-- jakarta.ws.rs-api is interfaces only; a real JAX-RS runtime (Jersey, RESTEasy...)
+             normally supplies the RuntimeDelegate implementation that Response.status(...)
+             needs. Consuming applications provide their own, so this stays test-scoped only —
+             it's not something this library ships or depends on at runtime. -->
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>3.1.12</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/IdenplaneAuthenticationFilter.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/IdenplaneAuthenticationFilter.java
@@ -1,0 +1,106 @@
+package com.idenplane.sdk.jakarta;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.idenplane.sdk.TokenValidationException;
+import com.idenplane.sdk.jakarta.internal.BearerTokenExtractor;
+import com.idenplane.sdk.jakarta.internal.JsonErrorBody;
+import com.idenplane.sdk.models.TokenClaims;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+/**
+ * Servlet {@link Filter} that validates the {@code Authorization: Bearer <token>} header of
+ * incoming requests against an Idenplane realm, rejecting unauthenticated/invalid requests with
+ * 401 before they reach the rest of the filter chain.
+ *
+ * <p>On success, the validated {@link TokenClaims} are exposed via
+ * {@link IdenplaneRequestAttributes#getClaims(ServletRequest)}.
+ *
+ * <p>Only {@link TokenValidationException} (bad token) becomes a 401 here — a genuine
+ * infrastructure failure ({@code IdenplaneClientException}, e.g. the realm's JWKS endpoint is
+ * unreachable) is deliberately left to propagate as an unchecked exception, so it surfaces as a
+ * 500 rather than being misreported as "your token is invalid".
+ *
+ * <p>Can be built with an already-configured {@link IdenplaneClient} (for programmatic/DI-based
+ * registration), or registered via {@code web.xml} with {@code issuer-uri}/{@code client-id}
+ * init-params, in which case {@link #init(FilterConfig)} builds the client itself.
+ */
+public class IdenplaneAuthenticationFilter implements Filter {
+
+    private static final String ISSUER_URI_PARAM = "issuer-uri";
+    private static final String CLIENT_ID_PARAM = "client-id";
+
+    private IdenplaneClient client;
+
+    /**
+     * For {@code web.xml}-based registration — {@link #init(FilterConfig)} builds the client
+     * from init-params.
+     */
+    public IdenplaneAuthenticationFilter() {
+    }
+
+    /**
+     * For programmatic registration with an already-configured client.
+     *
+     * @param client the client to validate access tokens against
+     */
+    public IdenplaneAuthenticationFilter(IdenplaneClient client) {
+        this.client = Objects.requireNonNull(client, "client is required");
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+        if (client != null) {
+            return;
+        }
+        String issuerUri = filterConfig.getInitParameter(ISSUER_URI_PARAM);
+        String clientId = filterConfig.getInitParameter(CLIENT_ID_PARAM);
+        if (issuerUri == null || clientId == null) {
+            throw new IllegalStateException(
+                    "IdenplaneAuthenticationFilter requires '" + ISSUER_URI_PARAM + "' and '"
+                            + CLIENT_ID_PARAM + "' init-params when constructed without an IdenplaneClient");
+        }
+        this.client = IdenplaneClient.builder(issuerUri, clientId).build();
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+        String token = BearerTokenExtractor.extract(httpRequest.getHeader("Authorization"));
+        if (token == null) {
+            unauthorized(httpResponse, "Missing Authorization: Bearer <token> header");
+            return;
+        }
+
+        TokenClaims claims;
+        try {
+            claims = client.validateAccessToken(token);
+        } catch (TokenValidationException e) {
+            unauthorized(httpResponse, e.getMessage());
+            return;
+        }
+
+        request.setAttribute(IdenplaneRequestAttributes.CLAIMS_ATTRIBUTE, claims);
+        chain.doFilter(request, response);
+    }
+
+    private static void unauthorized(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(JsonErrorBody.unauthorized(message));
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/IdenplaneRequestAttributes.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/IdenplaneRequestAttributes.java
@@ -1,0 +1,28 @@
+package com.idenplane.sdk.jakarta;
+
+import com.idenplane.sdk.models.TokenClaims;
+import jakarta.servlet.ServletRequest;
+
+/**
+ * Holds the request-attribute key {@link IdenplaneAuthenticationFilter} uses to expose the
+ * validated token claims to downstream servlets, and a convenience accessor.
+ */
+public final class IdenplaneRequestAttributes {
+
+    public static final String CLAIMS_ATTRIBUTE = "com.idenplane.sdk.claims";
+
+    private IdenplaneRequestAttributes() {
+    }
+
+    /**
+     * Gets the claims validated by {@link IdenplaneAuthenticationFilter} for this request.
+     *
+     * @param request the current request
+     * @return the validated claims, or {@code null} if the filter didn't run or authentication
+     *         failed
+     */
+    public static TokenClaims getClaims(ServletRequest request) {
+        Object claims = request.getAttribute(CLAIMS_ATTRIBUTE);
+        return claims instanceof TokenClaims ? (TokenClaims) claims : null;
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/internal/BearerTokenExtractor.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/internal/BearerTokenExtractor.java
@@ -1,0 +1,20 @@
+package com.idenplane.sdk.jakarta.internal;
+
+/**
+ * Shared by the Servlet and JAX-RS filters — not part of the public API.
+ */
+public final class BearerTokenExtractor {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private BearerTokenExtractor() {
+    }
+
+    public static String extract(String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            return null;
+        }
+        String token = authorizationHeader.substring(BEARER_PREFIX.length()).trim();
+        return token.isEmpty() ? null : token;
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/internal/JsonErrorBody.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/internal/JsonErrorBody.java
@@ -1,0 +1,18 @@
+package com.idenplane.sdk.jakarta.internal;
+
+/**
+ * Shared by the Servlet and JAX-RS filters — not part of the public API.
+ */
+public final class JsonErrorBody {
+
+    private JsonErrorBody() {
+    }
+
+    public static String unauthorized(String message) {
+        return "{\"error\":\"unauthorized\",\"error_description\":\"" + escape(message) + "\"}";
+    }
+
+    private static String escape(String value) {
+        return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/jaxrs/IdenplaneContainerRequestFilter.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/main/java/com/idenplane/sdk/jakarta/jaxrs/IdenplaneContainerRequestFilter.java
@@ -1,0 +1,75 @@
+package com.idenplane.sdk.jakarta.jaxrs;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.idenplane.sdk.TokenValidationException;
+import com.idenplane.sdk.jakarta.internal.BearerTokenExtractor;
+import com.idenplane.sdk.jakarta.internal.JsonErrorBody;
+import com.idenplane.sdk.models.TokenClaims;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Objects;
+
+/**
+ * JAX-RS {@link ContainerRequestFilter} that validates the {@code Authorization: Bearer <token>}
+ * header against an Idenplane realm, aborting the request with 401 if it's missing or invalid.
+ *
+ * <p>On success, the validated claims are stored as a JAX-RS request property, retrievable via
+ * {@link #getClaims(ContainerRequestContext)}.
+ *
+ * <p>Not annotated {@code @Provider} — register it explicitly (e.g.
+ * {@code ResourceConfig.register(new IdenplaneContainerRequestFilter(client))}) since it needs an
+ * {@link IdenplaneClient} instance, which a no-arg auto-discovered filter couldn't be given.
+ */
+public class IdenplaneContainerRequestFilter implements ContainerRequestFilter {
+
+    private static final String CLAIMS_PROPERTY = "com.idenplane.sdk.claims";
+
+    private final IdenplaneClient client;
+
+    public IdenplaneContainerRequestFilter(IdenplaneClient client) {
+        this.client = Objects.requireNonNull(client, "client is required");
+    }
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) {
+        String authorizationHeader = requestContext.getHeaderString(HttpHeaders.AUTHORIZATION);
+        String token = BearerTokenExtractor.extract(authorizationHeader);
+        if (token == null) {
+            abortUnauthorized(requestContext, "Missing Authorization: Bearer <token> header");
+            return;
+        }
+
+        TokenClaims claims;
+        try {
+            claims = client.validateAccessToken(token);
+        } catch (TokenValidationException e) {
+            abortUnauthorized(requestContext, e.getMessage());
+            return;
+        }
+
+        requestContext.setProperty(CLAIMS_PROPERTY, claims);
+    }
+
+    /**
+     * Gets the claims validated by this filter for the current request.
+     *
+     * @param requestContext the current request context
+     * @return the validated claims, or {@code null} if the filter didn't run or authentication
+     *         failed
+     */
+    public static TokenClaims getClaims(ContainerRequestContext requestContext) {
+        Object claims = requestContext.getProperty(CLAIMS_PROPERTY);
+        return claims instanceof TokenClaims ? (TokenClaims) claims : null;
+    }
+
+    private static void abortUnauthorized(ContainerRequestContext requestContext, String message) {
+        requestContext.abortWith(Response.status(Response.Status.UNAUTHORIZED)
+                .type(MediaType.APPLICATION_JSON)
+                .entity(JsonErrorBody.unauthorized(message))
+                .build());
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/IdenplaneAuthenticationFilterTest.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/IdenplaneAuthenticationFilterTest.java
@@ -1,0 +1,146 @@
+package com.idenplane.sdk.jakarta;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.nimbusds.jwt.JWTClaimsSet;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class IdenplaneAuthenticationFilterTest {
+
+    private static final String CLIENT_ID = "my-client";
+
+    private JakartaTestTokens tokens;
+    private LocalOidcServer oidc;
+    private IdenplaneAuthenticationFilter filter;
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private FilterChain chain;
+    private StringWriter responseBody;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tokens = JakartaTestTokens.generate();
+        oidc = LocalOidcServer.start(tokens);
+        IdenplaneClient client = IdenplaneClient.builder(oidc.issuer, CLIENT_ID).build();
+        filter = new IdenplaneAuthenticationFilter(client);
+
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        chain = mock(FilterChain.class);
+        responseBody = new StringWriter();
+        when(response.getWriter()).thenReturn(new PrintWriter(responseBody));
+    }
+
+    @AfterEach
+    void tearDown() {
+        oidc.close();
+    }
+
+    @Test
+    void rejectsRequestWithNoAuthorizationHeader() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(chain, never()).doFilter(any(), any());
+        assertThat(responseBody.toString()).contains("Missing Authorization");
+    }
+
+    @Test
+    void rejectsMalformedAuthorizationHeader() throws Exception {
+        when(request.getHeader("Authorization")).thenReturn("Basic dXNlcjpwYXNz");
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void acceptsValidTokenAndExposesClaims() throws Exception {
+        String token = tokens.sign(validClaims());
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+
+        filter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(request).setAttribute(org.mockito.ArgumentMatchers.eq(IdenplaneRequestAttributes.CLAIMS_ATTRIBUTE),
+                any());
+    }
+
+    @Test
+    void rejectsExpiredToken() throws Exception {
+        JWTClaimsSet expired = new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", "Bearer")
+                .issueTime(Date.from(Instant.now().minusSeconds(1200)))
+                .expirationTime(Date.from(Instant.now().minusSeconds(600)))
+                .build();
+        String token = tokens.sign(expired);
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        verify(chain, never()).doFilter(any(), any());
+    }
+
+    @Test
+    void initBuildsClientFromInitParamsWhenNoneProvided() throws Exception {
+        IdenplaneAuthenticationFilter webXmlFilter = new IdenplaneAuthenticationFilter();
+        FilterConfig config = mock(FilterConfig.class);
+        when(config.getInitParameter("issuer-uri")).thenReturn(oidc.issuer);
+        when(config.getInitParameter("client-id")).thenReturn(CLIENT_ID);
+
+        webXmlFilter.init(config);
+
+        String token = tokens.sign(validClaims());
+        when(request.getHeader("Authorization")).thenReturn("Bearer " + token);
+        webXmlFilter.doFilter(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void initThrowsWhenNoClientAndNoInitParams() {
+        IdenplaneAuthenticationFilter webXmlFilter = new IdenplaneAuthenticationFilter();
+        FilterConfig config = mock(FilterConfig.class);
+
+        assertThatThrownBy(() -> webXmlFilter.init(config)).isInstanceOf(IllegalStateException.class);
+    }
+
+    private JWTClaimsSet validClaims() {
+        return new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", "Bearer")
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .build();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/IdenplaneRequestAttributesTest.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/IdenplaneRequestAttributesTest.java
@@ -1,0 +1,38 @@
+package com.idenplane.sdk.jakarta;
+
+import com.idenplane.sdk.models.TokenClaims;
+import jakarta.servlet.ServletRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IdenplaneRequestAttributesTest {
+
+    @Test
+    void getClaims_returnsClaimsWhenPresent() {
+        TokenClaims claims = new TokenClaims();
+        claims.setSub("user-123");
+        ServletRequest request = mock(ServletRequest.class);
+        when(request.getAttribute(IdenplaneRequestAttributes.CLAIMS_ATTRIBUTE)).thenReturn(claims);
+
+        assertThat(IdenplaneRequestAttributes.getClaims(request)).isSameAs(claims);
+    }
+
+    @Test
+    void getClaims_returnsNullWhenAbsent() {
+        ServletRequest request = mock(ServletRequest.class);
+        when(request.getAttribute(IdenplaneRequestAttributes.CLAIMS_ATTRIBUTE)).thenReturn(null);
+
+        assertThat(IdenplaneRequestAttributes.getClaims(request)).isNull();
+    }
+
+    @Test
+    void getClaims_returnsNullWhenAttributeIsWrongType() {
+        ServletRequest request = mock(ServletRequest.class);
+        when(request.getAttribute(IdenplaneRequestAttributes.CLAIMS_ATTRIBUTE)).thenReturn("not-claims");
+
+        assertThat(IdenplaneRequestAttributes.getClaims(request)).isNull();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/JakartaTestTokens.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/JakartaTestTokens.java
@@ -1,0 +1,58 @@
+package com.idenplane.sdk.jakarta;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+/** Mints a real RS256-signed JWT and matching JWKS for tests. Public so the jaxrs test package can reuse it. */
+public final class JakartaTestTokens {
+
+    final RSAKey rsaJwk;
+    final String keyId;
+
+    private JakartaTestTokens(RSAKey rsaJwk) {
+        this.rsaJwk = rsaJwk;
+        this.keyId = rsaJwk.getKeyID();
+    }
+
+    public static JakartaTestTokens generate() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair keyPair = generator.generateKeyPair();
+            RSAKey jwk = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                    .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                    .keyID(UUID.randomUUID().toString())
+                    .build();
+            return new JakartaTestTokens(jwk);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public String jwksJson() {
+        return new JWKSet(rsaJwk.toPublicJWK()).toString();
+    }
+
+    public String sign(JWTClaimsSet claims) {
+        try {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(keyId).build(), claims);
+            jwt.sign(new RSASSASigner(rsaJwk));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/LocalOidcServer.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/LocalOidcServer.java
@@ -1,0 +1,53 @@
+package com.idenplane.sdk.jakarta;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A minimal real HTTP server serving an OIDC discovery document and JWKS, for real end-to-end
+ * validation. Public so the jaxrs test package can reuse it.
+ */
+public final class LocalOidcServer implements AutoCloseable {
+
+    private final HttpServer server;
+    public final String issuer;
+
+    private LocalOidcServer(HttpServer server, String issuer) {
+        this.server = server;
+        this.issuer = issuer;
+    }
+
+    public static LocalOidcServer start(JakartaTestTokens tokens) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        String issuer = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        server.createContext("/.well-known/openid-configuration", exchange -> respond(exchange, "{"
+                + "\"issuer\":\"" + issuer + "\","
+                + "\"authorization_endpoint\":\"" + issuer + "/protocol/openid-connect/auth\","
+                + "\"token_endpoint\":\"" + issuer + "/protocol/openid-connect/token\","
+                + "\"jwks_uri\":\"" + issuer + "/protocol/openid-connect/certs\""
+                + "}"));
+        server.createContext("/protocol/openid-connect/certs", exchange -> respond(exchange, tokens.jwksJson()));
+        server.start();
+
+        return new LocalOidcServer(server, issuer);
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/internal/BearerTokenExtractorTest.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/internal/BearerTokenExtractorTest.java
@@ -1,0 +1,34 @@
+package com.idenplane.sdk.jakarta.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BearerTokenExtractorTest {
+
+    @Test
+    void extractsTokenFromWellFormedHeader() {
+        assertThat(BearerTokenExtractor.extract("Bearer abc.def.ghi")).isEqualTo("abc.def.ghi");
+    }
+
+    @Test
+    void returnsNullForMissingHeader() {
+        assertThat(BearerTokenExtractor.extract(null)).isNull();
+    }
+
+    @Test
+    void returnsNullForNonBearerScheme() {
+        assertThat(BearerTokenExtractor.extract("Basic dXNlcjpwYXNz")).isNull();
+    }
+
+    @Test
+    void returnsNullForBearerWithNoToken() {
+        assertThat(BearerTokenExtractor.extract("Bearer ")).isNull();
+        assertThat(BearerTokenExtractor.extract("Bearer")).isNull();
+    }
+
+    @Test
+    void trimsWhitespaceAroundToken() {
+        assertThat(BearerTokenExtractor.extract("Bearer  abc.def.ghi  ")).isEqualTo("abc.def.ghi");
+    }
+}

--- a/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/jaxrs/IdenplaneContainerRequestFilterTest.java
+++ b/packages/idenplane-java/idenplane-java-jakarta/src/test/java/com/idenplane/sdk/jakarta/jaxrs/IdenplaneContainerRequestFilterTest.java
@@ -1,0 +1,111 @@
+package com.idenplane.sdk.jakarta.jaxrs;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.idenplane.sdk.jakarta.JakartaTestTokens;
+import com.idenplane.sdk.jakarta.LocalOidcServer;
+import com.nimbusds.jwt.JWTClaimsSet;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class IdenplaneContainerRequestFilterTest {
+
+    private static final String CLIENT_ID = "my-client";
+
+    private JakartaTestTokens tokens;
+    private LocalOidcServer oidc;
+    private IdenplaneContainerRequestFilter filter;
+    private ContainerRequestContext requestContext;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tokens = JakartaTestTokens.generate();
+        oidc = LocalOidcServer.start(tokens);
+
+        IdenplaneClient client = IdenplaneClient.builder(oidc.issuer, CLIENT_ID).build();
+        filter = new IdenplaneContainerRequestFilter(client);
+        requestContext = mock(ContainerRequestContext.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        oidc.close();
+    }
+
+    @Test
+    void rejectsRequestWithNoAuthorizationHeader() {
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn(null);
+
+        filter.filter(requestContext);
+
+        verify(requestContext).abortWith(argThatStatusIs(Response.Status.UNAUTHORIZED));
+        verify(requestContext, never()).setProperty(any(), any());
+    }
+
+    @Test
+    void acceptsValidTokenAndExposesClaims() {
+        String token = tokens.sign(validClaims());
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + token);
+
+        filter.filter(requestContext);
+
+        verify(requestContext, never()).abortWith(any());
+        verify(requestContext).setProperty(eq("com.idenplane.sdk.claims"), any());
+    }
+
+    @Test
+    void rejectsExpiredToken() {
+        JWTClaimsSet expired = new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", "Bearer")
+                .issueTime(Date.from(Instant.now().minusSeconds(1200)))
+                .expirationTime(Date.from(Instant.now().minusSeconds(600)))
+                .build();
+        String token = tokens.sign(expired);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION)).thenReturn("Bearer " + token);
+
+        filter.filter(requestContext);
+
+        verify(requestContext).abortWith(argThatStatusIs(Response.Status.UNAUTHORIZED));
+    }
+
+    @Test
+    void getClaims_returnsNullWhenPropertyAbsent() {
+        when(requestContext.getProperty("com.idenplane.sdk.claims")).thenReturn(null);
+
+        assertThat(IdenplaneContainerRequestFilter.getClaims(requestContext)).isNull();
+    }
+
+    private JWTClaimsSet validClaims() {
+        return new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", "Bearer")
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .build();
+    }
+
+    private static Response argThatStatusIs(Response.Status status) {
+        return org.mockito.ArgumentMatchers.argThat(
+                response -> response != null && response.getStatus() == status.getStatusCode());
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1, item 2 of the maintainer-approved Java-SDK-first plan for #1326 (Spring Boot starter ✅ → **Jakarta filter** → reactive module → sample app → docs).

`idenplane-java-jakarta` previously had dependencies declared but zero source files. Adds two filters sharing the same validation core, for apps not using Spring:

- `IdenplaneAuthenticationFilter` (`jakarta.servlet.Filter`): validates `Authorization: Bearer <token>` on incoming requests, rejects with 401 before the rest of the chain runs, exposes the validated `TokenClaims` via `IdenplaneRequestAttributes.getClaims(request)`. Buildable with an already-configured `IdenplaneClient` (programmatic/DI registration), or via `web.xml` init-params (`issuer-uri`/`client-id`).
- `IdenplaneContainerRequestFilter` (JAX-RS `ContainerRequestFilter`): same validation, for JAX-RS resources — aborts with 401 via `ContainerRequestContext.abortWith`.

Only `TokenValidationException` (bad token) becomes a 401 in either filter — a genuine `IdenplaneClientException` (e.g. the realm's JWKS endpoint is unreachable) is left to propagate as an unchecked exception, surfacing as a 500 rather than being misreported as "your token is invalid".

## Test plan
- [x] 18 tests: real RS256 tokens + a live local OIDC server back the actual validation boundary (valid/expired tokens); Mockito covers the Servlet/JAX-RS API glue.
- [x] Found along the way: `jakarta.ws.rs-api` is interfaces only — `Response.status(...)` needs a real `RuntimeDelegate`, which a consuming app's actual JAX-RS runtime supplies. Added `jersey-common` as a **test-scope-only** dependency so the JAX-RS filter test exercises real behavior instead of being skipped.
- [x] `mvn verify` passes locally (jacoco 80% coverage gate met)
- [x] CI green

## Still open on #1326
Reactive module, sample app, Docusaurus docs — next up per the approved order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)