### PR TITLE
feat(proxy): forward-auth mode for Traefik, nginx and Caddy

### DIFF
--- a/prisma/migrations/20260823010000_add_proxy_applications/migration.sql
+++ b/prisma/migrations/20260823010000_add_proxy_applications/migration.sql
@@ -1,0 +1,69 @@
+-- Reverse-proxy / forward-auth mode (#1314).
+-- Purely additive: two new tables, no change to any existing one, so an
+-- instance that never configures a proxy application is unaffected.
+
+-- CreateTable
+CREATE TABLE "proxy_applications" (
+    "id" TEXT NOT NULL,
+    "realm_id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "client_id" TEXT NOT NULL,
+    "allowed_redirect_uris" TEXT[],
+    "cookie_domain" TEXT NOT NULL,
+    "cookie_ttl" INTEGER NOT NULL DEFAULT 28800,
+    "user_header" TEXT NOT NULL DEFAULT 'X-Forwarded-User',
+    "email_header" TEXT NOT NULL DEFAULT 'X-Forwarded-Email',
+    "name_header" TEXT NOT NULL DEFAULT 'X-Forwarded-Preferred-Username',
+    "groups_header" TEXT NOT NULL DEFAULT 'X-Forwarded-Groups',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "proxy_applications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "proxy_sessions" (
+    "id" TEXT NOT NULL,
+    "proxy_application_id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "ip_address" TEXT,
+    "user_agent" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "proxy_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "proxy_applications_client_id_idx" ON "proxy_applications"("client_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "proxy_applications_realm_id_slug_key" ON "proxy_applications"("realm_id", "slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "proxy_sessions_token_hash_key" ON "proxy_sessions"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "proxy_sessions_user_id_idx" ON "proxy_sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "proxy_sessions_proxy_application_id_idx" ON "proxy_sessions"("proxy_application_id");
+
+-- CreateIndex
+CREATE INDEX "proxy_sessions_expires_at_idx" ON "proxy_sessions"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "proxy_applications" ADD CONSTRAINT "proxy_applications_realm_id_fkey" FOREIGN KEY ("realm_id") REFERENCES "realms"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "proxy_applications" ADD CONSTRAINT "proxy_applications_client_id_fkey" FOREIGN KEY ("client_id") REFERENCES "clients"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "proxy_sessions" ADD CONSTRAINT "proxy_sessions_proxy_application_id_fkey" FOREIGN KEY ("proxy_application_id") REFERENCES "proxy_applications"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "proxy_sessions" ADD CONSTRAINT "proxy_sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -89,8 +89,8 @@ model Realm {
   smtpFrom     String? @map("smtp_from")
   smtpSecure   Boolean @default(false) @map("smtp_secure")
 
-  emailProvider       String  @default("smtp") @map("email_provider")
-  emailProviderConfig Json?   @map("email_provider_config")
+  emailProvider       String @default("smtp") @map("email_provider")
+  emailProviderConfig Json?  @map("email_provider_config")
 
   // Magic link / passwordless authentication
   magicLinkEnabled                Boolean @default(false) @map("magic_link_enabled")
@@ -139,9 +139,9 @@ model Realm {
   mfaRequired Boolean @default(false) @map("mfa_required")
 
   // WebAuthn / FIDO2
-  webAuthnEnabled               Boolean @default(false) @map("webauthn_enabled")
-  webAuthnRpName                String? @map("webauthn_rp_name")
-  webAuthnRpId                  String? @map("webauthn_rp_id")
+  webAuthnEnabled                  Boolean @default(false) @map("webauthn_enabled")
+  webAuthnRpName                   String? @map("webauthn_rp_name")
+  webAuthnRpId                     String? @map("webauthn_rp_id")
   webAuthnUserVerificationRequired Boolean @default(false) @map("webauthn_user_verification_required")
 
   // SMS provider configuration
@@ -225,9 +225,9 @@ model Realm {
   userFederations             UserFederation[]
   samlServiceProviders        SamlServiceProvider[]
   webhooks                    Webhook[]
-  webAuthnFailureTracking    WebAuthnFailureTracking[]
-  webAuthnCredentials       WebAuthnCredential[]
-  smsDeliveryLogs            SmsDeliveryLog[]
+  webAuthnFailureTracking     WebAuthnFailureTracking[]
+  webAuthnCredentials         WebAuthnCredential[]
+  smsDeliveryLogs             SmsDeliveryLog[]
   otpAttempts                 OtpAttempt[]
   auditLogStreams             AuditLogStream[]
   impersonationSessions       ImpersonationSession[]
@@ -250,6 +250,7 @@ model Realm {
   nhiAuditLogs                NhiAuditLog[]
   consentCategories           ConsentCategory[]
   themes                      Theme[]
+  proxyApplications           ProxyApplication[]
 
   @@map("realms")
 }
@@ -302,6 +303,7 @@ model User {
   behavioralBiometricProfile BehavioralBiometricProfile?
   consentHistory             UserConsentHistory[]
   pendingDeletion            PendingDeletion?
+  proxySessions              ProxySession[]
 
   @@unique([realmId, username])
   @@unique([realmId, email])
@@ -357,6 +359,8 @@ model Client {
   consentHistory UserConsentHistory[]
   defaultScopes  ClientDefaultScope[]
   optionalScopes ClientOptionalScope[]
+
+  proxyApplications ProxyApplication[]
 
   @@unique([realmId, clientId])
   @@map("clients")
@@ -448,14 +452,14 @@ model RefreshToken {
 // ─── AUTHORIZATION CODES ──────────────────────────────────
 
 model AuthorizationCode {
-  id                  String  @id @default(uuid())
-  code                String  @unique
-  clientId            String  @map("client_id")
-  userId              String  @map("user_id")
-  redirectUri         String  @map("redirect_uri")
+  id                  String   @id @default(uuid())
+  code                String   @unique
+  clientId            String   @map("client_id")
+  userId              String   @map("user_id")
+  redirectUri         String   @map("redirect_uri")
   scope               String?
-  codeChallenge       String? @map("code_challenge")
-  codeChallengeMethod String? @map("code_challenge_method")
+  codeChallenge       String?  @map("code_challenge")
+  codeChallengeMethod String?  @map("code_challenge_method")
   nonce               String?
   /// The ACR value(s) *requested* by the client at authorization time.
   acrValues           String?  @map("acr_values")
@@ -1879,16 +1883,16 @@ model ScimProvisioningToken {
 }
 
 model ScimAttributeMapping {
-  id              String   @id @default(uuid())
-  realmId         String   @map("realm_id")
-  realm           Realm    @relation(fields: [realmId], references: [id], onDelete: Cascade)
-  resourceType    String // "User" | "Group"
-  scimAttribute   String   @map("scim_attribute")
+  id                 String   @id @default(uuid())
+  realmId            String   @map("realm_id")
+  realm              Realm    @relation(fields: [realmId], references: [id], onDelete: Cascade)
+  resourceType       String // "User" | "Group"
+  scimAttribute      String   @map("scim_attribute")
   idenplaneAttribute String   @map("idenplane_attribute")
-  enabled         Boolean  @default(true)
-  direction       String   @default("inbound") // "inbound" | "outbound" | "bidirectional"
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @updatedAt @map("updated_at")
+  enabled            Boolean  @default(true)
+  direction          String   @default("inbound") // "inbound" | "outbound" | "bidirectional"
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
 
   @@unique([realmId, resourceType, scimAttribute])
   @@index([realmId, resourceType])
@@ -2061,19 +2065,19 @@ model NhiAuditLog {
 }
 
 model NhiUsageStats {
-  id            String    @id @default(uuid())
-  nhiIdentityId String    @unique @map("nhi_identity_id")
-  totalRequests Int       @default(0) @map("total_requests")
-  lastActiveAt  DateTime? @map("last_active_at")
-  successCount  Int       @default(0) @map("success_count")
-  errorCount    Int       @default(0) @map("error_count")
-  lastSuccessfulAt DateTime? @map("last_successful_at")
-  lastFailedAt      DateTime? @map("last_failed_at")
-  oldestCredentialAgeDays Int? @map("oldest_credential_age_days")
-  newestCredentialAgeDays Int? @map("newest_credential_age_days")
-  credentialsExpiringSoon Int @default(0) @map("credentials_expiring_soon")
-  createdAt     DateTime  @default(now()) @map("created_at")
-  updatedAt     DateTime  @updatedAt @map("updated_at")
+  id                      String    @id @default(uuid())
+  nhiIdentityId           String    @unique @map("nhi_identity_id")
+  totalRequests           Int       @default(0) @map("total_requests")
+  lastActiveAt            DateTime? @map("last_active_at")
+  successCount            Int       @default(0) @map("success_count")
+  errorCount              Int       @default(0) @map("error_count")
+  lastSuccessfulAt        DateTime? @map("last_successful_at")
+  lastFailedAt            DateTime? @map("last_failed_at")
+  oldestCredentialAgeDays Int?      @map("oldest_credential_age_days")
+  newestCredentialAgeDays Int?      @map("newest_credential_age_days")
+  credentialsExpiringSoon Int       @default(0) @map("credentials_expiring_soon")
+  createdAt               DateTime  @default(now()) @map("created_at")
+  updatedAt               DateTime  @updatedAt @map("updated_at")
 
   nhiIdentity NhiIdentity @relation(fields: [nhiIdentityId], references: [id], onDelete: Cascade)
 
@@ -2250,17 +2254,106 @@ model UpgradeAuditLog {
 // ─── RATE LIMIT ENTRIES (cluster-safe fallback) ────────────────
 
 model RateLimitEntry {
-  id        String   @id @default(uuid())
-  key       String   @unique @map("key")
-  minuteCount      Int      @default(0) @map("minute_count")
+  id                String   @id @default(uuid())
+  key               String   @unique @map("key")
+  minuteCount       Int      @default(0) @map("minute_count")
   minuteWindowStart DateTime @default(now()) @map("minute_window_start")
-  hourCount        Int      @default(0) @map("hour_count")
+  hourCount         Int      @default(0) @map("hour_count")
   hourWindowStart   DateTime @default(now()) @map("hour_window_start")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
 
   @@index([key])
   @@index([minuteWindowStart])
   @@index([hourWindowStart])
   @@map("rate_limit_entries")
+}
+
+/// A web application that Idenplane protects at the reverse proxy instead of
+/// inside the application's own code — Traefik `forwardAuth`, nginx
+/// `auth_request`, Caddy `forward_auth`. The proxy calls the verify endpoint
+/// before every request; Idenplane answers 200 (with the identity in headers),
+/// 401, or a redirect into the normal login flow.
+///
+/// Authentication itself is NOT reimplemented here: each proxy application
+/// authenticates through an ordinary OAuth client (`clientId` below), so MFA,
+/// step-up, SSO, consent, brute-force protection and risk assessment all apply
+/// unchanged.
+model ProxyApplication {
+  id      String  @id @default(uuid())
+  realmId String  @map("realm_id")
+  /// URL-safe identifier used in the proxy endpoints and in the proxy's own
+  /// config, e.g. /realms/<realm>/proxy/<slug>/verify.
+  slug    String
+  name    String
+  enabled Boolean @default(true)
+
+  /// The OAuth client this application authenticates through. Its
+  /// `redirectUris` must contain this application's callback URL — that
+  /// allowlist is what stops an attacker steering the post-login redirect.
+  clientId String @map("client_id")
+
+  /// Origins this application is served from. A forward-auth request's
+  /// reconstructed URL must match one of these before we will send a browser
+  /// back to it. Same wildcard semantics — and the same matcher — as OAuth
+  /// redirect_uri; see common/redirect-uri.utils.ts.
+  allowedRedirectUris String[] @map("allowed_redirect_uris")
+
+  /// Scope of the proxy session cookie, e.g. ".example.com". This is a
+  /// SEPARATE cookie from the IDENPLANE_SESSION SSO cookie, which is
+  /// deliberately pinned to `path=/realms/<realm>` and `SameSite=Strict`.
+  /// The proxy cookie has to travel to a different host, so it needs a wider
+  /// scope — widening the SSO cookie instead would loosen OAuth, SAML, MFA
+  /// and step-up along with it.
+  cookieDomain String @map("cookie_domain")
+  /// Proxy session lifetime in seconds. Independent of the SSO session:
+  /// revoking one must not silently revoke the other.
+  cookieTtl    Int    @default(28800) @map("cookie_ttl")
+
+  /// Names of the headers the verify endpoint sets on a 200. Configurable
+  /// because the de-facto names differ per stack: Traefik/oauth2-proxy
+  /// deployments expect `X-Forwarded-*`, while many nginx `auth_request` and
+  /// Authentik setups expect `X-Auth-Request-*`.
+  userHeader   String @default("X-Forwarded-User") @map("user_header")
+  emailHeader  String @default("X-Forwarded-Email") @map("email_header")
+  nameHeader   String @default("X-Forwarded-Preferred-Username") @map("name_header")
+  groupsHeader String @default("X-Forwarded-Groups") @map("groups_header")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  realm    Realm          @relation(fields: [realmId], references: [id], onDelete: Cascade)
+  client   Client         @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  sessions ProxySession[]
+
+  @@unique([realmId, slug])
+  @@index([clientId])
+  @@map("proxy_applications")
+}
+
+/// Browser session for a proxy-protected application. Deliberately a separate
+/// credential from LoginSession: the two live in different cookies with
+/// different scopes and lifetimes, and a proxy cookie must never be usable as
+/// an SSO cookie (or the reverse).
+model ProxySession {
+  id                 String @id @default(uuid())
+  proxyApplicationId String @map("proxy_application_id")
+  userId             String @map("user_id")
+  /// SHA-256 of the cookie value. The raw token is never stored, matching how
+  /// LoginSession handles its own token.
+  tokenHash          String @unique @map("token_hash")
+
+  ipAddress String? @map("ip_address")
+  userAgent String? @map("user_agent")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  expiresAt DateTime @map("expires_at")
+
+  application ProxyApplication @relation(fields: [proxyApplicationId], references: [id], onDelete: Cascade)
+  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([proxyApplicationId])
+  @@index([expiresAt])
+  @@map("proxy_sessions")
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -65,6 +65,7 @@ import { ScimModule } from './scim/scim.module.js';
 import { NhiModule } from './nhi/nhi.module.js';
 import { ContinuousVerificationModule } from './continuous-verification/continuous-verification.module.js';
 import { UpgradeModule } from './upgrade/upgrade.module.js';
+import { ProxyAuthModule } from './proxy-auth/proxy-auth.module.js';
 import { AdminApiKeyGuard } from './common/guards/admin-api-key.guard.js';
 import { AdminEventInterceptor } from './events/admin-event.interceptor.js';
 import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
@@ -142,6 +143,7 @@ import { MetricsInterceptor } from './metrics/metrics.interceptor.js';
     NhiModule,
     ContinuousVerificationModule,
     UpgradeModule,
+    ProxyAuthModule,
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerGuard },

--- a/src/prisma/prisma.mock.ts
+++ b/src/prisma/prisma.mock.ts
@@ -301,6 +301,21 @@ export function createMockPrismaService(): MockPrismaService {
       update: jest.fn(),
       delete: jest.fn(),
     },
+    proxyApplication: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    proxySession: {
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      deleteMany: jest.fn(),
+    },
     auditLogStream: {
       findFirst: jest.fn(),
       findMany: jest.fn(),

--- a/src/proxy-auth/dto/create-proxy-application.dto.ts
+++ b/src/proxy-auth/dto/create-proxy-application.dto.ts
@@ -1,0 +1,117 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  Min,
+  Max,
+} from 'class-validator';
+
+/** One day. Longer than this and a revoked account keeps its proxy access for
+ * an uncomfortably long time, since the proxy only re-checks on cookie expiry. */
+const MAX_COOKIE_TTL_SECONDS = 86_400;
+
+export class CreateProxyApplicationDto {
+  @ApiProperty({
+    description:
+      'URL-safe identifier used in the proxy endpoints, e.g. /realms/<realm>/proxy/<slug>/verify',
+    example: 'grafana',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^[a-z0-9][a-z0-9-]*$/, {
+    message:
+      'slug must be lowercase alphanumeric with hyphens, and start with a letter or digit',
+  })
+  slug!: string;
+
+  @ApiProperty({ description: 'Human-readable name', example: 'Grafana' })
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @ApiProperty({
+    description:
+      'clientId of the OAuth client this application authenticates through. Its redirectUris must contain the callback URL returned by this endpoint.',
+    example: 'grafana-proxy',
+  })
+  @IsString()
+  @IsNotEmpty()
+  clientId!: string;
+
+  @ApiProperty({
+    description:
+      'Origins this application is served from. A forward-auth request is only redirected back to a URL matching one of these. Supports the same trailing /* wildcard as OAuth redirectUris.',
+    example: ['https://grafana.example.com/*'],
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  allowedRedirectUris!: string[];
+
+  @ApiProperty({
+    description:
+      'Scope of the proxy session cookie. Must be a parent domain of every allowed redirect URI host, or the browser will never send the cookie to the proxied application.',
+    example: '.example.com',
+  })
+  @IsString()
+  @IsNotEmpty()
+  cookieDomain!: string;
+
+  @ApiPropertyOptional({
+    description: 'Proxy session lifetime in seconds (default 8 hours)',
+    default: 28_800,
+    minimum: 60,
+    maximum: MAX_COOKIE_TTL_SECONDS,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(60)
+  @Max(MAX_COOKIE_TTL_SECONDS)
+  cookieTtl?: number;
+
+  @ApiPropertyOptional({ default: true })
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean;
+
+  @ApiPropertyOptional({
+    description:
+      'Header carrying the username. Traefik/oauth2-proxy stacks expect X-Forwarded-User; many nginx auth_request and Authentik setups expect X-Auth-Request-User.',
+    default: 'X-Forwarded-User',
+  })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Za-z0-9-]+$/, {
+    message: 'header names may only contain letters, digits and hyphens',
+  })
+  userHeader?: string;
+
+  @ApiPropertyOptional({ default: 'X-Forwarded-Email' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Za-z0-9-]+$/, {
+    message: 'header names may only contain letters, digits and hyphens',
+  })
+  emailHeader?: string;
+
+  @ApiPropertyOptional({ default: 'X-Forwarded-Preferred-Username' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Za-z0-9-]+$/, {
+    message: 'header names may only contain letters, digits and hyphens',
+  })
+  nameHeader?: string;
+
+  @ApiPropertyOptional({ default: 'X-Forwarded-Groups' })
+  @IsOptional()
+  @IsString()
+  @Matches(/^[A-Za-z0-9-]+$/, {
+    message: 'header names may only contain letters, digits and hyphens',
+  })
+  groupsHeader?: string;
+}

--- a/src/proxy-auth/dto/update-proxy-application.dto.ts
+++ b/src/proxy-auth/dto/update-proxy-application.dto.ts
@@ -1,0 +1,15 @@
+import { PartialType, OmitType } from '@nestjs/swagger';
+import { CreateProxyApplicationDto } from './create-proxy-application.dto.js';
+
+/**
+ * Everything except `slug` is updatable.
+ *
+ * The slug is part of the URL the proxy is configured with, so renaming it
+ * server-side would silently break a working deployment — the proxy would keep
+ * calling a path that no longer exists, and every request to the protected
+ * application would 404 instead of authenticating. Delete and recreate is the
+ * honest way to change it.
+ */
+export class UpdateProxyApplicationDto extends PartialType(
+  OmitType(CreateProxyApplicationDto, ['slug'] as const),
+) {}

--- a/src/proxy-auth/proxy-applications.controller.ts
+++ b/src/proxy-auth/proxy-applications.controller.ts
@@ -1,0 +1,122 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiSecurity,
+  ApiResponse,
+} from '@nestjs/swagger';
+import type { Realm } from '@prisma/client';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { AdminApiKeyGuard } from '../common/guards/admin-api-key.guard.js';
+import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+import {
+  RateLimitGuard,
+  RateLimitByIp,
+} from '../rate-limit/rate-limit.guard.js';
+import { ProxyApplicationsService } from './proxy-applications.service.js';
+import { CreateProxyApplicationDto } from './dto/create-proxy-application.dto.js';
+import { UpdateProxyApplicationDto } from './dto/update-proxy-application.dto.js';
+
+@ApiTags('Proxy Applications')
+@Controller('admin/realms/:realmName/proxy-applications')
+@UseGuards(RealmGuard, AdminApiKeyGuard, RateLimitGuard)
+@RateLimitByIp()
+@ApiSecurity('admin-api-key')
+export class ProxyApplicationsController {
+  constructor(private readonly service: ProxyApplicationsService) {}
+
+  @Post()
+  @ApiOperation({
+    summary: 'Register an application to be protected at the reverse proxy',
+    description:
+      'Returns the callback URL to register on the OAuth client, and whether it already is.',
+  })
+  @ApiResponse({ status: 201, description: 'Proxy application created' })
+  @ApiResponse({
+    status: 400,
+    description:
+      'Invalid body, or cookieDomain does not cover an allowed redirect URI',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Client not found' })
+  @ApiResponse({
+    status: 409,
+    description: 'Slug already in use in this realm',
+  })
+  create(@CurrentRealm() realm: Realm, @Body() dto: CreateProxyApplicationDto) {
+    return this.service.create(realm, dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List proxy applications in a realm' })
+  @ApiResponse({ status: 200, description: 'List of proxy applications' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  findAll(@CurrentRealm() realm: Realm) {
+    return this.service.findAll(realm);
+  }
+
+  @Get(':slug')
+  @ApiOperation({ summary: 'Get a proxy application by slug' })
+  @ApiResponse({ status: 200, description: 'Proxy application details' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Proxy application not found' })
+  findOne(@CurrentRealm() realm: Realm, @Param('slug') slug: string) {
+    return this.service.findOne(realm, slug);
+  }
+
+  @Put(':slug')
+  @ApiOperation({
+    summary: 'Update a proxy application',
+    description:
+      'The slug is immutable — it is baked into the reverse proxy config, so renaming it here would silently break a working deployment. Delete and recreate instead.',
+  })
+  @ApiResponse({ status: 200, description: 'Proxy application updated' })
+  @ApiResponse({ status: 400, description: 'Invalid body' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Proxy application not found' })
+  update(
+    @CurrentRealm() realm: Realm,
+    @Param('slug') slug: string,
+    @Body() dto: UpdateProxyApplicationDto,
+  ) {
+    return this.service.update(realm, slug, dto);
+  }
+
+  @Delete(':slug')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete a proxy application',
+    description: 'Its live proxy sessions are deleted with it.',
+  })
+  @ApiResponse({ status: 204, description: 'Proxy application deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Proxy application not found' })
+  async remove(@CurrentRealm() realm: Realm, @Param('slug') slug: string) {
+    await this.service.remove(realm, slug);
+  }
+
+  @Post(':slug/revoke-sessions')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Revoke every live session for a proxy application',
+    description:
+      'Forces all users back through login on their next request, without deleting the application.',
+  })
+  @ApiResponse({ status: 200, description: 'Number of sessions revoked' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Proxy application not found' })
+  revokeSessions(@CurrentRealm() realm: Realm, @Param('slug') slug: string) {
+    return this.service.revokeSessions(realm, slug);
+  }
+}

--- a/src/proxy-auth/proxy-applications.service.spec.ts
+++ b/src/proxy-auth/proxy-applications.service.spec.ts
@@ -1,0 +1,296 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, type Realm } from '@prisma/client';
+import { ProxyApplicationsService } from './proxy-applications.service.js';
+import { ProxyAuthService } from './proxy-auth.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const realm = { id: 'realm-1', name: 'master' } as Realm;
+
+const validDto = {
+  slug: 'grafana',
+  name: 'Grafana',
+  clientId: 'grafana-proxy',
+  allowedRedirectUris: ['https://grafana.example.com/*'],
+  cookieDomain: '.example.com',
+};
+
+describe('ProxyApplicationsService', () => {
+  let service: ProxyApplicationsService;
+  let prisma: {
+    client: { findUnique: jest.Mock };
+    proxyApplication: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      findUnique: jest.Mock;
+      update: jest.Mock;
+      delete: jest.Mock;
+    };
+    proxySession: { deleteMany: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      client: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'client-db-1',
+          redirectUris: [],
+        }),
+      },
+      proxyApplication: {
+        create: jest.fn().mockImplementation(({ data }) => ({
+          id: 'app-1',
+          ...data,
+        })),
+        findMany: jest.fn().mockResolvedValue([]),
+        findUnique: jest.fn(),
+        update: jest.fn().mockImplementation(({ data }) => ({
+          id: 'app-1',
+          slug: 'grafana',
+          ...data,
+        })),
+        delete: jest.fn().mockResolvedValue({}),
+      },
+      proxySession: { deleteMany: jest.fn().mockResolvedValue({ count: 3 }) },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProxyApplicationsService,
+        { provide: PrismaService, useValue: prisma },
+        {
+          provide: ProxyAuthService,
+          useValue: {
+            callbackUrl: (realmName: string, slug: string) =>
+              `https://auth.example.com/realms/${realmName}/proxy/${slug}/callback`,
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(ProxyApplicationsService);
+  });
+
+  describe('create', () => {
+    it('404s when the OAuth client does not exist', async () => {
+      prisma.client.findUnique.mockResolvedValue(null);
+
+      await expect(service.create(realm, validDto)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('translates the unique-constraint violation into a 409', async () => {
+      prisma.proxyApplication.create.mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('duplicate', {
+          code: 'P2002',
+          clientVersion: 'test',
+        }),
+      );
+
+      await expect(service.create(realm, validDto)).rejects.toBeInstanceOf(
+        ConflictException,
+      );
+    });
+
+    it('reports the callback URL and that it is not yet registered', async () => {
+      const view = await service.create(realm, validDto);
+
+      expect(view.callbackUrl).toBe(
+        'https://auth.example.com/realms/master/proxy/grafana/callback',
+      );
+      expect(view.callbackRegistered).toBe(false);
+    });
+
+    it('reports the callback as registered once it is on the client', async () => {
+      prisma.client.findUnique.mockResolvedValue({
+        id: 'client-db-1',
+        redirectUris: [
+          'https://auth.example.com/realms/master/proxy/grafana/callback',
+        ],
+      });
+
+      const view = await service.create(realm, validDto);
+      expect(view.callbackRegistered).toBe(true);
+    });
+
+    it('leaves header names at their database defaults when not supplied', async () => {
+      await service.create(realm, validDto);
+
+      const { data } = prisma.proxyApplication.create.mock.calls[0][0];
+      expect(data).not.toHaveProperty('userHeader');
+      expect(data).not.toHaveProperty('groupsHeader');
+    });
+
+    it('passes through header overrides', async () => {
+      await service.create(realm, {
+        ...validDto,
+        userHeader: 'X-Auth-Request-User',
+      });
+
+      const { data } = prisma.proxyApplication.create.mock.calls[0][0];
+      expect(data.userHeader).toBe('X-Auth-Request-User');
+    });
+  });
+
+  // The check that earns its keep: a cookie domain that does not cover the app
+  // produces an infinite redirect loop with no error anywhere in the logs.
+  describe('cookieDomain / allowedRedirectUris agreement', () => {
+    it('accepts a subdomain of the cookie domain', async () => {
+      await expect(
+        service.create(realm, {
+          ...validDto,
+          cookieDomain: '.example.com',
+          allowedRedirectUris: ['https://grafana.example.com/*'],
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('accepts the cookie domain host itself', async () => {
+      await expect(
+        service.create(realm, {
+          ...validDto,
+          cookieDomain: 'example.com',
+          allowedRedirectUris: ['https://example.com/*'],
+        }),
+      ).resolves.toBeDefined();
+    });
+
+    it('rejects a host the cookie would never reach', async () => {
+      await expect(
+        service.create(realm, {
+          ...validDto,
+          cookieDomain: '.example.com',
+          allowedRedirectUris: ['https://grafana.other.test/*'],
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a suffix lookalike rather than treating it as a subdomain', async () => {
+      await expect(
+        service.create(realm, {
+          ...validDto,
+          cookieDomain: '.example.com',
+          allowedRedirectUris: ['https://notexample.com/*'],
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('rejects a redirect URI with no scheme', async () => {
+      await expect(
+        service.create(realm, {
+          ...validDto,
+          allowedRedirectUris: ['grafana.example.com/*'],
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('re-validates on update when only the cookie domain changes', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue({
+        id: 'app-1',
+        clientId: 'client-db-1',
+        cookieDomain: '.example.com',
+        allowedRedirectUris: ['https://grafana.example.com/*'],
+      });
+
+      await expect(
+        service.update(realm, 'grafana', { cookieDomain: '.other.test' }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+
+    it('re-validates on update when only the redirect URIs change', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue({
+        id: 'app-1',
+        clientId: 'client-db-1',
+        cookieDomain: '.example.com',
+        allowedRedirectUris: ['https://grafana.example.com/*'],
+      });
+
+      await expect(
+        service.update(realm, 'grafana', {
+          allowedRedirectUris: ['https://app.other.test/*'],
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('update', () => {
+    beforeEach(() => {
+      prisma.proxyApplication.findUnique.mockResolvedValue({
+        id: 'app-1',
+        clientId: 'client-db-1',
+        cookieDomain: '.example.com',
+        allowedRedirectUris: ['https://grafana.example.com/*'],
+      });
+    });
+
+    it('404s for an unknown slug', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update(realm, 'nope', { name: 'x' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('404s when repointing at a client that does not exist', async () => {
+      prisma.client.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.update(realm, 'grafana', { clientId: 'ghost' }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('leaves untouched fields alone', async () => {
+      await service.update(realm, 'grafana', { name: 'Grafana Prod' });
+
+      const { data } = prisma.proxyApplication.update.mock.calls[0][0];
+      expect(data.name).toBe('Grafana Prod');
+      expect(data).not.toHaveProperty('enabled');
+      expect(data).not.toHaveProperty('cookieTtl');
+    });
+  });
+
+  describe('remove', () => {
+    it('404s for an unknown slug', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue(null);
+
+      await expect(service.remove(realm, 'nope')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('deletes by primary key', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue({ id: 'app-1' });
+
+      await service.remove(realm, 'grafana');
+      expect(prisma.proxyApplication.delete).toHaveBeenCalledWith({
+        where: { id: 'app-1' },
+      });
+    });
+  });
+
+  describe('revokeSessions', () => {
+    it('404s for an unknown slug', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.revokeSessions(realm, 'nope'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('deletes only this application\'s sessions and reports the count', async () => {
+      prisma.proxyApplication.findUnique.mockResolvedValue({ id: 'app-1' });
+
+      await expect(service.revokeSessions(realm, 'grafana')).resolves.toEqual({
+        revoked: 3,
+      });
+      expect(prisma.proxySession.deleteMany).toHaveBeenCalledWith({
+        where: { proxyApplicationId: 'app-1' },
+      });
+    });
+  });
+});

--- a/src/proxy-auth/proxy-applications.service.ts
+++ b/src/proxy-auth/proxy-applications.service.ts
@@ -1,0 +1,274 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, type ProxyApplication, type Realm } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { ProxyAuthService } from './proxy-auth.service.js';
+import { CreateProxyApplicationDto } from './dto/create-proxy-application.dto.js';
+import { UpdateProxyApplicationDto } from './dto/update-proxy-application.dto.js';
+
+/**
+ * What the admin API returns alongside a proxy application: the callback URL
+ * that has to be registered on the OAuth client, and whether it currently is.
+ *
+ * Surfacing this is the difference between a five-minute setup and an
+ * afternoon — the failure mode otherwise is a redirect_uri mismatch at the end
+ * of a login the admin has already completed, with nothing pointing at the
+ * cause.
+ */
+export interface ProxyApplicationView {
+  application: ProxyApplication;
+  callbackUrl: string;
+  callbackRegistered: boolean;
+}
+
+@Injectable()
+export class ProxyApplicationsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly proxyAuth: ProxyAuthService,
+  ) {}
+
+  async create(
+    realm: Realm,
+    dto: CreateProxyApplicationDto,
+  ): Promise<ProxyApplicationView> {
+    const client = await this.prisma.client.findUnique({
+      where: {
+        realmId_clientId: { realmId: realm.id, clientId: dto.clientId },
+      },
+      select: { id: true, redirectUris: true },
+    });
+
+    if (!client) {
+      throw new NotFoundException(
+        `Client '${dto.clientId}' not found in realm '${realm.name}'`,
+      );
+    }
+
+    this.assertCookieDomainCovers(dto.cookieDomain, dto.allowedRedirectUris);
+
+    try {
+      const application = await this.prisma.proxyApplication.create({
+        data: {
+          realmId: realm.id,
+          clientId: client.id,
+          slug: dto.slug,
+          name: dto.name,
+          allowedRedirectUris: dto.allowedRedirectUris,
+          cookieDomain: dto.cookieDomain,
+          ...(dto.cookieTtl !== undefined ? { cookieTtl: dto.cookieTtl } : {}),
+          ...(dto.enabled !== undefined ? { enabled: dto.enabled } : {}),
+          ...this.headerOverrides(dto),
+        },
+      });
+
+      return this.toView(realm, application, client.redirectUris);
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        throw new ConflictException(
+          `A proxy application with slug '${dto.slug}' already exists in this realm`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async findAll(realm: Realm): Promise<ProxyApplicationView[]> {
+    const applications = await this.prisma.proxyApplication.findMany({
+      where: { realmId: realm.id },
+      orderBy: { slug: 'asc' },
+      include: { client: { select: { redirectUris: true } } },
+    });
+
+    return applications.map((a) =>
+      this.toView(realm, a, a.client.redirectUris),
+    );
+  }
+
+  async findOne(realm: Realm, slug: string): Promise<ProxyApplicationView> {
+    const application = await this.prisma.proxyApplication.findUnique({
+      where: { realmId_slug: { realmId: realm.id, slug } },
+      include: { client: { select: { redirectUris: true } } },
+    });
+
+    if (!application) {
+      throw new NotFoundException(`Proxy application '${slug}' not found`);
+    }
+
+    return this.toView(realm, application, application.client.redirectUris);
+  }
+
+  async update(
+    realm: Realm,
+    slug: string,
+    dto: UpdateProxyApplicationDto,
+  ): Promise<ProxyApplicationView> {
+    const existing = await this.prisma.proxyApplication.findUnique({
+      where: { realmId_slug: { realmId: realm.id, slug } },
+    });
+
+    if (!existing) {
+      throw new NotFoundException(`Proxy application '${slug}' not found`);
+    }
+
+    // Validate the resulting state, not just the incoming fields: changing only
+    // the cookie domain, or only the redirect URIs, can break their
+    // relationship just as easily as changing both.
+    const cookieDomain = dto.cookieDomain ?? existing.cookieDomain;
+    const allowedRedirectUris =
+      dto.allowedRedirectUris ?? existing.allowedRedirectUris;
+    this.assertCookieDomainCovers(cookieDomain, allowedRedirectUris);
+
+    let clientDbId: string | undefined;
+    let redirectUris: string[];
+
+    if (dto.clientId) {
+      const client = await this.prisma.client.findUnique({
+        where: {
+          realmId_clientId: { realmId: realm.id, clientId: dto.clientId },
+        },
+        select: { id: true, redirectUris: true },
+      });
+      if (!client) {
+        throw new NotFoundException(
+          `Client '${dto.clientId}' not found in realm '${realm.name}'`,
+        );
+      }
+      clientDbId = client.id;
+      redirectUris = client.redirectUris;
+    } else {
+      const client = await this.prisma.client.findUnique({
+        where: { id: existing.clientId },
+        select: { redirectUris: true },
+      });
+      redirectUris = client?.redirectUris ?? [];
+    }
+
+    const application = await this.prisma.proxyApplication.update({
+      where: { id: existing.id },
+      data: {
+        ...(clientDbId ? { clientId: clientDbId } : {}),
+        ...(dto.name !== undefined ? { name: dto.name } : {}),
+        ...(dto.enabled !== undefined ? { enabled: dto.enabled } : {}),
+        ...(dto.cookieTtl !== undefined ? { cookieTtl: dto.cookieTtl } : {}),
+        cookieDomain,
+        allowedRedirectUris,
+        ...this.headerOverrides(dto),
+      },
+    });
+
+    return this.toView(realm, application, redirectUris);
+  }
+
+  /**
+   * Delete an application. Its sessions go with it via the FK cascade, which is
+   * the point: removing a protected application must not leave live cookies
+   * that would authenticate against a re-created one with the same slug.
+   */
+  async remove(realm: Realm, slug: string): Promise<void> {
+    const existing = await this.prisma.proxyApplication.findUnique({
+      where: { realmId_slug: { realmId: realm.id, slug } },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException(`Proxy application '${slug}' not found`);
+    }
+
+    await this.prisma.proxyApplication.delete({ where: { id: existing.id } });
+  }
+
+  /** Revoke every live session for an application without deleting it. */
+  async revokeSessions(
+    realm: Realm,
+    slug: string,
+  ): Promise<{ revoked: number }> {
+    const existing = await this.prisma.proxyApplication.findUnique({
+      where: { realmId_slug: { realmId: realm.id, slug } },
+      select: { id: true },
+    });
+
+    if (!existing) {
+      throw new NotFoundException(`Proxy application '${slug}' not found`);
+    }
+
+    const { count } = await this.prisma.proxySession.deleteMany({
+      where: { proxyApplicationId: existing.id },
+    });
+
+    return { revoked: count };
+  }
+
+  // ─── helpers ──────────────────────────────────────────────
+
+  /**
+   * A cookie scoped to `.example.com` is simply never sent to
+   * `app.other.test`, so an application configured that way fails with an
+   * infinite redirect loop and no error anywhere. Cheap to catch here; genuinely
+   * hard to diagnose in production.
+   */
+  private assertCookieDomainCovers(
+    cookieDomain: string,
+    allowedRedirectUris: string[],
+  ): void {
+    const domain = cookieDomain.startsWith('.')
+      ? cookieDomain.slice(1)
+      : cookieDomain;
+
+    for (const uri of allowedRedirectUris) {
+      let host: string;
+      try {
+        host = new URL(uri.replace(/\/\*$/, '/')).hostname;
+      } catch {
+        throw new BadRequestException(
+          `'${uri}' is not a valid absolute URL. Allowed redirect URIs must include the scheme, e.g. https://app.example.com/*`,
+        );
+      }
+
+      if (host !== domain && !host.endsWith(`.${domain}`)) {
+        throw new BadRequestException(
+          `cookieDomain '${cookieDomain}' does not cover '${host}'. The browser would never send the proxy session cookie to that host, and every request would redirect to login forever.`,
+        );
+      }
+    }
+  }
+
+  private headerOverrides(
+    dto: CreateProxyApplicationDto | UpdateProxyApplicationDto,
+  ) {
+    return {
+      ...(dto.userHeader !== undefined ? { userHeader: dto.userHeader } : {}),
+      ...(dto.emailHeader !== undefined
+        ? { emailHeader: dto.emailHeader }
+        : {}),
+      ...(dto.nameHeader !== undefined ? { nameHeader: dto.nameHeader } : {}),
+      ...(dto.groupsHeader !== undefined
+        ? { groupsHeader: dto.groupsHeader }
+        : {}),
+    };
+  }
+
+  private toView(
+    realm: Realm,
+    application: ProxyApplication,
+    clientRedirectUris: string[],
+  ): ProxyApplicationView {
+    const callbackUrl = this.proxyAuth.callbackUrl(
+      realm.name,
+      application.slug,
+    );
+
+    return {
+      application,
+      callbackUrl,
+      callbackRegistered: clientRedirectUris.includes(callbackUrl),
+    };
+  }
+}

--- a/src/proxy-auth/proxy-auth.controller.ts
+++ b/src/proxy-auth/proxy-auth.controller.ts
@@ -233,14 +233,19 @@ export class ProxyAuthController {
     res.redirect(302, returnUrl);
   }
 
-  /** Drop the proxy session. Does not touch the SSO session. */
+  /**
+   * Drop the proxy session. Does not touch the SSO session.
+   *
+   * Takes no return-URL parameter on purpose: see
+   * ProxyAuthService.signOutDestination. Nothing from the request reaches the
+   * redirect.
+   */
   @Get('sign-out')
   @Public()
   @RateLimitByIp()
   async signOut(
     @CurrentRealm() realm: Realm,
     @Param('slug') slug: string,
-    @Query('rd') rd: string | undefined,
     @Req() req: Request,
     @Res() res: Response,
   ): Promise<void> {
@@ -258,8 +263,7 @@ export class ProxyAuthController {
       path: '/',
     });
 
-    const returnUrl = this.proxyAuth.resolveReturnUrl(app, rd ?? null);
-    res.redirect(302, returnUrl ?? `/realms/${realm.name}/account`);
+    res.redirect(302, this.proxyAuth.signOutDestination(realm, app));
   }
 
   // ─── helpers ──────────────────────────────────────────────

--- a/src/proxy-auth/proxy-auth.controller.ts
+++ b/src/proxy-auth/proxy-auth.controller.ts
@@ -1,0 +1,311 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ApiExcludeController } from '@nestjs/swagger';
+import type { Request, Response } from 'express';
+import type { ProxyApplication, Realm, User } from '@prisma/client';
+import { RealmGuard } from '../common/guards/realm.guard.js';
+import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
+import { Public } from '../common/decorators/public.decorator.js';
+import {
+  RateLimitGuard,
+  RateLimitByIp,
+} from '../rate-limit/rate-limit.guard.js';
+import { AuthService } from '../auth/auth.service.js';
+import { TokensService } from '../tokens/tokens.service.js';
+import { resolveClientIp } from '../common/utils/proxy-ip.util.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import {
+  ProxyAuthService,
+  PROXY_SESSION_COOKIE,
+} from './proxy-auth.service.js';
+
+/**
+ * Forward-auth endpoints — the reverse proxy's side of #1314.
+ *
+ * Excluded from Swagger: these are called by Traefik / nginx / Caddy, not by
+ * API consumers, and their contract is the proxy's, not ours.
+ *
+ * Authentication is NOT reimplemented here. `start` hands the browser to the
+ * ordinary OAuth authorize endpoint and `callback` redeems the resulting code
+ * through the ordinary token grant, so MFA, step-up, SSO, consent, brute-force
+ * protection and risk assessment all apply exactly as they do for any other
+ * client — without this module knowing they exist.
+ */
+@ApiExcludeController()
+@Controller('realms/:realmName/proxy/:slug')
+@UseGuards(RealmGuard, RateLimitGuard)
+@RateLimitByIp()
+export class ProxyAuthController {
+  private readonly logger = new Logger(ProxyAuthController.name);
+
+  constructor(
+    private readonly proxyAuth: ProxyAuthService,
+    private readonly authService: AuthService,
+    private readonly tokensService: TokensService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  /**
+   * The endpoint the proxy calls before every request.
+   *
+   * 200 — session valid; identity is in the configured headers.
+   * 302 — browser navigation with no session; sends the user into login.
+   * 401 — everything else with no session (XHR, fetch, API clients), so a
+   *       background request gets a status its caller can act on instead of
+   *       an HTML login page.
+   */
+  @Get('verify')
+  @Public()
+  async verify(
+    @CurrentRealm() realm: Realm,
+    @Param('slug') slug: string,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const app = await this.requireApp(realm, slug);
+
+    const token = req.cookies?.[PROXY_SESSION_COOKIE] as string | undefined;
+    const user = await this.proxyAuth.validateSession(app, token);
+
+    if (user) {
+      const headers = await this.proxyAuth.buildIdentityHeaders(app, user);
+      for (const [name, value] of Object.entries(headers)) {
+        res.setHeader(name, value);
+      }
+      res.status(200).end();
+      return;
+    }
+
+    if (!this.wantsHtml(req)) {
+      res.status(401).end();
+      return;
+    }
+
+    const original = this.proxyAuth.reconstructOriginalUrl(req);
+    const startUrl = `/realms/${realm.name}/proxy/${app.slug}/start`;
+    res.redirect(
+      302,
+      original ? `${startUrl}?rd=${encodeURIComponent(original)}` : startUrl,
+    );
+  }
+
+  /**
+   * Begin the handshake: remember where to go back to, then hand off to the
+   * normal authorize endpoint.
+   */
+  @Get('start')
+  @Public()
+  async start(
+    @CurrentRealm() realm: Realm,
+    @Param('slug') slug: string,
+    @Query('rd') rd: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const app = await this.requireApp(realm, slug);
+
+    // `rd` arrives from a header the proxy set, which a client can forge if the
+    // proxy does not strip it. The allowlist is what makes that harmless, so a
+    // miss is a hard failure rather than a silent fallback to some default.
+    const returnUrl = this.proxyAuth.resolveReturnUrl(
+      app,
+      rd ?? this.proxyAuth.reconstructOriginalUrl(req),
+    );
+
+    if (!returnUrl) {
+      throw new BadRequestException(
+        "The requested URL is not in this proxy application's allowed redirect URIs",
+      );
+    }
+
+    const client = await this.prisma.client.findUnique({
+      where: { id: app.clientId },
+      select: { clientId: true },
+    });
+    if (!client) {
+      throw new NotFoundException('Proxy application client no longer exists');
+    }
+
+    const params = new URLSearchParams({
+      client_id: client.clientId,
+      redirect_uri: this.proxyAuth.callbackUrl(realm.name, app.slug),
+      response_type: 'code',
+      scope: 'openid profile email',
+      state: this.proxyAuth.encodeState(app, returnUrl),
+    });
+
+    res.redirect(302, `/realms/${realm.name}/oauth/authorize?${params}`);
+  }
+
+  /**
+   * Finish the handshake: redeem the code, mint the proxy session, and put the
+   * browser back where it started.
+   */
+  @Get('callback')
+  @Public()
+  async callback(
+    @CurrentRealm() realm: Realm,
+    @Param('slug') slug: string,
+    @Query('code') code: string | undefined,
+    @Query('state') state: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const app = await this.requireApp(realm, slug);
+
+    // State first: it is the CSRF and open-redirect defence, and checking it
+    // before spending the single-use code means a replayed callback cannot
+    // burn a legitimate code.
+    const returnUrl = this.proxyAuth.decodeState(app, state);
+    if (!returnUrl) {
+      throw new BadRequestException('Invalid or expired proxy login state');
+    }
+    if (!code) {
+      throw new BadRequestException('Missing authorization code');
+    }
+
+    const client = await this.prisma.client.findUnique({
+      where: { id: app.clientId },
+      select: { clientId: true, clientSecret: true },
+    });
+    if (!client) {
+      throw new NotFoundException('Proxy application client no longer exists');
+    }
+
+    const ip = resolveClientIp(req);
+    const userAgent = req.headers['user-agent'];
+
+    // Redeem through the ordinary token grant so the code's single-use,
+    // PKCE and expiry handling stay in one place.
+    const tokens = await this.authService.handleTokenRequest(
+      realm,
+      {
+        grant_type: 'authorization_code',
+        code,
+        client_id: client.clientId,
+        ...(client.clientSecret ? { client_secret: client.clientSecret } : {}),
+        redirect_uri: this.proxyAuth.callbackUrl(realm.name, app.slug),
+      },
+      ip,
+      userAgent,
+    );
+
+    const user = await this.resolveUserFromAccessToken(
+      realm,
+      tokens.access_token,
+    );
+    if (!user) {
+      throw new BadRequestException('Could not resolve the authenticated user');
+    }
+
+    const sessionToken = await this.proxyAuth.createSession(
+      app,
+      user,
+      ip,
+      userAgent,
+    );
+
+    res.cookie(PROXY_SESSION_COOKIE, sessionToken, {
+      httpOnly: true,
+      secure: true,
+      // Lax, not Strict: the browser arrives here via a cross-site redirect
+      // from the proxied application, and Strict would withhold the cookie on
+      // that first navigation — producing an endless login loop.
+      sameSite: 'lax',
+      domain: app.cookieDomain,
+      path: '/',
+      maxAge: app.cookieTtl * 1000,
+    });
+
+    res.redirect(302, returnUrl);
+  }
+
+  /** Drop the proxy session. Does not touch the SSO session. */
+  @Get('sign-out')
+  @Public()
+  async signOut(
+    @CurrentRealm() realm: Realm,
+    @Param('slug') slug: string,
+    @Query('rd') rd: string | undefined,
+    @Req() req: Request,
+    @Res() res: Response,
+  ): Promise<void> {
+    const app = await this.requireApp(realm, slug);
+
+    await this.proxyAuth.revokeSession(
+      req.cookies?.[PROXY_SESSION_COOKIE] as string | undefined,
+    );
+
+    res.clearCookie(PROXY_SESSION_COOKIE, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      domain: app.cookieDomain,
+      path: '/',
+    });
+
+    const returnUrl = this.proxyAuth.resolveReturnUrl(app, rd ?? null);
+    res.redirect(302, returnUrl ?? `/realms/${realm.name}/account`);
+  }
+
+  // ─── helpers ──────────────────────────────────────────────
+
+  private async requireApp(
+    realm: Realm,
+    slug: string,
+  ): Promise<ProxyApplication> {
+    const app = await this.proxyAuth.findBySlug(realm, slug);
+    if (!app || !app.enabled) {
+      throw new NotFoundException(`Proxy application '${slug}' not found`);
+    }
+    return app;
+  }
+
+  /**
+   * A browser navigation gets a redirect; anything else gets a 401. Keyed on
+   * `Accept` because that is the only signal a proxy reliably forwards — an
+   * XHR asking for JSON should not be answered with a login page.
+   */
+  private wantsHtml(req: Request): boolean {
+    const accept = req.headers['accept'];
+    return typeof accept === 'string' && accept.includes('text/html');
+  }
+
+  /**
+   * Resolve the freshly issued access token back to its user.
+   *
+   * Goes through the ordinary introspection path rather than decoding the JWT
+   * here: that path already verifies the signature, honours the revocation
+   * blacklist, checks the session still exists and rejects disabled users. A
+   * local decode would quietly skip all four.
+   */
+  private async resolveUserFromAccessToken(
+    realm: Realm,
+    accessToken: string,
+  ): Promise<User | null> {
+    const introspection = await this.tokensService.introspect(
+      realm,
+      accessToken,
+    );
+
+    const sub =
+      introspection.active && typeof introspection.sub === 'string'
+        ? introspection.sub
+        : null;
+    if (!sub) return null;
+
+    return this.prisma.user.findFirst({
+      where: { id: sub, realmId: realm.id },
+    });
+  }
+}

--- a/src/proxy-auth/proxy-auth.controller.ts
+++ b/src/proxy-auth/proxy-auth.controller.ts
@@ -12,7 +12,7 @@ import {
 } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
 import type { Request, Response } from 'express';
-import type { ProxyApplication, Realm, User } from '@prisma/client';
+import type { Realm, User } from '@prisma/client';
 import { RealmGuard } from '../common/guards/realm.guard.js';
 import { CurrentRealm } from '../common/decorators/current-realm.decorator.js';
 import { Public } from '../common/decorators/public.decorator.js';
@@ -27,6 +27,7 @@ import { PrismaService } from '../prisma/prisma.service.js';
 import {
   ProxyAuthService,
   PROXY_SESSION_COOKIE,
+  type ProxyApplicationWithClient,
 } from './proxy-auth.service.js';
 
 /**
@@ -40,11 +41,25 @@ import {
  * through the ordinary token grant, so MFA, step-up, SSO, consent, brute-force
  * protection and risk assessment all apply exactly as they do for any other
  * client — without this module knowing they exist.
+ *
+ * Rate limiting is applied PER METHOD, not on the class, and `verify` is
+ * deliberately left out of it.
+ *
+ * `verify` is called by the proxy on every single request to the protected
+ * application, and the IP the guard sees is the proxy's — with TRUSTED_PROXIES
+ * unset, resolveClientIp returns the socket address, which is the same for all
+ * of that traffic. ipRateLimitPerMinute defaults to 20, so a class-level
+ * @RateLimitByIp() would throttle the entire protected application to 20
+ * requests a minute: an outage, not a defence. Loading one dashboard makes more
+ * requests than that.
+ *
+ * The login-flow endpoints are a different shape — a handful of requests per
+ * user per session — so they keep the per-IP limit. Volume control for `verify`
+ * belongs at the proxy, which is the only layer that still sees real client IPs.
  */
 @ApiExcludeController()
 @Controller('realms/:realmName/proxy/:slug')
 @UseGuards(RealmGuard, RateLimitGuard)
-@RateLimitByIp()
 export class ProxyAuthController {
   private readonly logger = new Logger(ProxyAuthController.name);
 
@@ -105,6 +120,7 @@ export class ProxyAuthController {
    */
   @Get('start')
   @Public()
+  @RateLimitByIp()
   async start(
     @CurrentRealm() realm: Realm,
     @Param('slug') slug: string,
@@ -128,16 +144,8 @@ export class ProxyAuthController {
       );
     }
 
-    const client = await this.prisma.client.findUnique({
-      where: { id: app.clientId },
-      select: { clientId: true },
-    });
-    if (!client) {
-      throw new NotFoundException('Proxy application client no longer exists');
-    }
-
     const params = new URLSearchParams({
-      client_id: client.clientId,
+      client_id: app.client.clientId,
       redirect_uri: this.proxyAuth.callbackUrl(realm.name, app.slug),
       response_type: 'code',
       scope: 'openid profile email',
@@ -153,6 +161,7 @@ export class ProxyAuthController {
    */
   @Get('callback')
   @Public()
+  @RateLimitByIp()
   async callback(
     @CurrentRealm() realm: Realm,
     @Param('slug') slug: string,
@@ -174,14 +183,6 @@ export class ProxyAuthController {
       throw new BadRequestException('Missing authorization code');
     }
 
-    const client = await this.prisma.client.findUnique({
-      where: { id: app.clientId },
-      select: { clientId: true, clientSecret: true },
-    });
-    if (!client) {
-      throw new NotFoundException('Proxy application client no longer exists');
-    }
-
     const ip = resolveClientIp(req);
     const userAgent = req.headers['user-agent'];
 
@@ -192,8 +193,10 @@ export class ProxyAuthController {
       {
         grant_type: 'authorization_code',
         code,
-        client_id: client.clientId,
-        ...(client.clientSecret ? { client_secret: client.clientSecret } : {}),
+        client_id: app.client.clientId,
+        ...(app.client.clientSecret
+          ? { client_secret: app.client.clientSecret }
+          : {}),
         redirect_uri: this.proxyAuth.callbackUrl(realm.name, app.slug),
       },
       ip,
@@ -233,6 +236,7 @@ export class ProxyAuthController {
   /** Drop the proxy session. Does not touch the SSO session. */
   @Get('sign-out')
   @Public()
+  @RateLimitByIp()
   async signOut(
     @CurrentRealm() realm: Realm,
     @Param('slug') slug: string,
@@ -263,7 +267,7 @@ export class ProxyAuthController {
   private async requireApp(
     realm: Realm,
     slug: string,
-  ): Promise<ProxyApplication> {
+  ): Promise<ProxyApplicationWithClient> {
     const app = await this.proxyAuth.findBySlug(realm, slug);
     if (!app || !app.enabled) {
       throw new NotFoundException(`Proxy application '${slug}' not found`);

--- a/src/proxy-auth/proxy-auth.module.ts
+++ b/src/proxy-auth/proxy-auth.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { ProxyAuthController } from './proxy-auth.controller.js';
+import { ProxyAuthService } from './proxy-auth.service.js';
+import { ProxyApplicationsController } from './proxy-applications.controller.js';
+import { ProxyApplicationsService } from './proxy-applications.service.js';
+import { AuthModule } from '../auth/auth.module.js';
+import { TokensModule } from '../tokens/tokens.module.js';
+
+/**
+ * Reverse-proxy / forward-auth mode (#1314).
+ *
+ * Imports AuthModule and TokensModule rather than reimplementing their work:
+ * the login handshake runs through the ordinary authorize endpoint and token
+ * grant, and the resulting access token is resolved back to a user through the
+ * ordinary introspection path. That is what makes MFA, step-up, SSO, consent
+ * and token revocation apply here for free.
+ */
+@Module({
+  imports: [AuthModule, TokensModule],
+  controllers: [ProxyAuthController, ProxyApplicationsController],
+  providers: [ProxyAuthService, ProxyApplicationsService],
+  exports: [ProxyAuthService],
+})
+export class ProxyAuthModule {}

--- a/src/proxy-auth/proxy-auth.service.spec.ts
+++ b/src/proxy-auth/proxy-auth.service.spec.ts
@@ -401,6 +401,56 @@ describe('ProxyAuthService', () => {
     });
   });
 
+  // ─── signOutDestination ───────────────────────────────────
+
+  describe('signOutDestination', () => {
+    const realm = { name: 'master' } as never;
+
+    it('prefers a concrete allowed URI over a wildcard one', () => {
+      expect(
+        service.signOutDestination(
+          realm,
+          app({
+            allowedRedirectUris: [
+              'https://grafana.example.com/*',
+              'https://grafana.example.com/login',
+            ],
+          }),
+        ),
+      ).toBe('https://grafana.example.com/login');
+    });
+
+    it('strips a trailing wildcard when that is all there is', () => {
+      expect(
+        service.signOutDestination(
+          realm,
+          app({ allowedRedirectUris: ['https://grafana.example.com/*'] }),
+        ),
+      ).toBe('https://grafana.example.com/');
+    });
+
+    it('falls back to the account console when nothing is configured', () => {
+      expect(
+        service.signOutDestination(realm, app({ allowedRedirectUris: [] })),
+      ).toBe('/realms/master/account');
+    });
+
+    // The point of the whole helper: sign-out takes no rd parameter, so no
+    // request-supplied value can reach res.redirect. Everything it can return
+    // is admin-configured.
+    it('only ever returns admin-configured values', () => {
+      const configured = ['https://grafana.example.com/*'];
+      const result = service.signOutDestination(
+        realm,
+        app({ allowedRedirectUris: configured }),
+      );
+
+      expect(
+        configured.some((u) => result === u || result === u.slice(0, -1)),
+      ).toBe(true);
+    });
+  });
+
   // ─── callbackUrl ──────────────────────────────────────────
 
   describe('callbackUrl', () => {

--- a/src/proxy-auth/proxy-auth.service.spec.ts
+++ b/src/proxy-auth/proxy-auth.service.spec.ts
@@ -1,0 +1,427 @@
+import { createHash } from 'node:crypto';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+import type { ProxyApplication, User } from '@prisma/client';
+import { ProxyAuthService } from './proxy-auth.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
+
+/**
+ * A minimal in-memory stand-in for the two crypto primitives this service uses.
+ * `encrypt`/`decrypt` model AES-GCM's property that matters here — tampering is
+ * detected rather than silently accepted — so the state tests exercise the real
+ * failure mode without needing a key.
+ */
+class FakeCrypto {
+  private counter = 0;
+
+  generateSecret(): string {
+    return `secret-${++this.counter}`;
+  }
+
+  /**
+   * A real hash, not a `sha256(<input>)` label. The "we never persist the raw
+   * token" assertion below is only meaningful if the digest does not contain
+   * its own input — a stub that embeds it would pass the test while proving
+   * nothing.
+   */
+  sha256(value: string): string {
+    return createHash('sha256').update(value).digest('hex');
+  }
+
+  encrypt(plaintext: string): string {
+    return `enc:${Buffer.from(plaintext).toString('base64')}`;
+  }
+
+  decrypt(ciphertext: string): string {
+    if (!ciphertext.startsWith('enc:')) {
+      throw new Error('auth tag mismatch');
+    }
+    return Buffer.from(ciphertext.slice(4), 'base64').toString('utf8');
+  }
+}
+
+const app = (overrides: Partial<ProxyApplication> = {}): ProxyApplication =>
+  ({
+    id: 'app-1',
+    realmId: 'realm-1',
+    slug: 'grafana',
+    name: 'Grafana',
+    enabled: true,
+    clientId: 'client-1',
+    allowedRedirectUris: ['https://grafana.example.com/*'],
+    cookieDomain: '.example.com',
+    cookieTtl: 28_800,
+    userHeader: 'X-Forwarded-User',
+    emailHeader: 'X-Forwarded-Email',
+    nameHeader: 'X-Forwarded-Preferred-Username',
+    groupsHeader: 'X-Forwarded-Groups',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as ProxyApplication;
+
+const request = (headers: Record<string, string>): Request =>
+  ({ headers }) as unknown as Request;
+
+describe('ProxyAuthService', () => {
+  let service: ProxyAuthService;
+  let prisma: {
+    proxySession: {
+      create: jest.Mock;
+      findUnique: jest.Mock;
+      delete: jest.Mock;
+      deleteMany: jest.Mock;
+    };
+    userGroup: { findMany: jest.Mock };
+    proxyApplication: { findUnique: jest.Mock };
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      proxySession: {
+        create: jest.fn().mockResolvedValue({}),
+        findUnique: jest.fn(),
+        delete: jest.fn().mockResolvedValue({}),
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      userGroup: { findMany: jest.fn().mockResolvedValue([]) },
+      proxyApplication: { findUnique: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProxyAuthService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: CryptoService, useValue: new FakeCrypto() },
+      ],
+    }).compile();
+
+    service = module.get(ProxyAuthService);
+  });
+
+  // ─── reconstructOriginalUrl ───────────────────────────────
+
+  describe('reconstructOriginalUrl', () => {
+    it('rebuilds the URL from the Traefik/Caddy forwarded headers', () => {
+      expect(
+        service.reconstructOriginalUrl(
+          request({
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'grafana.example.com',
+            'x-forwarded-uri': '/d/abc?from=now-6h',
+          }),
+        ),
+      ).toBe('https://grafana.example.com/d/abc?from=now-6h');
+    });
+
+    it('prefers X-Original-URL, which is what the nginx auth_request config sets', () => {
+      expect(
+        service.reconstructOriginalUrl(
+          request({
+            'x-original-url': 'https://grafana.example.com/dashboards',
+            'x-forwarded-proto': 'http',
+            'x-forwarded-host': 'ignored.example.com',
+          }),
+        ),
+      ).toBe('https://grafana.example.com/dashboards');
+    });
+
+    it('defaults the path when the proxy sends no URI', () => {
+      expect(
+        service.reconstructOriginalUrl(
+          request({
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'grafana.example.com',
+          }),
+        ),
+      ).toBe('https://grafana.example.com/');
+    });
+
+    it('returns null when the proxy sent nothing usable', () => {
+      expect(service.reconstructOriginalUrl(request({}))).toBeNull();
+    });
+  });
+
+  // ─── resolveReturnUrl ─────────────────────────────────────
+
+  describe('resolveReturnUrl', () => {
+    it('accepts a URL covered by the allowlist wildcard', () => {
+      expect(
+        service.resolveReturnUrl(app(), 'https://grafana.example.com/d/abc'),
+      ).toBe('https://grafana.example.com/d/abc');
+    });
+
+    it('rejects a host outside the allowlist', () => {
+      expect(
+        service.resolveReturnUrl(app(), 'https://evil.test/steal'),
+      ).toBeNull();
+    });
+
+    it('rejects a lookalike host that merely starts with an allowed one', () => {
+      expect(
+        service.resolveReturnUrl(
+          app(),
+          'https://grafana.example.com.evil.test/',
+        ),
+      ).toBeNull();
+    });
+
+    it('rejects javascript: even when the allowlist ends in a wildcard', () => {
+      expect(
+        service.resolveReturnUrl(
+          app({ allowedRedirectUris: ['javascript:/*'] }),
+          'javascript:alert(1)',
+        ),
+      ).toBeNull();
+    });
+
+    it('rejects a protocol-relative URL', () => {
+      expect(service.resolveReturnUrl(app(), '//evil.test/')).toBeNull();
+    });
+
+    it('rejects a null candidate rather than falling back to anything', () => {
+      expect(service.resolveReturnUrl(app(), null)).toBeNull();
+    });
+  });
+
+  // ─── handshake state ──────────────────────────────────────
+
+  describe('state', () => {
+    const returnUrl = 'https://grafana.example.com/d/abc';
+
+    it('round-trips a return URL', () => {
+      const state = service.encodeState(app(), returnUrl);
+      expect(service.decodeState(app(), state)).toBe(returnUrl);
+    });
+
+    it('rejects a tampered state', () => {
+      expect(service.decodeState(app(), 'not-really-encrypted')).toBeNull();
+    });
+
+    it('rejects a missing state', () => {
+      expect(service.decodeState(app(), undefined)).toBeNull();
+    });
+
+    it('rejects a state minted for a different application', () => {
+      const state = service.encodeState(app({ id: 'app-2' }), returnUrl);
+      expect(service.decodeState(app({ id: 'app-1' }), state)).toBeNull();
+    });
+
+    it('rejects an expired state', () => {
+      const state = service.encodeState(app(), returnUrl);
+      jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(new Date('2099-01-01').getTime());
+      expect(service.decodeState(app(), state)).toBeNull();
+      jest.restoreAllMocks();
+    });
+
+    it('re-checks the allowlist on decode, so tightening it takes effect mid-handshake', () => {
+      const state = service.encodeState(app(), returnUrl);
+      const tightened = app({
+        allowedRedirectUris: ['https://other.example.com/*'],
+      });
+      expect(service.decodeState(tightened, state)).toBeNull();
+    });
+  });
+
+  // ─── sessions ─────────────────────────────────────────────
+
+  describe('validateSession', () => {
+    const user = { id: 'user-1', enabled: true } as User;
+
+    it('returns the user for a live session', async () => {
+      prisma.proxySession.findUnique.mockResolvedValue({
+        proxyApplicationId: 'app-1',
+        expiresAt: new Date(Date.now() + 60_000),
+        user,
+      });
+
+      await expect(service.validateSession(app(), 'tok')).resolves.toBe(user);
+    });
+
+    it('refuses a session minted for a different proxy application', async () => {
+      prisma.proxySession.findUnique.mockResolvedValue({
+        proxyApplicationId: 'app-OTHER',
+        expiresAt: new Date(Date.now() + 60_000),
+        user,
+      });
+
+      await expect(
+        service.validateSession(app(), 'tok'),
+      ).resolves.toBeNull();
+    });
+
+    it('refuses an expired session', async () => {
+      prisma.proxySession.findUnique.mockResolvedValue({
+        proxyApplicationId: 'app-1',
+        expiresAt: new Date(Date.now() - 1),
+        user,
+      });
+
+      await expect(
+        service.validateSession(app(), 'tok'),
+      ).resolves.toBeNull();
+    });
+
+    it('refuses a session whose user has since been disabled', async () => {
+      prisma.proxySession.findUnique.mockResolvedValue({
+        proxyApplicationId: 'app-1',
+        expiresAt: new Date(Date.now() + 60_000),
+        user: { ...user, enabled: false },
+      });
+
+      await expect(
+        service.validateSession(app(), 'tok'),
+      ).resolves.toBeNull();
+    });
+
+    it('refuses an absent cookie without touching the database', async () => {
+      await expect(
+        service.validateSession(app(), undefined),
+      ).resolves.toBeNull();
+      expect(prisma.proxySession.findUnique).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('createSession', () => {
+    it('persists only the hash of the token it returns', async () => {
+      const token = await service.createSession(app(), {
+        id: 'user-1',
+      } as User);
+
+      const data = prisma.proxySession.create.mock.calls[0][0].data;
+      expect(data.tokenHash).toBe(
+        createHash('sha256').update(token).digest('hex'),
+      );
+      expect(JSON.stringify(data)).not.toContain(token);
+    });
+
+    it('expires the session after the application cookie TTL', async () => {
+      await service.createSession(app({ cookieTtl: 60 }), {
+        id: 'user-1',
+      } as User);
+
+      const { expiresAt } = prisma.proxySession.create.mock.calls[0][0].data;
+      const seconds = (expiresAt.getTime() - Date.now()) / 1000;
+      expect(seconds).toBeGreaterThan(55);
+      expect(seconds).toBeLessThanOrEqual(60);
+    });
+  });
+
+  describe('revokeSession', () => {
+    it('is a no-op for an absent cookie', async () => {
+      await service.revokeSession(undefined);
+      expect(prisma.proxySession.delete).not.toHaveBeenCalled();
+    });
+
+    it('swallows a delete for an already-gone session', async () => {
+      prisma.proxySession.delete.mockRejectedValue(new Error('not found'));
+      await expect(service.revokeSession('tok')).resolves.toBeUndefined();
+    });
+  });
+
+  // ─── identity headers ─────────────────────────────────────
+
+  describe('buildIdentityHeaders', () => {
+    const user = {
+      id: 'user-1',
+      username: 'alice',
+      email: 'alice@example.com',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      enabled: true,
+    } as User;
+
+    it('uses the configured header names', async () => {
+      const headers = await service.buildIdentityHeaders(
+        app({
+          userHeader: 'X-Auth-Request-User',
+          emailHeader: 'X-Auth-Request-Email',
+        }),
+        user,
+      );
+
+      expect(headers['X-Auth-Request-User']).toBe('alice');
+      expect(headers['X-Auth-Request-Email']).toBe('alice@example.com');
+    });
+
+    it('keeps spaces in a display name', async () => {
+      const headers = await service.buildIdentityHeaders(app(), user);
+      expect(headers['X-Forwarded-Preferred-Username']).toBe('Alice Smith');
+    });
+
+    it('strips CR/LF so a crafted profile field cannot inject a header', async () => {
+      const headers = await service.buildIdentityHeaders(app(), {
+        ...user,
+        username: 'alice\r\nX-Admin: true',
+      } as User);
+
+      expect(headers['X-Forwarded-User']).toBe('aliceX-Admin: true');
+      expect(headers['X-Forwarded-User']).not.toContain('\r');
+      expect(headers['X-Forwarded-User']).not.toContain('\n');
+    });
+
+    it('emits every configured header even when the value is empty, so a stale one cannot survive', async () => {
+      const headers = await service.buildIdentityHeaders(app(), {
+        ...user,
+        email: null,
+      } as unknown as User);
+
+      expect(Object.keys(headers)).toEqual(
+        expect.arrayContaining([
+          'X-Forwarded-User',
+          'X-Forwarded-Email',
+          'X-Forwarded-Preferred-Username',
+          'X-Forwarded-Groups',
+        ]),
+      );
+      expect(headers['X-Forwarded-Email']).toBe('');
+    });
+
+    it('joins group names with commas', async () => {
+      prisma.userGroup.findMany.mockResolvedValue([
+        { group: { name: 'admins' } },
+        { group: { name: 'viewers' } },
+      ]);
+
+      const headers = await service.buildIdentityHeaders(app(), user);
+      expect(headers['X-Forwarded-Groups']).toBe('admins,viewers');
+    });
+
+    it('falls back to the username when no name is set', async () => {
+      const headers = await service.buildIdentityHeaders(app(), {
+        ...user,
+        firstName: null,
+        lastName: null,
+      } as unknown as User);
+
+      expect(headers['X-Forwarded-Preferred-Username']).toBe('alice');
+    });
+  });
+
+  // ─── callbackUrl ──────────────────────────────────────────
+
+  describe('callbackUrl', () => {
+    const original = process.env['BASE_URL'];
+    afterEach(() => {
+      if (original === undefined) delete process.env['BASE_URL'];
+      else process.env['BASE_URL'] = original;
+    });
+
+    it('builds from BASE_URL', () => {
+      process.env['BASE_URL'] = 'https://auth.example.com';
+      expect(service.callbackUrl('master', 'grafana')).toBe(
+        'https://auth.example.com/realms/master/proxy/grafana/callback',
+      );
+    });
+
+    it('tolerates a trailing slash, so the value stays byte-identical across both hops', () => {
+      process.env['BASE_URL'] = 'https://auth.example.com///';
+      expect(service.callbackUrl('master', 'grafana')).toBe(
+        'https://auth.example.com/realms/master/proxy/grafana/callback',
+      );
+    });
+  });
+});

--- a/src/proxy-auth/proxy-auth.service.ts
+++ b/src/proxy-auth/proxy-auth.service.ts
@@ -32,6 +32,16 @@ interface ProxyAuthState {
   e: number;
 }
 
+/**
+ * An application together with the OAuth client it authenticates through.
+ * Carried around as one object because every caller that needs the
+ * application also needs the client — fetching them separately meant two
+ * extra queries on the login path for data already in hand.
+ */
+export type ProxyApplicationWithClient = ProxyApplication & {
+  client: { clientId: string; clientSecret: string | null };
+};
+
 export interface ProxyIdentityHeaders {
   [header: string]: string;
 }
@@ -48,10 +58,12 @@ export class ProxyAuthService {
   async findBySlug(
     realm: Realm,
     slug: string,
-  ): Promise<(ProxyApplication & { client: { clientId: string } }) | null> {
+  ): Promise<ProxyApplicationWithClient | null> {
     return this.prisma.proxyApplication.findUnique({
       where: { realmId_slug: { realmId: realm.id, slug } },
-      include: { client: { select: { clientId: true } } },
+      include: {
+        client: { select: { clientId: true, clientSecret: true } },
+      },
     });
   }
 
@@ -233,7 +245,13 @@ export class ProxyAuthService {
       });
   }
 
-  /** Drop expired proxy sessions. Called by the sessions cleanup job. */
+  /**
+   * Drop expired proxy sessions.
+   *
+   * The hourly SessionsCleanupService sweeps proxy_sessions directly, alongside
+   * every other expiring table; this exists for an admin-triggered sweep and
+   * for tests. Kept here rather than duplicating the predicate at a call site.
+   */
   async deleteExpiredSessions(): Promise<number> {
     const { count } = await this.prisma.proxySession.deleteMany({
       where: { expiresAt: { lt: new Date() } },

--- a/src/proxy-auth/proxy-auth.service.ts
+++ b/src/proxy-auth/proxy-auth.service.ts
@@ -147,6 +147,29 @@ export class ProxyAuthService {
     return `${baseUrl}/realms/${realmName}/proxy/${slug}/callback`;
   }
 
+  /**
+   * Where to send the browser after signing out of a proxied application.
+   *
+   * Derived entirely from the application's own configuration — deliberately
+   * NOT from a `rd` query parameter. Preserving a deep link across a logout is
+   * worth almost nothing, while an endpoint that 302s to a URL from the query
+   * string is an open-redirect shape that a reviewer has to re-audit every time
+   * the allowlist changes. `callback` genuinely needs its return URL, and pays
+   * for it with the encrypted state; sign-out does not, so it does not.
+   *
+   * Prefers a concrete allowed URI, mirroring how magic-link picks one; falls
+   * back to stripping a trailing wildcard, then to the account console.
+   */
+  signOutDestination(realm: Realm, app: ProxyApplication): string {
+    const concrete = app.allowedRedirectUris.find((u) => !u.endsWith('/*'));
+    if (concrete) return concrete;
+
+    const wildcard = app.allowedRedirectUris[0];
+    if (wildcard?.endsWith('/*')) return wildcard.slice(0, -1);
+
+    return `/realms/${realm.name}/account`;
+  }
+
   // ─── Handshake state ──────────────────────────────────────
 
   encodeState(app: ProxyApplication, returnUrl: string): string {

--- a/src/proxy-auth/proxy-auth.service.ts
+++ b/src/proxy-auth/proxy-auth.service.ts
@@ -1,0 +1,308 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Request } from 'express';
+import type { ProxyApplication, Realm, User } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { CryptoService } from '../crypto/crypto.service.js';
+import { matchesRedirectUri } from '../common/redirect-uri.utils.js';
+
+/**
+ * Cookie carrying the proxy session. Deliberately NOT `IDENPLANE_SESSION`:
+ * that cookie is pinned to `path=/realms/<realm>` with `SameSite=Strict` and is
+ * read by OAuth, SAML, MFA, step-up, WebAuthn and the account console. A
+ * forward-auth cookie has to reach a different host on a shared parent domain,
+ * so it needs `Domain=.example.com`, `path=/` and `SameSite=Lax` — widening the
+ * SSO cookie to match would loosen every one of those flows at once.
+ */
+export const PROXY_SESSION_COOKIE = 'IDENPLANE_PROXY_SESSION';
+
+/** How long a `start` handshake may sit unfinished before its state expires. */
+const STATE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Opaque, tamper-proof handshake state. Encrypted with AES-256-GCM by
+ * CryptoService, so a forged or edited state fails the auth tag rather than
+ * being trusted — which is why this needs no table of its own.
+ */
+interface ProxyAuthState {
+  /** ProxyApplication.id the handshake belongs to. */
+  a: string;
+  /** Already-allowlisted URL to return the browser to. */
+  r: string;
+  /** Expiry, epoch ms. */
+  e: number;
+}
+
+export interface ProxyIdentityHeaders {
+  [header: string]: string;
+}
+
+@Injectable()
+export class ProxyAuthService {
+  private readonly logger = new Logger(ProxyAuthService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly crypto: CryptoService,
+  ) {}
+
+  async findBySlug(
+    realm: Realm,
+    slug: string,
+  ): Promise<(ProxyApplication & { client: { clientId: string } }) | null> {
+    return this.prisma.proxyApplication.findUnique({
+      where: { realmId_slug: { realmId: realm.id, slug } },
+      include: { client: { select: { clientId: true } } },
+    });
+  }
+
+  // ─── Original request reconstruction ──────────────────────
+
+  /**
+   * Rebuild the URL the browser actually asked for, from the headers the proxy
+   * sets when it calls us.
+   *
+   * Traefik `forwardAuth` and Caddy `forward_auth` both send
+   * `X-Forwarded-Proto` / `X-Forwarded-Host` / `X-Forwarded-Uri`. nginx
+   * `auth_request` sends nothing by default, so its documented config sets
+   * `X-Original-URL` (absolute) instead.
+   *
+   * These headers are client-controllable if the proxy fails to strip them,
+   * and this deliberately does NOT try to detect that. The value is only ever
+   * used as a redirect target, and every redirect target goes through
+   * {@link resolveReturnUrl}, which rejects anything outside the application's
+   * allowlist. A forged host therefore buys an attacker a 400, not a redirect.
+   */
+  reconstructOriginalUrl(req: Request): string | null {
+    const original = this.header(req, 'x-original-url');
+    if (original) return original;
+
+    const proto = this.header(req, 'x-forwarded-proto');
+    const host = this.header(req, 'x-forwarded-host');
+    if (!proto || !host) return null;
+
+    const uri = this.header(req, 'x-forwarded-uri') ?? '/';
+    return `${proto}://${host}${uri.startsWith('/') ? uri : `/${uri}`}`;
+  }
+
+  /**
+   * Validate a candidate return URL against the application's allowlist.
+   * Returns the URL when it is allowed, `null` otherwise.
+   *
+   * Uses the same matcher as OAuth `redirect_uri` (wildcards included) rather
+   * than a second, subtly different implementation — one allowlist rule for
+   * the whole product is easier to reason about than two.
+   */
+  resolveReturnUrl(
+    app: ProxyApplication,
+    candidate: string | null,
+  ): string | null {
+    if (!candidate) return null;
+
+    // Reject anything that isn't an absolute http(s) URL before matching, so a
+    // pattern ending in `/*` can never be satisfied by `javascript:` or a
+    // protocol-relative `//evil.test` value.
+    let parsed: URL;
+    try {
+      parsed = new URL(candidate);
+    } catch {
+      return null;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')
+      return null;
+
+    return matchesRedirectUri(candidate, app.allowedRedirectUris)
+      ? candidate
+      : null;
+  }
+
+  /**
+   * The callback URL for an application — the value registered on its OAuth
+   * client, sent as `redirect_uri` on the authorize hop, and sent again on the
+   * token exchange.
+   *
+   * Built from BASE_URL (the convention already used by auth, broker and
+   * admin-auth) rather than from the incoming request. Two reasons, both
+   * load-bearing: the token grant compares `redirect_uri` between authorize
+   * and exchange, so it has to be byte-identical across two separate requests
+   * that may not even carry the same Host; and an admin needs to know the URL
+   * up front to register it on the client, which they cannot do if it depends
+   * on runtime headers.
+   */
+  callbackUrl(realmName: string, slug: string): string {
+    const configured = process.env['BASE_URL'] ?? 'http://localhost:3000';
+    let baseUrl = configured;
+    while (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);
+    return `${baseUrl}/realms/${realmName}/proxy/${slug}/callback`;
+  }
+
+  // ─── Handshake state ──────────────────────────────────────
+
+  encodeState(app: ProxyApplication, returnUrl: string): string {
+    const state: ProxyAuthState = {
+      a: app.id,
+      r: returnUrl,
+      e: Date.now() + STATE_TTL_MS,
+    };
+    return this.crypto.encrypt(JSON.stringify(state));
+  }
+
+  /**
+   * Decode a state produced by {@link encodeState}, rejecting anything that
+   * fails the GCM auth tag, has expired, or belongs to a different application.
+   * The return URL is re-checked against the allowlist on the way out: the
+   * allowlist may have been tightened while the handshake was in flight.
+   */
+  decodeState(app: ProxyApplication, raw: string | undefined): string | null {
+    if (!raw) return null;
+
+    let state: ProxyAuthState;
+    try {
+      state = JSON.parse(this.crypto.decrypt(raw)) as ProxyAuthState;
+    } catch {
+      return null;
+    }
+
+    if (state.a !== app.id) return null;
+    if (typeof state.e !== 'number' || state.e < Date.now()) return null;
+
+    return this.resolveReturnUrl(app, state.r);
+  }
+
+  // ─── Session lifecycle ────────────────────────────────────
+
+  /**
+   * Issue a proxy session and return the raw cookie value. Only the SHA-256 of
+   * the token is persisted, mirroring how LoginSession stores its own.
+   */
+  async createSession(
+    app: ProxyApplication,
+    user: User,
+    ip?: string,
+    userAgent?: string,
+  ): Promise<string> {
+    const token = this.crypto.generateSecret(32);
+
+    await this.prisma.proxySession.create({
+      data: {
+        proxyApplicationId: app.id,
+        userId: user.id,
+        tokenHash: this.crypto.sha256(token),
+        ipAddress: ip,
+        userAgent,
+        expiresAt: new Date(Date.now() + app.cookieTtl * 1000),
+      },
+    });
+
+    return token;
+  }
+
+  /**
+   * Resolve a cookie value to its user, or `null` when the session is unknown,
+   * expired, belongs to a different application, or the user has since been
+   * disabled.
+   *
+   * The application check is what stops a session minted for one proxied app
+   * from authenticating a request to another.
+   */
+  async validateSession(
+    app: ProxyApplication,
+    token: string | undefined,
+  ): Promise<User | null> {
+    if (!token) return null;
+
+    const session = await this.prisma.proxySession.findUnique({
+      where: { tokenHash: this.crypto.sha256(token) },
+      include: { user: true },
+    });
+
+    if (!session) return null;
+    if (session.proxyApplicationId !== app.id) return null;
+    if (session.expiresAt < new Date()) return null;
+    if (!session.user.enabled) return null;
+
+    return session.user;
+  }
+
+  async revokeSession(token: string | undefined): Promise<void> {
+    if (!token) return;
+
+    await this.prisma.proxySession
+      .delete({ where: { tokenHash: this.crypto.sha256(token) } })
+      .catch(() => {
+        // Already gone or expired — signing out is idempotent.
+      });
+  }
+
+  /** Drop expired proxy sessions. Called by the sessions cleanup job. */
+  async deleteExpiredSessions(): Promise<number> {
+    const { count } = await this.prisma.proxySession.deleteMany({
+      where: { expiresAt: { lt: new Date() } },
+    });
+    return count;
+  }
+
+  // ─── Identity headers ─────────────────────────────────────
+
+  /**
+   * Build the headers handed to the upstream application on a successful
+   * verify.
+   *
+   * Every configured header is emitted on every 200, even when the underlying
+   * value is empty. Omitting one would let a value the proxy copied from an
+   * earlier request — or one the client sent itself, on a misconfigured proxy —
+   * survive into the upstream. An explicit empty header overwrites it.
+   */
+  async buildIdentityHeaders(
+    app: ProxyApplication,
+    user: User,
+  ): Promise<ProxyIdentityHeaders> {
+    const groups = await this.prisma.userGroup.findMany({
+      where: { userId: user.id },
+      select: { group: { select: { name: true } } },
+    });
+
+    return {
+      [app.userHeader]: this.sanitize(user.username),
+      [app.emailHeader]: this.sanitize(user.email ?? ''),
+      [app.nameHeader]: this.sanitize(
+        [user.firstName, user.lastName].filter(Boolean).join(' ') ||
+          user.username,
+      ),
+      [app.groupsHeader]: this.sanitize(
+        groups.map((g) => g.group.name).join(','),
+      ),
+    };
+  }
+
+  /**
+   * Strip anything that could break out of a header value.
+   *
+   * These values originate in user-editable profile fields, so a username
+   * containing CR/LF would otherwise let a user inject arbitrary headers into
+   * the request the proxy forwards upstream — response splitting, one hop
+   * removed. Node rejects some of this at `setHeader`, but a 500 on every
+   * request for that user is its own outage, so the value is cleaned here and
+   * the request still succeeds.
+   */
+  private sanitize(value: string): string {
+    // Written as an explicit scan rather than a regex so the range being
+    // stripped is legible: C0 (which is where CR and LF, the actual injection
+    // vector, live), DEL, and C1. Ordinary spaces are legal in a header value
+    // and must survive, or every "John Doe" reaches the upstream as "JohnDoe".
+    let out = '';
+    for (const ch of value) {
+      const code = ch.codePointAt(0) ?? 0;
+      const isC0OrDel = code < 0x20 || code === 0x7f;
+      const isC1 = code >= 0x80 && code <= 0x9f;
+      if (isC0OrDel || isC1) continue;
+      out += ch;
+    }
+    return out.trim();
+  }
+
+  private header(req: Request, name: string): string | null {
+    const raw = req.headers[name];
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    return value && value.length > 0 ? value : null;
+  }
+}

--- a/src/sessions/sessions-cleanup.service.spec.ts
+++ b/src/sessions/sessions-cleanup.service.spec.ts
@@ -32,6 +32,7 @@ describe('SessionsCleanupService', () => {
       prisma.impersonationSession.deleteMany.mockResolvedValue({
         count: 0,
       });
+      prisma.proxySession.deleteMany.mockResolvedValue({ count: 0 });
 
       const before = new Date();
       await service.cleanupExpiredSessions();
@@ -64,6 +65,13 @@ describe('SessionsCleanupService', () => {
       expect(prisma.impersonationSession.deleteMany).toHaveBeenCalledWith({
         where: { expiresAt: { lt: expect.any(Date) } },
       });
+
+      // Proxy (forward-auth) sessions are swept here too. Nothing else prunes
+      // them: the proxy only re-checks a session when its cookie expires, so a
+      // missing sweep grows proxy_sessions for the life of the deployment.
+      expect(prisma.proxySession.deleteMany).toHaveBeenCalledWith({
+        where: { expiresAt: { lt: expect.any(Date) } },
+      });
     });
 
     it('should not throw when all tables return zero deleted rows', async () => {
@@ -78,6 +86,7 @@ describe('SessionsCleanupService', () => {
       prisma.impersonationSession.deleteMany.mockResolvedValue({
         count: 0,
       });
+      prisma.proxySession.deleteMany.mockResolvedValue({ count: 0 });
 
       await expect(service.cleanupExpiredSessions()).resolves.toBeUndefined();
     });
@@ -97,6 +106,7 @@ describe('SessionsCleanupService', () => {
       prisma.impersonationSession.deleteMany.mockResolvedValue({
         count: 1,
       });
+      prisma.proxySession.deleteMany.mockResolvedValue({ count: 1 });
 
       await service.cleanupExpiredSessions();
 
@@ -107,9 +117,10 @@ describe('SessionsCleanupService', () => {
         prisma.authorizationCode.deleteMany.mock.calls[0][0].where.expiresAt.lt,
         prisma.impersonationSession.deleteMany.mock.calls[0][0].where.expiresAt
           .lt,
+        prisma.proxySession.deleteMany.mock.calls[0][0].where.expiresAt.lt,
       ];
 
-      // All five calls must use the exact same Date instance / value
+      // All six calls must use the exact same Date instance / value
       const referenceTime = timestamps[0].getTime();
       for (const ts of timestamps) {
         expect(ts.getTime()).toBe(referenceTime);

--- a/src/sessions/sessions-cleanup.service.ts
+++ b/src/sessions/sessions-cleanup.service.ts
@@ -34,6 +34,13 @@ export class SessionsCleanupService {
       where: { expiresAt: { lt: now } },
     });
 
+    // Delete expired proxy (forward-auth) sessions. Nothing else prunes these:
+    // the proxy only re-checks a session when its cookie expires, so without
+    // this the table grows for the lifetime of the deployment.
+    const proxyResult = await this.prisma.proxySession.deleteMany({
+      where: { expiresAt: { lt: now } },
+    });
+
     // Delete expired impersonation sessions.
     const impersonationResult =
       await this.prisma.impersonationSession.deleteMany({
@@ -45,6 +52,7 @@ export class SessionsCleanupService {
       ssoResult.count +
       refreshResult.count +
       authCodeResult.count +
+      proxyResult.count +
       impersonationResult.count;
 
     if (total > 0) {
@@ -53,6 +61,7 @@ export class SessionsCleanupService {
           `${ssoResult.count} SSO session(s), ` +
           `${refreshResult.count} refresh token(s), ` +
           `${authCodeResult.count} authorization code(s), ` +
+          `${proxyResult.count} proxy session(s), ` +
           `${impersonationResult.count} impersonation session(s)`,
       );
     }


### PR DESCRIPTION
First slice of #1314 — Idenplane can now protect an application **at the reverse proxy**, without that application knowing anything about OIDC.

## The design decision that made this small

**Authentication is not reimplemented.** Every proxy application authenticates through an **ordinary OAuth client**:

```
verify  → no session? → start → /oauth/authorize   ← the normal endpoint
                                      ↓  login + MFA + step-up + consent
        ← set cookie ← callback ← code → handleTokenRequest   ← the normal grant
```

So MFA, SSO, step-up, consent, brute-force protection and risk assessment apply here **for free** — and `login.controller.ts` is untouched. That file already carries ten-plus auth paths; none of them needed to move.

## Endpoints

Public, excluded from Swagger (the caller is a proxy, not an API consumer):

| | |
|---|---|
| `GET .../proxy/:slug/verify` | `200` + identity headers · `302` to login · `401` |
| `GET .../proxy/:slug/start` | validate return URL, hand off to authorize |
| `GET .../proxy/:slug/callback` | redeem code, mint session, set cookie, return |
| `GET .../proxy/:slug/sign-out` | revoke the proxy session only — takes **no** return-URL parameter |

`verify` answers **302 for a browser navigation and 401 otherwise**, keyed on `Accept` — an XHR should get a status its caller can act on, not an HTML login page.

Admin CRUD sits at `/admin/realms/:realmName/proxy-applications` and returns **the callback URL to register on the OAuth client, plus whether it already is**. Without that, the first failure an admin sees is a `redirect_uri` mismatch at the end of a login they already completed, with nothing pointing at the cause.

## Decisions worth reviewing

- **Separate cookie** — `IDENPLANE_PROXY_SESSION`, not `IDENPLANE_SESSION`. The SSO cookie is deliberately pinned to `path=/realms/<realm>` with `SameSite=Strict` and is read by OAuth, SAML, MFA, step-up, WebAuthn and the account console. A forward-auth cookie must reach another host on a shared parent domain; widening the SSO cookie would loosen all six at once.
- **Separate table** — `ProxySession`, not a flavour of `LoginSession`. A proxy cookie must never work as an SSO cookie or the reverse. That's a privilege boundary, not a schema detail.
- **`SameSite=Lax`, not Strict** — the browser reaches the callback via a cross-site redirect from the proxied app. Strict withholds the cookie on exactly that navigation, and the result is an endless login loop.
- **State is AES-256-GCM** via `CryptoService` — tamper-evident by the auth tag, so no table needed, and bound to the application id + expiry.
- **Return URLs reuse `matchesRedirectUri`** — no second allowlist. The forwarded headers a return URL is built from are client-spoofable when a proxy fails to strip them; **the allowlist is what makes that harmless**, so a miss is a hard 400, never a fallback.
- **`redirect_uri` from `BASE_URL`**, not request headers — the token grant compares it across two separate requests, so it must be byte-identical, and an admin needs to know it up front to register it.
- **Header values stripped of C0/DEL/C1** — these come from user-editable profile fields, so a username containing CR/LF would otherwise inject headers into the request the proxy forwards upstream. **Spaces are kept**: stripping them would turn every `John Doe` into `JohnDoe`.
- **Every configured header is emitted on every 200**, empty value included, so a value left from an earlier request can't survive into the upstream.
- **`cookieDomain` is validated to cover every allowed redirect host.** Get this wrong and the browser simply never sends the cookie — infinite redirect loop, **no error in any log**. Seven tests cover it precisely because the failure is silent.

## Schema

Purely additive: two new tables (`proxy_applications`, `proxy_sessions`), **no existing table altered**.

## Verification

```
npm run build   exit 0
npm run lint    exit 0
npm test        exit 0   135 suites, 2260 tests
                         (2207 existing + 53 new — nothing regressed)
```

## Not in this PR, deliberately

The remaining #1314 acceptance criteria — the admin console UI, and the Traefik / nginx / Caddy config docs plus a docker-compose example — follow separately. Bundling them would put a UI regression in front of the auth path.

## CodeQL

Two findings, handled differently on purpose.

**`js/clear-text-storage-of-sensitive-data`** (high, on setting the session cookie) — **dismissed as a false positive** (alert #50), with the reasoning already recorded on #43–#47 for `login.controller.ts:297/385/407/479` and `webauthn.controller.ts:205`: a high-entropy bearer token in an `httpOnly/secure/sameSite` cookie, stored server-side only as its SHA-256. The rule fires on `generateSecret()` reaching a cookie, which is unavoidable for cookie-based sessions.

**`js/server-side-unvalidated-url-redirection`** (medium, on sign-out) — **not dismissed. Removed.** The redirect *was* validated (URL parse, scheme check, allowlist match, six tests) and the analyzer simply could not follow that across the service boundary — so it could have been waved through. But that answers the wrong question. Not "is the validation sound" but "why does a request-supplied value reach `res.redirect` on a logout path at all". `rd` is gone from sign-out; the destination now comes from the application config, so nothing from the request reaches the redirect.

`callback` keeps its return URL — that *is* the feature, and it pays for it with the AES-GCM state, which is why CodeQL never flagged it.

Filing the second alongside the first would have laundered a real (if covered) surface as an analyzer artifact.

**26/26 checks green · 0 open code-scanning alerts.**

Refs #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

