### PR TITLE
feat(java-sdk): add Project Reactor wrapper for reactive apps

### DIFF
--- a/packages/idenplane-java/idenplane-java-reactive/src/main/java/com/idenplane/sdk/reactive/ReactiveIdenplaneClient.java
+++ b/packages/idenplane-java/idenplane-java-reactive/src/main/java/com/idenplane/sdk/reactive/ReactiveIdenplaneClient.java
@@ -1,0 +1,123 @@
+package com.idenplane.sdk.reactive;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.idenplane.sdk.models.OpenIDConfiguration;
+import com.idenplane.sdk.models.TokenClaims;
+import com.idenplane.sdk.models.TokenResponse;
+import com.idenplane.sdk.models.UserInfo;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Reactive (Project Reactor) wrapper around {@link IdenplaneClient}.
+ *
+ * <p>{@code IdenplaneClient} itself is synchronous — it uses blocking HTTP I/O internally, which
+ * would stall a WebFlux event loop thread if called directly. Every operation here that can
+ * perform I/O (including {@link #buildAuthorizationUrl} and {@link #buildLogoutUrl}, which read
+ * the cached discovery document and can trigger a blocking fetch on a cold cache) runs on
+ * {@link Schedulers#boundedElastic()} instead.
+ *
+ * <p>{@link com.idenplane.sdk.PkceUtil} is pure CPU-bound work with no I/O — use it directly,
+ * it doesn't need a reactive wrapper.
+ */
+public final class ReactiveIdenplaneClient {
+
+    private final IdenplaneClient delegate;
+    private final Scheduler scheduler;
+
+    private ReactiveIdenplaneClient(IdenplaneClient delegate, Scheduler scheduler) {
+        this.delegate = delegate;
+        this.scheduler = scheduler;
+    }
+
+    /**
+     * Wraps an existing {@link IdenplaneClient}, dispatching its blocking calls to
+     * {@link Schedulers#boundedElastic()}.
+     *
+     * @param delegate the client to wrap
+     * @return a reactive wrapper around it
+     */
+    public static ReactiveIdenplaneClient wrap(IdenplaneClient delegate) {
+        return wrap(delegate, Schedulers.boundedElastic());
+    }
+
+    /**
+     * Wraps an existing {@link IdenplaneClient}, dispatching its blocking calls to the given
+     * scheduler. Intended for tests that want a deterministic/synchronous scheduler instead of
+     * {@code boundedElastic()}.
+     *
+     * @param delegate  the client to wrap
+     * @param scheduler the scheduler to run blocking calls on
+     * @return a reactive wrapper around it
+     */
+    public static ReactiveIdenplaneClient wrap(IdenplaneClient delegate, Scheduler scheduler) {
+        Objects.requireNonNull(delegate, "delegate is required");
+        Objects.requireNonNull(scheduler, "scheduler is required");
+        return new ReactiveIdenplaneClient(delegate, scheduler);
+    }
+
+    /**
+     * @see IdenplaneClient#discover()
+     */
+    public Mono<OpenIDConfiguration> discover() {
+        return blocking(delegate::discover);
+    }
+
+    /**
+     * @see IdenplaneClient#validateIdToken(String)
+     */
+    public Mono<TokenClaims> validateIdToken(String idToken) {
+        return blocking(() -> delegate.validateIdToken(idToken));
+    }
+
+    /**
+     * @see IdenplaneClient#validateAccessToken(String)
+     */
+    public Mono<TokenClaims> validateAccessToken(String accessToken) {
+        return blocking(() -> delegate.validateAccessToken(accessToken));
+    }
+
+    /**
+     * @see IdenplaneClient#buildAuthorizationUrl(String, String, String, List)
+     */
+    public Mono<String> buildAuthorizationUrl(String redirectUri, String state, String codeChallenge,
+                                               List<String> scopes) {
+        return blocking(() -> delegate.buildAuthorizationUrl(redirectUri, state, codeChallenge, scopes));
+    }
+
+    /**
+     * @see IdenplaneClient#exchangeAuthorizationCode(String, String, String)
+     */
+    public Mono<TokenResponse> exchangeAuthorizationCode(String code, String redirectUri, String codeVerifier) {
+        return blocking(() -> delegate.exchangeAuthorizationCode(code, redirectUri, codeVerifier));
+    }
+
+    /**
+     * @see IdenplaneClient#refreshToken(String)
+     */
+    public Mono<TokenResponse> refreshToken(String refreshToken) {
+        return blocking(() -> delegate.refreshToken(refreshToken));
+    }
+
+    /**
+     * @see IdenplaneClient#getUserInfo(String)
+     */
+    public Mono<UserInfo> getUserInfo(String accessToken) {
+        return blocking(() -> delegate.getUserInfo(accessToken));
+    }
+
+    /**
+     * @see IdenplaneClient#buildLogoutUrl(String, String)
+     */
+    public Mono<String> buildLogoutUrl(String idTokenHint, String postLogoutRedirectUri) {
+        return blocking(() -> delegate.buildLogoutUrl(idTokenHint, postLogoutRedirectUri));
+    }
+
+    private <T> Mono<T> blocking(java.util.concurrent.Callable<T> call) {
+        return Mono.fromCallable(call).subscribeOn(scheduler);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-reactive/src/test/java/com/idenplane/sdk/reactive/LocalOidcServer.java
+++ b/packages/idenplane-java/idenplane-java-reactive/src/test/java/com/idenplane/sdk/reactive/LocalOidcServer.java
@@ -1,0 +1,56 @@
+package com.idenplane.sdk.reactive;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/** A minimal real HTTP server serving an OIDC discovery document, JWKS, and token endpoint. */
+final class LocalOidcServer implements AutoCloseable {
+
+    private final HttpServer server;
+    final String issuer;
+
+    private LocalOidcServer(HttpServer server, String issuer) {
+        this.server = server;
+        this.issuer = issuer;
+    }
+
+    static LocalOidcServer start(ReactiveTestTokens tokens) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        String issuer = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        server.createContext("/.well-known/openid-configuration", exchange -> respond(exchange, "{"
+                + "\"issuer\":\"" + issuer + "\","
+                + "\"authorization_endpoint\":\"" + issuer + "/protocol/openid-connect/auth\","
+                + "\"token_endpoint\":\"" + issuer + "/protocol/openid-connect/token\","
+                + "\"userinfo_endpoint\":\"" + issuer + "/protocol/openid-connect/userinfo\","
+                + "\"end_session_endpoint\":\"" + issuer + "/protocol/openid-connect/logout\","
+                + "\"jwks_uri\":\"" + issuer + "/protocol/openid-connect/certs\""
+                + "}"));
+        server.createContext("/protocol/openid-connect/certs", exchange -> respond(exchange, tokens.jwksJson()));
+        server.createContext("/protocol/openid-connect/token", exchange -> respond(exchange,
+                "{\"access_token\":\"at-123\",\"token_type\":\"Bearer\",\"expires_in\":300}"));
+        server.createContext("/protocol/openid-connect/userinfo", exchange -> respond(exchange,
+                "{\"sub\":\"user-123\",\"preferred_username\":\"ada\"}"));
+        server.start();
+
+        return new LocalOidcServer(server, issuer);
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-reactive/src/test/java/com/idenplane/sdk/reactive/ReactiveIdenplaneClientTest.java
+++ b/packages/idenplane-java/idenplane-java-reactive/src/test/java/com/idenplane/sdk/reactive/ReactiveIdenplaneClientTest.java
@@ -1,0 +1,151 @@
+package com.idenplane.sdk.reactive;
+
+import com.idenplane.sdk.IdenplaneClient;
+import com.idenplane.sdk.TokenValidationException;
+import com.idenplane.sdk.models.TokenClaims;
+import com.idenplane.sdk.models.TokenResponse;
+import com.idenplane.sdk.models.UserInfo;
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReactiveIdenplaneClientTest {
+
+    private static final String CLIENT_ID = "my-client";
+
+    private ReactiveTestTokens tokens;
+    private LocalOidcServer oidc;
+    private ReactiveIdenplaneClient reactiveClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tokens = ReactiveTestTokens.generate();
+        oidc = LocalOidcServer.start(tokens);
+        IdenplaneClient client = IdenplaneClient.builder(oidc.issuer, CLIENT_ID).build();
+        // Schedulers.immediate() runs "blocking" calls synchronously on the test thread, so
+        // StepVerifier assertions don't need to deal with cross-thread timing — this still
+        // exercises the Mono.fromCallable wrapping and error-propagation logic for real.
+        reactiveClient = ReactiveIdenplaneClient.wrap(client, Schedulers.immediate());
+    }
+
+    @AfterEach
+    void tearDown() {
+        oidc.close();
+    }
+
+    @Test
+    void discover_emitsConfiguration() {
+        StepVerifier.create(reactiveClient.discover())
+                .assertNext(config -> assertThat(config.getIssuer()).isEqualTo(oidc.issuer))
+                .verifyComplete();
+    }
+
+    @Test
+    void validateAccessToken_emitsClaimsForValidToken() {
+        String token = tokens.sign(validClaims("Bearer"));
+
+        StepVerifier.create(reactiveClient.validateAccessToken(token))
+                .assertNext(claims -> assertThat(claims.getSub()).isEqualTo("user-123"))
+                .verifyComplete();
+    }
+
+    @Test
+    void validateAccessToken_propagatesValidationErrorForExpiredToken() {
+        JWTClaimsSet expired = new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", "Bearer")
+                .issueTime(Date.from(Instant.now().minusSeconds(1200)))
+                .expirationTime(Date.from(Instant.now().minusSeconds(600)))
+                .build();
+        String token = tokens.sign(expired);
+
+        StepVerifier.create(reactiveClient.validateAccessToken(token))
+                .expectError(TokenValidationException.class)
+                .verify();
+    }
+
+    @Test
+    void validateIdToken_emitsClaimsForValidToken() {
+        String token = tokens.sign(validClaims("ID"));
+
+        StepVerifier.create(reactiveClient.validateIdToken(token))
+                .assertNext(claims -> assertThat(claims.getTyp()).isEqualTo("ID"))
+                .verifyComplete();
+    }
+
+    @Test
+    void exchangeAuthorizationCode_emitsTokenResponse() {
+        StepVerifier.create(reactiveClient.exchangeAuthorizationCode("code", "https://app.example.com/cb", "verifier"))
+                .assertNext((TokenResponse response) -> assertThat(response.getAccessToken()).isEqualTo("at-123"))
+                .verifyComplete();
+    }
+
+    @Test
+    void refreshToken_emitsTokenResponse() {
+        StepVerifier.create(reactiveClient.refreshToken("old-refresh-token"))
+                .assertNext((TokenResponse response) -> assertThat(response.getAccessToken()).isEqualTo("at-123"))
+                .verifyComplete();
+    }
+
+    @Test
+    void getUserInfo_emitsUserInfo() {
+        StepVerifier.create(reactiveClient.getUserInfo("some-access-token"))
+                .assertNext((UserInfo info) -> assertThat(info.getPreferredUsername()).isEqualTo("ada"))
+                .verifyComplete();
+    }
+
+    @Test
+    void buildAuthorizationUrl_emitsUrlContainingExpectedParams() {
+        StepVerifier.create(reactiveClient.buildAuthorizationUrl(
+                        "https://app.example.com/cb", "state-1", "challenge-1", List.of()))
+                .assertNext(url -> {
+                    assertThat(url).contains("response_type=code");
+                    assertThat(url).contains("client_id=" + CLIENT_ID);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void buildLogoutUrl_emitsUrl() {
+        StepVerifier.create(reactiveClient.buildLogoutUrl("id-token", "https://app.example.com/bye"))
+                .assertNext(url -> assertThat(url).contains("id_token_hint=id-token"))
+                .verifyComplete();
+    }
+
+    @Test
+    void defaultWrap_runsOffTheCallingThread() throws Exception {
+        IdenplaneClient client = IdenplaneClient.builder(oidc.issuer, CLIENT_ID).build();
+        ReactiveIdenplaneClient defaultClient = ReactiveIdenplaneClient.wrap(client);
+        String callingThread = Thread.currentThread().getName();
+        AtomicReference<String> executionThread = new AtomicReference<>();
+
+        StepVerifier.create(defaultClient.discover().doOnNext(config -> executionThread.set(Thread.currentThread().getName())))
+                .expectNextCount(1)
+                .verifyComplete();
+
+        assertThat(executionThread.get()).isNotEqualTo(callingThread);
+    }
+
+    private JWTClaimsSet validClaims(String typ) {
+        return new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", typ)
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .build();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-reactive/src/test/java/com/idenplane/sdk/reactive/ReactiveTestTokens.java
+++ b/packages/idenplane-java/idenplane-java-reactive/src/test/java/com/idenplane/sdk/reactive/ReactiveTestTokens.java
@@ -1,0 +1,58 @@
+package com.idenplane.sdk.reactive;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+/** Mints a real RS256-signed JWT and matching JWKS for tests. */
+final class ReactiveTestTokens {
+
+    final RSAKey rsaJwk;
+    final String keyId;
+
+    private ReactiveTestTokens(RSAKey rsaJwk) {
+        this.rsaJwk = rsaJwk;
+        this.keyId = rsaJwk.getKeyID();
+    }
+
+    static ReactiveTestTokens generate() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair keyPair = generator.generateKeyPair();
+            RSAKey jwk = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                    .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                    .keyID(UUID.randomUUID().toString())
+                    .build();
+            return new ReactiveTestTokens(jwk);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    String jwksJson() {
+        return new JWKSet(rsaJwk.toPublicJWK()).toString();
+    }
+
+    String sign(JWTClaimsSet claims) {
+        try {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(keyId).build(), claims);
+            jwt.sign(new RSASSASigner(rsaJwk));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1, item 3 of the maintainer-approved Java-SDK-first plan for #1326 (Spring Boot starter ✅ → Jakarta filter ✅ → **reactive module** → sample app → docs).

`idenplane-java-reactive` previously had dependencies declared but zero source files. Adds `ReactiveIdenplaneClient`, a thin wrapper exposing every `IdenplaneClient` operation as a `Mono`, for WebFlux-style apps that can't call a blocking client directly from an event-loop thread.

Every method that can perform I/O — including `buildAuthorizationUrl`/`buildLogoutUrl`, which read the cached discovery document and can trigger a blocking fetch on a cold cache, not just the obviously-networked calls — runs via `Mono.fromCallable(...).subscribeOn(Schedulers.boundedElastic())`. `PkceUtil` is pure CPU-bound work with no I/O, so it's used directly rather than wrapped.

`wrap(client, Scheduler)` accepts a custom scheduler (in addition to the `wrap(client)` default using `boundedElastic()`) specifically so tests can use `Schedulers.immediate()` for deterministic `StepVerifier` assertions without giving up real behavior.

## Test plan
- [x] 10 tests: real RS256 tokens + a live local OIDC/token/userinfo server back every operation, plus one test using the actual default scheduler that asserts the emission happens off the calling thread — proving `boundedElastic()` is really wired in, not just assumed from the one-line factory method.
- [x] `mvn verify` passes locally (jacoco 80% coverage gate met)
- [x] CI green

## Still open on #1326
Sample app and Docusaurus docs — next up per the approved order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)