### PR TITLE
feat(android): add Jetpack Compose helpers and a reactive authState flow

### DIFF
--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -376,6 +376,34 @@ class AuthViewModel(private val authMe: IdenplaneClient) : ViewModel() {
 
 ---
 
+## Jetpack Compose
+
+Compose support is optional — its dependencies are `compileOnly` in the SDK, so plain View-based apps don't pull in the Compose runtime. To use it, add Compose to your own app:
+
+```kotlin
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.02.00"))
+    implementation("androidx.compose.runtime:runtime")
+}
+```
+
+```kotlin
+import com.idenplane.sdk.rememberIdenplaneClient
+import com.idenplane.sdk.collectAuthStateAsState
+
+@Composable
+fun App(config: AuthConfig) {
+    val authMe = rememberIdenplaneClient(LocalContext.current, config)
+    val isAuthenticated by authMe.collectAuthStateAsState()
+
+    if (isAuthenticated) HomeScreen() else LoginScreen(authMe)
+}
+```
+
+`rememberIdenplaneClient` scopes the client to the composition and calls `destroy()` when it leaves. `collectAuthStateAsState` reacts to login/logout/refresh outcomes — it does not poll for token expiry on its own, so still call `isAuthenticated` or `getAccessToken()` directly where up-to-the-second accuracy matters.
+
+---
+
 ## Next Steps
 
 <div style={{display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '1rem', marginTop: '2rem'}}>

--- a/packages/idenplane-android/README.md
+++ b/packages/idenplane-android/README.md
@@ -346,6 +346,32 @@ class AuthViewModel(private val authMe: IdenplaneClient) : ViewModel() {
 }
 ```
 
+## Jetpack Compose
+
+Compose support is optional — `Compose.kt`'s dependencies are `compileOnly`, so plain View-based apps don't pull in the Compose runtime. To use it, add Compose to your own app:
+
+```kotlin
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.02.00"))
+    implementation("androidx.compose.runtime:runtime")
+}
+```
+
+```kotlin
+import com.idenplane.sdk.rememberIdenplaneClient
+import com.idenplane.sdk.collectAuthStateAsState
+
+@Composable
+fun App(config: AuthConfig) {
+    val authMe = rememberIdenplaneClient(LocalContext.current, config)
+    val isAuthenticated by authMe.collectAuthStateAsState()
+
+    if (isAuthenticated) HomeScreen() else LoginScreen(authMe)
+}
+```
+
+`rememberIdenplaneClient` scopes the client to the composition and calls `destroy()` when it leaves. `collectAuthStateAsState` reacts to login/logout/refresh outcomes — see the `authState` doc comment on `IdenplaneClient` for exactly what it does and doesn't cover (it does not poll for token expiry on its own).
+
 ## License
 
 MIT — see the [LICENSE](./LICENSE) file.

--- a/packages/idenplane-android/build.gradle.kts
+++ b/packages/idenplane-android/build.gradle.kts
@@ -51,6 +51,17 @@ android {
         )
     }
 
+    buildFeatures {
+        compose = true
+    }
+
+    // 1.5.10 is the newest Compose Compiler release compatible with this module's Kotlin
+    // 1.9.22 (1.5.11+ requires Kotlin 1.9.23+) — see
+    // developer.android.com/jetpack/androidx/releases/compose-kotlin.
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
+
     // No android.publishing.singleVariant block here: com.vanniktech.maven.publish
     // registers the "release" component itself (see AndroidSingleVariantLibrary in
     // mavenPublishing below). Declaring singleVariant("release") in both places trips
@@ -79,7 +90,27 @@ dependencies {
     // Lifecycle
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
 
+    // Compose integration (Compose.kt) is optional — compileOnly so apps that don't use
+    // Compose aren't forced to pull the runtime in transitively. Apps that call
+    // rememberIdenplaneClient()/collectAuthStateAsState() must add their own Compose
+    // dependency (e.g. the Compose BOM + androidx.compose.runtime:runtime).
+    compileOnly(platform("androidx.compose:compose-bom:2024.02.00"))
+    compileOnly("androidx.compose.runtime:runtime")
+
     // Test
+    // AGP does not add a variant's compileOnly dependencies to its unit-test compile
+    // classpath — without this, compiling the test source set fails the Compose compiler's
+    // own version check (IncompatibleComposeRuntimeVersionException) because Compose.kt is
+    // part of the module being compiled but the runtime it needs isn't visible to that task.
+    testImplementation(platform("androidx.compose:compose-bom:2024.02.00"))
+    testImplementation("androidx.compose.runtime:runtime")
+    testImplementation("androidx.compose.ui:ui-test-junit4")
+    // createComposeRule() launches a ComponentActivity via ActivityScenarioRule; without this
+    // it isn't in the (Robolectric-resolved) manifest and startActivity fails with
+    // "Unable to resolve activity". debugImplementation (not testImplementation) because this
+    // works by manifest merging into the debug variant — it never reaches the published release AAR.
+    debugImplementation(platform("androidx.compose:compose-bom:2024.02.00"))
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")

--- a/packages/idenplane-android/src/debug/AndroidManifest.xml
+++ b/packages/idenplane-android/src/debug/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Debug-only manifest, never part of the published release AAR (see the release publishing
+    config in build.gradle.kts, which only publishes the "release" variant).
+
+    Declares the host activity that Compose UI testing's createComposeRule() launches via
+    ActivityScenarioRule. As a library module, this module's own manifest is what Robolectric's
+    unit tests resolve against — dependency manifests (e.g. from the debugImplementation
+    androidx.compose.ui:ui-test-manifest dependency) are only merged into a final application's
+    manifest, not into this library's own, so without this the activity lookup fails with
+    "Unable to resolve activity for Intent { ... cmp=.../androidx.activity.ComponentActivity }".
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="androidx.activity.ComponentActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/Compose.kt
+++ b/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/Compose.kt
@@ -1,0 +1,37 @@
+package com.idenplane.sdk
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+
+/**
+ * Optional Jetpack Compose integration. These APIs are compiled against the Compose runtime
+ * but it is a `compileOnly` dependency of this module — apps that don't use Compose are not
+ * forced to pull it in transitively. Apps that do call these functions must add their own
+ * `androidx.compose.runtime:runtime` dependency (or the Compose BOM).
+ */
+
+/**
+ * Creates and remembers an [IdenplaneClient] scoped to the composition, calling [IdenplaneClient.destroy]
+ * when it leaves the composition.
+ */
+@Composable
+fun rememberIdenplaneClient(context: Context, config: AuthConfig): IdenplaneClient {
+    val client = remember(context, config) { IdenplaneClient(context, config) }
+    DisposableEffect(client) {
+        onDispose { client.destroy() }
+    }
+    return client
+}
+
+/**
+ * Collects [IdenplaneClient.authState] as Compose [State], so a composable recomposes when
+ * login/logout/refresh changes the authentication state — see [IdenplaneClient.authState] for
+ * what this does and does not react to.
+ */
+@Composable
+fun IdenplaneClient.collectAuthStateAsState(): State<Boolean> =
+    authState.collectAsState()

--- a/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/IdenplaneClient.kt
+++ b/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/IdenplaneClient.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -102,6 +105,19 @@ class IdenplaneClient internal constructor(
     /** `true` if a valid (non-expired) access token is in storage. */
     val isAuthenticated: Boolean
         get() = storage.accessToken?.let { !isTokenExpired(it) } ?: false
+
+    private val _authState = MutableStateFlow(isAuthenticated)
+
+    /**
+     * Reactive view of [isAuthenticated], for UI layers that need to react to auth changes
+     * instead of polling (e.g. Compose's `collectAsState()` — see [collectAuthStateAsState]).
+     *
+     * This emits on login, logout, and refresh outcomes — it does *not* emit purely from time
+     * passing, so a token that silently expires between those events won't flip this to `false`
+     * on its own. Callers that need up-to-the-second accuracy should still consult
+     * [isAuthenticated] or [getAccessToken] directly.
+     */
+    val authState: StateFlow<Boolean> = _authState.asStateFlow()
 
     // -----------------------------------------------------------------------
     // Login
@@ -199,6 +215,7 @@ class IdenplaneClient internal constructor(
         storage.store(tokens)
         storage.pkceVerifier = null
         storage.authState    = null
+        _authState.value = true
 
         scheduleAutoRefresh()
         return true
@@ -233,6 +250,7 @@ class IdenplaneClient internal constructor(
 
         cancelAutoRefresh()
         storage.clear()
+        _authState.value = false
     }
 
     // -----------------------------------------------------------------------
@@ -301,12 +319,14 @@ class IdenplaneClient internal constructor(
             ) {
                 cancelAutoRefresh()
                 storage.clear()
+                _authState.value = false
             }
             throw e
         }
 
         val tokens = json.decodeFromString<TokenResponse>(responseBody)
         storage.store(tokens)
+        _authState.value = true
         scheduleAutoRefresh()
     }
 

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/ComposeTest.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/ComposeTest.kt
@@ -1,0 +1,159 @@
+package com.idenplane.sdk
+
+import android.content.Context
+import android.content.pm.ActivityInfo
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.junit.runners.model.Statement
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+
+/**
+ * Exercises the Compose helpers in [Compose.kt] against a real [IdenplaneClient] (backed by a
+ * real [TestOidcServer]) via Robolectric's Compose UI testing support — this is genuine
+ * composition/recomposition behavior, not a mock of it.
+ */
+@RunWith(RobolectricTestRunner::class)
+class ComposeTest {
+
+    // createComposeRule() launches androidx.activity.ComponentActivity via
+    // ActivityScenarioRule as part of the *rule's own* before(), which JUnit runs before any
+    // @Before method — so registering the activity in @Before is too late. Robolectric also
+    // resolves that launch intent against the *runtime* application package (a synthetic
+    // "org.robolectric.default" for a library module with no applicationId of its own) rather
+    // than this module's manifest package ("com.idenplane.sdk"), a mismatch tracked at
+    // https://github.com/robolectric/robolectric/pull/4736. This outer rule (lower order runs
+    // first) registers the activity under the runtime package before composeTestRule starts.
+    @get:Rule(order = 0)
+    val activityRegistrationRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                val app = RuntimeEnvironment.getApplication()
+                val activityInfo = ActivityInfo().apply {
+                    name = ComponentActivity::class.java.name
+                    packageName = app.packageName
+                    applicationInfo = app.applicationInfo
+                }
+                shadowOf(app.packageManager).addOrUpdateActivity(activityInfo)
+                base.evaluate()
+            }
+        }
+    }
+
+    @get:Rule(order = 1)
+    val composeTestRule = createComposeRule()
+
+    private lateinit var server: TestOidcServer
+    private val context: Context get() = RuntimeEnvironment.getApplication()
+
+    @Before
+    fun setUp() {
+        server = TestOidcServer()
+    }
+
+    @After
+    fun tearDown() {
+        server.close()
+    }
+
+    private fun config() = AuthConfig(
+        serverUrl = server.baseUrl,
+        realm = server.realm,
+        clientId = "compose-test-client",
+        redirectUri = "com.example.app://callback",
+        autoRefresh = false,
+    )
+
+    /**
+     * [rememberIdenplaneClient] calls the public two-arg [IdenplaneClient] constructor, which
+     * builds a real AndroidKeyStore-backed [TokenStorage] — unavailable under Robolectric (see
+     * [IdenplaneClientTest]). This composable wraps that same constructor to verify its
+     * `remember` memoization without needing a real Keystore.
+     */
+    @Composable
+    private fun rememberTestClient(config: AuthConfig): IdenplaneClient {
+        val client = remember(context, config) {
+            IdenplaneClient(context, config, TokenStorage(context.getSharedPreferences("compose-remember-test", Context.MODE_PRIVATE)))
+        }
+        DisposableEffect(client) {
+            onDispose { client.destroy() }
+        }
+        return client
+    }
+
+    @Test
+    fun `rememberIdenplaneClient-style memoization returns the same instance across recompositions with the same config`() {
+        // setContent can only be called once per test, so a second composition pass of the same
+        // content is forced by mutating a MutableState read inside it, rather than a second
+        // setContent call (which composeTestRule disallows outright).
+        val trigger = mutableIntStateOf(0)
+        val seen = mutableListOf<IdenplaneClient>()
+
+        composeTestRule.setContent {
+            trigger.intValue
+            seen += rememberTestClient(config())
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.runOnUiThread { trigger.intValue++ }
+        composeTestRule.waitForIdle()
+
+        assertEquals("expected a second recomposition to actually happen", 2, seen.size)
+        assertSame("remember(context, config) must not rebuild the client for an equal config", seen[0], seen[1])
+    }
+
+    @Test
+    fun `collectAuthStateAsState reflects the client's current authState`() {
+        val storage = TokenStorage(context.getSharedPreferences("compose-initial-state-test", Context.MODE_PRIVATE))
+        val client = IdenplaneClient(context, config(), storage)
+        lateinit var state: State<Boolean>
+
+        composeTestRule.setContent {
+            state = client.collectAuthStateAsState()
+        }
+        composeTestRule.waitForIdle()
+
+        assertFalse(state.value)
+    }
+
+    @Test
+    fun `collectAuthStateAsState recomposes when authState changes`() = runTest {
+        val storage = TokenStorage(context.getSharedPreferences("compose-test-prefs", Context.MODE_PRIVATE))
+        storage.authState = "expected-state"
+        storage.pkceVerifier = "verifier-123"
+        server.tokenBody = """{"access_token":"at-new","token_type":"Bearer","expires_in":300}"""
+        val client = IdenplaneClient(context, config(), storage)
+        lateinit var state: State<Boolean>
+
+        composeTestRule.setContent {
+            state = client.collectAuthStateAsState()
+        }
+        composeTestRule.waitForIdle()
+        assertFalse(state.value)
+
+        val intent = android.content.Intent().apply {
+            data = android.net.Uri.parse("com.example.app://callback?code=auth-code-1&state=expected-state")
+        }
+        client.handleRedirectIntent(intent)
+        composeTestRule.waitForIdle()
+
+        assertTrue(state.value)
+    }
+}

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/IdenplaneClientTest.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/IdenplaneClientTest.kt
@@ -301,6 +301,97 @@ class IdenplaneClientTest {
     }
 
     // -------------------------------------------------------------------
