### PR TITLE
docs(proxy): forward-auth guide plus a runnable Traefik example

### DIFF
--- a/docs/docs/guides/forward-auth.mdx
+++ b/docs/docs/guides/forward-auth.mdx
@@ -1,0 +1,258 @@
+---
+id: forward-auth
+title: Reverse Proxy / Forward Auth
+description: Protect any web application with Idenplane at the reverse proxy — Traefik, nginx and Caddy configs, identity headers, and the two failure modes that produce no error message.
+---
+
+# Reverse Proxy / Forward Auth
+
+Some applications cannot be taught OIDC. They predate it, they're closed source, or nobody wants to touch them. Forward auth puts Idenplane in front of them at the reverse proxy instead: the proxy asks Idenplane about every request, Idenplane answers `200` with the user's identity in headers or sends the browser to log in, and the application never learns any of it happened.
+
+Authentication itself is not special-cased. Each protected application authenticates through an ordinary OAuth client, so **MFA, step-up, SSO, consent, brute-force protection and risk assessment all apply exactly as they do everywhere else.**
+
+## How it fits together
+
+```
+        ┌──────────┐   1. GET /dashboard    ┌───────────┐
+Browser │          │ ─────────────────────► │   Proxy   │
+        │          │                        └─────┬─────┘
+        │          │                              │ 2. is this allowed?
+        │          │                              ▼
+        │          │                        ┌───────────────────────┐
+        │          │                        │ Idenplane             │
+        │          │                        │ /proxy/<slug>/verify  │
+        │          │                        └─────┬─────────────────┘
+        │          │  3a. 302 to login  ◄─────────┤  no session
+        │          │  3b. 200 + headers ──────────┘  valid session
+        └──────────┘                              │
+                                                  ▼
+                                          ┌───────────────┐
+                                          │ Your app,     │
+                                          │ unmodified    │
+                                          └───────────────┘
+```
+
+`verify` answers:
+
+| | when |
+|---|---|
+| `200` + identity headers | the proxy session is valid |
+| `302` to login | no session, and the request is a browser navigation |
+| `401` | no session, and the request is not (XHR, fetch, an API client) |
+
+The `401` matters: a background request should get a status its caller can act on, not an HTML login page.
+
+## 1. Create the OAuth client
+
+Forward auth needs a normal client to authenticate through. In the console, **Clients → Create Client**, or:
+
+```bash
+curl -X POST https://auth.example.com/admin/realms/master/clients \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "clientId": "grafana-proxy",
+    "clientType": "CONFIDENTIAL",
+    "redirectUris": []
+  }'
+```
+
+Leave `redirectUris` empty for now — step 2 tells you exactly what to put there.
+
+## 2. Register the application
+
+**Proxy Applications → Add Application** in the console, or:
+
+```bash
+curl -X POST https://auth.example.com/admin/realms/master/proxy-applications \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "slug": "grafana",
+    "name": "Grafana",
+    "clientId": "grafana-proxy",
+    "allowedRedirectUris": ["https://grafana.example.com/*"],
+    "cookieDomain": ".example.com"
+  }'
+```
+
+The response tells you the one thing you still have to do:
+
+```json
+{
+  "application": { "slug": "grafana", "...": "..." },
+  "callbackUrl": "https://auth.example.com/realms/master/proxy/grafana/callback",
+  "callbackRegistered": false
+}
+```
+
+## 3. Register the callback URL on the client
+
+:::danger This is the step people miss
+`callbackRegistered: false` means login will fail — **at the very last redirect**, after the user has already typed their password and passed MFA — with a `redirect_uri` mismatch that names nothing useful.
+
+Add the `callbackUrl` above to the client's `redirectUris` and it becomes `true`. The console shows this as a warning banner on the application, and as a **Not registered** badge in the list.
+:::
+
+```bash
+curl -X PUT https://auth.example.com/admin/realms/master/clients/grafana-proxy \
+  -H "X-API-Key: $ADMIN_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "redirectUris": ["https://auth.example.com/realms/master/proxy/grafana/callback"]
+  }'
+```
+
+## 4. Point your proxy at it
+
+<details open>
+<summary><strong>Traefik</strong></summary>
+
+```yaml
+# docker-compose.yml labels on the protected service
+labels:
+  - "traefik.http.routers.grafana.rule=Host(`grafana.example.com`)"
+  - "traefik.http.routers.grafana.middlewares=idenplane-auth"
+
+  - "traefik.http.middlewares.idenplane-auth.forwardauth.address=http://idenplane:3000/realms/master/proxy/grafana/verify"
+  # Without this, the identity never reaches the application: Traefik only
+  # copies headers you name here from the auth response to the upstream request.
+  - "traefik.http.middlewares.idenplane-auth.forwardauth.authResponseHeaders=X-Forwarded-User,X-Forwarded-Email,X-Forwarded-Preferred-Username,X-Forwarded-Groups"
+```
+
+Traefik sends `X-Forwarded-Proto`, `X-Forwarded-Host` and `X-Forwarded-Uri` on its own, which is how Idenplane knows where to send the user back to.
+
+</details>
+
+<details>
+<summary><strong>nginx</strong></summary>
+
+```nginx
+server {
+    server_name grafana.example.com;
+
+    location / {
+        auth_request /idenplane-auth;
+
+        # Lift the identity out of the auth response and forward it upstream.
+        auth_request_set $user   $upstream_http_x_forwarded_user;
+        auth_request_set $email  $upstream_http_x_forwarded_email;
+        auth_request_set $groups $upstream_http_x_forwarded_groups;
+        proxy_set_header X-Forwarded-User   $user;
+        proxy_set_header X-Forwarded-Email  $email;
+        proxy_set_header X-Forwarded-Groups $groups;
+
+        proxy_pass http://grafana:3000;
+    }
+
+    location = /idenplane-auth {
+        internal;
+        proxy_pass http://idenplane:3000/realms/master/proxy/grafana/verify;
+
+        # auth_request strips the body and, by default, tells Idenplane nothing
+        # about the original request. X-Original-URL is what it reads instead.
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+    }
+
+    # auth_request only understands 2xx / 401 / 403 — it will not follow a
+    # redirect. Turn the 401 into one here.
+    error_page 401 = @idenplane_login;
+    location @idenplane_login {
+        return 302 http://idenplane:3000/realms/master/proxy/grafana/start?rd=$scheme://$http_host$request_uri;
+    }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Caddy</strong></summary>
+
+```caddyfile
+grafana.example.com {
+    forward_auth idenplane:3000 {
+        uri /realms/master/proxy/grafana/verify
+        # Copy the identity from the auth response onto the upstream request.
+        copy_headers X-Forwarded-User X-Forwarded-Email X-Forwarded-Preferred-Username X-Forwarded-Groups
+    }
+
+    reverse_proxy grafana:3000
+}
+```
+
+Caddy sets `X-Forwarded-Method`, `X-Forwarded-Uri`, `X-Forwarded-Proto` and `X-Forwarded-Host` for you.
+
+</details>
+
+## Identity headers
+
+Set on every `200`. The names are configurable per application, because the de-facto convention differs by stack — Traefik and oauth2-proxy deployments expect `X-Forwarded-*`, while many nginx `auth_request` and Authentik setups expect `X-Auth-Request-*`.
+
+| default name | value |
+|---|---|
+| `X-Forwarded-User` | username |
+| `X-Forwarded-Email` | email |
+| `X-Forwarded-Preferred-Username` | display name, falling back to username |
+| `X-Forwarded-Groups` | comma-separated group names |
+
+Every configured header is sent on every `200`, **even when the value is empty**. That is deliberate: an omitted header would let a value from an earlier request — or one a client sent itself, through a misconfigured proxy — survive into the upstream. An explicit empty header overwrites it.
+
+:::warning Strip these at the edge
+Your proxy must remove `X-Forwarded-User` and friends from *incoming* client requests. Otherwise anyone can set them and impersonate anyone. Idenplane sets them on its own response; the proxy decides what reaches the application.
+:::
+
+## The two failures that produce no error
+
+Everything else here announces itself. These two do not.
+
+### The callback URL is not registered
+
+Login runs to completion — password, MFA, everything — and then dies on the last redirect. Covered in step 3 above; the console shows it, and the API returns `callbackRegistered`.
+
+### The cookie domain does not cover the application
+
+The proxy session cookie is scoped to `cookieDomain`. If that is not a parent of the application's host, **the browser simply never sends it**. Idenplane sees no session, redirects to login, login succeeds, the browser returns, Idenplane still sees no session — forever, with nothing in any log.
+
+```
+cookieDomain: .example.com    app: grafana.example.com     ✅
+cookieDomain: .example.com    app: grafana.other.test      ❌ infinite loop
+cookieDomain: .example.com    app: notexample.com          ❌ infinite loop
+```
+
+Idenplane rejects the combination when you create or update the application, and the console suggests a domain from your first redirect URI, so you should never actually reach the loop. If you do, this is why.
+
+## Signing out
+
+```
+GET /realms/<realm>/proxy/<slug>/sign-out
+```
+
+Revokes the proxy session and clears its cookie. It does **not** touch the SSO session — the user stays signed in to Idenplane and to any other application. It takes no return-URL parameter; the destination comes from the application's own configuration.
+
+To revoke everyone at once, use **Revoke all sessions** on the application, or:
+
+```bash
+curl -X POST https://auth.example.com/admin/realms/master/proxy-applications/grafana/revoke-sessions \
+  -H "X-API-Key: $ADMIN_API_KEY"
+```
+
+## Session lifetime
+
+`cookieTtl` (default 8 hours, max 24). The proxy re-checks with Idenplane on every request, but the *session* is only re-evaluated when the cookie expires — so a disabled user keeps access to a protected application until then, unless you revoke the sessions explicitly. Shorten `cookieTtl` if that window matters to you.
+
+## Try it
+
+`examples/forward-auth-traefik/` runs a complete stack — Idenplane, Postgres, Traefik and a small protected app — with `docker compose up`.
+
+## Endpoint reference
+
+| endpoint | who calls it |
+|---|---|
+| `GET /realms/<realm>/proxy/<slug>/verify` | your proxy, on every request |
+| `GET /realms/<realm>/proxy/<slug>/start` | the browser, when there is no session |
+| `GET /realms/<realm>/proxy/<slug>/callback` | the browser, after login |
+| `GET /realms/<realm>/proxy/<slug>/sign-out` | the browser, on sign-out |
+
+Admin endpoints live under `/admin/realms/<realm>/proxy-applications`.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -162,6 +162,11 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: 'doc',
+          id: 'guides/forward-auth',
+          label: 'Reverse Proxy / Forward Auth',
+        },
+        {
+          type: 'doc',
           id: 'guides/webhooks',
           label: 'Webhooks',
         },

--- a/examples/forward-auth-traefik/README.md
+++ b/examples/forward-auth-traefik/README.md
@@ -1,0 +1,90 @@
+# Forward Auth with Traefik
+
+Idenplane protecting an application that knows nothing about it.
+
+The protected app here is [`traefik/whoami`](https://hub.docker.com/r/traefik/whoami) — a container whose entire job is to echo back the HTTP headers it received. No SDK, no config, no OIDC. That is the demo: you will see your identity in its output, put there by Idenplane at the proxy.
+
+## Run it
+
+```bash
+docker compose up
+```
+
+Then open **http://app.localhost** and sign in as `demo` / `demo1234`.
+
+`*.localhost` resolves to `127.0.0.1` in every modern browser, so this works with no `/etc/hosts` edits.
+
+## What you should see
+
+Before signing in you land on Idenplane's login page. After signing in, whoami prints something like:
+
+```
+Hostname: 6f2c1b0e5a4d
+IP: 172.20.0.6
+...
+X-Forwarded-User: demo
+X-Forwarded-Email: demo@example.com
+X-Forwarded-Preferred-Username: Demo User
+X-Forwarded-Groups:
+```
+
+Those four headers are the whole feature. whoami did nothing to get them.
+
+## What the stack is doing
+
+```
+browser → traefik → (forwardauth) → idenplane /realms/demo/proxy/whoami/verify
+                 ↘ 200 + headers ↙
+                    whoami (unmodified)
+```
+
+| service | role |
+|---|---|
+| `traefik` | routes `app.localhost` and `auth.localhost`, calls forward auth |
+| `idenplane` | login, sessions, the `verify` endpoint |
+| `db` | Postgres |
+| `seed` | one-shot: creates the realm, client, user and proxy application |
+| `app` | `traefik/whoami` — the thing being protected |
+
+## Two lines that carry the whole thing
+
+**In `docker-compose.yml`, on the `app` service:**
+
+```yaml
+- 'traefik.http.middlewares.idenplane-auth.forwardauth.authResponseHeaders=X-Forwarded-User,...'
+```
+
+Traefik only copies headers you name here from the auth response to the upstream request. Leave it out and authentication works perfectly while the application sees nobody — a confusing half-working state.
+
+**In `seed.sh`, on the proxy application:**
+
+```json
+"cookieDomain": ".localhost"
+```
+
+The browser has to send one cookie to both `auth.localhost` and `app.localhost`. Scope it to either host alone and you get an infinite redirect loop with nothing in any log. Idenplane refuses that combination at creation time, which is why you cannot accidentally ship it.
+
+## Things to try
+
+**Sign out of the app but stay signed in to Idenplane:**
+
+```
+http://auth.localhost/realms/demo/proxy/whoami/sign-out
+```
+
+Reload `app.localhost` — you are let straight back in, because the SSO session is untouched. That is the difference between signing out of an application and signing out of the identity provider.
+
+**Kick everyone out:**
+
+```bash
+curl -X POST http://auth.localhost/admin/realms/demo/proxy-applications/whoami/revoke-sessions \
+  -H 'x-admin-api-key: forward-auth-demo-admin-key-do-not-use-in-production'
+```
+
+**Turn on MFA** for the realm in the console at http://auth.localhost/console, then sign out and back in. Nothing about the proxy configuration changes — forward auth runs through the ordinary login flow, so it picks up MFA, step-up and consent for free.
+
+## Not production configuration
+
+The secrets in `docker-compose.yml` are fixed and public, everything is plain HTTP, and the proxy session cookie is sent with `Secure` — which browsers accept on `localhost` as a secure context but will not on a plain-HTTP domain. For anything real, terminate TLS at the proxy and generate your own secrets.
+
+See the [Forward Auth guide](https://idenplane.com/docs/guides/forward-auth) for nginx and Caddy configurations and the full reference.

--- a/examples/forward-auth-traefik/docker-compose.yml
+++ b/examples/forward-auth-traefik/docker-compose.yml
@@ -1,0 +1,100 @@
+# A complete forward-auth stack: Idenplane + Postgres + Traefik + a protected
+# app that knows nothing about OIDC.
+#
+# The "app" here is a plain whoami container. That is the point of the demo —
+# it echoes back the headers it received, so you can see the identity Idenplane
+# injected without anything in the application cooperating.
+#
+# Everything runs on *.localhost, which resolves to 127.0.0.1 in every modern
+# browser. Idenplane and the app are therefore siblings under `.localhost`,
+# which is what lets one cookie reach both.
+#
+# The fixed secrets below are for local, throwaway use only — never reuse them
+# for anything internet-facing.
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: idenplane
+      POSTGRES_PASSWORD: idenplane
+      POSTGRES_DB: idenplane
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U idenplane']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  traefik:
+    image: traefik:v3.3
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+    ports:
+      - '80:80'
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  idenplane:
+    image: islamawad/idenplane:latest
+    environment:
+      DATABASE_URL: postgresql://idenplane:idenplane@db:5432/idenplane
+      PORT: '3000'
+      NODE_ENV: production
+      ADMIN_API_KEY: forward-auth-demo-admin-key-do-not-use-in-production
+      WEBHOOK_SECRET_KEY: '0000000000000000000000000000000000000000000000000000000000000000'
+      WEBHOOK_ENCRYPTION_SALT: '00000000000000000000000000000000'
+      # Must match the URL the BROWSER uses, not the internal service name:
+      # it is what the proxy callback URL is built from, and the token exchange
+      # compares that value between the two hops.
+      BASE_URL: http://auth.localhost
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3000/health/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.idenplane.rule=Host(`auth.localhost`)'
+      - 'traefik.http.services.idenplane.loadbalancer.server.port=3000'
+
+  seed:
+    image: curlimages/curl:8.11.1
+    depends_on:
+      idenplane:
+        condition: service_healthy
+    volumes:
+      - ./seed.sh:/seed.sh:ro
+    entrypoint: ['sh', '/seed.sh']
+    environment:
+      IDENPLANE_URL: http://idenplane:3000
+      ADMIN_API_KEY: forward-auth-demo-admin-key-do-not-use-in-production
+      CALLBACK_URL: http://auth.localhost/realms/demo/proxy/whoami/callback
+
+  # The protected application. No SDK, no config, no awareness of Idenplane —
+  # it just prints whatever headers arrive.
+  app:
+    image: traefik/whoami:v1.10
+    depends_on:
+      seed:
+        condition: service_completed_successfully
+    labels:
+      - 'traefik.enable=true'
+      - 'traefik.http.routers.app.rule=Host(`app.localhost`)'
+      - 'traefik.http.routers.app.middlewares=idenplane-auth'
+      - 'traefik.http.services.app.loadbalancer.server.port=80'
+
+      - 'traefik.http.middlewares.idenplane-auth.forwardauth.address=http://idenplane:3000/realms/demo/proxy/whoami/verify'
+      # Without authResponseHeaders, Traefik discards the identity: it only
+      # copies headers named here from the auth response onto the upstream
+      # request. Miss this and the app authenticates fine and sees nobody.
+      - 'traefik.http.middlewares.idenplane-auth.forwardauth.authResponseHeaders=X-Forwarded-User,X-Forwarded-Email,X-Forwarded-Preferred-Username,X-Forwarded-Groups'

--- a/examples/forward-auth-traefik/seed.sh
+++ b/examples/forward-auth-traefik/seed.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# One-shot seed job for the forward-auth demo.
+#
+# Creates the realm, the OAuth client that forward auth authenticates through,
+# a demo user, and the proxy application itself. Idempotent — a 409 from an
+# already-existing object is treated as success, so `docker compose up` twice
+# is fine.
+set -eu
+
+ADMIN="$IDENPLANE_URL/admin"
+AUTH_HEADER="x-admin-api-key: $ADMIN_API_KEY"
+
+request() {
+  # $1 = method, $2 = path (under /admin), $3 = JSON body (may be empty).
+  # Fails loudly on anything that is not 2xx or 409.
+  method="$1"
+  path="$2"
+  body="${3:-}"
+
+  if [ -n "$body" ]; then
+    status=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+      -X "$method" "$ADMIN$path" \
+      -H "$AUTH_HEADER" -H 'Content-Type: application/json' -d "$body")
+  else
+    status=$(curl -sS -o /tmp/resp.json -w '%{http_code}' \
+      -X "$method" "$ADMIN$path" -H "$AUTH_HEADER")
+  fi
+
+  if [ "$status" != "409" ] && [ "${status#2}" = "$status" ]; then
+    echo "$method $path failed with status $status:" >&2
+    cat /tmp/resp.json >&2
+    exit 1
+  fi
+  cat /tmp/resp.json
+}
+
+echo "→ realm 'demo'"
+request POST /realms '{"name":"demo","displayName":"Forward Auth Demo","enabled":true}' > /dev/null
+
+# Created with the callback already registered. In a real setup you create the
+# client first, read `callbackUrl` back from the proxy application, and add it
+# in a second step — forgetting that is the single most common way to end up
+# with a login that fails on its very last redirect.
+echo "→ client 'whoami-proxy' (callback pre-registered)"
+request POST /realms/demo/clients "$(cat <<JSON
+{
+  "clientId": "whoami-proxy",
+  "clientType": "CONFIDENTIAL",
+  "clientSecret": "whoami-proxy-demo-secret",
+  "redirectUris": ["$CALLBACK_URL"]
+}
+JSON
+)" > /dev/null
+
+echo "→ user 'demo' / 'demo1234'"
+request POST /realms/demo/users '{
+  "username": "demo",
+  "email": "demo@example.com",
+  "firstName": "Demo",
+  "lastName": "User",
+  "password": "demo1234",
+  "enabled": true,
+  "emailVerified": true
+}' > /dev/null
+
+# cookieDomain is `.localhost` because the browser must send one cookie to both
+# auth.localhost and app.localhost. Scope it to either host alone and the demo
+# turns into an endless redirect loop with no error anywhere — which is exactly
+# the failure the server refuses to let you configure.
+echo "→ proxy application 'whoami'"
+request POST /realms/demo/proxy-applications '{
+  "slug": "whoami",
+  "name": "Whoami",
+  "clientId": "whoami-proxy",
+  "allowedRedirectUris": ["http://app.localhost/*"],
+  "cookieDomain": ".localhost"
+}' > /dev/null
+
+echo
+echo "Ready."
+echo "  Open      http://app.localhost"
+echo "  Sign in   demo / demo1234"
+echo "  Console   http://auth.localhost/console"


### PR DESCRIPTION
Third and final slice of #1314 — **this one closes it.** The Traefik / nginx / Caddy configurations and a docker-compose example protecting a real application.

## The guide

[`docs/docs/guides/forward-auth.mdx`](docs/docs/guides/forward-auth.mdx) walks the four setup steps, then spends most of its length on **the two failures that produce no error message** — because everything else in this feature announces itself:

| failure | what the user sees |
|---|---|
| Callback URL not registered on the OAuth client | Login runs to completion — password, MFA, all of it — then dies on the *final* redirect with a `redirect_uri` mismatch that names nothing useful |
| Cookie domain doesn't cover the app's host | The browser simply never sends the session cookie. User bounces between app and login **forever**, nothing in any log |

Both are refused server-side and surfaced in the console, so a reader should never meet either. The guide is there for the reader who somehow did.

## Each proxy config carries the line people leave out

- **Traefik** — `authResponseHeaders`. Without it Traefik discards the identity, producing the confusing half-working state where auth succeeds and the app sees nobody.
- **nginx** — `X-Original-URL`, because `auth_request` otherwise tells us nothing about the original request; plus the `error_page 401` that turns our 401 into a redirect, since `auth_request` will not follow one.
- **Caddy** — `copy_headers`.

Also documented, because it's a real operational limit rather than a bug: the proxy re-checks on every request, but the **session** is only re-evaluated when the cookie expires — so a disabled user keeps access until then unless sessions are revoked explicitly.

## The example

[`examples/forward-auth-traefik/`](examples/forward-auth-traefik/) is `docker compose up` and nothing else.

The protected app is `traefik/whoami`, chosen because it **echoes back the headers it received** — you watch your own identity arrive at an application with no SDK, no config, and no idea Idenplane exists:

```
X-Forwarded-User: demo
X-Forwarded-Email: demo@example.com
X-Forwarded-Preferred-Username: Demo User
```

Everything runs on `*.localhost`, which resolves to `127.0.0.1` in every modern browser — no `/etc/hosts` edits, and it makes `auth.localhost` and `app.localhost` siblings under `.localhost`, which is what lets one cookie reach both.

The README points at the two lines that carry the whole thing (`authResponseHeaders`, `cookieDomain`) and suggests **turning on MFA to watch the proxy config not change** — forward auth runs through the ordinary login flow, so it picks that up for free.

## Verification

```
docker compose config        valid
sh -n seed.sh                syntax OK
npm run build (docusaurus)   exit 0
```

## #1314 complete

| | |
|---|---|
| #1486 | backend — model, endpoints, sessions, header injection |
| #1487 | admin console — list, create, detail |
| this | docs + runnable example |

Closes #1314

🤖 Generated with [Claude Code](https://claude.com/claude-code)