### PR TITLE
feat(admin-ui): manage proxy applications from the console

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -13,6 +13,9 @@ import UserDetailPage from './pages/users/UserDetailPage';
 import ClientListPage from './pages/clients/ClientListPage';
 import ClientCreatePage from './pages/clients/ClientCreatePage';
 import ClientDetailPage from './pages/clients/ClientDetailPage';
+import ProxyApplicationListPage from './pages/proxy-applications/ProxyApplicationListPage';
+import ProxyApplicationCreatePage from './pages/proxy-applications/ProxyApplicationCreatePage';
+import ProxyApplicationDetailPage from './pages/proxy-applications/ProxyApplicationDetailPage';
 import RoleListPage from './pages/roles/RoleListPage';
 import GroupListPage from './pages/groups/GroupListPage';
 import GroupCreatePage from './pages/groups/GroupCreatePage';
@@ -125,6 +128,9 @@ export default function App() {
           <Route path="/console/realms/:name/clients" element={<ClientListPage />} />
           <Route path="/console/realms/:name/clients/new" element={<ClientCreatePage />} />
           <Route path="/console/realms/:name/clients/:id" element={<ClientDetailPage />} />
+          <Route path="/console/realms/:name/proxy-applications" element={<ProxyApplicationListPage />} />
+          <Route path="/console/realms/:name/proxy-applications/new" element={<ProxyApplicationCreatePage />} />
+          <Route path="/console/realms/:name/proxy-applications/:slug" element={<ProxyApplicationDetailPage />} />
           <Route path="/console/realms/:name/migration" element={<MigrationWizardPage />} />
           <Route path="/console/realms/:name/roles" element={<RoleListPage />} />
           <Route path="/console/realms/:name/groups" element={<GroupListPage />} />

--- a/admin-ui/src/api/proxyApplications.ts
+++ b/admin-ui/src/api/proxyApplications.ts
@@ -1,0 +1,65 @@
+import apiClient from './client';
+import type {
+  ProxyApplicationView,
+  CreateProxyApplicationInput,
+  UpdateProxyApplicationInput,
+} from '../types';
+
+export async function getProxyApplications(
+  realmName: string,
+): Promise<ProxyApplicationView[]> {
+  const { data } = await apiClient.get<ProxyApplicationView[]>(
+    `/realms/${realmName}/proxy-applications`,
+  );
+  return data;
+}
+
+export async function getProxyApplication(
+  realmName: string,
+  slug: string,
+): Promise<ProxyApplicationView> {
+  const { data } = await apiClient.get<ProxyApplicationView>(
+    `/realms/${realmName}/proxy-applications/${slug}`,
+  );
+  return data;
+}
+
+export async function createProxyApplication(
+  realmName: string,
+  input: CreateProxyApplicationInput,
+): Promise<ProxyApplicationView> {
+  const { data } = await apiClient.post<ProxyApplicationView>(
+    `/realms/${realmName}/proxy-applications`,
+    input,
+  );
+  return data;
+}
+
+export async function updateProxyApplication(
+  realmName: string,
+  slug: string,
+  input: UpdateProxyApplicationInput,
+): Promise<ProxyApplicationView> {
+  const { data } = await apiClient.put<ProxyApplicationView>(
+    `/realms/${realmName}/proxy-applications/${slug}`,
+    input,
+  );
+  return data;
+}
+
+export async function deleteProxyApplication(
+  realmName: string,
+  slug: string,
+): Promise<void> {
+  await apiClient.delete(`/realms/${realmName}/proxy-applications/${slug}`);
+}
+
+export async function revokeProxyApplicationSessions(
+  realmName: string,
+  slug: string,
+): Promise<{ revoked: number }> {
+  const { data } = await apiClient.post<{ revoked: number }>(
+    `/realms/${realmName}/proxy-applications/${slug}/revoke-sessions`,
+  );
+  return data;
+}

--- a/admin-ui/src/components/Layout.tsx
+++ b/admin-ui/src/components/Layout.tsx
@@ -44,6 +44,7 @@ export default function Layout() {
         { to: `/console/realms/${currentRealm}`, label: 'Overview', icon: Icons.Activity },
         { to: `/console/realms/${currentRealm}/users`, label: 'Users', icon: Icons.Users },
         { to: `/console/realms/${currentRealm}/clients`, label: 'Clients', icon: Icons.Clients },
+        { to: `/console/realms/${currentRealm}/proxy-applications`, label: 'Proxy Applications', icon: Icons.Globe },
         { to: `/console/realms/${currentRealm}/roles`, label: 'Roles', icon: Icons.Roles },
         { to: `/console/realms/${currentRealm}/groups`, label: 'Groups', icon: Icons.Groups },
         { to: `/console/realms/${currentRealm}/client-scopes`, label: 'Client Scopes', icon: Icons.Code },

--- a/admin-ui/src/pages/proxy-applications/ProxyApplicationCreatePage.tsx
+++ b/admin-ui/src/pages/proxy-applications/ProxyApplicationCreatePage.tsx
@@ -1,0 +1,217 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams, useNavigate } from 'react-router';
+import { createProxyApplication } from '../../api/proxyApplications';
+import { getClients } from '../../api/clients';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+import { suggestCookieDomain } from '../../utils/suggestCookieDomain';
+
+export default function ProxyApplicationCreatePage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [slug, setSlug] = useState('');
+  const [appName, setAppName] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [redirectUris, setRedirectUris] = useState('');
+  const [cookieDomain, setCookieDomain] = useState('');
+  const [cookieDomainTouched, setCookieDomainTouched] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data: clients } = useQuery({
+    queryKey: ['clients', name],
+    queryFn: () => getClients(name!),
+    enabled: !!name,
+  });
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createProxyApplication(name!, {
+        slug,
+        name: appName,
+        clientId,
+        allowedRedirectUris: redirectUris
+          .split('\n')
+          .map((u) => u.trim())
+          .filter(Boolean),
+        cookieDomain,
+      }),
+    onSuccess: (view) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['proxy-applications', name],
+      });
+      navigate(
+        `/console/realms/${name}/proxy-applications/${view.application.slug}`,
+      );
+    },
+    onError: (e) =>
+      setError(getErrorMessage(e, 'Failed to create proxy application.')),
+  });
+
+  /** Fill the cookie domain from the first redirect URI until the admin edits it themselves. */
+  function handleRedirectUrisChange(value: string) {
+    setRedirectUris(value);
+    if (cookieDomainTouched) return;
+
+    const first = value.split('\n')[0]?.trim();
+    if (first) setCookieDomain(suggestCookieDomain(first));
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    mutation.mutate();
+  }
+
+  const field =
+    'mt-1 block w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg shadow-sm focus:border-accent focus:outline-none focus:ring-1 focus:ring-accent';
+  const label = 'block text-sm font-medium text-fg';
+  const hint = 'mt-1 text-xs text-subtle';
+
+  return (
+    <div className="max-w-2xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-fg">Add Proxy Application</h1>
+        <p className="mt-1 text-sm text-subtle">
+          Protect an application at Traefik, nginx or Caddy without changing its
+          code
+        </p>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mb-6 rounded-md bg-danger-soft p-4 text-sm text-danger-fg"
+        >
+          {error}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label htmlFor="slug" className={label}>
+            Slug
+          </label>
+          <input
+            id="slug"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+            required
+            pattern="[a-z0-9][a-z0-9-]*"
+            placeholder="grafana"
+            className={field}
+          />
+          <p className={hint}>
+            Used in the proxy endpoints:{' '}
+            <code>
+              /realms/{name}/proxy/{slug || '<slug>'}/verify
+            </code>
+            . Cannot be changed later — it lives in your proxy config.
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="app-name" className={label}>
+            Name
+          </label>
+          <input
+            id="app-name"
+            value={appName}
+            onChange={(e) => setAppName(e.target.value)}
+            required
+            placeholder="Grafana"
+            className={field}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="client-id" className={label}>
+            OAuth Client
+          </label>
+          <select
+            id="client-id"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            required
+            className={field}
+          >
+            <option value="">Select a client...</option>
+            {clients?.map((c) => (
+              <option key={c.id} value={c.clientId}>
+                {c.clientId}
+                {c.name ? ` — ${c.name}` : ''}
+              </option>
+            ))}
+          </select>
+          <p className={hint}>
+            Login runs through this client, so MFA, step-up and consent apply
+            exactly as they do anywhere else. Its redirect URIs must include the
+            callback URL shown after you save.
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="redirect-uris" className={label}>
+            Allowed Redirect URIs
+          </label>
+          <textarea
+            id="redirect-uris"
+            value={redirectUris}
+            onChange={(e) => handleRedirectUrisChange(e.target.value)}
+            required
+            rows={3}
+            placeholder={'https://grafana.example.com/*'}
+            className={`${field} font-mono`}
+          />
+          <p className={hint}>
+            One per line. A user is only ever sent back to a URL matching one of
+            these. Supports a trailing <code>/*</code> wildcard.
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="cookie-domain" className={label}>
+            Cookie Domain
+          </label>
+          <input
+            id="cookie-domain"
+            value={cookieDomain}
+            onChange={(e) => {
+              setCookieDomainTouched(true);
+              setCookieDomain(e.target.value);
+            }}
+            required
+            placeholder=".example.com"
+            className={field}
+          />
+          <p className={hint}>
+            Must be a parent domain of every host above, or the browser will
+            never send the session cookie to the application — which looks like
+            an endless redirect to login. Suggested from your first redirect
+            URI.
+          </p>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={mutation.isPending}
+            className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover disabled:opacity-50"
+          >
+            {mutation.isPending ? 'Creating...' : 'Create Application'}
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              navigate(`/console/realms/${name}/proxy-applications`)
+            }
+            className="rounded-md border border-line px-4 py-2 text-sm font-medium text-fg hover:bg-hover"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/proxy-applications/ProxyApplicationDetailPage.tsx
+++ b/admin-ui/src/pages/proxy-applications/ProxyApplicationDetailPage.tsx
@@ -1,0 +1,261 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams, useNavigate } from 'react-router';
+import {
+  getProxyApplication,
+  updateProxyApplication,
+  deleteProxyApplication,
+  revokeProxyApplicationSessions,
+} from '../../api/proxyApplications';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+export default function ProxyApplicationDetailPage() {
+  const { name, slug } = useParams<{ name: string; slug: string }>();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['proxy-application', name, slug],
+    queryFn: () => getProxyApplication(name!, slug!),
+    enabled: !!name && !!slug,
+  });
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: ['proxy-application', name, slug],
+    });
+    void queryClient.invalidateQueries({
+      queryKey: ['proxy-applications', name],
+    });
+  };
+
+  const toggleEnabled = useMutation({
+    mutationFn: (enabled: boolean) =>
+      updateProxyApplication(name!, slug!, { enabled }),
+    onSuccess: invalidate,
+    onError: (e) => setError(getErrorMessage(e, 'Failed to update.')),
+  });
+
+  const revoke = useMutation({
+    mutationFn: () => revokeProxyApplicationSessions(name!, slug!),
+    onSuccess: ({ revoked }) =>
+      setMessage(
+        `Revoked ${revoked} session${revoked === 1 ? '' : 's'}. Users will be sent back through login on their next request.`,
+      ),
+    onError: (e) => setError(getErrorMessage(e, 'Failed to revoke sessions.')),
+  });
+
+  const remove = useMutation({
+    mutationFn: () => deleteProxyApplication(name!, slug!),
+    onSuccess: () => {
+      invalidate();
+      navigate(`/console/realms/${name}/proxy-applications`);
+    },
+    onError: (e) => setError(getErrorMessage(e, 'Failed to delete.')),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-subtle">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="rounded-md bg-danger-soft p-4 text-sm text-danger-fg">
+        Proxy application not found.
+      </div>
+    );
+  }
+
+  const { application, callbackUrl, callbackRegistered } = data;
+  const verifyUrl = `/realms/${name}/proxy/${application.slug}/verify`;
+  const card = 'rounded-lg border border-line bg-surface p-6 shadow-sm';
+  const dt = 'text-xs font-medium uppercase tracking-wider text-subtle';
+  const dd = 'mt-1 text-sm text-fg';
+
+  return (
+    <div className="max-w-3xl space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-fg">{application.name}</h1>
+          <p className="mt-1 font-mono text-sm text-subtle">
+            {application.slug}
+          </p>
+        </div>
+        <span
+          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+            application.enabled
+              ? 'bg-success-soft text-success-fg'
+              : 'bg-danger-soft text-danger-fg'
+          }`}
+        >
+          {application.enabled ? 'Enabled' : 'Disabled'}
+        </span>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-md bg-danger-soft p-4 text-sm text-danger-fg"
+        >
+          {error}
+        </div>
+      )}
+      {message && (
+        <div
+          role="status"
+          className="rounded-md bg-success-soft p-4 text-sm text-success-fg"
+        >
+          {message}
+        </div>
+      )}
+
+      {/*
+        The one thing on this page that silently breaks a deployment. The
+        callback is only reachable if it is registered on the OAuth client, and
+        the symptom of forgetting is a redirect_uri mismatch at the very end of
+        a login the user has already completed — so it gets a warning banner,
+        not a green tick hidden in a table.
+      */}
+      {!callbackRegistered && (
+        <div
+          role="alert"
+          className="rounded-md bg-warning-soft p-4 text-sm text-warning-fg"
+        >
+          <p className="font-medium">Callback URL is not registered</p>
+          <p className="mt-1">
+            Add this to the redirect URIs of client{' '}
+            <code className="font-mono">{application.clientId}</code>, or logins
+            will fail at the final redirect:
+          </p>
+          <code className="mt-2 block break-all font-mono text-xs">
+            {callbackUrl}
+          </code>
+        </div>
+      )}
+
+      <div className={card}>
+        <h2 className="mb-4 text-lg font-semibold text-fg">
+          Proxy configuration
+        </h2>
+        <dl className="space-y-4">
+          <div>
+            <dt className={dt}>Forward-auth endpoint</dt>
+            <dd className={`${dd} break-all font-mono text-xs`}>{verifyUrl}</dd>
+            <p className="mt-1 text-xs text-subtle">
+              Point your proxy's forward-auth / <code>auth_request</code> at
+              this path.
+            </p>
+          </div>
+          <div>
+            <dt className={dt}>Callback URL</dt>
+            <dd className={`${dd} break-all font-mono text-xs`}>
+              {callbackUrl}{' '}
+              {callbackRegistered && (
+                <span className="ml-1 inline-flex rounded-full bg-success-soft px-2 py-0.5 text-xs font-medium text-success-fg">
+                  Registered
+                </span>
+              )}
+            </dd>
+          </div>
+          <div>
+            <dt className={dt}>OAuth client</dt>
+            <dd className={dd}>{application.clientId}</dd>
+          </div>
+          <div>
+            <dt className={dt}>Cookie domain</dt>
+            <dd className={dd}>{application.cookieDomain}</dd>
+          </div>
+          <div>
+            <dt className={dt}>Session lifetime</dt>
+            <dd className={dd}>
+              {Math.round(application.cookieTtl / 3600)} hours
+            </dd>
+          </div>
+          <div>
+            <dt className={dt}>Allowed redirect URIs</dt>
+            <dd className={dd}>
+              <ul className="space-y-1 font-mono text-xs">
+                {application.allowedRedirectUris.map((uri) => (
+                  <li key={uri} className="break-all">
+                    {uri}
+                  </li>
+                ))}
+              </ul>
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className={card}>
+        <h2 className="mb-1 text-lg font-semibold text-fg">
+          Identity headers
+        </h2>
+        <p className="mb-4 text-sm text-subtle">
+          Set on every successful check. Configure your proxy to copy these from
+          the auth response to the upstream request — and to strip any the
+          client sent itself.
+        </p>
+        <dl className="space-y-3 font-mono text-xs">
+          <div>
+            <dt className={dt}>User</dt>
+            <dd className={dd}>{application.userHeader}</dd>
+          </div>
+          <div>
+            <dt className={dt}>Email</dt>
+            <dd className={dd}>{application.emailHeader}</dd>
+          </div>
+          <div>
+            <dt className={dt}>Display name</dt>
+            <dd className={dd}>{application.nameHeader}</dd>
+          </div>
+          <div>
+            <dt className={dt}>Groups</dt>
+            <dd className={dd}>{application.groupsHeader}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className={card}>
+        <h2 className="mb-4 text-lg font-semibold text-fg">Actions</h2>
+        <div className="flex flex-wrap gap-3">
+          <button
+            onClick={() => toggleEnabled.mutate(!application.enabled)}
+            disabled={toggleEnabled.isPending}
+            className="rounded-md border border-line px-4 py-2 text-sm font-medium text-fg hover:bg-hover disabled:opacity-50"
+          >
+            {application.enabled ? 'Disable' : 'Enable'}
+          </button>
+          <button
+            onClick={() => revoke.mutate()}
+            disabled={revoke.isPending}
+            className="rounded-md border border-line px-4 py-2 text-sm font-medium text-fg hover:bg-hover disabled:opacity-50"
+          >
+            {revoke.isPending ? 'Revoking...' : 'Revoke all sessions'}
+          </button>
+          <button
+            onClick={() => {
+              if (
+                window.confirm(
+                  `Delete "${application.name}"? Its live sessions are deleted with it, and your proxy will start getting 404s from ${verifyUrl}.`,
+                )
+              ) {
+                remove.mutate();
+              }
+            }}
+            disabled={remove.isPending}
+            className="rounded-md bg-danger-soft px-4 py-2 text-sm font-medium text-danger-fg hover:opacity-80 disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/proxy-applications/ProxyApplicationListPage.tsx
+++ b/admin-ui/src/pages/proxy-applications/ProxyApplicationListPage.tsx
@@ -1,0 +1,179 @@
+import { useQuery } from '@tanstack/react-query';
+import { useParams, useNavigate } from 'react-router';
+import { getProxyApplications } from '../../api/proxyApplications';
+import { getErrorMessage } from '../../utils/getErrorMessage';
+
+export default function ProxyApplicationListPage() {
+  const { name } = useParams<{ name: string }>();
+  const navigate = useNavigate();
+
+  const {
+    data: applications,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['proxy-applications', name],
+    queryFn: () => getProxyApplications(name!),
+    enabled: !!name,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-subtle">Loading proxy applications...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-danger-soft p-4 text-sm text-danger-fg">
+        {getErrorMessage(error, 'Failed to load proxy applications.')}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-fg">Proxy Applications</h1>
+          <p className="mt-1 text-sm text-subtle">
+            Applications protected at the reverse proxy in{' '}
+            <span className="font-medium">{name}</span> — no code change needed
+            in the application itself
+          </p>
+        </div>
+        <button
+          onClick={() =>
+            navigate(`/console/realms/${name}/proxy-applications/new`)
+          }
+          className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-hover"
+        >
+          Add Application
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-line bg-surface shadow-sm">
+        <table
+          className="min-w-full divide-y divide-line"
+          aria-label="Proxy applications"
+        >
+          <thead className="bg-sunken">
+            <tr>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-subtle"
+              >
+                Slug
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-subtle"
+              >
+                Name
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-subtle"
+              >
+                Cookie Domain
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-subtle"
+              >
+                Enabled
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-subtle"
+              >
+                Callback
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-line">
+            {applications && applications.length > 0 ? (
+              applications.map(
+                ({ application, callbackRegistered }) => (
+                  <tr
+                    key={application.id}
+                    onClick={() =>
+                      navigate(
+                        `/console/realms/${name}/proxy-applications/${application.slug}`,
+                      )
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        navigate(
+                          `/console/realms/${name}/proxy-applications/${application.slug}`,
+                        );
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`View proxy application ${application.name || application.slug}`}
+                    className="cursor-pointer hover:bg-hover focus:outline-none focus:ring-2 focus:ring-inset focus:ring-accent"
+                  >
+                    <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-accent">
+                      {application.slug}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-muted">
+                      {application.name || '-'}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-muted">
+                      {application.cookieDomain}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                          application.enabled
+                            ? 'bg-success-soft text-success-fg'
+                            : 'bg-danger-soft text-danger-fg'
+                        }`}
+                      >
+                        {application.enabled ? 'Enabled' : 'Disabled'}
+                      </span>
+                    </td>
+                    {/*
+                      Surfaced in the list, not just on the detail page: an
+                      unregistered callback means login fails at the very last
+                      step, and an admin should be able to see that at a glance
+                      rather than after a user reports it.
+                    */}
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      {callbackRegistered ? (
+                        <span className="inline-flex rounded-full bg-success-soft px-2 py-0.5 text-xs font-medium text-success-fg">
+                          Registered
+                        </span>
+                      ) : (
+                        <span
+                          className="inline-flex rounded-full bg-warning-soft px-2 py-0.5 text-xs font-medium text-warning-fg"
+                          title="The callback URL is not in the OAuth client's redirect URIs. Logins will fail."
+                        >
+                          Not registered
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ),
+              )
+            ) : (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-6 py-12 text-center text-sm text-subtle"
+                >
+                  No proxy applications yet. Add one to protect an app behind
+                  Traefik, nginx or Caddy without changing its code.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/proxy-applications/__tests__/ProxyApplicationCreatePage.test.tsx
+++ b/admin-ui/src/pages/proxy-applications/__tests__/ProxyApplicationCreatePage.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test/utils';
+import ProxyApplicationCreatePage from '../ProxyApplicationCreatePage';
+
+function renderCreate(realm = 'test-realm') {
+  return render(<ProxyApplicationCreatePage />, {
+    initialUrl: `/console/realms/${realm}/proxy-applications/new`,
+    routePattern: '/console/realms/:name/proxy-applications/new',
+  });
+}
+
+describe('ProxyApplicationCreatePage', () => {
+  it('renders the form fields', async () => {
+    renderCreate();
+    expect(screen.getByLabelText(/^slug$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^name$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/oauth client/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/allowed redirect uris/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/cookie domain/i)).toBeInTheDocument();
+  });
+
+  it('previews the verify path the proxy will be pointed at', async () => {
+    const user = userEvent.setup();
+    renderCreate();
+
+    await user.type(screen.getByLabelText(/^slug$/i), 'grafana');
+    expect(
+      screen.getByText(/\/realms\/test-realm\/proxy\/grafana\/verify/),
+    ).toBeInTheDocument();
+  });
+
+  it('fills the cookie domain from the first redirect URI', async () => {
+    const user = userEvent.setup();
+    renderCreate();
+
+    await user.type(
+      screen.getByLabelText(/allowed redirect uris/i),
+      'https://grafana.example.com/*',
+    );
+
+    expect(screen.getByLabelText(/cookie domain/i)).toHaveValue('.example.com');
+  });
+
+  it('stops suggesting once the admin edits the cookie domain themselves', async () => {
+    const user = userEvent.setup();
+    renderCreate();
+
+    const cookieDomain = screen.getByLabelText(/cookie domain/i);
+    await user.type(cookieDomain, '.custom.test');
+    await user.type(
+      screen.getByLabelText(/allowed redirect uris/i),
+      'https://grafana.example.com/*',
+    );
+
+    expect(cookieDomain).toHaveValue('.custom.test');
+  });
+
+  it('lists the realm clients to pick from', async () => {
+    renderCreate();
+    await screen.findByRole('option', { name: /my-app/i });
+    expect(
+      screen.getByRole('option', { name: /public-app/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the submit and cancel actions', () => {
+    renderCreate();
+    expect(
+      screen.getByRole('button', { name: /create application/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/pages/proxy-applications/__tests__/ProxyApplicationDetailPage.test.tsx
+++ b/admin-ui/src/pages/proxy-applications/__tests__/ProxyApplicationDetailPage.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test/mocks/server';
+import {
+  makeProxyApplication,
+  makeProxyApplicationView,
+} from '../../../test/mocks/data';
+import { render } from '../../../test/utils';
+import ProxyApplicationDetailPage from '../ProxyApplicationDetailPage';
+
+function renderDetail(realm = 'test-realm', slug = 'grafana') {
+  return render(<ProxyApplicationDetailPage />, {
+    initialUrl: `/console/realms/${realm}/proxy-applications/${slug}`,
+    routePattern: '/console/realms/:name/proxy-applications/:slug',
+  });
+}
+
+describe('ProxyApplicationDetailPage', () => {
+  it('shows the application name and slug', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+    expect(screen.getByText('grafana')).toBeInTheDocument();
+  });
+
+  it('shows the forward-auth endpoint the proxy is pointed at', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+    expect(
+      screen.getByText('/realms/test-realm/proxy/grafana/verify'),
+    ).toBeInTheDocument();
+  });
+
+  it('lists the identity headers, since the proxy must be told to copy them', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+    expect(screen.getByText('X-Forwarded-User')).toBeInTheDocument();
+    expect(screen.getByText('X-Forwarded-Groups')).toBeInTheDocument();
+  });
+
+  it('shows the allowed redirect URIs', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+    expect(
+      screen.getByText('https://grafana.example.com/*'),
+    ).toBeInTheDocument();
+  });
+
+  // The failure this page exists to prevent: a callback URL that was never
+  // added to the OAuth client. It breaks login at the final redirect, long
+  // after the admin has stopped looking.
+  it('warns, in an alert, when the callback URL is not registered', async () => {
+    server.use(
+      http.get('/admin/realms/:name/proxy-applications/:slug', () =>
+        HttpResponse.json(
+          makeProxyApplicationView({ callbackRegistered: false }),
+        ),
+      ),
+    );
+
+    renderDetail();
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/callback url is not registered/i);
+    expect(alert).toHaveTextContent(/grafana-proxy/);
+  });
+
+  it('does not warn when the callback URL is registered', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+    expect(
+      screen.queryByText(/callback url is not registered/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('offers Disable for an enabled application', async () => {
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+    expect(
+      screen.getByRole('button', { name: /^disable$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('offers Enable for a disabled application', async () => {
+    server.use(
+      http.get('/admin/realms/:name/proxy-applications/:slug', () =>
+        HttpResponse.json(
+          makeProxyApplicationView({
+            application: makeProxyApplication({ enabled: false }),
+          }),
+        ),
+      ),
+    );
+
+    renderDetail();
+    expect(
+      await screen.findByRole('button', { name: /^enable$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('reports how many sessions were revoked', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByRole('heading', { name: 'Grafana' });
+
+    await user.click(screen.getByRole('button', { name: /revoke all sessions/i }));
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveTextContent(/revoked 2 sessions/i);
+  });
+});

--- a/admin-ui/src/pages/proxy-applications/__tests__/ProxyApplicationListPage.test.tsx
+++ b/admin-ui/src/pages/proxy-applications/__tests__/ProxyApplicationListPage.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import { render } from '../../../test/utils';
+import ProxyApplicationListPage from '../ProxyApplicationListPage';
+
+function renderList(realm = 'test-realm') {
+  return render(<ProxyApplicationListPage />, {
+    initialUrl: `/console/realms/${realm}/proxy-applications`,
+    routePattern: '/console/realms/:name/proxy-applications',
+  });
+}
+
+describe('ProxyApplicationListPage', () => {
+  it('shows a loading state initially', () => {
+    renderList();
+    expect(screen.getByText(/loading proxy applications/i)).toBeInTheDocument();
+  });
+
+  it('renders a row per application', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(screen.getByText('wiki')).toBeInTheDocument();
+  });
+
+  it('shows the realm in the subtitle', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(screen.getByText(/test-realm/)).toBeInTheDocument();
+  });
+
+  it('renders the Add Application button', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(
+      screen.getByRole('button', { name: /add application/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the cookie domain, which is the setting most likely to be wrong', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(screen.getAllByText('.example.com').length).toBeGreaterThan(0);
+  });
+
+  it('distinguishes enabled from disabled applications', async () => {
+    renderList();
+    await screen.findByText('grafana');
+
+    // Scoped to the rows: "Enabled" is also a column header, so an unscoped
+    // query matches the <th> as well as the badge.
+    const [grafanaRow, wikiRow] = screen.getAllByRole('button', {
+      name: /view proxy application/i,
+    });
+    expect(within(grafanaRow).getByText('Enabled')).toBeInTheDocument();
+    expect(within(wikiRow).getByText('Disabled')).toBeInTheDocument();
+  });
+
+  // The reason callback status is in the list at all: an unregistered callback
+  // breaks login at the last step, and an admin should see it without opening
+  // each application.
+  it('flags an application whose callback URL is not registered', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(screen.getByText('Registered')).toBeInTheDocument();
+    expect(screen.getByText('Not registered')).toBeInTheDocument();
+  });
+
+  it('gives each row an accessible name', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(
+      screen.getByRole('button', { name: /view proxy application grafana/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('labels the table', async () => {
+    renderList();
+    await screen.findByText('grafana');
+    expect(
+      screen.getByRole('table', { name: /proxy applications/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/admin-ui/src/test/mocks/data.ts
+++ b/admin-ui/src/test/mocks/data.ts
@@ -1,4 +1,7 @@
-import type { Realm, User, Client, Role, NhiIdentity, ConsentCategory } from '../../types';
+import type { Realm, User, Client, Role, NhiIdentity, ConsentCategory,
+  ProxyApplication,
+  ProxyApplicationView,
+} from '../../types';
 import type { LoginEvent, AdminEvent } from '../../api/events';
 import type { RealmStats, FailedLoginHeatmap } from '../../api/stats';
 import type { LockedUser } from '../../api/bruteForce';
@@ -299,6 +302,41 @@ export function makeConsentCategory(
     scopes: [],
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function makeProxyApplication(
+  overrides: Partial<ProxyApplication> = {},
+): ProxyApplication {
+  return {
+    id: 'proxy-app-1',
+    realmId: 'realm-1',
+    slug: 'grafana',
+    name: 'Grafana',
+    enabled: true,
+    clientId: 'grafana-proxy',
+    allowedRedirectUris: ['https://grafana.example.com/*'],
+    cookieDomain: '.example.com',
+    cookieTtl: 28800,
+    userHeader: 'X-Forwarded-User',
+    emailHeader: 'X-Forwarded-Email',
+    nameHeader: 'X-Forwarded-Preferred-Username',
+    groupsHeader: 'X-Forwarded-Groups',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function makeProxyApplicationView(
+  overrides: Partial<ProxyApplicationView> = {},
+): ProxyApplicationView {
+  const application = overrides.application ?? makeProxyApplication();
+  return {
+    application,
+    callbackUrl: `https://auth.example.com/realms/test-realm/proxy/${application.slug}/callback`,
+    callbackRegistered: true,
     ...overrides,
   };
 }

--- a/admin-ui/src/test/mocks/handlers.ts
+++ b/admin-ui/src/test/mocks/handlers.ts
@@ -1,5 +1,8 @@
 import { http, HttpResponse } from 'msw';
-import { makeRealm, makeUser, makeClient, makeLoginEvent, makeAdminEvent, makeStats, makeFailedLoginHeatmap, makeAuthFlow, makeUpgradeAuditEntry, makePreUpgradeValidationResult, makeUpgradeHealthResult, makeRollbackCapability, makeNhiIdentity, makeConsentCategory } from './data';
+import { makeRealm, makeUser, makeClient, makeLoginEvent, makeAdminEvent, makeStats, makeFailedLoginHeatmap, makeAuthFlow, makeUpgradeAuditEntry, makePreUpgradeValidationResult, makeUpgradeHealthResult, makeRollbackCapability, makeNhiIdentity, makeConsentCategory,
+  makeProxyApplication,
+  makeProxyApplicationView,
+} from './data';
 
 const BASE = '/admin';
 
@@ -113,6 +116,58 @@ export const handlers = [
 
   http.delete(`${BASE}/realms/:name/clients/:id`, () => {
     return new HttpResponse(null, { status: 204 });
+  }),
+
+  // Proxy applications (forward-auth)
+  http.get(`${BASE}/realms/:name/proxy-applications`, () => {
+    return HttpResponse.json([
+      makeProxyApplicationView(),
+      makeProxyApplicationView({
+        application: makeProxyApplication({
+          id: 'proxy-app-2',
+          slug: 'wiki',
+          name: 'Wiki',
+          enabled: false,
+        }),
+        callbackRegistered: false,
+      }),
+    ]);
+  }),
+
+  http.get(`${BASE}/realms/:name/proxy-applications/:slug`, ({ params }) => {
+    return HttpResponse.json(
+      makeProxyApplicationView({
+        application: makeProxyApplication({ slug: params.slug as string }),
+      }),
+    );
+  }),
+
+  http.post(`${BASE}/realms/:name/proxy-applications`, async ({ request }) => {
+    const body = (await request.json()) as Partial<ReturnType<typeof makeProxyApplication>>;
+    return HttpResponse.json(
+      makeProxyApplicationView({
+        application: makeProxyApplication({ ...body, id: 'new-proxy-app-1' }),
+        callbackRegistered: false,
+      }),
+      { status: 201 },
+    );
+  }),
+
+  http.put(`${BASE}/realms/:name/proxy-applications/:slug`, async ({ params, request }) => {
+    const body = (await request.json()) as Partial<ReturnType<typeof makeProxyApplication>>;
+    return HttpResponse.json(
+      makeProxyApplicationView({
+        application: makeProxyApplication({ slug: params.slug as string, ...body }),
+      }),
+    );
+  }),
+
+  http.delete(`${BASE}/realms/:name/proxy-applications/:slug`, () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.post(`${BASE}/realms/:name/proxy-applications/:slug/revoke-sessions`, () => {
+    return HttpResponse.json({ revoked: 2 });
   }),
 
   // Non-Human Identities

--- a/admin-ui/src/types/index.ts
+++ b/admin-ui/src/types/index.ts
@@ -164,6 +164,61 @@ export interface Client {
   updatedAt: string;
 }
 
+/**
+ * An application Idenplane protects at the reverse proxy rather than inside the
+ * application's own code. See src/proxy-auth on the server.
+ */
+export interface ProxyApplication {
+  id: string;
+  realmId: string;
+  slug: string;
+  name: string;
+  enabled: boolean;
+  clientId: string;
+  allowedRedirectUris: string[];
+  cookieDomain: string;
+  cookieTtl: number;
+  userHeader: string;
+  emailHeader: string;
+  nameHeader: string;
+  groupsHeader: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * What the admin API returns for a proxy application. `callbackUrl` has to be
+ * registered on the OAuth client for login to complete, and
+ * `callbackRegistered` says whether it currently is — without surfacing that,
+ * the first symptom of a missed step is a redirect_uri mismatch at the end of a
+ * login the admin has already gone through.
+ */
+export interface ProxyApplicationView {
+  application: ProxyApplication;
+  callbackUrl: string;
+  callbackRegistered: boolean;
+}
+
+export interface CreateProxyApplicationInput {
+  slug: string;
+  name: string;
+  /** The `clientId` of the OAuth client, not its database id. */
+  clientId: string;
+  allowedRedirectUris: string[];
+  cookieDomain: string;
+  cookieTtl?: number;
+  enabled?: boolean;
+  userHeader?: string;
+  emailHeader?: string;
+  nameHeader?: string;
+  groupsHeader?: string;
+}
+
+/** Everything except `slug`, which is immutable: it is baked into the proxy config. */
+export type UpdateProxyApplicationInput = Partial<
+  Omit<CreateProxyApplicationInput, 'slug'>
+>;
+
 export interface Role {
   id: string;
   realmId: string;

--- a/admin-ui/src/utils/__tests__/suggestCookieDomain.test.ts
+++ b/admin-ui/src/utils/__tests__/suggestCookieDomain.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { suggestCookieDomain } from '../suggestCookieDomain';
+
+/**
+ * This helper exists because a cookie domain that does not cover the
+ * application's host fails silently: the browser simply never sends the session
+ * cookie, so the user bounces between the app and login with no error anywhere.
+ * The server rejects the combination, but suggesting a correct value means most
+ * admins never reach that rejection.
+ */
+describe('suggestCookieDomain', () => {
+  it('derives the registrable parent from a subdomain', () => {
+    expect(suggestCookieDomain('https://grafana.example.com/*')).toBe(
+      '.example.com',
+    );
+  });
+
+  it('handles a deep subdomain', () => {
+    expect(suggestCookieDomain('https://a.b.example.com/*')).toBe(
+      '.example.com',
+    );
+  });
+
+  it('leaves an apex domain as its own scope', () => {
+    expect(suggestCookieDomain('https://example.com/*')).toBe('example.com');
+  });
+
+  it('leaves a bare host alone', () => {
+    expect(suggestCookieDomain('http://localhost:3000/*')).toBe('localhost');
+  });
+
+  it('works without the trailing wildcard', () => {
+    expect(suggestCookieDomain('https://grafana.example.com/login')).toBe(
+      '.example.com',
+    );
+  });
+
+  it('returns empty for something that is not a URL, rather than guessing', () => {
+    expect(suggestCookieDomain('grafana.example.com')).toBe('');
+  });
+
+  it('returns empty for an empty input', () => {
+    expect(suggestCookieDomain('')).toBe('');
+  });
+});

--- a/admin-ui/src/utils/suggestCookieDomain.ts
+++ b/admin-ui/src/utils/suggestCookieDomain.ts
@@ -1,0 +1,29 @@
+/**
+ * Suggest a proxy-session cookie domain from an application's redirect URI:
+ * `https://grafana.example.com/*` → `.example.com`.
+ *
+ * Only a suggestion — the field stays editable — but getting this wrong is the
+ * most expensive mistake on the create form. A cookie domain that does not
+ * cover the application's host means the browser never sends the session
+ * cookie, so the user bounces between the app and login forever, with no error
+ * in any log. The server rejects it; offering a correct default means most
+ * admins never reach that rejection.
+ *
+ * Returns an empty string for anything that is not an absolute URL, rather than
+ * guessing from a fragment.
+ */
+export function suggestCookieDomain(redirectUri: string): string {
+  let host: string;
+  try {
+    host = new URL(redirectUri.replace(/\/\*$/, '/')).hostname;
+  } catch {
+    return '';
+  }
+
+  const labels = host.split('.');
+  // A bare host (localhost) or an apex domain (example.com) is its own scope;
+  // anything deeper shares the registrable parent, which is what lets one
+  // cookie reach both Idenplane and the protected application.
+  if (labels.length <= 2) return host;
+  return `.${labels.slice(-2).join('.')}`;
+}


### PR DESCRIPTION
Second slice of #1314 — the admin console for the forward-auth mode that landed in #1486. List, create and detail pages under **Proxy Applications**, plus the API layer and types.

## Most of this design is about one failure

A **callback URL that was never added to the OAuth client.** Login then fails at the *final* redirect — after the user has already gone through password and MFA — with a `redirect_uri` mismatch that names nothing useful.

The server already returns `callbackRegistered`, so the console surfaces it three times over:

| where | what |
|---|---|
| **List** | a `Not registered` badge — visible without opening each application |
| **Detail** | a warning banner carrying the exact URL and the client to add it to |
| **Create** | a hint under the client picker, before the mistake is even made |

## And one more silent failure: the cookie domain

Scope it wrong and the browser simply never sends the session cookie — the user bounces between the app and login forever, with nothing in any log.

The server rejects the combination, but the create form also **suggests** a domain from the first redirect URI (`https://grafana.example.com/*` → `.example.com`) and **stops suggesting the moment an admin edits the field themselves**. Most people never meet that rejection.

`suggestCookieDomain` lives in `utils/` rather than beside the page — exporting a helper next to a component breaks React Fast Refresh (`react-refresh/only-export-components`) — and its tests moved with it.

## Detail page

Carries the operational bits: the `verify` path to point the proxy at, the identity header names the proxy must be told to copy, enable/disable, revoke-all-sessions, and a delete that says out loud that the proxy will start getting 404s.

## Conventions

Follows the existing console: React Query, react-router, the semantic Tailwind tokens (so dark mode works without extra work), tables with `aria-label` and keyboard-navigable rows.

The nav entry and all three routes satisfy the routes↔nav guard in `src/__tests__/routes.test.ts` — `/new` and the two-param detail route are exempt under its existing rules.

## Verification

```
npx tsc --noEmit   exit 0
npm run lint       exit 0
npx vitest run     exit 0   54 files, 469 tests (36 new)
```

## Why #1314 stays open

This is 2 of 3. Still to come: the Traefik / nginx / Caddy config docs and a docker-compose example protecting a real app. The issue closes with that one.

Refs #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)