### PR TITLE
fix(docker): revert node:25-alpine to 22 — breaks prisma generate on arm64

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,14 @@ updates:
     labels:
       - dependencies
       - docker
+    ignore:
+      # node:25 breaks `prisma generate` under QEMU arm64 emulation (this repo
+      # builds linux/arm64 in docker-publish.yml) — see the Dockerfile comment
+      # and https://github.com/prisma/prisma/issues/29464. Remove once that's
+      # fixed upstream and re-bump deliberately (with an arm64 build actually
+      # verified, not just amd64 CI).
+      - dependency-name: "node"
+        versions: ["25.x", "25"]
 
   # Documentation site (was unmonitored — a transitive uuid advisory sat here
   # with no fix PR because Dependabot wasn't watching this directory).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
+# node:25-alpine (and node:25-slim) breaks `prisma generate` under QEMU arm64
+# emulation with a nonsensical "does not start with any known Prisma schema
+# keyword" error — actually a JSON-parsing bug in Prisma's engine on that
+# combination, unrelated to schema content. amd64 is unaffected; this only
+# surfaced because docker-publish.yml's actual tag-generation bug (fixed
+# separately) had been silently preventing this stage from ever running on a
+# push to main. Tracked upstream: https://github.com/prisma/prisma/issues/29464.
+# Pinned to 22 (not just reverted) to match what CI's actions/setup-node already
+# tests against everywhere else in this repo — re-bump once that issue closes.
 # Stage 1: Dependencies
-FROM node:25-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 # --ignore-scripts: the root "postinstall" runs `prisma generate`, which needs
@@ -8,13 +17,13 @@ COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
 
 # Stage 1b: Admin UI dependencies
-FROM node:25-alpine AS admin-deps
+FROM node:22-alpine AS admin-deps
 WORKDIR /app/admin-ui
 COPY admin-ui/package.json admin-ui/package-lock.json ./
 RUN npm ci
 
 # Stage 2: Build
-FROM node:25-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=admin-deps /app/admin-ui/node_modules ./admin-ui/node_modules
@@ -28,7 +37,7 @@ RUN npm run build
 RUN cp -r admin-ui/dist dist/admin-ui
 
 # Stage 3: Production
-FROM node:25-alpine AS production
+FROM node:22-alpine AS production
 WORKDIR /app
 
 # pg_dump / pg_restore, used by the upgrade flow to take a backup before running


### PR DESCRIPTION
## Summary
The docker-publish.yml tag fix (#1413/#1414) just ran for real for the first time on a push to main — and surfaced a second, unrelated bug that #1406 (Dependabot's node:22->25-alpine bump) had introduced: the `linux/arm64` build stage fails at `npx prisma generate` with a nonsensical "does not start with any known Prisma schema keyword" error.

Root cause: `node:25-alpine`/`slim` + QEMU arm64 emulation has a known upstream bug in Prisma's engine — a JSON-parsing failure, not an actual schema problem ([prisma/prisma#29464](https://github.com/prisma/prisma/issues/29464)). `linux/amd64` builds fine on the same image; only the emulated arm64 stage is affected.

#1406 passed CI cleanly because CI only ever runs Node natively (pinned to 22 everywhere via `actions/setup-node`) and never actually builds the Docker image's `arm64` stage — that only happens in `docker-publish.yml`, which had been silently failing before it even got this far due to the tag-generation bug just fixed. So this has been broken since #1406 merged, with nothing surfacing it until now.

Fix:
- Revert `Dockerfile`'s four `node:25-alpine` references back to `node:22-alpine` (matches what CI already tests against, not an arbitrary choice)
- Add a Dependabot `ignore` rule for `node: 25.x` on the docker ecosystem so it doesn't immediately re-propose the same break

## Test plan
- [ ] CI passes
- [ ] After merging through to `main`, confirm `docker-publish.yml`'s next run builds and pushes both `linux/amd64` and `linux/arm64` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)