### PR TITLE
chore(deps): move the whole spring-boot family to 3.5.15, not just one artifact

### DIFF
--- a/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
+++ b/packages/idenplane-java/idenplane-java-spring-sample/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.15</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -92,7 +92,7 @@
                      versions only, not plugin versions — that's spring-boot-starter-parent's
                      job, which this module can't also extend (see the dependencyManagement
                      comment above). Version pinned explicitly instead. -->
-                <version>3.5.4</version>
+                <version>3.5.15</version>
             </plugin>
         </plugins>
     </build>

--- a/packages/idenplane-java/pom.xml
+++ b/packages/idenplane-java/pom.xml
@@ -177,7 +177,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-autoconfigure</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.15</version>
             </dependency>
 
             <!-- Test support for exercising @AutoConfiguration classes via
@@ -185,14 +185,14 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-test</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.15</version>
                 <scope>test</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-test-autoconfigure</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.15</version>
                 <scope>test</scope>
             </dependency>
 
@@ -200,7 +200,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-configuration-processor</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.15</version>
             </dependency>
 
             <!-- Jakarta EE -->


### PR DESCRIPTION
Closes Dependabot alert **#388** — [GHSA-ggg2-9786-hwc8](https://github.com/advisories/GHSA-ggg2-9786-hwc8), *"Predictable Temp Directory in Artemis Auto-configuration"*, affecting `>=3.5.0 <=3.5.14`.

## Why not just merge #1440

#1440 proposed exactly **one** of these artifacts — `spring-boot-autoconfigure` — leaving its three siblings on 3.5.4. Dependabot has since reported it can no longer rebase that PR now that maven is configured (#1443) and asked for it to be closed. So rather than take the one-artifact version, this moves the family together, which is what #1456 configured Dependabot to do from here on.

```
packages/idenplane-java/pom.xml
  spring-boot-autoconfigure            3.5.4 -> 3.5.15
  spring-boot-test                     3.5.4 -> 3.5.15
  spring-boot-test-autoconfigure       3.5.4 -> 3.5.15
  spring-boot-configuration-processor  3.5.4 -> 3.5.15
```

## The part that was easy to miss

`idenplane-java-spring-sample` imports the **`spring-boot-dependencies` BOM itself** rather than inheriting a second parent. Leaving it behind would have reintroduced the exact skew this fixes — SDK modules on 3.5.15 while the sample resolves 3.5.4 through its own BOM.

```
idenplane-java-spring-sample/pom.xml
  spring-boot-dependencies (imported BOM)  3.5.4 -> 3.5.15
  spring-boot-maven-plugin                 3.5.4 -> 3.5.15
```

No `3.5.4` reference remains anywhere under `packages/idenplane-java`. All moves are within **3.5.x** — a patch line, no API surface shifting.

## Verification

Maven isn't available on the machine this was prepared on, so verification is the **`Java SDK`** job's `mvn -B verify`, which builds every module in the reactor — the sample included. Not merging until that's green.

Supersedes #1440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)