### PR TITLE
chore(deps): override deepmerge-ts to 8.0.2 — root audit goes to zero

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7193,12 +7193,22 @@
       }
     },
     "node_modules/deepmerge-ts": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-      "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz",
+      "integrity": "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==",
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/deepmerge-ts"
+        }
+      ],
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/defaults": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
     "@nestjs/swagger": {
       "js-yaml": "^5.2.2"
     },
-    "@babel/core": "^7.29.6"
+    "@babel/core": "^7.29.6",
+    "deepmerge-ts": "^8.0.2"
   },
   "prisma": {
     "seed": "ts-node prisma/seed.ts"


### PR DESCRIPTION
Closes Dependabot alert **#387** — [GHSA-ggr8-5vv4-36mx](https://github.com/advisories/GHSA-ggr8-5vv4-36mx), stack exhaustion when merging recursive object graphs.

## Why an override at all

There is no upstream path to this fix:

```
prisma 7.9.1 (current latest)  ->  @prisma/config  ->  deepmerge-ts 7.1.5  (pinned EXACTLY)
```

`deepmerge-ts@8.0.2` exists, but nothing upstream consumes it yet. npm's only proposed remedy is **downgrading prisma to 6.12.0** — a semver-major downgrade of a core dependency. So it was an override or nothing.

## Why this is tested rather than argued

I didn't want to force a major under an ORM's config loader on the argument that it "should be fine". `@prisma/config` is the package that consumes `deepmerge-ts`, and `prisma.config.ts` is what it merges — so **`prisma validate` is the check that matters**, because it exercises the real code path instead of just proving the tree installs.

```
npm install                        exit 0    deepmerge-ts resolves to 8.0.2
npm audit --audit-level=moderate   found 0 vulnerabilities      ← was 3 high
npx prisma generate                exit 0
npx prisma validate                exit 0    "Loaded Prisma config from
                                              prisma.config.ts" + schema valid
npm run build  (nest build)        exit 0
npm test                           exit 0    133 suites, 2207 tests, all pass
```

## Result

**The root lockfile now audits clean.** Combined with #1442 (nanoid, js-yaml, brace-expansion), `package-lock.json` goes from **6 high advisories to none**.

## Remove this later

Delete the override once prisma ships a release whose `@prisma/config` depends on `deepmerge-ts` 8.x. It's a workaround for someone else's pin, not a preference of ours — leaving it would silently hold back whatever they move to next.

Diff is one line of `package.json` plus 18 lines of lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)