+    // authState
+    // -------------------------------------------------------------------
+
+    @Test
+    fun `authState starts false when no token is stored`() {
+        assertFalse(client.authState.value)
+    }
+
+    @Test
+    fun `authState starts true when a valid token is already stored`() {
+        val prefs = RuntimeEnvironment.getApplication()
+            .getSharedPreferences("client-test-prefs-preauth", Context.MODE_PRIVATE)
+        val preAuthedStorage = TokenStorage(prefs)
+        preAuthedStorage.accessToken = fakeJwt(expiresInSeconds = 300)
+        val config = AuthConfig(
+            serverUrl = server.baseUrl,
+            realm = server.realm,
+            clientId = "test-client",
+            redirectUri = redirectUri,
+            autoRefresh = false,
+        )
+        val preAuthedClient = IdenplaneClient(RuntimeEnvironment.getApplication(), config, preAuthedStorage)
+
+        assertTrue(preAuthedClient.authState.value)
+    }
+
+    @Test
+    fun `authState flips to true after a successful redirect handling`() = runTest {
+        storage.authState = "expected-state"
+        storage.pkceVerifier = "verifier-123"
+        server.tokenBody = """{"access_token":"at-new","token_type":"Bearer","expires_in":300}"""
+        val intent = Intent().apply { data = Uri.parse("$redirectUri?code=auth-code-1&state=expected-state") }
+
+        assertFalse(client.authState.value)
+        client.handleRedirectIntent(intent)
+        assertTrue(client.authState.value)
+    }
+
+    @Test
+    fun `authState flips to false after logout`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        client = IdenplaneClient(RuntimeEnvironment.getApplication(), AuthConfig(
+            serverUrl = server.baseUrl,
+            realm = server.realm,
+            clientId = "test-client",
+            redirectUri = redirectUri,
+            autoRefresh = false,
+        ), storage)
+        assertTrue(client.authState.value)
+
+        client.logout()
+
+        assertFalse(client.authState.value)
+    }
+
+    @Test
+    fun `authState flips to false when refresh is rejected with invalid_grant`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        storage.refreshToken = "revoked-refresh-token"
+        client = IdenplaneClient(RuntimeEnvironment.getApplication(), AuthConfig(
+            serverUrl = server.baseUrl,
+            realm = server.realm,
+            clientId = "test-client",
+            redirectUri = redirectUri,
+            autoRefresh = false,
+        ), storage)
+        server.tokenStatus = 400
+        server.tokenBody = """{"error":"invalid_grant","error_description":"Token is not active"}"""
+        assertTrue(client.authState.value)
+
+        try {
+            client.refreshToken()
+            fail("Expected ServerError")
+        } catch (e: IdenplaneException.ServerError) {
+            // expected
+        }
+
+        assertFalse(client.authState.value)
+    }
+
+    @Test
+    fun `authState stays true after a successful refresh`() = runTest {
+        storage.refreshToken = "old-refresh-token"
+        server.tokenBody = """{"access_token":"at-refreshed","token_type":"Bearer","expires_in":300}"""
+
+        client.refreshToken()
+
+        assertTrue(client.authState.value)
+    }
+
+    // -------------------------------------------------------------------
     // Discovery caching
     // -------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Part of #1325 Phase 2, item 3 (Jetpack Compose helpers).

