### PR TITLE
test(android): add unit tests for IdenplaneClient, TokenStorage, BiometricAuth

### DIFF
--- a/packages/idenplane-android/build.gradle.kts
+++ b/packages/idenplane-android/build.gradle.kts
@@ -83,6 +83,11 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    // com.sun.net.httpserver.HttpServer (used for this kind of real-local-server test in the
+    // plain-JVM Java SDK modules) isn't resolvable from Android's unit-test compilation
+    // classpath — MockWebServer is the standard substitute for exercising real HTTP/JSON
+    // handling in Android JVM unit tests.
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     // Plain JVM unit tests run against a stub android.jar whose methods throw
     // ("not mocked") rather than doing anything — Robolectric swaps in real
     // framework-class implementations (needed here for android.util.Base64).

--- a/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/BiometricAuth.kt
+++ b/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/BiometricAuth.kt
@@ -22,7 +22,18 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  * val token = client.getAccessToken()
  * ```
  */
-class BiometricAuth(private val activity: FragmentActivity) {
+class BiometricAuth internal constructor(
+    private val activity: FragmentActivity,
+    private val biometricManager: BiometricManager,
+) {
+
+    /**
+     * Public constructor — builds the real [BiometricManager] for [activity]. The two-arg
+     * primary constructor above is `internal` purely so tests can inject a mocked
+     * [BiometricManager], since there's no Robolectric shadow for it to drive real
+     * hardware/enrollment states from a JVM unit test.
+     */
+    constructor(activity: FragmentActivity) : this(activity, BiometricManager.from(activity))
 
     // -----------------------------------------------------------------------
     // Availability
@@ -33,12 +44,9 @@ class BiometricAuth(private val activity: FragmentActivity) {
      * user has enrolled at least one biometric credential.
      */
     val isBiometricAvailable: Boolean
-        get() {
-            val manager = BiometricManager.from(activity)
-            return manager.canAuthenticate(
-                Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK
-            ) == BiometricManager.BIOMETRIC_SUCCESS
-        }
+        get() = biometricManager.canAuthenticate(
+            Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK
+        ) == BiometricManager.BIOMETRIC_SUCCESS
 
     /**
      * Returns a human-readable description of the biometric type available,
@@ -46,13 +54,22 @@ class BiometricAuth(private val activity: FragmentActivity) {
      */
     fun getBiometricType(context: Context): String? {
         val manager = BiometricManager.from(context)
-        return when (manager.canAuthenticate(Authenticators.BIOMETRIC_STRONG)) {
-            BiometricManager.BIOMETRIC_SUCCESS -> "Strong biometrics (fingerprint / face / iris)"
-            else -> when (manager.canAuthenticate(Authenticators.BIOMETRIC_WEAK)) {
-                BiometricManager.BIOMETRIC_SUCCESS -> "Weak biometrics"
-                else -> null
+        return describeBiometricType(
+            strongResult = manager.canAuthenticate(Authenticators.BIOMETRIC_STRONG),
+            weakResult = manager.canAuthenticate(Authenticators.BIOMETRIC_WEAK),
+        )
+    }
+
+    companion object {
+        /** Extracted so this mapping is unit-testable without needing a real BiometricManager. */
+        internal fun describeBiometricType(strongResult: Int, weakResult: Int): String? =
+            when (strongResult) {
+                BiometricManager.BIOMETRIC_SUCCESS -> "Strong biometrics (fingerprint / face / iris)"
+                else -> when (weakResult) {
+                    BiometricManager.BIOMETRIC_SUCCESS -> "Weak biometrics"
+                    else -> null
+                }
             }
-        }
     }
 
     // -----------------------------------------------------------------------

--- a/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/IdenplaneClient.kt
+++ b/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/IdenplaneClient.kt
@@ -43,16 +43,25 @@ import java.util.Base64
  * authMe.handleRedirectIntent(intent)
  * ```
  */
