### PR TITLE
fix(android): implement the Custom Tab logout the doc comment promised

### DIFF
--- a/docs/docs/guides/sdks/android.mdx
+++ b/docs/docs/guides/sdks/android.mdx
@@ -263,7 +263,16 @@ if (biometric.isBiometricAvailable) {
 ```kotlin
 lifecycleScope.launch {
     authMe.logout()
-    // Tokens are cleared; server session is terminated
+    // Tokens are cleared locally and the refresh token is revoked server-side.
+    redirectToLogin()
+}
+```
+
+Passing the current `Activity` also clears the browser-side session (a silent back-channel call alone can't touch cookies set during login) — requires that a valid ID token was stored from a prior login, and opens a Custom Tab showing a blank response the user has to dismiss (deliberately not redirected back to the app, to avoid it being misread as a login callback):
+
+```kotlin
+lifecycleScope.launch {
+    authMe.logout(this@MainActivity)
     redirectToLogin()
 }
 ```

--- a/examples/android-quickstart/app/src/main/kotlin/com/idenplane/example/quickstart/MainActivity.kt
+++ b/examples/android-quickstart/app/src/main/kotlin/com/idenplane/example/quickstart/MainActivity.kt
@@ -113,7 +113,14 @@ private fun QuickstartApp(authMe: IdenplaneClient, pendingRedirect: MutableState
                         }
                     }) { Text("Verify with biometrics") }
                     Spacer(modifier = Modifier.height(8.dp))
