### PR TITLE
chore(java): remove temp verification step, fix flattened POM's url/scm

### DIFF
--- a/.github/workflows/publish-java.yml
+++ b/.github/workflows/publish-java.yml
@@ -75,18 +75,6 @@ jobs:
             exit 1
           fi
 
-      # Temporary — remove once the flatten-maven-plugin fix (added to fix Central Portal's
-      # "Failed to get coordinates from pom file" validation failure on deployment
-      # c8a4c343-d5d6-4b08-9adb-0d11848eca58) has been confirmed correct on a real run. Runs
-      # before the actual publish step so a workflow_dispatch run can be cancelled here if the
-      # flattened POM looks wrong, without creating another FAILED Central Portal deployment.
-      - name: Print flattened POM for verification
-        run: |
-          mvn -B -pl idenplane-java-core -Pcentral-publish process-resources
-          echo "::group::Flattened POM (idenplane-java-core/.flattened-pom.xml)"
-          cat idenplane-java-core/.flattened-pom.xml
-          echo "::endgroup::"
-
       - name: Publish idenplane-java-core to Maven Central
         run: mvn -B -pl idenplane-java-core deploy -Pcentral-publish -DskipTests
         env:

--- a/packages/idenplane-java/idenplane-java-core/pom.xml
+++ b/packages/idenplane-java/idenplane-java-core/pom.xml
@@ -16,6 +16,18 @@
     <name>Idenplane Java SDK - Core</name>
     <description>Core module of the Idenplane Java SDK providing token validation and user management API</description>
 
+    <!-- Overrides Maven's default child-URL inheritance, which would otherwise append this
+         module's artifactId onto the parent's repo-root url/scm.url (e.g.
+         .../idenplane/idenplane-java-core) — not a real path, since this module actually lives
+         at packages/idenplane-java/idenplane-java-core in the monorepo. connection and
+         developerConnection are left inherited as-is: it's the same git repo either way. -->
+    <url>https://github.com/idenplane/idenplane/tree/main/packages/idenplane-java/idenplane-java-core</url>
+    <scm>
+        <connection>scm:git:https://github.com/idenplane/idenplane.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/idenplane/idenplane.git</developerConnection>
+        <url>https://github.com/idenplane/idenplane/tree/main/packages/idenplane-java/idenplane-java-core</url>
+    </scm>
+
     <dependencies>
         <!-- HTTP Client -->
         <dependency>


### PR DESCRIPTION
## Summary
- Confirmed via a real `workflow_dispatch` run that the flatten-maven-plugin fix (#1409) works: idenplane-java-core published successfully and Central Portal validated the deployment (`ef44d4f9-7acb-4d58-ad14-c80b6d6e6d34`). Removes the temporary verification step added to inspect the flattened POM before trusting it with a publish attempt.
- Fixes a cosmetic issue found while inspecting that run's flattened POM: `<url>`/`<scm><url>` resolved to `.../idenplane/idenplane-java-core` — Maven's default child-URL inheritance appending the artifactId onto the parent's repo-root URL, which isn't a real path since the module lives at `packages/idenplane-java/idenplane-java-core`. Didn't block validation (Central only checks presence), but it's the link shown on the module's Central page, so worth having point somewhere real.

## Test plan
- [ ] CI passes (no functional change to the default build — `<url>`/`<scm>` override and step removal only affect `-Pcentral-publish` deploys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)