### PR TITLE
docs(android): replace JitPack install instructions with Maven Central

### DIFF
--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -21,23 +21,15 @@ The Idenplane Android SDK provides native Kotlin bindings for the Idenplane Iden
 
 ## Installation
 
-Add JitPack to your project-level `settings.gradle.kts`:
+:::note
+This SDK isn't published to Maven Central yet. The coordinates below are what it will resolve to once released — check the [GitHub releases page](https://github.com/idenplane/idenplane/releases) before using them in a real project.
+:::
 
-```kotlin
-dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
-}
-```
-
-Add the dependency to your app or library module `build.gradle.kts`:
+`mavenCentral()` is part of the default Gradle repositories — no extra repository setup is needed:
 
 ```kotlin
 dependencies {
-    implementation("com.github.Islamawad132:Idenplane:0.3.0")
+    implementation("com.idenplane:idenplane-android:1.0.0")
 }
 ```
 

--- a/packages/idenplane-android/README.md
+++ b/packages/idenplane-android/README.md
@@ -15,25 +15,16 @@ Implements the **OAuth 2.0 Authorization Code flow with PKCE** (RFC 7636) using 
 
 ## Installation
 
+> [!NOTE]
+> This SDK isn't published to Maven Central yet. The coordinates below are what it will resolve to once released — check the [GitHub releases page](https://github.com/idenplane/idenplane/releases) before using them in a real project.
+
 ### Gradle (Kotlin DSL)
 
-Add JitPack to your project-level `settings.gradle.kts`:
-
-```kotlin
-dependencyResolutionManagement {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url = uri("https://jitpack.io") }
-    }
-}
-```
-
-Add the dependency to your app or library module `build.gradle.kts`:
+`mavenCentral()` is part of the default Gradle repositories — no extra repository setup is needed:
 
 ```kotlin
 dependencies {
-    implementation("com.github.Islamawad132:Idenplane:1.0.0")
+    implementation("com.idenplane:idenplane-android:1.0.0")
 }
 ```
 


### PR DESCRIPTION
## Summary

Part of #1325 Phase 2, item 5 (README Maven Central docs).

The Android SDK's README and Docusaurus guide both documented installing via a JitPack coordinate (`com.github.Islamawad132:Idenplane`) that predates the real `com.idenplane` Maven Central publishing setup (the `com.vanniktech.maven.publish` config already in `build.gradle.kts`). That JitPack path no longer reflects how the SDK is actually meant to be distributed.

Replaces both with the real Maven Central coordinates (`com.idenplane:idenplane-android:1.0.0`), wrapped in the same "not yet published, here's what it will resolve to" disclaimer already used in the Java SDK's guide (`docs/docs/guides/sdks/java.mdx`), pointing at the GitHub releases page. Consistent with the standing decision not to publish/tag either SDK until they hit minimum usable completeness.

Docs-only change, no code touched.

## Test plan

- [ ] CI green (docs build)