### PR TITLE
ci(deps): defer the Spring Boot 4 / Security 7 majors to #1468

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -209,3 +209,25 @@ updates:
         patterns:
           - "org.apache.httpcomponents.client5:*"
           - "org.apache.httpcomponents.core5:*"
+    ignore:
+      # Spring Boot 4 and Spring Security 7 are a migration, not a bump, and
+      # they are tracked in #1468. Grouping (above) did its job — it turned
+      # them into two coherent PRs, #1463 and #1464 — and both fail `Java SDK`
+      # for reasons that live in library code, not in the poms:
+      #   Boot 4      removes TestRestTemplate; the sample's test won't compile
+      #   Security 7  breaks the authorities mapping — a valid token stops
+      #               producing ROLE_user (#1445, SpringBootSampleApplication
+      #               Tests:89), which points at IdenplaneAuthoritiesConverter
+      # This is an identity SDK: a wrong role-to-authority mapping still
+      # returns 200 and still builds green, so it is not something to land on
+      # a dependency sweep. Ignoring the majors keeps the same red PR from
+      # being re-proposed every Monday while #1468 is open.
+      # Minor and patch updates are untouched — 3.5.x and 6.5.x keep flowing,
+      # which is how #1462 shipped the Artemis advisory fix.
+      # DELETE THIS BLOCK as part of #1468.
+      - dependency-name: "org.springframework.boot:*"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "org.springframework.security:*"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
Grouping (#1456) did exactly what it was meant to. Instead of #1448's single artifact, Dependabot now proposes the whole family — #1463 (`spring-boot`, 6 updates) and #1464 (`spring-security`, 4). **Both fail `Java SDK`**, and for reasons that live in library code, not in the poms.

## What breaks

**Boot 4 removes `TestRestTemplate`** — the sample's test doesn't compile:

```
SpringBootSampleApplicationTests.java:[7,48]
  package org.springframework.boot.test.web.client does not exist
SpringBootSampleApplicationTests.java:[54,19] cannot find symbol: class TestRestTemplate
```

Mechanical. One file, three call sites.

**Security 7 breaks the authorities mapping** — this is the one that matters:

```
SpringBootSampleApplicationTests.meEndpoint_returnsSubjectAndAuthoritiesForAValidToken:89
```

Line 89 is `assertThat((List<String>) response.getBody().get("authorities")).contains("ROLE_user")`. A valid token stops producing `ROLE_user`. That's `IdenplaneAuthoritiesConverter` / `IdenplaneAutoConfiguration` in `idenplane-java-spring/src/main/java/` — **library code, not sample code**. Seen twice now: #1445 (Security 7 alone) and again in #1464.

## Why defer rather than push through

This is an identity SDK. A wrong role-to-authority mapping **still returns 200 and still builds green** — it's a security defect that passes CI. It needs someone to read what Security 7 changed in resource-server authority conversion and decide deliberately whether the SDK follows the new behaviour or preserves the current contract.

That's #1468, with the full evidence and a scope checklist. Not a dependency sweep.

## What this PR does

Ignores **majors only** for `org.springframework.boot:*` and `org.springframework.security:*` while #1468 is open, so the same red PR isn't re-proposed every Monday and burning a full CI matrix to fail identically.

**Minors and patches are deliberately untouched** — 3.5.x and 6.5.x keep flowing. That's the path #1462 used to ship the Artemis advisory fix (alert #388), and it stays open.

The ignore block names #1468 inline and says to delete it as part of that work.

Closes #1463
Closes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)