### PR TITLE
feat(java-sdk): add runnable Spring Boot sample app

### DIFF
--- a/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.idenplane</groupId>
+        <artifactId>idenplane-java</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>idenplane-java-spring-sample</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Idenplane Java SDK - Spring Boot Sample</name>
+    <description>Runnable Spring Boot app demonstrating idenplane-java-spring's OAuth2 Resource Server auto-configuration</description>
+
+    <!-- This module needs its own parent (idenplane-java, for reactor resolution of
+         idenplane-java-spring by source, since it isn't published to Maven Central yet) — so it
+         can't also extend spring-boot-starter-parent. Importing the Spring Boot BOM here gets
+         the same managed dependency versions without a second parent. -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.5.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!-- idenplane-java-core directly pins jackson-databind:2.22.1, which wins over
+                 spring-boot-dependencies' older jackson-databind — but that BOM's
+                 jackson-annotations/jackson-core versions (2.19.2) still win for those two
+                 artifacts since core doesn't declare them directly, leaving jackson-databind
+                 paired with mismatched sibling jars (ObjectMapper fails at class-init:
+                 "Could not initialize class ... JsonSerializeAs missing"). Pin all three
+                 together explicitly rather than relying on either BOM alone. -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.22</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.22.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.idenplane</groupId>
+            <artifactId>idenplane-java-spring</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <!-- No jacoco here deliberately: this is a runnable demo, not a library, and the parent
+         reactor's 80%-line-coverage gate doesn't make sense for illustrative wiring code. -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- spring-boot-dependencies (imported above) manages regular <dependencies>
+                     versions only, not plugin versions — that's spring-boot-starter-parent's
+                     job, which this module can't also extend (see the dependencyManagement
+                     comment above). Version pinned explicitly instead. -->
+                <version>3.5.4</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/main/java/com/idenplane/sdk/samples/spring/MeController.java
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/main/java/com/idenplane/sdk/samples/spring/MeController.java
@@ -1,0 +1,37 @@
+package com.idenplane.sdk.samples.spring;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class MeController {
+
+    @GetMapping("/public")
+    public Map<String, String> publicEndpoint() {
+        return Map.of("message", "No authentication required for this endpoint.");
+    }
+
+    /**
+     * Requires a valid access token. The subject and authorities here come straight from
+     * {@code idenplane-java-spring}'s auto-configured {@code JwtDecoder} (signature/issuer/
+     * audience validated) and {@code JwtAuthenticationConverter} (realm_access/resource_access
+     * roles mapped to {@code ROLE_...} authorities) — this controller does no OIDC work itself.
+     */
+    @GetMapping("/api/me")
+    public MeResponse me(@AuthenticationPrincipal Jwt jwt, Authentication authentication) {
+        List<String> authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+        return new MeResponse(jwt.getSubject(), authorities);
+    }
+
+    public record MeResponse(String sub, List<String> authorities) {
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/main/java/com/idenplane/sdk/samples/spring/SecurityConfig.java
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/main/java/com/idenplane/sdk/samples/spring/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.idenplane.sdk.samples.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * {@code /public} needs no authentication; everything else needs a valid access token. The
+ * {@code JwtDecoder} and {@code JwtAuthenticationConverter} beans come entirely from
+ * {@code idenplane-java-spring}'s auto-configuration — nothing OIDC-specific is configured here.
+ */
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/public").permitAll()
+                        .anyRequest().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()))
+                .csrf(csrf -> csrf.disable());
+        return http.build();
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/main/java/com/idenplane/sdk/samples/spring/SpringBootSampleApplication.java
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/main/java/com/idenplane/sdk/samples/spring/SpringBootSampleApplication.java
@@ -1,0 +1,25 @@
+package com.idenplane.sdk.samples.spring;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Runnable demo of {@code idenplane-java-spring}'s OAuth2 Resource Server auto-configuration.
+ *
+ * <p>Set {@code idenplane.issuer-uri} and {@code idenplane.client-id} (e.g. in
+ * {@code application.yml}, or as {@code IDENPLANE_ISSUER_URI}/{@code IDENPLANE_CLIENT_ID}
+ * environment variables) to point at a real realm, then:
+ *
+ * <pre>{@code
+ * mvn spring-boot:run
+ * curl http://localhost:8080/public
+ * curl -H "Authorization: Bearer <access-token>" http://localhost:8080/api/me
+ * }</pre>
+ */
+@SpringBootApplication
+public class SpringBootSampleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SpringBootSampleApplication.class, args);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/main/resources/application.yml
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+# Point these at a real Idenplane realm before running this sample — without idenplane.issuer-uri
+# set, idenplane-java-spring's auto-configuration never activates and every request to /api/me
+# will fail (no JwtDecoder bean exists).
+idenplane:
+  issuer-uri: ${IDENPLANE_ISSUER_URI:https://idenplane.example.com/realms/my-realm}
+  client-id: ${IDENPLANE_CLIENT_ID:my-spring-app}
+
+server:
+  port: 8080

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/test/java/com/idenplane/sdk/samples/spring/LocalOidcServer.java
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/test/java/com/idenplane/sdk/samples/spring/LocalOidcServer.java
@@ -1,0 +1,50 @@
+package com.idenplane.sdk.samples.spring;
+
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+/** A minimal real HTTP server serving an OIDC discovery document and JWKS. */
+final class LocalOidcServer implements AutoCloseable {
+
+    private final HttpServer server;
+    final String issuer;
+
+    private LocalOidcServer(HttpServer server, String issuer) {
+        this.server = server;
+        this.issuer = issuer;
+    }
+
+    static LocalOidcServer start(SampleTestTokens tokens) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        String issuer = "http://127.0.0.1:" + server.getAddress().getPort();
+
+        server.createContext("/.well-known/openid-configuration", exchange -> respond(exchange, "{"
+                + "\"issuer\":\"" + issuer + "\","
+                + "\"authorization_endpoint\":\"" + issuer + "/protocol/openid-connect/auth\","
+                + "\"token_endpoint\":\"" + issuer + "/protocol/openid-connect/token\","
+                + "\"jwks_uri\":\"" + issuer + "/protocol/openid-connect/certs\""
+                + "}"));
+        server.createContext("/protocol/openid-connect/certs", exchange -> respond(exchange, tokens.jwksJson()));
+        server.start();
+
+        return new LocalOidcServer(server, issuer);
+    }
+
+    private static void respond(com.sun.net.httpserver.HttpExchange exchange, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().add("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, bytes.length);
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/test/java/com/idenplane/sdk/samples/spring/SampleTestTokens.java
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/test/java/com/idenplane/sdk/samples/spring/SampleTestTokens.java
@@ -1,0 +1,58 @@
+package com.idenplane.sdk.samples.spring;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.UUID;
+
+/** Mints a real RS256-signed JWT and matching JWKS for the sample app's smoke test. */
+final class SampleTestTokens {
+
+    final RSAKey rsaJwk;
+    final String keyId;
+
+    private SampleTestTokens(RSAKey rsaJwk) {
+        this.rsaJwk = rsaJwk;
+        this.keyId = rsaJwk.getKeyID();
+    }
+
+    static SampleTestTokens generate() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            KeyPair keyPair = generator.generateKeyPair();
+            RSAKey jwk = new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
+                    .privateKey((RSAPrivateKey) keyPair.getPrivate())
+                    .keyID(UUID.randomUUID().toString())
+                    .build();
+            return new SampleTestTokens(jwk);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    String jwksJson() {
+        return new JWKSet(rsaJwk.toPublicJWK()).toString();
+    }
+
+    String sign(JWTClaimsSet claims) {
+        try {
+            SignedJWT jwt = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(keyId).build(), claims);
+            jwt.sign(new RSASSASigner(rsaJwk));
+            return jwt.serialize();
+        } catch (JOSEException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/packages/idenplane-java/idenplane-java-spring-sample/src/test/java/com/idenplane/sdk/samples/spring/SpringBootSampleApplicationTests.java
+++ b/packages/idenplane-java/idenplane-java-spring-sample/src/test/java/com/idenplane/sdk/samples/spring/SpringBootSampleApplicationTests.java
@@ -1,0 +1,97 @@
+package com.idenplane.sdk.samples.spring;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end smoke test: a real embedded servlet container, the real Spring Security filter
+ * chain, and a real local OIDC server — proving idenplane-java-spring's auto-configuration
+ * actually protects an endpoint and maps roles, not just that the app context loads.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class SpringBootSampleApplicationTests {
+
+    private static final String CLIENT_ID = "my-spring-app";
+
+    private static SampleTestTokens tokens;
+    private static LocalOidcServer oidc;
+
+    @DynamicPropertySource
+    static void idenplaneProperties(DynamicPropertyRegistry registry) throws IOException {
+        tokens = SampleTestTokens.generate();
+        oidc = LocalOidcServer.start(tokens);
+        registry.add("idenplane.issuer-uri", () -> oidc.issuer);
+        registry.add("idenplane.client-id", () -> CLIENT_ID);
+    }
+
+    @AfterAll
+    static void tearDown() {
+        oidc.close();
+    }
+
+    @LocalServerPort
+    private int port;
+
+    private final TestRestTemplate restTemplate = new TestRestTemplate();
+
+    @Test
+    void publicEndpoint_isAccessibleWithoutAuthentication() {
+        ResponseEntity<String> response = restTemplate.getForEntity(url("/public"), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void meEndpoint_rejectsRequestsWithNoToken() {
+        ResponseEntity<String> response = restTemplate.getForEntity(url("/api/me"), String.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void meEndpoint_returnsSubjectAndAuthoritiesForAValidToken() {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .claim("iss", oidc.issuer)
+                .claim("sub", "user-123")
+                .claim("aud", CLIENT_ID)
+                .claim("typ", "Bearer")
+                .claim("realm_access", Map.of("roles", List.of("user")))
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .build();
+        String token = tokens.sign(claims);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+
+        ResponseEntity<Map> response =
+                restTemplate.exchange(url("/api/me"), HttpMethod.GET, new HttpEntity<>(headers), Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("sub")).isEqualTo("user-123");
+        assertThat((List<String>) response.getBody().get("authorities")).contains("ROLE_user");
+    }
+
+    private String url(String path) {
+        return "http://localhost:" + port + path;
+    }
+}

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -42,6 +42,9 @@
         <module>idenplane-java-reactive</module>
         <module>idenplane-java-spring</module>
         <module>idenplane-java-jakarta</module>
+        <!-- A runnable demo, not a library — never published (publish-java.yml only ever
+             targets idenplane-java-core). -->
+        <module>idenplane-java-spring-sample</module>
     </modules>
 
     <properties>
@@ -82,11 +85,35 @@
                 <version>${project.version}</version>
             </dependency>
 
-            <!-- HTTP Client -->
+            <!-- HTTP Client. Bumped from 5.3 — Spring Boot 3.5.x's HttpClientAutoConfiguration
+                 unconditionally tries to build an Apache HttpClient5-based
+                 ClientHttpRequestFactoryBuilder bean whenever httpclient5 is on the classpath
+                 (regardless of whether the app actually uses RestTemplate/RestClient), and 5.3
+                 predates TlsSocketStrategy, breaking application context startup for any Spring
+                 Boot app depending on this SDK — found via idenplane-java-spring-sample's own
+                 context failing to start, not a hypothetical. -->
             <dependency>
                 <groupId>org.apache.httpcomponents.client5</groupId>
                 <artifactId>httpclient5</artifactId>
-                <version>5.3</version>
+                <version>5.6.3</version>
+            </dependency>
+
+            <!-- httpclient5's own pom.xml doesn't hardcode a httpcore5 version — it delegates
+                 to httpclient5-parent's ${httpcore.version} property (5.4.3 for httpclient5
+                 5.6.3). Without pinning this explicitly, it resolves to whatever version wins
+                 dependency mediation elsewhere (here, an older 5.3.4 via Spring Boot's own BOM),
+                 which is missing APIs httpclient5 5.6.3 actually calls at runtime
+                 (NoSuchMethodError on MessageSupport.parseHeaders). -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>5.4.3</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>5.4.3</version>
             </dependency>
 
             <!-- JSON Processing -->


### PR DESCRIPTION
## Summary
Phase 1, item 4 of the maintainer-approved Java-SDK-first plan for #1326 (Spring Boot starter ✅ → Jakarta filter ✅ → reactive module ✅ → **sample app** → docs).

`idenplane-java-spring-sample` is a new reactor module (not published — `publish-java.yml` only ever targets `idenplane-java-core`) demonstrating `idenplane-java-spring`'s auto-configuration end-to-end: a `/public` endpoint open to everyone and a `/api/me` endpoint protected by `http.oauth2ResourceServer(...)`, returning the authenticated subject and realm-role-derived authorities. It's a reactor module rather than an `examples/` entry because it depends on `idenplane-java-spring` by source — that artifact isn't published to Maven Central yet.

## Two real bugs found and fixed (not sample-specific workarounds)
Getting this to actually run surfaced two latent dependency conflicts in the shared parent `pom.xml`:

- `httpclient5` was pinned to 5.3, which predates `TlsSocketStrategy`. Spring Boot 3.5.x's `HttpClientAutoConfiguration` unconditionally tries to build an Apache-HttpClient5-backed factory bean whenever httpclient5 is on the classpath — **regardless of whether the app ever uses `RestTemplate`/`RestClient`** — so this broke the sample's application context from starting at all, not just its tests. Bumped to 5.6.3.
- httpclient5 doesn't hardcode its own `httpcore5` version (delegates to `httpclient5-parent`'s BOM, not imported here), so `httpcore5` resolved to 5.3.4 via Spring Boot's own BOM instead — missing an API httpclient5 5.6.3 calls at runtime (`NoSuchMethodError: MessageSupport.parseHeaders`). Pinned `httpcore5`/`httpcore5-h2` to 5.4.3, the version `httpclient5-parent:5.6.3` actually declares.
- Also hit (module-local only): importing `spring-boot-dependencies` into this module's own `dependencyManagement` let its `jackson-annotations`/`jackson-core` versions win over `idenplane-java-core`'s directly-pinned `jackson-databind`, pairing incompatible sibling jars. Pinned all three together in this module's own `dependencyManagement`.

All four already-verified modules (core/reactive/spring/jakarta) still pass after the shared version bumps.

## Test plan
- [x] 3 end-to-end tests: real embedded Tomcat + real Spring Security filter chain + a real local OIDC server — `/public` reachable with no auth, `/api/me` rejects with no token, `/api/me` returns the right subject and `ROLE_user` authority for a validly signed token.
- [x] `mvn verify` passes for the whole reactor
- [x] CI green

## Still open on #1326
Docusaurus docs — last item per the approved order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)