### PR TITLE
fix(java): switch to the maintained central-publishing-maven-plugin fork

### DIFF
--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -108,18 +108,16 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.sonatype.central</groupId>
+                        <groupId>io.github.mavenplugins</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
                         <!-- Declared explicitly rather than relying on inheriting this from
                              pluginManagement. Note: `mvn help:describe -Dcmd=deploy -Pcentral-publish`
                              reports `deploy` as still bound to the stock maven-deploy-plugin even
                              with this — that's help:describe not simulating a profile-injected
-                             extension correctly, not a real problem. Verified against an actual
-                             `mvn -Pcentral-publish deploy` run instead: the log shows
-                             `central-publishing:0.11.0:publish (injected-central-publishing)`
-                             executing, which then failed on a 401 against the Central Portal —
-                             i.e. it reached real auth with no credentials configured, exactly
-                             the safe failure mode this dormant config is meant to have. -->
+                             extension correctly, not a real problem. groupId must match the
+                             parent pluginManagement entry exactly (Maven resolves plugin config
+                             by groupId+artifactId) — see that entry for why it's
+                             io.github.mavenplugins and not org.sonatype.central. -->
                         <extensions>true</extensions>
                     </plugin>
                 </plugins>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -313,10 +313,17 @@
                     </executions>
                 </plugin>
 
+                <!-- org.sonatype.central:central-publishing-maven-plugin (last released 0.11.0)
+                     rejects real uploads with a bare 401 even with fresh, verified-valid
+                     credentials — confirmed by hitting the Central Portal API directly with the
+                     same token, which got past auth (500 on the deliberately-empty body sent,
+                     not 401). Its own SCM went private/inaccessible, and io.github.mavenplugins
+                     is the actively maintained community fork of the same plugin (same
+                     configuration shape, only the groupId and version differ). -->
                 <plugin>
-                    <groupId>org.sonatype.central</groupId>
+                    <groupId>io.github.mavenplugins</groupId>
                     <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>0.11.0</version>
+                    <version>1.3.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
## Summary
The real Java publish attempt (java-v1.0.0) has been failing with a bare 401 from Central Portal, even after regenerating the Maven Central user token. Isolated the cause with a throwaway diagnostic workflow (added and removed in this session): a raw request to the Central Portal Publisher API with the same token, sent with `Authorization: Bearer <token>` directly (bypassing Maven/Gradle entirely), got a 500 — not 401. A 500 means it got past auth and choked on the empty body we deliberately sent. So the credentials are valid; the 401 is specific to how `org.sonatype.central:central-publishing-maven-plugin` (last released 0.11.0) builds its request.

That plugin's own source repo has gone private/inaccessible. `io.github.mavenplugins:central-publishing-maven-plugin` is the actively maintained community fork of the same plugin — same configuration shape (`publishingServerId`, `deploymentName`, `autoPublish`), only the groupId and version (1.3.0) differ.

Changed:
- Parent `pom.xml`'s `pluginManagement` entry: groupId `org.sonatype.central` → `io.github.mavenplugins`, version `0.11.0` → `1.3.0`
- `idenplane-java-core/pom.xml`'s plugin activation (must match groupId+artifactId exactly for Maven to apply the pluginManagement config — this was the one other place the old groupId appeared)

## Test plan
- [x] CI's "Java SDK" job builds the full reactor with the new plugin coordinates (doesn't exercise the actual `central-publish` profile/deploy, since that needs real credentials, but confirms the reactor resolves and builds with the new plugin dependency)
- [ ] Real test is the next `java-v1.0.0` publish attempt after this merges