-class IdenplaneClient(
+class IdenplaneClient internal constructor(
     private val context: Context,
     private val config: AuthConfig,
+    private val storage: TokenStorage,
 ) {
+
+    /**
+     * Public constructor — builds the real AndroidKeyStore-backed [TokenStorage]. The
+     * three-arg primary constructor above is `internal` so tests can inject a plain
+     * (non-encrypted) [TokenStorage] instead, since AndroidKeyStore has no Robolectric shadow
+     * and cannot run outside a real device/emulator.
+     */
+    constructor(context: Context, config: AuthConfig) :
+        this(context, config, TokenStorage(context, config.realm, config.clientId))
 
     // -----------------------------------------------------------------------
     // Internal state
     // -----------------------------------------------------------------------
 
-    private val storage     = TokenStorage(context, config.realm, config.clientId)
     private val json        = Json { ignoreUnknownKeys = true }
     private val scope       = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     @Volatile private var oidcConfig  : OIDCConfiguration? = null

--- a/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/TokenStorage.kt
+++ b/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/TokenStorage.kt
@@ -12,7 +12,10 @@ import androidx.security.crypto.MasterKey
  * Android Keystore. The preference file is scoped to the realm + clientId
  * combination so multiple Idenplane realms can coexist without key collisions.
  */
-internal class TokenStorage(context: Context, realm: String, clientId: String) {
+internal class TokenStorage(private val prefs: SharedPreferences) {
+
+    constructor(context: Context, realm: String, clientId: String) :
+        this(createEncryptedPreferences(context, realm, clientId))
 
     // -----------------------------------------------------------------------
     // Keys
@@ -26,26 +29,34 @@ internal class TokenStorage(context: Context, realm: String, clientId: String) {
         const val AUTH_STATE    = "auth_state"
     }
 
-    // -----------------------------------------------------------------------
-    // Encrypted prefs
-    // -----------------------------------------------------------------------
+    companion object {
+        // AndroidKeyStore-backed crypto has no Robolectric shadow and cannot run in a plain
+        // JVM unit test — only a real device/emulator instrumentation test can exercise this
+        // factory. The primary constructor above takes a plain SharedPreferences directly so
+        // TokenStorageTest can exercise the actual field-mapping/store()/clear() logic (the part
+        // this SDK owns and that has previously had real bugs, e.g. #438-6) against a real
+        // Robolectric-backed SharedPreferences, without needing a real Keystore to do it.
+        private fun createEncryptedPreferences(
+            context: Context,
+            realm: String,
+            clientId: String,
+        ): SharedPreferences {
+            val masterKey = MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
 
-    private val prefs: SharedPreferences
+            return EncryptedSharedPreferences.create(
+                context,
+                preferencesFileName(realm, clientId),
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+            )
+        }
 
-    init {
-        val masterKey = MasterKey.Builder(context)
-            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
-            .build()
-
-        val fileName = "idenplane_${realm}_${clientId}".replace(Regex("[^a-zA-Z0-9_]"), "_")
-
-        prefs = EncryptedSharedPreferences.create(
-            context,
-            fileName,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
-        )
+        /** Extracted so the realm/clientId scoping itself is unit-testable without a Keystore. */
+        internal fun preferencesFileName(realm: String, clientId: String): String =
+            "idenplane_${realm}_${clientId}".replace(Regex("[^a-zA-Z0-9_]"), "_")
     }
 
     // -----------------------------------------------------------------------

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/BiometricAuthTest.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/BiometricAuthTest.kt
@@ -1,0 +1,89 @@
+package com.idenplane.sdk
+
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators
+import androidx.fragment.app.FragmentActivity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * [BiometricAuth.authenticate] shows a real [androidx.biometric.BiometricPrompt] dialog and
+ * suspends until the *user* interacts with it — there is no Robolectric shadow that can drive
+ * that callback the way a real device/emulator instrumentation test could, so it isn't covered
+ * here. What's covered is everything synchronous: availability checks (via a mocked
+ * [BiometricManager], since Robolectric has no shadow for it either) and the biometric-type
+ * description mapping (extracted into a pure function so it needs no BiometricManager at all).
+ */
+@RunWith(RobolectricTestRunner::class)
+class BiometricAuthTest {
+
+    private val activity: FragmentActivity =
+        Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+
+    @Test
+    fun `isBiometricAvailable is true when the manager reports success`() {
+        val manager = mock<BiometricManager> {
+            on { canAuthenticate(Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK) } doReturn
+                BiometricManager.BIOMETRIC_SUCCESS
+        }
+
+        assertTrue(BiometricAuth(activity, manager).isBiometricAvailable)
+    }
+
+    @Test
+    fun `isBiometricAvailable is false when no biometric hardware is available`() {
+        val manager = mock<BiometricManager> {
+            on { canAuthenticate(Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK) } doReturn
+                BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE
+        }
+
+        assertFalse(BiometricAuth(activity, manager).isBiometricAvailable)
+    }
+
+    @Test
+    fun `isBiometricAvailable is false when hardware exists but nothing is enrolled`() {
+        val manager = mock<BiometricManager> {
+            on { canAuthenticate(Authenticators.BIOMETRIC_STRONG or Authenticators.BIOMETRIC_WEAK) } doReturn
+                BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
+        }
+
+        assertFalse(BiometricAuth(activity, manager).isBiometricAvailable)
+    }
+
+    @Test
+    fun `describeBiometricType prefers strong over weak`() {
+        val description = BiometricAuth.describeBiometricType(
+            strongResult = BiometricManager.BIOMETRIC_SUCCESS,
+            weakResult = BiometricManager.BIOMETRIC_SUCCESS,
+        )
+
+        assertTrue(description!!.contains("Strong", ignoreCase = true))
+    }
+
+    @Test
+    fun `describeBiometricType falls back to weak when strong is unavailable`() {
+        val description = BiometricAuth.describeBiometricType(
+            strongResult = BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+            weakResult = BiometricManager.BIOMETRIC_SUCCESS,
+        )
+
+        assertTrue(description!!.contains("Weak", ignoreCase = true))
+    }
+
+    @Test
+    fun `describeBiometricType is null when neither is available`() {
+        val description = BiometricAuth.describeBiometricType(
+            strongResult = BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+            weakResult = BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE,
+        )
+
+        assertNull(description)
+    }
+}

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/IdenplaneClientTest.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/IdenplaneClientTest.kt
@@ -1,0 +1,332 @@
+package com.idenplane.sdk
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import kotlinx.coroutines.test.runTest
+import org.json.JSONObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import java.util.Base64
+
+/**
+ * Exercises [IdenplaneClient] against a real local HTTP server ([TestOidcServer]) and a real
+ * (Robolectric-backed) [TokenStorage], via the internal test-only constructor — so this covers
+ * actual discovery caching, JSON parsing, and HTTP error handling, not a mock of them.
+ *
+ * [IdenplaneClient.login] is not covered here: it launches a real Chrome Custom Tab against a
+ * [androidx.fragment.app.FragmentActivity], which needs a real device/emulator instrumentation
+ * test, not a JVM unit test.
+ */
+@RunWith(RobolectricTestRunner::class)
+class IdenplaneClientTest {
+
+    private lateinit var server: TestOidcServer
+    private lateinit var client: IdenplaneClient
+    private lateinit var storage: TokenStorage
+    private val redirectUri = "com.example.app://callback"
+
+    @Before
+    fun setUp() {
+        server = TestOidcServer()
+        val prefs = RuntimeEnvironment.getApplication()
+            .getSharedPreferences("client-test-prefs", Context.MODE_PRIVATE)
+        storage = TokenStorage(prefs)
+        val config = AuthConfig(
+            serverUrl = server.baseUrl,
+            realm = server.realm,
+            clientId = "test-client",
+            redirectUri = redirectUri,
+            autoRefresh = false,
+        )
+        client = IdenplaneClient(RuntimeEnvironment.getApplication(), config, storage)
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    // -------------------------------------------------------------------
+    // isAuthenticated / getAccessToken
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `isAuthenticated is false when no token is stored`() {
+        assertFalse(client.isAuthenticated)
+    }
+
+    @Test
+    fun `isAuthenticated is true for a non-expired token`() {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        assertTrue(client.isAuthenticated)
+    }
+
+    @Test
+    fun `isAuthenticated is false for an expired token`() {
+        storage.accessToken = fakeJwt(expiresInSeconds = -300)
+        assertFalse(client.isAuthenticated)
+    }
+
+    @Test
+    fun `getAccessToken returns null when nothing is stored`() {
+        assertNull(client.getAccessToken())
+    }
+
+    @Test
+    fun `getAccessToken returns null for an expired token`() {
+        storage.accessToken = fakeJwt(expiresInSeconds = -300)
+        assertNull(client.getAccessToken())
+    }
+
+    @Test
+    fun `getAccessToken returns the token when valid`() {
+        val token = fakeJwt(expiresInSeconds = 300)
+        storage.accessToken = token
+        assertEquals(token, client.getAccessToken())
+    }
+
+    // -------------------------------------------------------------------
+    // handleRedirectIntent
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `handleRedirectIntent returns false for an intent with no data`() = runTest {
+        assertFalse(client.handleRedirectIntent(Intent()))
+    }
+
+    @Test
+    fun `handleRedirectIntent returns false for a URI that does not match the redirect base`() = runTest {
+        val intent = Intent().apply {
+            data = Uri.parse("com.example.app://callback.evil.com?code=abc&state=xyz")
+        }
+        assertFalse(client.handleRedirectIntent(intent))
+    }
+
+    @Test
+    fun `handleRedirectIntent throws CallbackError when the callback carries an error`() = runTest {
+        val intent = Intent().apply {
+            data = Uri.parse("$redirectUri?error=access_denied&error_description=User+cancelled")
+        }
+        try {
+            client.handleRedirectIntent(intent)
+            fail("Expected CallbackError")
+        } catch (e: IdenplaneException.CallbackError) {
+            assertEquals("User cancelled", e.message)
+        }
+    }
+
+    @Test
+    fun `handleRedirectIntent throws CallbackError when the authorization code is missing`() = runTest {
+        val intent = Intent().apply { data = Uri.parse("$redirectUri?state=xyz") }
+        try {
+            client.handleRedirectIntent(intent)
+            fail("Expected CallbackError")
+        } catch (e: IdenplaneException.CallbackError) {
+            assertTrue(e.message!!.contains("Missing authorization code"))
+        }
+    }
+
+    @Test
+    fun `handleRedirectIntent throws StateMismatch when the returned state does not match`() = runTest {
+        storage.authState = "expected-state"
+        storage.pkceVerifier = "verifier"
+        val intent = Intent().apply { data = Uri.parse("$redirectUri?code=abc&state=wrong-state") }
+
+        try {
+            client.handleRedirectIntent(intent)
+            fail("Expected StateMismatch")
+        } catch (e: IdenplaneException.StateMismatch) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `handleRedirectIntent throws PkceVerifierMissing when no verifier was stored`() = runTest {
+        storage.authState = "expected-state"
+        val intent = Intent().apply { data = Uri.parse("$redirectUri?code=abc&state=expected-state") }
+
+        try {
+            client.handleRedirectIntent(intent)
+            fail("Expected PkceVerifierMissing")
+        } catch (e: IdenplaneException.PkceVerifierMissing) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `handleRedirectIntent exchanges the code and stores tokens on success`() = runTest {
+        storage.authState = "expected-state"
+        storage.pkceVerifier = "verifier-123"
+        server.tokenBody = """{"access_token":"at-new","token_type":"Bearer","expires_in":300,"refresh_token":"rt-new"}"""
+        val intent = Intent().apply { data = Uri.parse("$redirectUri?code=auth-code-1&state=expected-state") }
+
+        val handled = client.handleRedirectIntent(intent)
+
+        assertTrue(handled)
+        assertEquals("at-new", storage.accessToken)
+        assertEquals("rt-new", storage.refreshToken)
+        assertNull("PKCE verifier must be cleared after use", storage.pkceVerifier)
+        assertNull("Auth state must be cleared after use", storage.authState)
+        val requestBody = server.tokenRequestBodies.single()
+        assertTrue(requestBody.contains("code=auth-code-1"))
+        assertTrue(requestBody.contains("code_verifier=verifier-123"))
+        assertTrue(requestBody.contains("grant_type=authorization_code"))
+    }
+
+    // -------------------------------------------------------------------
+    // refreshToken
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `refreshToken throws NoRefreshToken when nothing is stored`() = runTest {
+        try {
+            client.refreshToken()
+            fail("Expected NoRefreshToken")
+        } catch (e: IdenplaneException.NoRefreshToken) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `refreshToken stores the new tokens on success`() = runTest {
+        storage.refreshToken = "old-refresh-token"
+        server.tokenBody = """{"access_token":"at-refreshed","token_type":"Bearer","expires_in":300}"""
+
+        client.refreshToken()
+
+        assertEquals("at-refreshed", storage.accessToken)
+        assertTrue(server.tokenRequestBodies.single().contains("grant_type=refresh_token"))
+    }
+
+    @Test
+    fun `refreshToken clears storage when the server rejects with invalid_grant`() = runTest {
+        storage.accessToken = "stale-access-token"
+        storage.refreshToken = "revoked-refresh-token"
+        server.tokenStatus = 400
+        server.tokenBody = """{"error":"invalid_grant","error_description":"Token is not active"}"""
+
+        try {
+            client.refreshToken()
+            fail("Expected ServerError")
+        } catch (e: IdenplaneException.ServerError) {
+            // expected
+        }
+
+        assertNull("Access token must be cleared after a definitive 4xx rejection", storage.accessToken)
+        assertNull("Refresh token must be cleared after a definitive 4xx rejection", storage.refreshToken)
+    }
+
+    @Test
+    fun `refreshToken preserves storage on a 5xx server error`() = runTest {
+        storage.accessToken = "still-valid-access-token"
+        storage.refreshToken = "still-valid-refresh-token"
+        server.tokenStatus = 500
+        server.tokenBody = """{"error":"internal_error"}"""
+
+        try {
+            client.refreshToken()
+            fail("Expected ServerError")
+        } catch (e: IdenplaneException.ServerError) {
+            // expected
+        }
+
+        assertEquals(
+            "A transient 5xx must not clear tokens that may still be valid",
+            "still-valid-access-token", storage.accessToken,
+        )
+        assertEquals("still-valid-refresh-token", storage.refreshToken)
+    }
+
+    // -------------------------------------------------------------------
+    // getUserInfo
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `getUserInfo throws NotAuthenticated without a valid access token`() = runTest {
+        try {
+            client.getUserInfo()
+            fail("Expected NotAuthenticated")
+        } catch (e: IdenplaneException.NotAuthenticated) {
+            // expected
+        }
+    }
+
+    @Test
+    fun `getUserInfo sends the bearer token and parses the response`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        server.userInfoBody = """{"sub":"user-42","preferred_username":"ada","email":"ada@example.com"}"""
+
+        val user = client.getUserInfo()
+
+        assertEquals("user-42", user.sub)
+        assertEquals("ada", user.preferredUsername)
+        assertEquals("ada@example.com", user.email)
+        assertNotNull(server.lastUserInfoAuthHeader)
+        assertTrue(server.lastUserInfoAuthHeader!!.startsWith("Bearer "))
+    }
+
+    // -------------------------------------------------------------------
+    // logout
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `logout clears storage even with no refresh token`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+
+        client.logout()
+
+        assertNull(storage.accessToken)
+    }
+
+    @Test
+    fun `logout clears storage after notifying the end-session endpoint`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        storage.refreshToken = "rt-to-revoke"
+
+        client.logout()
+
+        assertNull(storage.accessToken)
+        assertNull(storage.refreshToken)
+    }
+
+    // -------------------------------------------------------------------
+    // Discovery caching
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `discovery document is fetched once and cached across calls`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        server.userInfoBody = """{"sub":"user-1"}"""
+
+        client.getUserInfo()
+        client.getUserInfo()
+
+        assertEquals(1, server.discoveryHitCount)
+    }
+
+    // -------------------------------------------------------------------
+    // Test helpers
+    // -------------------------------------------------------------------
+
+    /** Builds an unsigned JWT with only an `exp` claim — IdenplaneClient never verifies signatures locally. */
+    private fun fakeJwt(expiresInSeconds: Long): String {
+        val header = base64Url("""{"alg":"none","typ":"JWT"}""")
+        val exp = System.currentTimeMillis() / 1000L + expiresInSeconds
+        val payload = base64Url(JSONObject().put("exp", exp).toString())
+        return "$header.$payload.sig"
+    }
+
+    private fun base64Url(json: String): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(json.toByteArray(Charsets.UTF_8))
+}

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/TestOidcServer.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/TestOidcServer.kt
@@ -1,0 +1,85 @@
+package com.idenplane.sdk
+
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+
+/**
+ * A minimal real HTTP server (via [MockWebServer]) serving OIDC discovery, token, userinfo, and
+ * end-session endpoints, so [IdenplaneClient] tests exercise its actual HTTP/JSON handling
+ * rather than a mock of it. Response status/body for the token and userinfo endpoints are
+ * mutable so a test can simulate error responses.
+ *
+ * (`com.sun.net.httpserver.HttpServer`, used for the same purpose in the plain-JVM Java SDK
+ * modules, isn't resolvable from Android's unit-test compilation classpath.)
+ */
+class TestOidcServer(val realm: String = "test-realm") : AutoCloseable {
+
+    private val server = MockWebServer()
+    val baseUrl: String
+
+    @Volatile var tokenStatus: Int = 200
+    @Volatile var tokenBody: String =
+        """{"access_token":"at-1","token_type":"Bearer","expires_in":300}"""
+
+    @Volatile var userInfoStatus: Int = 200
+    @Volatile var userInfoBody: String = """{"sub":"user-1"}"""
+
+    @Volatile var discoveryHitCount: Int = 0
+        private set
+    val tokenRequestBodies = mutableListOf<String>()
+    var lastUserInfoAuthHeader: String? = null
+        private set
+
+    init {
+        val prefix = "/realms/$realm"
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path.orEmpty().substringBefore('?')
+                return when (path) {
+                    "$prefix/.well-known/openid-configuration" -> {
+                        discoveryHitCount++
+                        jsonResponse(200, discoveryJson(prefix))
+                    }
+                    "$prefix/protocol/openid-connect/token" -> {
+                        tokenRequestBodies.add(request.body.readUtf8())
+                        jsonResponse(tokenStatus, tokenBody)
+                    }
+                    "$prefix/protocol/openid-connect/userinfo" -> {
+                        lastUserInfoAuthHeader = request.getHeader("Authorization")
+                        jsonResponse(userInfoStatus, userInfoBody)
+                    }
+                    "$prefix/protocol/openid-connect/logout" -> jsonResponse(200, "")
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+        server.start()
+        baseUrl = server.url("/").toString().trimEnd('/')
+    }
+
+    private fun discoveryJson(prefix: String): String {
+        val issuer = "$baseUrl$prefix"
+        return """
+            {
+              "issuer": "$issuer",
+              "authorization_endpoint": "$issuer/protocol/openid-connect/auth",
+              "token_endpoint": "$issuer/protocol/openid-connect/token",
+              "userinfo_endpoint": "$issuer/protocol/openid-connect/userinfo",
+              "jwks_uri": "$issuer/protocol/openid-connect/certs",
+              "end_session_endpoint": "$issuer/protocol/openid-connect/logout"
+            }
+        """.trimIndent()
+    }
+
+    private fun jsonResponse(status: Int, body: String): MockResponse =
+        MockResponse()
+            .setResponseCode(status)
+            .setHeader("Content-Type", "application/json")
+            .setBody(body)
+
+    override fun close() {
+        server.shutdown()
+    }
+}

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/TokenStorageTest.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/TokenStorageTest.kt
@@ -1,0 +1,126 @@
+package com.idenplane.sdk
+
+import android.content.Context
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+// TokenStorage's real constructor builds an AndroidKeyStore-backed EncryptedSharedPreferences,
+// which has no Robolectric shadow and cannot run in a plain JVM unit test (only a real
+// device/emulator instrumentation test can exercise that path). These tests use the
+// SharedPreferences-accepting constructor directly to exercise TokenStorage's own
+// field-mapping/store()/clear() logic — the part this SDK owns — against a real
+// Robolectric-backed SharedPreferences instead.
+@RunWith(RobolectricTestRunner::class)
+class TokenStorageTest {
+
+    private lateinit var storage: TokenStorage
+
+    @Before
+    fun setUp() {
+        val prefs = RuntimeEnvironment.getApplication()
+            .getSharedPreferences("test-prefs", Context.MODE_PRIVATE)
+        storage = TokenStorage(prefs)
+    }
+
+    @Test
+    fun `individual fields round trip through the store`() {
+        storage.accessToken = "at-1"
+        storage.refreshToken = "rt-1"
+        storage.idToken = "idt-1"
+        storage.pkceVerifier = "verifier-1"
+        storage.authState = "state-1"
+
+        assertEquals("at-1", storage.accessToken)
+        assertEquals("rt-1", storage.refreshToken)
+        assertEquals("idt-1", storage.idToken)
+        assertEquals("verifier-1", storage.pkceVerifier)
+        assertEquals("state-1", storage.authState)
+    }
+
+    @Test
+    fun `setting a field to null removes it`() {
+        storage.accessToken = "at-1"
+        storage.accessToken = null
+
+        assertNull(storage.accessToken)
+    }
+
+    @Test
+    fun `fields are absent before anything is stored`() {
+        assertNull(storage.accessToken)
+        assertNull(storage.refreshToken)
+        assertNull(storage.idToken)
+        assertNull(storage.pkceVerifier)
+        assertNull(storage.authState)
+    }
+
+    @Test
+    fun `store persists all three token fields from a token response`() {
+        // Regression test for bug #438-6: a previous version mixed Editor chaining with
+        // Kotlin's `apply` scope function, so only the first putString ever actually committed.
+        // Assert all three fields independently so a regression to that bug fails here again.
+        storage.store(
+            TokenResponse(
+                accessToken = "at-2", tokenType = "Bearer", expiresIn = 300,
+                refreshToken = "rt-2", idToken = "idt-2",
+            )
+        )
+
+        assertEquals("at-2", storage.accessToken)
+        assertEquals("rt-2", storage.refreshToken)
+        assertEquals("idt-2", storage.idToken)
+    }
+
+    @Test
+    fun `store does not clear refresh or id token when absent from the response`() {
+        storage.refreshToken = "stale-rt"
+        storage.idToken = "stale-idt"
+
+        // A refresh response commonly omits refresh_token/id_token (no rotation) — that must
+        // not erase the ones already on file.
+        storage.store(TokenResponse(accessToken = "at-3", tokenType = "Bearer", expiresIn = 300))
+
+        assertEquals("at-3", storage.accessToken)
+        assertEquals("stale-rt", storage.refreshToken)
+        assertEquals("stale-idt", storage.idToken)
+    }
+
+    @Test
+    fun `clear removes everything`() {
+        storage.accessToken = "at-4"
+        storage.refreshToken = "rt-4"
+        storage.pkceVerifier = "verifier-4"
+        storage.authState = "state-4"
+
+        storage.clear()
+
+        assertNull(storage.accessToken)
+        assertNull(storage.refreshToken)
+        assertNull(storage.idToken)
+        assertNull(storage.pkceVerifier)
+        assertNull(storage.authState)
+    }
+
+    @Test
+    fun `preferences file name is scoped to realm and clientId`() {
+        val name1 = TokenStorage.preferencesFileName("realm-a", "client-1")
+        val name2 = TokenStorage.preferencesFileName("realm-b", "client-1")
+        val name3 = TokenStorage.preferencesFileName("realm-a", "client-2")
+
+        assertNotEquals("Different realms must not share a file", name1, name2)
+        assertNotEquals("Different clientIds must not share a file", name1, name3)
+    }
+
+    @Test
+    fun `preferences file name strips characters unsafe for a filename`() {
+        val name = TokenStorage.preferencesFileName("realm/with spaces", "client:id")
+
+        assertEquals("idenplane_realm_with_spaces_client_id", name)
+    }
+}


### PR DESCRIPTION
## Summary
Phase 2, item 1 of the maintainer-approved Android plan for #1325 (tests → TokenStorage/BiometricAuth coverage → WebAuthn → Compose helpers → demo app → README).

Before this, only `PKCEHelper` had a test file — `IdenplaneClient` (530 lines, the main entry point), `TokenStorage`, and `BiometricAuth` had zero coverage. 43 tests total.

## Real testability fixes, not workarounds
Each class needed a genuine (small) refactor before it could be tested at all:

- **TokenStorage**: its real constructor builds an AndroidKeyStore-backed `EncryptedSharedPreferences`, which has no Robolectric shadow and cannot run in a plain JVM unit test. Split the constructor so the primary one takes a plain `SharedPreferences` directly (what the test uses, via Robolectric's real `SharedPreferences`), while the existing `(context, realm, clientId)` constructor still builds the real encrypted one, unchanged. Also extracted the realm/clientId filename-scoping logic into a pure, directly-testable function.
- **IdenplaneClient**: same problem one level up. Made the 3-arg `(context, config, storage)` constructor `internal` (test-only), with the existing 2-arg public constructor delegating to it — public API unchanged.
- **BiometricAuth**: made the constructor accept an injectable `BiometricManager` (internal, test-only — Robolectric has no shadow for it either), and extracted the strong/weak-availability-to-description mapping into a pure function.

## What's covered
- **TokenStorage** (8 tests): field round-trips, `store()`/`clear()`, a regression test for the already-fixed #438-6 Editor/`apply()` bug, and the file-naming scoping logic.
- **IdenplaneClient** (22 tests) against a real local HTTP server (OkHttp `MockWebServer` — `com.sun.net.httpserver.HttpServer`, used for this in the plain-JVM Java SDK modules, isn't resolvable from Android's unit-test classpath): discovery caching, the full redirect-callback flow (wrong base URI, error param, missing code, state mismatch, missing PKCE verifier, success), `refreshToken`'s 4xx-clears/5xx-preserves distinction, `getUserInfo`, `getAccessToken`/`isAuthenticated` expiry handling, and `logout`.
- **BiometricAuth** (6 tests): availability checks and the type-description mapping.

## What's explicitly not covered
`login()` (launches a real Chrome Custom Tab against a `FragmentActivity`) and `BiometricAuth.authenticate()` (shows a real `BiometricPrompt` dialog and suspends for actual user interaction) both need a real device/emulator instrumentation test, not a JVM unit test — no emulator is available in this environment. Flagging explicitly rather than claiming full coverage.

## Test plan
- [x] `./gradlew testDebugUnitTest` — 43/43 pass
- [x] `./gradlew assembleDebug assembleRelease` — still builds cleanly
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)