### PR TITLE
fix(examples): bump nanoid to 3.3.18 — unblocks the whole PR queue

### DIFF
--- a/examples/nextjs-quickstart/package-lock.json
+++ b/examples/nextjs-quickstart/package-lock.json
@@ -4207,9 +4207,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## The problem

`Examples — nextjs-quickstart` runs `npm audit --audit-level=moderate` as a **hard gate** (`.github/workflows/ci.yml`). `nanoid 3.3.16` in this example's lockfile trips [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8), so the step exits 1 in ~15s — and it runs **before** `npm run build`, so that build has never actually executed on any open PR.

**11 of the 13 open PRs fail on this one check and nothing else.** None of them touch this example. A freshly published advisory turned the entire queue red with zero code change.

| Blocked by this alone | Failing for their own reasons |
|---|---|
| #1440 #1439 #1438 #1437 #1436 #1435 #1433 #1432 #1431 #1430 #1429 | #1369, #1362 (typescript 6→7 majors) |

## The fix

`postcss` already declares `nanoid: ^3.3.16`, which permits the patched `3.3.18` — the lockfile was simply stale. So this is a lockfile-only bump: no `package.json` change, no `overrides` entry.

```
 "node_modules/nanoid": {
-  "version": "3.3.16",
+  "version": "3.3.18",
```

## Verification

Ran the exact CI steps in `examples/nextjs-quickstart`:

```
npm audit --audit-level=moderate   ->  found 0 vulnerabilities   (exit 0)
npm run build                      ->  exit 0
                                       Next.js 15.5.22, compiled in 38.4s,
                                       6/6 static pages generated
```

The `Build` step passing is new information — the audit gate had always short-circuited before it.

## Scope

Deliberately **one file, three lines**. The root and `docs/` lockfiles carry their own Dependabot alerts (nanoid, js-yaml ×2, deepmerge-ts, dompurify, image-size) and follow in separate PRs — bundling them here would risk a regression taking this unblocking fix down with it.

Two follow-ups worth doing after this lands, filed separately:
- The audit hard-gate is systemic: any new advisory against any transitive dep reddens every PR in the repo. It belongs in a scheduled run (or `continue-on-error`), not a per-PR gate.
- `.github/dependabot.yml` doesn't cover `examples/*` or `packages/idenplane-java` — which is exactly why this lockfile went stale with no version-update PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)