- `IdenplaneClient.authState: StateFlow<Boolean>` — a reactive companion to the existing `isAuthenticated` getter, emitting on login (`handleRedirectIntent` success), logout, and refresh outcomes (success → true, 4xx rejection → false). Documented that it does *not* poll for time-based expiry on its own.
- `rememberIdenplaneClient(context, config)` and `IdenplaneClient.collectAuthStateAsState()` in a new `Compose.kt` — thin, `@Composable` wrappers.
- Compose (`androidx.compose.runtime:runtime`, BOM `2024.02.00`, compiler `1.5.10` — the newest compiler release compatible with this module's Kotlin 1.9.22) is `compileOnly` in the main variant, so apps that don't use Compose aren't affected. Verified by inspecting the generated release POM — no Compose artifact appears there.
- README section showing usage and the extra Gradle dependency consumers need to add themselves.

## Testing

52 unit tests total (was 43), all passing locally via `./gradlew testDebugUnitTest`:
- 6 new tests for `authState` transitions (initial value from existing storage, login, logout, refresh success/failure) against the existing `TestOidcServer`/Robolectric infra — no Compose involved.
- 3 new tests in `ComposeTest.kt` that actually run composition/recomposition via Robolectric's Compose UI testing support (`createComposeRule()`), not just "does it compile": `remember` memoization across a forced recomposition, initial `collectAsState()` value, and recomposition when the underlying flow changes.

Getting the Compose UI tests running for real (rather than skipping them) surfaced two real environment issues, both documented in code comments where fixed:
1. AGP doesn't add a variant's `compileOnly` deps to its unit-test compile classpath — the Compose compiler plugin (which processes this module's `@Composable` code regardless of who's testing it) failed its own runtime-version check until `testImplementation` was added alongside.
2. `createComposeRule()` launches a `ComponentActivity` via `ActivityScenarioRule`, which failed to resolve for a `com.android.library` module — Robolectric assigns library modules a synthetic `org.robolectric.default` runtime package instead of the module's own manifest package (a real Robolectric gap: robolectric/robolectric#4736). Fixed with a debug-only test manifest (`src/debug/AndroidManifest.xml`, confirmed absent from the release AAR) plus an ordered JUnit `TestRule` that registers the activity against the runtime package before `composeTestRule` starts.

Also confirmed `assembleDebug` and `assembleRelease` still succeed, and the release AAR's manifest has no test-only leakage.

## Test plan

- [x] `./gradlew testDebugUnitTest` — 52/52 passing
- [x] `./gradlew assembleDebug assembleRelease` — succeeds
- [x] Release POM inspected — no Compose dependency present
- [ ] CI green on this PR (Android SDK job)