### PR TITLE
docs(java-sdk): fix stale AGPL-3.0-or-later reference in pom.xml comment

### DIFF
--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -13,7 +13,7 @@
     <description>Java SDK for the Idenplane Identity and Access Management Server</description>
     <url>https://github.com/idenplane/idenplane</url>
 
-    <!-- Client SDK license, distinct from the AGPL-3.0-or-later server this SDK talks to —
+    <!-- Client SDK license, distinct from the AGPL-3.0-only server this SDK talks to —
          matches the convention already used for the Android/npm SDK packages, since forcing
          AGPL's copyleft onto every downstream consumer of a client library would make it
          unusable in most commercial contexts. Required by Maven Central for POM validation. -->


### PR DESCRIPTION
## Summary

One-line comment fix, found while double-checking for any lingering `AGPL-3.0-or-later` references before the eventual first release (per the standing pre-release instruction to move the server from `AGPL-3.0-or-later` to `AGPL-3.0-only`, already done for the root `package.json`).

`packages/idenplane-java/pom.xml`'s license comment (describing the *server* this SDK talks to, not the SDK's own MIT license) still said `AGPL-3.0-or-later` — stale since the root package.json was updated. No functional change; the SDK's own declared license was already correctly MIT.

## Test plan

- [ ] CI green (docs-only change, no build/test impact expected)