### PR TITLE
fix(ci): docker-publish's latest/main-<sha> tags never fire on push to main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,9 +58,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: islamawad/idenplane
+          # {{is_default_branch}} checks the repo's configured GitHub default branch,
+          # which is dev here, not main — so it never matched a push to main and every
+          # such push failed with "tag is needed when pushing to registry" (no tags
+          # generated at all). Check the actual ref pushed to instead.
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=main-,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=main-,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 


### PR DESCRIPTION
## Summary
Every plain push to `main` (i.e. a dev->main promotion PR merge, not a `v*` tag push) has been failing `docker-publish.yml` with `tag is needed when pushing to registry` — confirmed on #1330, #1405, and most recently #1411. Root cause: `docker/metadata-action`'s `{{is_default_branch}}` checks the repo's *configured GitHub default branch*, which is `dev` here, not `main`. It never matched, so `latest`/`main-<sha>` never got generated on a push to `main`, leaving zero tags for `docker/build-push-action` to push.

Not previously user-visible in practice: releases (`v*` tags, e.g. `v0.4.0`) publish via `type=semver` tags, which don't depend on `is_default_branch` at all — so `islamawad/idenplane:0.4.0` / `:0.4` / `:latest` are all already correctly published from the `v0.4.0` tag push. This only affected the separate `latest`-on-every-main-push and `main-<sha>` convenience tags.

Fix: check `github.ref == 'refs/heads/main'` directly instead of relying on the default-branch heuristic.

## Test plan
- [ ] CI passes
- [ ] After merging to `dev` and promoting to `main`, confirm the next `main` push actually produces `latest` and `main-<sha>` tags on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)