### PR TITLE
Promote dev to main — revert Docker base image to node:22-alpine (arm64 prisma fix)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,14 @@ updates:
     labels:
       - dependencies
       - docker
+    ignore:
+      # node:25 breaks `prisma generate` under QEMU arm64 emulation (this repo
+      # builds linux/arm64 in docker-publish.yml) — see the Dockerfile comment
+      # and https://github.com/prisma/prisma/issues/29464. Remove once that's
+      # fixed upstream and re-bump deliberately (with an arm64 build actually
+      # verified, not just amd64 CI).
+      - dependency-name: "node"
+        versions: ["25.x", "25"]
 
   # Documentation site (was unmonitored — a transitive uuid advisory sat here
   # with no fix PR because Dependabot wasn't watching this directory).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
+# node:25-alpine (and node:25-slim) breaks `prisma generate` under QEMU arm64
+# emulation with a nonsensical "does not start with any known Prisma schema
+# keyword" error — actually a JSON-parsing bug in Prisma's engine on that
+# combination, unrelated to schema content. amd64 is unaffected; this only
+# surfaced because docker-publish.yml's actual tag-generation bug (fixed
+# separately) had been silently preventing this stage from ever running on a
+# push to main. Tracked upstream: https://github.com/prisma/prisma/issues/29464.
+# Pinned to 22 (not just reverted) to match what CI's actions/setup-node already
+# tests against everywhere else in this repo — re-bump once that issue closes.
 # Stage 1: Dependencies
-FROM node:25-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 # --ignore-scripts: the root "postinstall" runs `prisma generate`, which needs
@@ -8,13 +17,13 @@ COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
 
 # Stage 1b: Admin UI dependencies
-FROM node:25-alpine AS admin-deps
+FROM node:22-alpine AS admin-deps
 WORKDIR /app/admin-ui
 COPY admin-ui/package.json admin-ui/package-lock.json ./
 RUN npm ci
 
 # Stage 2: Build
-FROM node:25-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=admin-deps /app/admin-ui/node_modules ./admin-ui/node_modules
@@ -28,7 +37,7 @@ RUN npm run build
 RUN cp -r admin-ui/dist dist/admin-ui
 
 # Stage 3: Production
-FROM node:25-alpine AS production
+FROM node:22-alpine AS production
 WORKDIR /app
 
 # pg_dump / pg_restore, used by the upgrade flow to take a backup before running


### PR DESCRIPTION
## Summary
Single-commit promotion.

- #1417: reverts `Dockerfile`'s `node:25-alpine` back to `node:22-alpine`. #1406's bump broke the `linux/arm64` Docker build stage — `npx prisma generate` fails under QEMU emulation on node:25-alpine due to a known upstream Prisma engine bug ([prisma/prisma#29464](https://github.com/prisma/prisma/issues/29464)), not a real schema problem. This went undetected until now because the separate docker-publish.yml tag bug (#1413/#1414) had been silently preventing the build from ever running on a push to `main`. Also adds a Dependabot `ignore` rule so `node: 25.x` isn't immediately re-proposed for the docker ecosystem.

## Test plan
- [ ] CI passes
- [ ] After merge, confirm `docker-publish.yml`'s run on this push builds and pushes both `linux/amd64` and `linux/arm64` successfully — this will be the first real end-to-end verification of both the tag fix (#1413) and this fix together
- [ ] Merge as a merge commit, not squash, per established dev/main parity convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)