-                    Button(onClick = { scope.launch { authMe.logout() } }) { Text("Sign out") }
+                    Button(onClick = {
+                        scope.launch {
+                            // Passing the activity also clears the browser-side session via a
+                            // Custom Tab (blank response, dismissed manually) — a no-argument
+                            // logout() only revokes the refresh token, silently.
+                            authMe.logout(activity)
+                        }
+                    }) { Text("Sign out") }
                 } else {
                     Button(onClick = {
                         scope.launch {

--- a/packages/idenplane-android/README.md
+++ b/packages/idenplane-android/README.md
@@ -242,7 +242,16 @@ if (biometric.isBiometricAvailable) {
 ```kotlin
 lifecycleScope.launch {
     authMe.logout()
-    // Tokens are cleared; server session is terminated
+    // Tokens are cleared locally and the refresh token is revoked server-side.
+    redirectToLogin()
+}
+```
+
+Passing the current `Activity` also clears the browser-side session (a silent back-channel call alone can't touch cookies set during [login](#login-flow)) — requires that a valid ID token was stored from a prior login, and opens a Custom Tab showing a blank response the user has to dismiss (deliberately not redirected back to the app, to avoid it being misread as a login callback):
+
+```kotlin
+lifecycleScope.launch {
+    authMe.logout(this@MainActivity)
     redirectToLogin()
 }
 ```

--- a/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/IdenplaneClient.kt
+++ b/packages/idenplane-android/src/main/kotlin/com/idenplane/sdk/IdenplaneClient.kt
@@ -226,16 +226,23 @@ class IdenplaneClient internal constructor(
     // -----------------------------------------------------------------------
 
     /**
-     * Clear local tokens and attempt server-side session termination.
+     * Clear local tokens and revoke the server-side session.
      *
-     * Optionally launches a Custom Tab to the end-session endpoint if the
-     * server requires user interaction for logout.
+     * Always sends a silent back-channel request to revoke the refresh token. That alone
+     * cannot clear a browser-side session cookie set during [login] — a back-channel call from
+     * the app's own HTTP client isn't the browser — so pass [activity] to additionally open the
+     * end-session endpoint in a Custom Tab, which does clear it. That request is not given a
+     * redirect back to the app: deliberately, since one would land in [handleRedirectIntent] and
+     * be misread as a failed login callback (no `code`, no `error`). The tab is left showing a
+     * blank response for the user to dismiss. This requires a stored ID token (`id_token_hint`);
+     * if none is available, [activity] is ignored and this falls back to back-channel-only logout.
      *
-     * @param activity Pass a [FragmentActivity] to open the end-session URL
-     *                 in a Custom Tab, or `null` for a silent back-channel logout.
+     * @param activity Pass a [FragmentActivity] to also clear the browser-side session via a
+     *                 Custom Tab, or `null` for a silent, no-UI logout.
      */
     suspend fun logout(activity: FragmentActivity? = null) {
         val refreshToken = storage.refreshToken
+        val idToken      = storage.idToken
         val oidc         = runCatching { fetchDiscovery() }.getOrNull()
 
         if (refreshToken != null && oidc?.endSessionEndpoint != null) {
@@ -245,6 +252,13 @@ class IdenplaneClient internal constructor(
                     body = "refresh_token=${Uri.encode(refreshToken)}&client_id=${Uri.encode(config.clientId)}",
                     contentType = "application/x-www-form-urlencoded",
                 )
+            }
+        }
+
+        if (activity != null && idToken != null && oidc?.endSessionEndpoint != null) {
+            runCatching {
+                CustomTabsIntent.Builder().build()
+                    .launchUrl(activity, buildEndSessionUri(oidc.endSessionEndpoint, idToken))
             }
         }
 
@@ -556,4 +570,16 @@ class IdenplaneClient internal constructor(
         joinToString("&") { (k, v) ->
             "${Uri.encode(k)}=${Uri.encode(v)}"
         }
+
+    companion object {
+        /**
+         * Extracted so the logout Custom Tab's URI is unit-testable without needing a real
+         * Activity/CustomTabsIntent. Deliberately omits `post_logout_redirect_uri` — see
+         * [logout]'s doc comment for why.
+         */
+        internal fun buildEndSessionUri(endSessionEndpoint: String, idToken: String): Uri =
+            Uri.parse(endSessionEndpoint).buildUpon()
+                .appendQueryParameter("id_token_hint", idToken)
+                .build()
+    }
 }

--- a/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/IdenplaneClientTest.kt
+++ b/packages/idenplane-android/src/test/kotlin/com/idenplane/sdk/IdenplaneClientTest.kt
@@ -3,6 +3,7 @@ package com.idenplane.sdk
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.fragment.app.FragmentActivity
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.After
@@ -15,8 +16,10 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import java.util.Base64
 
 /**
@@ -298,6 +301,48 @@ class IdenplaneClientTest {
 
         assertNull(storage.accessToken)
         assertNull(storage.refreshToken)
+    }
+
+    @Test
+    fun `logout launches a Custom Tab when an activity and idToken are both available`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        storage.idToken = "stored-id-token"
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+
+        client.logout(activity)
+
+        assertNotNull(
+            "Expected logout(activity) to start a Custom Tab activity to clear the browser session",
+            shadowOf(activity).nextStartedActivity,
+        )
+    }
+
+    @Test
+    fun `logout does not launch a Custom Tab without a stored idToken`() = runTest {
+        storage.accessToken = fakeJwt(expiresInSeconds = 300)
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+
+        client.logout(activity)
+
+        assertNull(
+            "Without an idToken the server can't honor id_token_hint, so no Custom Tab should launch",
+            shadowOf(activity).nextStartedActivity,
+        )
+    }
+
+    @Test
+    fun `buildEndSessionUri appends only id_token_hint`() {
+        val uri = IdenplaneClient.buildEndSessionUri(
+            endSessionEndpoint = "https://auth.example.com/realms/test/protocol/openid-connect/logout",
+            idToken = "the-id-token",
+        )
+
+        assertEquals("the-id-token", uri.getQueryParameter("id_token_hint"))
+        assertNull(
+            "post_logout_redirect_uri is deliberately omitted — see logout()'s doc comment",
+            uri.getQueryParameter("post_logout_redirect_uri"),
+        )
+        assertNull(uri.getQueryParameter("client_id"))
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`IdenplaneClient.logout(activity: FragmentActivity? = null)`'s doc comment claimed it "optionally launches a Custom Tab to the end-session endpoint if the server requires user interaction for logout" — `activity` was actually unused (flagged by the Kotlin compiler: `Parameter 'activity' is never used`, noted on #1325). The method only ever did a silent back-channel `POST` that revokes the refresh token server-side but can't touch a browser session cookie set during `login()` (a back-channel HTTP call from the app isn't the browser).

Before implementing, verified the real server contract (this server has previously had real, surprising deviations from generic OIDC assumptions — see the WebAuthn session-cookie finding on #1325) rather than assuming standard RP-Initiated Logout behavior:
- `GET realms/:realm/protocol/openid-connect/logout` clears the `IDENPLANE_SESSION` cookie when given `id_token_hint` — this is the one that actually needs a browser.
- `POST` (the existing SDK behavior) never touches cookies at all, confirmed real/working (not a no-op) for refresh-token revocation.
- Providing `post_logout_redirect_uri` without `id_token_hint` throws server-side and falls through to an error page instead of redirecting back.

`logout(activity)` now opens the GET endpoint in a Custom Tab when a stored ID token is available (falls back to back-channel-only logout if not — the server can't honor `id_token_hint` without one). Deliberately **not** passing `post_logout_redirect_uri`: reusing the login redirect URI for the logout callback would land in `handleRedirectIntent()`, which throws `CallbackError("Missing authorization code")` for anything without a `code` or `error` param — exactly matching the existing, deliberately-tested "missing code" behavior for a real login callback. Redesigning that contract to disambiguate a logout callback is a separate, larger change; the Custom Tab is left showing a blank response the user dismisses manually instead, which still achieves the actual goal (clearing the cookie) safely.

## Testing

55 unit tests total (52 → 55): extracted `buildEndSessionUri()` as a pure function and tested it directly, plus two tests exercising `logout(activity)` end-to-end via a real Robolectric `FragmentActivity` and `shadowOf(activity).nextStartedActivity` — confirming a Custom Tab activity actually starts when an ID token is available, and that it doesn't when one isn't. This turned out to be testable despite `login()`'s equivalent Custom Tab launch being previously treated as needing a real device.

Also updated the demo app (`examples/android-quickstart`) to use the activity-passing form, and both docs pages (SDK README, Docusaurus guide) to document the new behavior and its blank-page caveat honestly.

## Test plan

- [x] `./gradlew testDebugUnitTest` — 55/55 passing
- [x] `./gradlew assembleDebug assembleRelease` — succeeds
- [x] Demo app rebuilds against the fixed SDK via its composite build
- [ ] CI green