### PR TITLE
ci(deps): stop Dependabot re-proposing TypeScript 7 — the toolchain can't take it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,17 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # TypeScript 7 cannot install here at all: ts-jest's peer range is
+      # `>=4.3 <7` and 29.4.12 is its latest release, so `npm ci` dies with
+      # ERESOLVE before a single test runs. That is what killed #1369 — not
+      # our code. Re-proposing the same major every week just re-runs the
+      # whole matrix to fail identically.
+      # Remove this once ts-jest ships a release accepting TypeScript 7, and
+      # do that bump deliberately with the toolchain moved in the same PR.
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major
 
   # Admin UI
   - package-ecosystem: npm
@@ -59,6 +70,16 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+    ignore:
+      # Same wall as the root, different package holding it up: typescript-eslint
+      # 8.67.0 (its latest) peers on `>=4.8.4 <6.1.0`, so TypeScript 7 fails
+      # `npm ci` with ERESOLVE here too — that is what killed #1362. Note the
+      # ceiling is 6.1, not 7: even a TypeScript 6.1 minor would trip it, so
+      # revisit this pin rather than assuming only majors are affected.
+      # Remove once typescript-eslint widens its peer range.
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major
 
   # GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
#1369 and #1362 have both been red since 2026-08-03. Neither failed on anything this repo wrote — **TypeScript 7 cannot be installed at all:**

| directory | blocker (at its own latest release) | peer range |
|---|---|---|
| `/` | `ts-jest@29.4.12` | `typescript >=4.3 <7` |
| `/admin-ui` | `typescript-eslint@8.67.0` | `typescript >=4.8.4 <6.1.0` |

Both die in `npm ci` with `ERESOLVE` before a single test runs:

```
npm error Could not resolve dependency:
npm error peer typescript@">=4.3 <7" from ts-jest@29.4.12
```

Every weekly re-proposal spends the whole CI matrix arriving at the identical failure.

## What this does

Ignores `typescript` **semver-majors** in both directories, with the blocking peer named in each comment and the condition for removal. This is a pin against a known upstream wall — not a decision to stay behind. When ts-jest and typescript-eslint widen their ranges, the bump should be done deliberately, moving the toolchain in the same PR.

## Worth reading twice

admin-ui's ceiling is **`<6.1.0`, not `<7`**. A TypeScript **6.1 minor** would trip it too — so that pin needs re-reading when the time comes, rather than assuming majors are the whole story.

## Deliberately *not* included

No ignore for `jsdom` or anything else. #1431 (jsdom 29 → 30) has never had a CI run that wasn't poisoned by the old audit gate — it gets judged on a real result, not pre-emptively silenced.

Overlaps the dependabot.yml half of the draft #1435; that PR's remaining value is its `frontend-dev-tooling` group and the `ClientCreatePage` flaky-test fix, which are untouched here.

Closes #1369
Closes #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)