### PR TITLE
fix(mcp): poll for the audit event instead of asserting on the first read

### DIFF
--- a/packages/idenplane-mcp/tests/integration.mjs
+++ b/packages/idenplane-mcp/tests/integration.mjs
@@ -56,6 +56,22 @@ async function callTool(name, args) {
   return JSON.parse(text);
 }
 
+/**
+ * Retries `fn` while it throws, up to `attempts` times with `delayMs` between tries. For
+ * polling an intentionally-eventually-consistent read (e.g. #1372's fire-and-forget admin
+ * event writes) rather than asserting on the very next read after a write.
+ */
+async function waitFor(fn, { attempts = 5, delayMs = 300 } = {}) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= attempts) throw err;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+}
+
 describe('Idenplane MCP integration (over protocol)', { skip: await skipReason() }, () => {
   before(async () => {
     const transport = new StdioClientTransport({
@@ -167,23 +183,28 @@ describe('Idenplane MCP integration (over protocol)', { skip: await skipReason()
     it('query_audit_events returns a USER CREATE admin event via MCP tool', async () => {
       assert.ok(createdUserId, 'Requires user to be created first');
 
-      const result = await callTool('query_audit_events', {
-        realmName: TEST_REALM,
-        kind: 'admin',
-        limit: 20,
+      // AdminEventInterceptor records admin events fire-and-forget (see #1345's discussion),
+      // so the write isn't guaranteed to have landed yet immediately after create_user
+      // returns. Poll briefly instead of asserting on the very first read (#1372).
+      await waitFor(async () => {
+        const result = await callTool('query_audit_events', {
+          realmName: TEST_REALM,
+          kind: 'admin',
+          limit: 20,
+        });
+
+        const events = result.adminEvents ?? [];
+        const userCreation = events.find(
+          (e) => e.resourceType === 'USER' && e.operationType === 'CREATE',
+        );
+
+        assert.ok(
+          userCreation !== undefined,
+          `Expected USER/CREATE admin event. Got: ${JSON.stringify(
+            events.map((e) => ({ rt: e.resourceType, op: e.operationType })),
+          )}`,
+        );
       });
-
-      const events = result.adminEvents ?? [];
-      const userCreation = events.find(
-        (e) => e.resourceType === 'USER' && e.operationType === 'CREATE',
-      );
-
-      assert.ok(
-        userCreation !== undefined,
-        `Expected USER/CREATE admin event. Got: ${JSON.stringify(
-          events.map((e) => ({ rt: e.resourceType, op: e.operationType })),
-        )}`,
-      );
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1372.

`AdminEventInterceptor` records admin events via a deliberately fire-and-forget call (see #1345's discussion) — the audit-log write happens asynchronously and isn't guaranteed to have landed by the time `query_audit_events` runs immediately after `create_user`, as the integration test does with no wait in between. That's an eventual-consistency window, not a bug, so the fix is in the test: wrap the assertion in a short bounded retry (5 attempts, 300ms apart — a max of ~1.2s) instead of asserting on the very first read, per the issue's own suggested fix.

Deliberately not making the write synchronous — that would put audit-log latency on every admin request's response path, which is the tradeoff #1345 already reasoned through and rejected.

## Testing

No Docker/Postgres available in this environment, so this couldn't be run end-to-end against a live server locally. What was verified:
- `node --check` — syntax is valid.
- `node --test tests/integration.mjs` — loads correctly and self-skips cleanly (no Idenplane instance reachable), confirming the edit didn't break module loading or the existing skip-guard.

The real verification is this PR's own `SDK Integration Tests` CI job, which boots a real Postgres + backend and runs this exact suite.

## Test plan

- [ ] CI green, in particular `SDK Integration Tests` (`idenplane-mcp integration suite`)