### PR TITLE
ci(deps): group the Java SDK's BOM families so they can't drift apart

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -161,3 +161,30 @@ updates:
     labels:
       - dependencies
       - java
+    # Every artifact below is pinned individually in pom.xml rather than
+    # inherited from a Spring BOM, so ungrouped Dependabot proposes them one at
+    # a time — and a single artifact moving alone leaves the family skewed. The
+    # first week of watching this directory produced exactly that:
+    #   #1448 spring-boot-configuration-processor 3.5.4 -> 4.1.0, while
+    #         autoconfigure / test / test-autoconfigure stay on 3.5.4
+    #   #1445 spring-security-oauth2-resource-server 6.5.10 -> 7.1.0, while
+    #         core / web / oauth2-jose stay on 6.5.x
+    #   #1447 reactor-test 3.7.3 -> 3.8.6, while reactor-core stays 3.7.3
+    # Split majors across one BOM are how you get a NoSuchMethodError that no
+    # compile step catches. Grouping makes each family move as a unit — and
+    # makes a major upgrade one reviewable PR instead of four that are only
+    # correct together.
+    groups:
+      spring-boot:
+        patterns:
+          - "org.springframework.boot:*"
+      spring-security:
+        patterns:
+          - "org.springframework.security:*"
+      reactor:
+        patterns:
+          - "io.projectreactor:*"
+      httpcomponents:
+        patterns:
+          - "org.apache.httpcomponents.client5:*"
+          - "org.apache.httpcomponents.core5:*"


### PR DESCRIPTION
`packages/idenplane-java/pom.xml` pins every Spring, Reactor and HttpComponents artifact **individually** rather than importing a BOM — so ungrouped Dependabot proposes them one at a time. The first week of watching this directory (added in #1443) produced three PRs that are each wrong on their own:

| PR | proposes | leaves behind |
|---|---|---|
| #1448 | `spring-boot-configuration-processor` 3.5.4 → **4.1.0** | `autoconfigure`, `test`, `test-autoconfigure` on 3.5.4 |
| #1445 | `spring-security-oauth2-resource-server` 6.5.10 → **7.1.0** | `core`, `web`, `oauth2-jose` on 6.5.x |
| #1447 | `reactor-test` 3.7.3 → 3.8.6 | `reactor-core` on 3.7.3 |

Two of those are **major** bumps of one member of a coordinated release train. `mvn verify` can pass on that and still leave a `NoSuchMethodError` waiting at runtime, because the compile step only sees the artifacts it happens to resolve.

This isn't theoretical drift either — `spring-security` is already skewed today: `spring-security-web` is on **6.5.11** while its three siblings sit on **6.5.10**.

## The change

```yaml
groups:
  spring-boot:      "org.springframework.boot:*"
  spring-security:  "org.springframework.security:*"
  reactor:          "io.projectreactor:*"
  httpcomponents:   "org.apache.httpcomponents.client5:*"
                    "org.apache.httpcomponents.core5:*"
```

Each family now moves as a unit — a major upgrade arrives as **one reviewable PR** instead of four that are only correct together.

## For whoever picks up Spring Boot 4 / Security 7

This module targets **Java 17**, and those releases are a coordinated jump across the whole train. It's a deliberate migration, not a dependency bump. #1448 and #1445 should be closed rather than merged — grouping will re-propose them properly.

Config parses clean; 8 update entries, 4 maven groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)