### PR TITLE
ci: stop a new advisory from reddening every open PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -111,3 +111,53 @@ updates:
         update-types:
           - minor
           - patch
+
+  # Examples — these are the copy-paste starting point we hand new users, so a
+  # stale lockfile here is a vulnerable dependency we actively ship. Neither
+  # directory was watched until #1441: nanoid sat at 3.3.16 with no version
+  # update PR, and because ci.yml gated on `npm audit` the resulting advisory
+  # turned 11 of 13 open PRs red without a line of code changing.
+  - package-ecosystem: npm
+    directory: "/examples/nextjs-quickstart"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: "Africa/Cairo"
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - examples
+    groups:
+      example-dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/examples/vanilla-js-quickstart"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: "Africa/Cairo"
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - examples
+
+  # Java SDK — Dependabot's security updates already opened PRs here (they need
+  # no config), so the module only ever moved when an advisory forced it. This
+  # adds the routine version updates that keep it from drifting in between.
+  - package-ecosystem: maven
+    directory: "/packages/idenplane-java"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "08:00"
+      timezone: "Africa/Cairo"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - java

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,22 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # Reported, not enforced. `npm audit` resolves against the advisory
+      # database at run time, so a newly published advisory against any
+      # transitive dep fails this step on every open PR at once — with no
+      # code change and nothing the PR author can do about it. That is not
+      # hypothetical: GHSA-2v37-7h3g-55p8 (nanoid, a postcss transitive) put
+      # 11 of the 13 then-open PRs red on this step and nothing else, and
+      # because it runs before `npm run build`, that build had never once
+      # executed here (#1441).
+      #
+      # Enforcement belongs to Dependabot: it alerts on these lockfiles, and
+      # now that examples/* are listed in dependabot.yml it also opens the
+      # update PRs that stop them going stale to begin with. What this job
+      # uniquely proves is that the example still *builds* — so let it get
+      # that far.
       - name: Audit for known-vulnerable dependencies
+        continue-on-error: true
         run: npm audit --audit-level=moderate
 
       # nextjs-quickstart has a real Next.js build; vanilla-js-quickstart has


### PR DESCRIPTION
Two halves of the same failure, both surfaced while clearing the queue in #1441.

## 1. The gate

`Examples — nextjs-quickstart` ran `npm audit --audit-level=moderate` as a **hard gate**. `npm audit` resolves against the advisory database *at run time*, so it fails on advisories published after a PR was opened, against dependencies that PR never touched.

That isn't hypothetical. [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) landed against `nanoid` — a `postcss` transitive — and put **11 of the 13 then-open PRs red on this step and nothing else**. Worse, the step runs *before* `npm run build`, so the build this job exists to perform had **never once executed**.

```diff
   - name: Audit for known-vulnerable dependencies
+    continue-on-error: true
     run: npm audit --audit-level=moderate
```

The step stays — a vulnerable example is worth seeing next to the build that ships it — but it no longer blocks. Enforcement is Dependabot's job: it alerts on these lockfiles and opens the fix PRs. What this job *uniquely* proves is that the example still builds, so let it get that far.

## 2. Why the lockfile went stale in the first place

`dependabot.yml` watched npm at `/`, `/admin-ui` and `/docs`, plus github-actions and docker. It did **not** watch `examples/*` or `packages/idenplane-java`.

Security updates open PRs without any config — which is why the Java module still got advisory-driven bumps (#1440) — but nothing ever opened a *routine version update* for either, so `examples/nextjs-quickstart`'s lockfile sat untouched until an advisory finally caught it.

Added, matching the existing entries' shape and schedule:

| ecosystem | directory |
|---|---|
| npm | `/examples/nextjs-quickstart` |
| npm | `/examples/vanilla-js-quickstart` |
| maven | `/packages/idenplane-java` |

Examples matter more than their size suggests — they're the copy-paste starting point handed to new users, so a stale lockfile there is a vulnerable dependency we actively ship.

## Checks

Both files parse clean; `dependabot.yml` now resolves **8** update entries (was 5).

---

> **Note on CI:** `Examples — nextjs-quickstart` shows red here until #1441 lands. It does **not** clear on its own once #1441 merges — click **Update branch** after merging #1441. Once *this* PR merges, that failure mode stops being able to block anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
