### PR TITLE
chore: group admin-ui dev deps, and stop two tests leaking work into the suite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,18 @@ updates:
         patterns:
           - "vitest"
           - "@vitest/*"
+      # The root and /docs entries both have this catch-all; admin-ui never
+      # did, so every dev-tooling patch arrived as its own PR — #1470
+      # (@testing-library/jest-dom 7.0.0->7.0.1), #1471
+      # (eslint-plugin-react-refresh 0.5.3->0.5.4), #1472
+      # (@fontsource-variable/jetbrains-mono) and #1473 (eslint 10.8.0->10.8.1)
+      # all opened in the same Monday run, four full CI matrices for four
+      # patch bumps. Named groups above still win for anything they match.
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
     ignore:
       # Same wall as the root, different package holding it up: typescript-eslint
       # 8.67.0 (its latest) peers on `>=4.8.4 <6.1.0`, so TypeScript 7 fails

--- a/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
+++ b/admin-ui/src/pages/clients/__tests__/ClientCreatePage.test.tsx
@@ -98,9 +98,14 @@ describe('ClientCreatePage', () => {
   });
 
   it('shows "Creating..." while the mutation is pending', async () => {
+    let completeRequest!: () => void;
+    const requestPending = new Promise<void>((resolve) => {
+      completeRequest = resolve;
+    });
+
     server.use(
       http.post('/admin/realms/:name/clients', async () => {
-        await new Promise((r) => setTimeout(r, 100));
+        await requestPending;
         return HttpResponse.json({}, { status: 201 });
       }),
     );
@@ -111,9 +116,15 @@ describe('ClientCreatePage', () => {
     await user.type(screen.getByLabelText(/^client id$/i), 'slow-client');
     await user.click(screen.getByRole('button', { name: /^create client$/i }));
 
-    expect(await screen.findByRole('button', { name: /creating/i })).toBeInTheDocument();
-    // Let the delayed 201 land before the test ends — see DashboardPage.test.tsx
-    // for why an in-flight request outliving the test breaks the whole run.
+    try {
+      expect(await screen.findByRole('button', { name: /creating/i })).toBeInTheDocument();
+    } finally {
+      // Always release the MSW handler, including when the assertion fails, so
+      // a failure cannot strand an open request and hang the remaining suite.
+      completeRequest();
+    }
+    // Let the response land before the test ends — an in-flight request that
+    // outlives the test can leak work into the rest of the suite.
     await waitForElementToBeRemoved(() => screen.queryByRole('button', { name: /creating/i }));
   });
 

--- a/src/admin-auth/admin-auth.service.spec.ts
+++ b/src/admin-auth/admin-auth.service.spec.ts
@@ -109,6 +109,10 @@ describe('AdminAuthService', () => {
     );
   });
 
+  afterEach(() => {
+    service.onModuleDestroy();
+  });
+
   // ─── login ─────────────────────────────────────────────
 
   describe('login', () => {


### PR DESCRIPTION
Takes the parts of #1435 that still stand on their own, and drops the parts that don't.

## 1. admin-ui `dev-dependencies` group

The root and `/docs` entries both have this catch-all. **admin-ui never did** — so every dev-tooling patch arrives as its own PR. One Monday run opened four:

| PR | bump |
|---|---|
| #1470 | `@testing-library/jest-dom` 7.0.0 → 7.0.1 |
| #1471 | `eslint-plugin-react-refresh` 0.5.3 → 0.5.4 |
| #1472 | `@fontsource-variable/jetbrains-mono` 5.2.8 → 5.3.0 |
| #1473 | `eslint` 10.8.0 → 10.8.1 |

Four full CI matrices for four patch bumps.

#1435 proposed a narrower `frontend-dev-tooling` group listing `vite` / `@vitejs/*` / `typescript-eslint` / `eslint*` by name. The catch-all covers those **and** everything else, and matches how the other two directories are already written. The named groups (`react`, `tailwind`, `vitest`) still win for anything they match.

## 2. Two tests that could leak work into the rest of the run

**`ClientCreatePage` — "shows Creating... while the mutation is pending"**
The MSW handler slept on a real `setTimeout(r, 100)` and the test relied on the response landing before it ended. Now the handler awaits a promise the test resolves itself — no wall-clock timing left to lose — and the release sits in a `finally`, so a failed assertion can't strand an open request and hang the remainder of the suite.

**`admin-auth.service.spec`**
Adds the missing `afterEach` calling `service.onModuleDestroy()`, so its timers don't outlive the suite.

## Deliberately *not* carried over from #1435

The **`jsdom` major ignore**. jsdom 29 → 30 (#1431) had never had a CI run that wasn't poisoned by the old `npm audit` hard gate (removed in #1443). Given a clean run it came back **green and merged** — pre-emptively ignoring it would have pinned a dependency on no evidence.

#1435's dependabot.yml TypeScript half was already superseded by #1455, which records the blocking peer ranges (`ts-jest` `<7`, `typescript-eslint` `<6.1.0`).

## Verified locally

```
admin-ui   vitest  ClientCreatePage.test.tsx    18 passed
root       jest    admin-auth.service.spec.ts   25 passed
```

Closes #1435

🤖 Generated with [Claude Code](https://claude.com/claude-code)