### PR TITLE
fix(ci): correct actions/setup-java inputs for Maven Central publish

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -22,14 +22,25 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # server-username/server-password take the NAME of an env var (populated in the
+      # "Publish" step below), not the secret itself — actions/setup-java has no
+      # "-env-var"-suffixed variant of these inputs. An earlier version of this workflow
+      # used server-username-env-var/server-password-env-var, which don't exist: the
+      # action silently ignored them (a warning, not a failure) and fell back to its
+      # GitHub Packages default of GITHUB_ACTOR/GITHUB_TOKEN. That sent our own GitHub
+      # username and the literal unresolved string "${env.GITHUB_TOKEN}" to Central
+      # Portal as credentials — a real Maven Central token was never actually sent,
+      # which is why every plugin swap and token regeneration during that investigation
+      # kept hitting an identical 401 (confirmed by Sonatype support reading their
+      # server-side logs).
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
           cache: maven
           server-id: central
-          server-username-env-var: MAVEN_CENTRAL_USERNAME
-          server-password-env-var: MAVEN_CENTRAL_PASSWORD
+          server-username: MAVEN_CENTRAL_USERNAME
+          server-password: MAVEN_CENTRAL_PASSWORD
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 
       - name: Verify tag matches idenplane-java-core's project version


### PR DESCRIPTION
## Summary
Root cause of the java-v1.0.0 publish 401, confirmed by Sonatype support after they checked their server-side logs directly: `publish-java.yml` was sending our GitHub username and the literal unresolved string `\${env.GITHUB_TOKEN}` as credentials to Central Portal — never our real Maven Central token.

`server-username-env-var` / `server-password-env-var` are not real `actions/setup-java@v4` inputs (confirmed in the workflow's own logs: `##[warning]Unexpected input(s) 'server-username-env-var', 'server-password-env-var'`). The action silently ignored them and fell back to its GitHub Packages convenience default (`GITHUB_ACTOR` / `GITHUB_TOKEN`), which is exactly what Sonatype's ops team found in their logs.

This explains the entire earlier investigation: two plugins (`org.sonatype.central` and the `io.github.mavenplugins` fork) and two tokens all failed identically, because none of it mattered — the real credentials never left this misconfigured step.

## Fix
`server-username` / `server-password` (no `-env-var` suffix) — these take the *name* of an env var, which the "Publish" step already populates correctly from `secrets.MAVEN_CENTRAL_USERNAME`/`PASSWORD`.

## Test plan
- [ ] Real test is the next `java-v1.0.0` publish attempt after this merges — should now show `Islamawad132`/`GITHUB_TOKEN` nowhere in the logs, and either succeed or fail with a *different*, real error