### PR TITLE
Promote dev to main — fix docker-publish's latest/main-<sha> tag bug

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,9 +58,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: islamawad/idenplane
+          # {{is_default_branch}} checks the repo's configured GitHub default branch,
+          # which is dev here, not main — so it never matched a push to main and every
+          # such push failed with "tag is needed when pushing to registry" (no tags
+          # generated at all). Check the actual ref pushed to instead.
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,prefix=main-,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=main-,enable=${{ github.ref == 'refs/heads/main' }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 


### PR DESCRIPTION
## Summary
Single-commit promotion — dev is exactly one commit ahead of main.

- #1413: fixes `docker-publish.yml`'s `{{is_default_branch}}` bug (checked the repo's configured default branch, `dev`, instead of the actual pushed ref) that made every plain push to `main` fail with "tag is needed when pushing to registry", silently skipping the `latest`/`main-<sha>` Docker Hub tags. `v*`-tag-triggered releases were never affected — this is the first `main` push since the fix, so it's also the first real-world verification that it works.

## Test plan
- [ ] CI passes
- [ ] After merge, confirm `docker-publish.yml`'s run on this push actually produces and pushes `latest` + `main-<sha>` tags (previously always failed at this point)
- [ ] Merge as a merge commit, not squash, per established dev/main parity convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)