### PR TITLE
chore: temporary Central Portal auth diagnostic

### DIFF
--- a/.github/workflows/_debug-central-auth.yml
+++ b/.github/workflows/_debug-central-auth.yml
@@ -1,0 +1,29 @@
+name: _debug-central-auth
+
+# Throwaway diagnostic — isolates whether MAVEN_CENTRAL_USERNAME/PASSWORD are rejected by the
+# Central Portal Publisher API itself, independent of the Maven/Gradle plugins that wrap it.
+# Deleted once the answer is known; never wired into any trigger but manual dispatch.
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  test-auth:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe Central Portal auth (no bundle uploaded)
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        run: |
+          set -e
+          TOKEN=$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 -w0)
+          echo "Sending an empty POST to the upload endpoint — expecting 400 (bad request, no bundle) if auth passes, or 401 if it doesn't."
+          HTTP_CODE=$(curl -s -o /tmp/resp.txt -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "https://central.sonatype.com/api/v1/publisher/upload")
+          echo "HTTP status: ${HTTP_CODE}"
+          echo "Response body:"
+          cat /tmp/resp.txt
+          echo ""


### PR DESCRIPTION
Throwaway diagnostic to isolate whether MAVEN_CENTRAL_USERNAME/PASSWORD are rejected by the Central Portal Publisher API itself vs. by the Maven plugin wrapping it (publish-java.yml is failing with a 401 on upload). Will be removed in a follow-up PR immediately after use.