### PR TITLE
chore(deps): bump nanoid to 3.3.18 in /docs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14509,9 +14509,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Clears [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (Dependabot alert **#382**).

Lockfile-only: `postcss` already declares `nanoid ^3.3.16`, so the patched 3.3.18 was always in range — the entry was just stale. No `package.json` change, no `overrides`.

```diff
   "node_modules/nanoid": {
-    "version": "3.3.16",
+    "version": "3.3.18",
```

## Scoped to nanoid on purpose

`dompurify` (alert #368) has its own open PR — #1429 — and is deliberately left alone here so the two don't collide.

## Verified locally

```
npm ci                   exit 0   (1412 packages)
npm run build            exit 0   docusaurus: Server 1.18m, Client 2.28m,
                                  "Generated static files in build"
```

## What this does *not* fix

`docs/` still carries **image-size ≤2.0.2** (alerts #369, #370, CVSS 7.5) via `@docusaurus/mdx-loader`. There is **no patched version published** — nothing to bump to. It cascades into 18 of the 19 highs `npm audit` reports here, which makes the docs audit look far worse than it is: it's one unfixable transitive, counted once per parent.

Left open rather than dismissed, deliberately — an open alert auto-resolves the day a patch ships; a dismissed one stays silent. The exposure is a build-time DoS on malformed image input, where the input is this repo's own images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)