### PR TITLE
chore(java): bump version off 1.0.0-SNAPSHOT to 1.0.0

### DIFF
--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>idenplane-java-core</artifactId>

--- a/packages/idenplane-java/idenplane-java-jakarta/pom.xml
+++ b/packages/idenplane-java/idenplane-java-jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>idenplane-java-jakarta</artifactId>

--- a/packages/idenplane-java/idenplane-java-reactive/pom.xml
+++ b/packages/idenplane-java/idenplane-java-reactive/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>idenplane-java-reactive</artifactId>

--- a/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>idenplane-java-spring-sample</artifactId>

--- a/packages/idenplane-java/idenplane-java-spring/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.idenplane</groupId>
         <artifactId>idenplane-java</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
     </parent>
 
     <artifactId>idenplane-java-spring</artifactId>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.idenplane</groupId>
     <artifactId>idenplane-java</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
     <packaging>pom</packaging>
 
     <name>Idenplane Java SDK</name>


### PR DESCRIPTION
## Summary
Bumps all 6 Java SDK poms (parent + `idenplane-java-core`, `idenplane-java-jakarta`, `idenplane-java-reactive`, `idenplane-java-spring`, `idenplane-java-spring-sample`) from `1.0.0-SNAPSHOT` to `1.0.0`.

This was previously deferred (see the finding on #1326) because `publish-java.yml`'s "Refuse to publish a SNAPSHOT version" check is currently the only thing standing between a `workflow_dispatch` and a real Maven Central publish — bumping the version removes that guard. That was a real reason to wait for an explicit go-ahead rather than doing it as routine housekeeping. The maintainer has now given that go-ahead, and the Android SDK is already tagged (`android-v1.0.0`) and uploaded to the Central Portal as a pending deployment, so this clears the equivalent prerequisite for Java.

No tag is pushed in this PR — publishing is a separate, deliberate step (`java-v1.0.0`) after this merges.

## Test plan
- [x] Confirmed only these 6 files reference `1.0.0-SNAPSHOT`, each with exactly one occurrence
- [ ] CI's "Java SDK" job runs the full reactor build/test on this PR (Maven isn't installed on this machine to verify locally — relying on CI, consistent with how this repo's `publish-java.yml` itself verifies the version)