### PR TITLE
docs: add Architecture Decision Records and fill CONTRIBUTING.md gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,48 +4,60 @@ Thank you for your interest in contributing to Idenplane!
 
 ## Getting Started
 
-### Development Setup
+### Fork and clone
 
-1. **Clone the repository**
+1. **Fork the repository** on GitHub (the "Fork" button at the top of [idenplane/idenplane](https://github.com/idenplane/idenplane)).
+
+2. **Clone your fork** and add the upstream repo as a remote:
 ```bash
-git clone https://github.com/idenplane/idenplane.git
-cd Idenplane
+git clone https://github.com/<your-username>/idenplane.git
+cd idenplane
+git remote add upstream https://github.com/idenplane/idenplane.git
 ```
 
-2. **Install dependencies**
+3. **Keep your fork in sync** before starting new work:
+```bash
+git fetch upstream
+git checkout dev
+git merge upstream/dev
+```
+
+### Development Setup
+
+1. **Install dependencies**
 ```bash
 npm install
 ```
 
-3. **Set up environment**
+2. **Set up environment**
 ```bash
 cp .env.example .env
 # Edit .env with your database credentials
 ```
 
-4. **Start development database**
+3. **Start development database**
 ```bash
 docker compose up -d
 ```
 
-5. **Run database migrations**
+4. **Run database migrations**
 ```bash
 npm run db:migrate
 ```
 
-6. **Seed development data**
+5. **Seed development data**
 ```bash
 npm run db:seed
 ```
 
-7. **Start development server**
+6. **Start development server**
 ```bash
 npm run start:dev
 ```
 
 ### Required Tools
 
-- Node.js 20+
+- Node.js 22+
 - npm 10+
 - Docker & Docker Compose
 - Git
@@ -136,6 +148,15 @@ When submitting a PR:
    - One feature or fix per PR
    - Smaller PRs are reviewed faster
 
+### 5. Review Process
+
+Idenplane currently has a single maintainer, so review turnaround depends on their availability rather than a formal rotation — there's no assigned-reviewer system or required approval count beyond that.
+
+- All required CI checks (build, lint, tests) must be green before a PR is merged; a red check is treated as "not ready," not "waiting for an override."
+- The maintainer may ask for changes directly on the PR — respond with new commits rather than force-pushing over review comments, so the diff stays reviewable.
+- Approved PRs are squash-merged, so write your PR title/description as you'd want the resulting commit message to read; the individual commits within a PR don't need to be clean or atomic.
+- There's no fixed SLA on review time. For anything time-sensitive (a security fix, a broken build), say so explicitly in the PR description.
+
 ## Code Standards
 
 ### TypeScript
@@ -166,27 +187,24 @@ When submitting a PR:
 
 ## Project Structure
 
+The backend has around 60 NestJS modules under `src/`, each self-contained (its own controllers/services/DTOs) — too many to keep an accurate list here without it going stale. A representative sample:
+
 ```
 src/
-├── auth/           # Authentication logic
-├── admin-auth/     # Admin authentication
-├── clients/         # Client management
-├── groups/          # Group management
-├── roles/          # Role-based access control
-├── users/           # User management
-├── tokens/          # Token issuance & validation
-├── login/           # Login flows
-├── mfa/             # Multi-factor authentication
-├── oauth/           # OAuth 2.0 implementation
-├── saml/            # SAML 2.0 implementation
-├── webauthn/        # WebAuthn/FIDO2
-├── realms/          # Realm management
-├── common/          # Shared utilities
-├── crypto/          # Cryptographic operations
-├── prisma/          # Database service
-├── rate-limit/      # Rate limiting
+├── auth/              # Authentication logic
+├── admin-auth/        # Admin authentication
+├── oauth/             # OAuth 2.0 implementation
+├── saml/              # SAML 2.0 implementation
+├── webauthn/          # WebAuthn/FIDO2
+├── realms/            # Realm management
+├── users/, groups/, roles/, clients/  # Core identity model
+├── plugins/           # Plugin loading & integrity verification
+├── prisma/            # Database service
+├── common/            # Shared utilities
 └── ...
 ```
+
+For the full module map, grouped by concern, with a system diagram, see the [Architecture Overview](/contributing/architecture) on the docs site.
 
 ## Database Guidelines
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -2,6 +2,8 @@
 
 This document records important architectural and technical decisions made during Idenplane development.
 
+The subset of these with the broadest relevance for contributors is written up as formal ADRs (Context/Decision/Consequences, with links to source commits and PRs) on the [docs site](https://idenplane.com/docs/contributing/adrs).
+
 ---
 
 ## 2026-05-04: Security Issues Resolution

--- a/README.md
+++ b/README.md
@@ -706,12 +706,12 @@ REDIS_URL=redis://your-redis:6379
 
 ## Contributing
 
-Contributions are welcome! Please open an issue or submit a pull request.
+Contributions are welcome! Please open an issue or submit a pull request. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide.
 
 1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
+2. Create your feature branch (`git checkout -b feat/amazing-feature`)
+3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
+4. Push to the branch (`git push origin feat/amazing-feature`)
 5. Open a Pull Request
 
 ---

--- a/docs/docs/contributing/adrs.mdx
+++ b/docs/docs/contributing/adrs.mdx
@@ -1,0 +1,166 @@
+---
+id: adrs
+title: Architecture Decision Records
+description: Documented rationale behind Idenplane's key technical decisions — sourced from commit history, DECISIONS.md, and maintainer PR discussion, not reconstructed after the fact.
+---
+
+# Architecture Decision Records
+
+Each entry below is sourced from an actual commit, PR description, or the project's [`DECISIONS.md`](https://github.com/idenplane/idenplane/blob/dev/DECISIONS.md) log — linked inline so you can read the original reasoning yourself. A decision only appears here if the *why*, not just the *what*, is on the record somewhere; several commonly-asked "why X" questions (framework choice, templating engine, per-language vs. generated SDKs) don't have a documented answer yet and are listed at the bottom instead of being guessed at.
+
+---
+
+## ADR-001: AGPL-3.0 for the server, MIT for SDKs and clients
+
+**Status**: Accepted
+
+**Context**: Idenplane's server is a full IAM engine competing with both open-source (Keycloak) and commercial (Auth0, Okta) identity providers. A permissive license risks the code being absorbed into a closed-source SaaS competitor with no contribution back; a fully proprietary license would undercut the "open" part of open-source IAM.
+
+**Decision**: The server/core stays AGPL-3.0 — if you run a modified version as a network service, you must publish the complete source of your modifications. Every SDK and client package (Java, Android, JS, Python, Go, iOS, CLI, Terraform provider) is MIT, so applications that merely *talk to* Idenplane over its API aren't dragged under AGPL's copyleft.
+
+**Consequences**:
+- Self-hosting and modifying the server for internal use is unrestricted; offering a modified server as a hosted service requires open-sourcing the modifications, or a commercial license for organizations that can't comply.
+- SDK consumers (a Spring Boot app, an Android app, a Terraform config) can adopt any Idenplane client library without their own codebase inheriting AGPL obligations — this was a deliberate split, not an oversight.
+
+**References**: README.md § License; PR #874 ("AGPL-3.0 keeps the project genuinely open while leaving room for a dual-licensing offer"); PR #1377 ("the server/core is the IAM engine and stays AGPL-3.0, but every SDK/client package should be MIT"); issue #1326 maintainer discussion.
+
+---
+
+## ADR-002: Maven Central groupId is `com.idenplane`, not `io.idenplane`
+
+**Status**: Accepted (correcting an earlier mistake)
+
+**Context**: The Java SDK was initially going to publish under `io.idenplane`. `io.idenplane` reverse-domain-notates to `idenplane.io`, a domain the project does not own or control — the owned domains are `idenplane.com`, `.org`, and `.cloud`. Every Java package inside the module already lives under `com.idenplane.sdk`, matching the Android SDK's namespace.
+
+**Decision**: Publish the Java SDK to Maven Central under groupId `com.idenplane`.
+
+**Consequences**: Consistent Maven coordinate space across the whole SDK family (Java and Android share `com.idenplane`); avoids publishing under a domain the project doesn't control, which Maven Central's namespace verification would reject or which would misrepresent ownership to consumers.
+
+**References**: Issue #1326; PR #1331 ("Publishing under the mismatched groupId would fragment the Maven coordinate space from the rest of the SDK family").
+
+---
+
+## ADR-003: Prisma over raw SQL or a query builder
+
+**Status**: Accepted — 2026-01-15
+
+**Context**: The backend needs to support PostgreSQL, MySQL, and SQLite from the same codebase, with a migration story that doesn't require hand-written SQL per database dialect.
+
+**Decision**: Use Prisma ORM instead of raw SQL or a lower-level query builder.
+
+**Rationale** (from `DECISIONS.md`): type-safe queries; built-in migration management; easy database switching across PostgreSQL, MySQL, and SQLite.
+
+**References**: `DECISIONS.md` § Architecture Decisions.
+
+---
+
+## ADR-004: Argon2id for password hashing
+
+**Status**: Accepted — 2025-11-20
+
+**Context**: Password hashing needs to resist offline brute-force attacks, including GPU/ASIC-accelerated ones, better than older algorithms.
+
+**Decision**: Use Argon2id (RFC 9106) for password hashing.
+
+**Rationale** (from `DECISIONS.md`): memory-hard function resistant to GPU attacks; better suited to modern security requirements than bcrypt.
+
+**References**: `DECISIONS.md` § Architecture Decisions.
+
+---
+
+## ADR-005: JWT signing with RS256
+
+**Status**: Accepted — 2025-10-05
+
+**Context**: Access and ID tokens need a signing scheme that works across multiple services and clients without sharing a secret.
+
+**Decision**: Sign JWTs with RS256 (RSA + SHA-256) rather than a symmetric algorithm like HS256.
+
+**Rationale** (from `DECISIONS.md`): asymmetric signing means the private key signs and only the public key is needed to verify — better suited to multi-service architectures than HS256, where every verifier would need the same shared secret as the signer.
+
+**References**: `DECISIONS.md` § Architecture Decisions.
+
+---
+
+## ADR-006: Redis as an optional cache/session layer, not a hard dependency
+
+**Status**: Accepted — 2025-08-12
+
+**Context**: Caching and session storage benefit from a shared, fast store, but requiring Redis for every deployment (including single-instance, low-traffic ones) raises the bar for self-hosting.
+
+**Decision**: Use Redis as an optional layer for caching and session sharing, with a graceful in-memory fallback when it isn't configured.
+
+**Rationale** (from `DECISIONS.md`): improves performance for frequent lookups; enables horizontal scaling via shared session state; falls back gracefully when Redis is unavailable.
+
+**Consequences**: Documented tradeoff — the in-memory fallback is per-instance, so distributed (multi-instance) deployments need Redis for *consistent* rate limiting and session behavior across instances; a single instance works fine without it.
+
+**References**: `DECISIONS.md` § Architecture Decisions; `DECISIONS.md` § "In-Memory Rate Limiting" (2026-04-13, issue #581).
+
+---
+
+## ADR-007: Plugins are denied by default in production without a verified integrity hash
+
+**Status**: Accepted, after a security regression
+
+**Context**: The plugin system allows third-party code to run inside the server process (auth providers, token enrichment, event listeners, custom themes). An early version of the integrity check was opt-in, meaning production deployments could silently run unverified plugin code — reported as issue #465 after a related regression (#430/#448) let a previously-fixed integrity issue reopen.
+
+**Decision**: In production (`NODE_ENV === 'production'`), the plugin loader computes a SHA-256 hash of the plugin file and refuses to load it if there's no matching manifest hash to verify against. Outside production, a missing hash only logs a warning.
+
+**Consequences**: A plugin author must generate a manifest hash (`idenplane plugins hash`) before a plugin will load in production — friction that's deliberate, not accidental. Development stays low-friction (warn, don't block) so local plugin iteration isn't blocked on re-hashing after every change.
+
+**References**: Issues #400, #430, #448, #465; commit `0f4f541` ("Plugin loader denies unverified plugins in production (#465)"); `src/plugins/plugin-loader.service.ts`.
+
+---
+
+## ADR-008: TypeScript/Node over a JVM stack for the server
+
+**Status**: Accepted
+
+**Context**: The identity-provider space is dominated by JVM-based incumbents (Keycloak) that are powerful but heavy to self-host and unfamiliar to a large share of potential contributors.
+
+**Decision**: Build the server on TypeScript/NestJS rather than Java or another JVM stack.
+
+**Rationale**: README.md's comparison table frames this directly against Keycloak-class competitors: "Most identity solutions are either too complex to self-host (Keycloak — 1GB+ RAM, Java)... Modern stack — TypeScript, NestJS, React, PostgreSQL. No Java, no XML." The project roadmap makes the contributor-facing angle explicit: the TypeScript/NestJS stack is "a contributor-friendliness advantage over Java/Go competitors," which matters directly because of the project's single-maintainer bus-factor risk.
+
+**References**: README.md § Comparison; `.auto-claude/roadmap/roadmap.json`, `feature-20` rationale.
+
+---
+
+## ADR-009: Terraform only for infrastructure-as-code — the Pulumi provider was abandoned, not chosen against upfront
+
+**Status**: Accepted (by removal)
+
+**Context**: A Pulumi provider and example usages existed alongside the Terraform provider, but were never in a working state: the Pulumi Go SDK it depended on (`github.com/idenplane/pulumi-idenplane`) was never published, the provider's own `go.mod` pointed at an unpublished module with no `replace` directive and no `go.sum`, and nothing in CI, the Makefile, or the docs referenced it. It also carried unfixable Dependabot alerts, since Dependabot cannot resolve a dependency graph rooted in a module that doesn't exist.
+
+**Decision**: Remove the Pulumi provider, its Go/C# examples, and the orphaned Terraform scaffolding that documented a provider schema (`base_url`, `auth_method`, `admin_user`, `admin_pass`) that no longer matches the real provider's schema (`url`, `api_key`). Keep `terraform-provider-idenplane` as the one supported IaC path.
+
+**Consequences**: One IaC integration to maintain and document instead of two, one of which never worked. This is a decision made honestly by removing broken, unreferenced code rather than by patching versions to silence security alerts on code nobody could compile or run.
+
+**References**: PRs #1195, #1227, #1233.
+
+---
+
+## ADR-010: Native `fetch`, not vendor SDKs, for third-party email provider integrations
+
+**Status**: Accepted
+
+**Context**: Adding multi-provider email support (Resend, SendGrid, Mailgun, Postmark, alongside existing SMTP) could have pulled in each provider's official Node SDK as a dependency.
+
+**Decision**: Implement each provider as a small adapter against its HTTP API using native `fetch`, with no additional SDK dependencies.
+
+**Consequences**: Five provider integrations add zero new runtime dependencies between them, keeping the dependency-security surface (and Dependabot's workload) smaller than one SDK per provider would.
+
+**References**: PR #1067 ("5 concrete implementations using native fetch (no extra SDK deps)").
+
+---
+
+## Known gaps — not written up because the rationale isn't documented
+
+These are commonly-asked "why X" questions where only the choice, not the reasoning behind it, could be found in the repo. Writing an ADR for any of these would mean inventing a justification after the fact rather than recording one that was actually made — so they're listed here as open gaps instead:
+
+- **Why NestJS specifically, over Express or another Node framework** — the codebase uses NestJS throughout and README's comparison covers TypeScript/Node vs. a JVM stack (see ADR-008), but no commit, PR, or doc compares NestJS against alternative Node frameworks.
+- **Why Handlebars for templates** — commits describe *what* the template engine does (inheritance, i18n) and fix a packaging bug, but none compare Handlebars to EJS, Pug, or another templating approach.
+- **Why hand-written per-language SDKs instead of one client generated from the OpenAPI spec** — the SDK family's shape (Java, Android, JS, Python, Go, iOS, CLI, Terraform) is well documented, but not why that shape was chosen over codegen.
+- **Why the plugin system's specific architecture** (4 plugin types, 2 discovery sources) — its existence and purpose are documented (issue #274, commit `a591186`), but not why this shape was chosen over alternatives.
+
+If you have context on any of these — even a Slack thread or a design doc that didn't make it into a commit message — opening a PR to fill in the gap is welcome.

--- a/docs/docs/contributing/architecture.mdx
+++ b/docs/docs/contributing/architecture.mdx
@@ -133,6 +133,9 @@ These are independently-versioned packages under `packages/` (JS/React/Next.js/V
 [**Contributing Guide**](https://github.com/idenplane/idenplane/blob/dev/CONTRIBUTING.md)
 Dev setup, branch naming, commit conventions, PR process
 
+[**Architecture Decision Records**](/contributing/adrs)
+Why Prisma, why AGPL-3.0-for-server/MIT-for-SDKs, why the plugin integrity check, and more
+
 [**Custom Auth Flows**](/guides/auth-flows)
 The flow model in detail, including what's and isn't wired up today
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -236,9 +236,20 @@ const sidebars: SidebarsConfig = {
       label: 'Troubleshooting & FAQ',
     },
     {
-      type: 'doc',
-      id: 'contributing/architecture',
-      label: 'Architecture Overview',
+      type: 'category',
+      label: 'Contributing',
+      items: [
+        {
+          type: 'doc',
+          id: 'contributing/architecture',
+          label: 'Architecture Overview',
+        },
+        {
+          type: 'doc',
+          id: 'contributing/adrs',
+          label: 'Architecture Decision Records',
+        },
+      ],
     },
   ],
 };


### PR DESCRIPTION
## Summary
Partial progress on #1316 — the ADR and CONTRIBUTING.md-gap slices, done in a way that avoids the issue's biggest trap.

- Adds 10 ADRs at `docs/docs/contributing/adrs.mdx`, each sourced from a real commit, PR description, or `DECISIONS.md` entry (linked inline). A "Known gaps" section explicitly lists the commonly-asked "why X" questions with no documented rationale anywhere in the repo (why NestJS vs Express, why Handlebars, why per-language SDKs over a generated client, why the plugin system's specific shape) — these are left as open gaps rather than invented, per the constraint noted on a prior pass at this issue (#1341).
- Fills two real gaps in `CONTRIBUTING.md` that #1316 asks for: a fork-and-clone workflow (previously had contributors clone upstream directly with no fork step) and a Review Process section (previously undocumented).
- Fixes staleness found while in there: `Node.js 20+` → `22+` (CI and README both already require 22), and a hand-maintained Project Structure module list that had drifted from the real `src/` tree — replaced with a short representative sample plus a link to the Architecture Overview's full module map.
- Groups the existing Architecture Overview (#1341) and the new ADR page under a proper "Contributing" sidebar category instead of a stray top-level entry.
- Cross-links `DECISIONS.md` ↔ the new docs page, and the Architecture Overview ↔ the new ADR page.

## Not attempted
- Dev environment setup guide verified on macOS/Linux/WSL — would require actually running it on each platform, not something checkable from here.
- Diagrams / module-by-module developer guide — already covered by #1341's Architecture Overview.
- "Good first issue" labeling strategy — issue #1316 itself says this needs maintainer judgment, not automation.

## Test plan
- [x] `npm run build` in `docs/` succeeds with the new page and sidebar category (no broken links, no new warnings beyond a pre-existing unrelated duplicate-route one)
- [x] Every ADR's cited commit hash / PR / issue number / file:line verified directly (not taken on a sub-agent's word) before writing
- [x] Read the full resulting `CONTRIBUTING.md` for numbering/formatting after the fork-workflow insert